### PR TITLE
Fixes memory leak and moves allocation into stuct.

### DIFF
--- a/src/kex/test_kex.c
+++ b/src/kex/test_kex.c
@@ -15,7 +15,7 @@
 	printf("\n"); \
 }
 
-static int kex_test_correctness(OQS_RAND *rand, OQS_KEX *(*new_method)(OQS_RAND *, const uint8_t *, const size_t), int print, unsigned long occurrences[256]) {
+static int kex_test_correctness(OQS_RAND *rand, OQS_KEX * (*new_method)(OQS_RAND *, const uint8_t *, const size_t), int print, unsigned long occurrences[256]) {
 
 	OQS_KEX *kex = NULL;
 	int rc;
@@ -110,11 +110,11 @@ cleanup:
 	OQS_KEX_alice_priv_free(kex, alice_priv);
 	OQS_KEX_free(kex);
 
-	return rc;	
+	return rc;
 
 }
 
-static int kex_test_correctness_wrapper(OQS_RAND *rand, OQS_KEX *(*new_method)(OQS_RAND *, const uint8_t *, const size_t), int iterations) {
+static int kex_test_correctness_wrapper(OQS_RAND *rand, OQS_KEX * (*new_method)(OQS_RAND *, const uint8_t *, const size_t), int iterations) {
 
 	OQS_KEX *kex = NULL;
 	int ret;
@@ -152,7 +152,7 @@ err:
 cleanup:
 	OQS_KEX_free(kex);
 
-	return ret;	
+	return ret;
 
 }
 

--- a/src/kex_rlwe_bcns15/kex_rlwe_bcns15.c
+++ b/src/kex_rlwe_bcns15/kex_rlwe_bcns15.c
@@ -24,10 +24,6 @@ OQS_KEX *OQS_KEX_rlwe_bcns15_new(OQS_RAND *rand, UNUSED const uint8_t *seed, UNU
 	if (NULL == k->ctx) {
 		return NULL;
 	}
-	int ok = oqs_kex_rlwe_bcns15_fft_ctx_init(k->ctx);
-	if (ok != 1) {
-		return NULL;
-	}
 
 	k->method_name = strdup("RLWE BCNS15");
 	k->estimated_classical_security = 163;

--- a/src/kex_rlwe_bcns15/local.h
+++ b/src/kex_rlwe_bcns15/local.h
@@ -16,30 +16,28 @@
 #include <oqs/rand.h>
 
 struct oqs_kex_rlwe_bcns15_fft_ctx {
-	uint32_t **x1;
-	uint32_t **y1;
-	uint32_t **z1;
-	uint32_t *t1;
+	uint32_t x1[64][64];
+	uint32_t y1[64][64];
+	uint32_t z1[64][64];
+	uint32_t t1[64];
 };
 
-void oqs_kex_rlwe_bcns15_fft_mul(uint32_t *z, const uint32_t *x, const uint32_t *y, struct oqs_kex_rlwe_bcns15_fft_ctx *ctx);
-void oqs_kex_rlwe_bcns15_fft_add(uint32_t *z, const uint32_t *x, const uint32_t *y);
+void oqs_kex_rlwe_bcns15_fft_mul(uint32_t z[1024], const uint32_t x[1024], const uint32_t y[1024], struct oqs_kex_rlwe_bcns15_fft_ctx *ctx);
+void oqs_kex_rlwe_bcns15_fft_add(uint32_t z[1024], const uint32_t x[1024], const uint32_t y[1024]);
 
-int oqs_kex_rlwe_bcns15_fft_ctx_init(struct oqs_kex_rlwe_bcns15_fft_ctx *ctx);
 void oqs_kex_rlwe_bcns15_fft_ctx_clear(struct oqs_kex_rlwe_bcns15_fft_ctx *ctx);
-void oqs_kex_rlwe_bcns15_fft_ctx_free(struct oqs_kex_rlwe_bcns15_fft_ctx *ctx);
 
-void oqs_kex_rlwe_bcns15_sample_ct(uint32_t *s, OQS_RAND *rand);
-void oqs_kex_rlwe_bcns15_round2_ct(uint64_t *out, const uint32_t *in);
-void oqs_kex_rlwe_bcns15_crossround2_ct(uint64_t *out, const uint32_t *in, OQS_RAND *rand);
-void oqs_kex_rlwe_bcns15_rec_ct(uint64_t *out, const uint32_t *w, const uint64_t *b);
+void oqs_kex_rlwe_bcns15_sample_ct(uint32_t s[1024], OQS_RAND *rand);
+void oqs_kex_rlwe_bcns15_round2_ct(uint64_t out[16], const uint32_t in[1024]);
+void oqs_kex_rlwe_bcns15_crossround2_ct(uint64_t out[16], const uint32_t in[1024], OQS_RAND *rand);
+void oqs_kex_rlwe_bcns15_rec_ct(uint64_t out[16], const uint32_t w[1024], const uint64_t b[16]);
 
-void oqs_kex_rlwe_bcns15_sample(uint32_t *s, OQS_RAND *rand);
-void oqs_kex_rlwe_bcns15_round2(uint64_t *out, const uint32_t *in);
-void oqs_kex_rlwe_bcns15_crossround2(uint64_t *out, const uint32_t *in, OQS_RAND *rand);
-void oqs_kex_rlwe_bcns15_rec(uint64_t *out, const uint32_t *w, const uint64_t *b);
+void oqs_kex_rlwe_bcns15_sample(uint32_t s[1024], OQS_RAND *rand);
+void oqs_kex_rlwe_bcns15_round2(uint64_t out[16], const uint32_t in[1024]);
+void oqs_kex_rlwe_bcns15_crossround2(uint64_t out[16], const uint32_t in[1024], OQS_RAND *rand);
+void oqs_kex_rlwe_bcns15_rec(uint64_t out[16], const uint32_t w[1024], const uint64_t b[16]);
 
-void oqs_kex_rlwe_bcns15_a_times_s_plus_e(uint32_t *out, const uint32_t *a, const uint32_t *s, const uint32_t *e, struct oqs_kex_rlwe_bcns15_fft_ctx *fft_ctx);
+void oqs_kex_rlwe_bcns15_a_times_s_plus_e(uint32_t out[1024], const uint32_t a[1024], const uint32_t s[1024], const uint32_t e[1024], struct oqs_kex_rlwe_bcns15_fft_ctx *fft_ctx);
 
 void oqs_kex_rlwe_bcns15_generate_keypair(const uint32_t *a, uint32_t s[1024], uint32_t b[1024], struct oqs_kex_rlwe_bcns15_fft_ctx *ctx, OQS_RAND *rand);
 void oqs_kex_rlwe_bcns15_compute_key_alice(const uint32_t b[1024], const uint32_t s[1024], const uint64_t c[16], uint64_t k[16], struct oqs_kex_rlwe_bcns15_fft_ctx *ctx);

--- a/src/kex_rlwe_bcns15/rlwe.c
+++ b/src/kex_rlwe_bcns15/rlwe.c
@@ -149,7 +149,7 @@ static uint32_t single_sample_ct(uint64_t *in) {
 	return index;
 }
 
-void oqs_kex_rlwe_bcns15_sample_ct(uint32_t *s, OQS_RAND *rand) {
+void oqs_kex_rlwe_bcns15_sample_ct(uint32_t s[1024], OQS_RAND *rand) {
 	int i, j;
 	for (i = 0; i < 16; i++) {
 		uint64_t r = rand->rand_64(rand);
@@ -170,7 +170,7 @@ void oqs_kex_rlwe_bcns15_sample_ct(uint32_t *s, OQS_RAND *rand) {
 	}
 }
 
-void oqs_kex_rlwe_bcns15_round2_ct(uint64_t *out, const uint32_t *in) {
+void oqs_kex_rlwe_bcns15_round2_ct(uint64_t out[16], const uint32_t in[1024]) {
 	int i;
 	memset(out, 0, 128);
 	for (i = 0; i < 1024; i++) {
@@ -180,7 +180,7 @@ void oqs_kex_rlwe_bcns15_round2_ct(uint64_t *out, const uint32_t *in) {
 	}
 }
 
-void oqs_kex_rlwe_bcns15_crossround2_ct(uint64_t *out, const uint32_t *in, OQS_RAND *rand) {
+void oqs_kex_rlwe_bcns15_crossround2_ct(uint64_t out[16], const uint32_t in[1024], OQS_RAND *rand) {
 	int i, j;
 	memset(out, 0, 128);
 	for (i = 0; i < 64; i++) {
@@ -197,7 +197,7 @@ void oqs_kex_rlwe_bcns15_crossround2_ct(uint64_t *out, const uint32_t *in, OQS_R
 	}
 }
 
-void oqs_kex_rlwe_bcns15_rec_ct(uint64_t *out, const uint32_t *w, const uint64_t *b) {
+void oqs_kex_rlwe_bcns15_rec_ct(uint64_t out[16], const uint32_t w[1024], const uint64_t b[16]) {
 	int i;
 	memset(out, 0, 128);
 	for (i = 0; i < 1024; i++) {
@@ -212,7 +212,7 @@ void oqs_kex_rlwe_bcns15_rec_ct(uint64_t *out, const uint32_t *w, const uint64_t
 	}
 }
 
-void oqs_kex_rlwe_bcns15_sample(uint32_t *s, OQS_RAND *rand) {
+void oqs_kex_rlwe_bcns15_sample(uint32_t s[1024], OQS_RAND *rand) {
 	int i, j;
 	for (i = 0; i < 16; i++) {
 		uint64_t r = rand->rand_64(rand);
@@ -232,7 +232,7 @@ void oqs_kex_rlwe_bcns15_sample(uint32_t *s, OQS_RAND *rand) {
 	}
 }
 
-void oqs_kex_rlwe_bcns15_round2(uint64_t *out, const uint32_t *in) {
+void oqs_kex_rlwe_bcns15_round2(uint64_t out[16], const uint32_t in[1024]) {
 	int i;
 
 	// out should have enough space for 1024-bits
@@ -246,7 +246,7 @@ void oqs_kex_rlwe_bcns15_round2(uint64_t *out, const uint32_t *in) {
 	}
 }
 
-void oqs_kex_rlwe_bcns15_crossround2(uint64_t *out, const uint32_t *in, OQS_RAND *rand) {
+void oqs_kex_rlwe_bcns15_crossround2(uint64_t out[16], const uint32_t in[1024], OQS_RAND *rand) {
 	int i, j;
 	// out should have enough space for 1024-bits
 	memset(out, 0, 128);
@@ -264,7 +264,7 @@ void oqs_kex_rlwe_bcns15_crossround2(uint64_t *out, const uint32_t *in, OQS_RAND
 	}
 }
 
-void oqs_kex_rlwe_bcns15_rec(uint64_t *out, const uint32_t *w, const uint64_t *b) {
+void oqs_kex_rlwe_bcns15_rec(uint64_t out[16], const uint32_t w[1024], const uint64_t b[16]) {
 	int i;
 
 	// out should have enough space for 1024 bits
@@ -286,7 +286,7 @@ void oqs_kex_rlwe_bcns15_rec(uint64_t *out, const uint32_t *w, const uint64_t *b
 	}
 }
 
-void oqs_kex_rlwe_bcns15_a_times_s_plus_e(uint32_t *out, const uint32_t *a, const uint32_t *s, const uint32_t *e, struct oqs_kex_rlwe_bcns15_fft_ctx *ctx) {
+void oqs_kex_rlwe_bcns15_a_times_s_plus_e(uint32_t out[1024], const uint32_t a[1024], const uint32_t s[1024], const uint32_t e[1024], struct oqs_kex_rlwe_bcns15_fft_ctx *ctx) {
 	oqs_kex_rlwe_bcns15_fft_mul(out, a, s, ctx);
 	oqs_kex_rlwe_bcns15_fft_add(out, out, e);
 }

--- a/src/rand/rand.c
+++ b/src/rand/rand.c
@@ -55,7 +55,7 @@ double OQS_RAND_test_statistical_distance_from_uniform(const unsigned long occur
 	//         = 1/2 \sum_z | 1/256   - Pr[Y=z] |
 	double distance = 0.0;
 	for (int i = 0; i < 256; i++) {
-		distance += fabs(1.0/256.0 - (double) occurrences[i] / (double) total);
+		distance += fabs(1.0 / 256.0 - (double) occurrences[i] / (double) total);
 	}
 	distance /= 2.0;
 

--- a/src/rand/test_rand.c
+++ b/src/rand/test_rand.c
@@ -50,7 +50,7 @@ static int rand_test_distribution_n(OQS_RAND *rand, unsigned long occurrences[25
 	return 1;
 }
 
-static int rand_test_distribution_wrapper(OQS_RAND *(*new_method)(), int iterations) {
+static int rand_test_distribution_wrapper(OQS_RAND * (*new_method)(), int iterations) {
 
 	OQS_RAND *rand = new_method();
 	if (rand == NULL) {
@@ -67,16 +67,16 @@ static int rand_test_distribution_wrapper(OQS_RAND *(*new_method)(), int iterati
 		occurrences[i] = 0;
 	}
 
-	printf("1-byte mode for %d iterations\n", 8*iterations);
-	rand_test_distribution_8(rand, occurrences, 8*iterations);
+	printf("1-byte mode for %d iterations\n", 8 * iterations);
+	rand_test_distribution_8(rand, occurrences, 8 * iterations);
 	printf("    Statistical distance from uniform: %12.10f\n", OQS_RAND_test_statistical_distance_from_uniform(occurrences));
 
 	for (int i = 0; i < 256; i++) {
 		occurrences[i] = 0;
 	}
 
-	printf("4-byte mode for %d iterations\n", 2*iterations);
-	rand_test_distribution_32(rand, occurrences, 2*iterations);
+	printf("4-byte mode for %d iterations\n", 2 * iterations);
+	rand_test_distribution_32(rand, occurrences, 2 * iterations);
 	printf("    Statistical distance from uniform: %12.10f\n", OQS_RAND_test_statistical_distance_from_uniform(occurrences));
 
 	for (int i = 0; i < 256; i++) {
@@ -91,8 +91,8 @@ static int rand_test_distribution_wrapper(OQS_RAND *(*new_method)(), int iterati
 		occurrences[i] = 0;
 	}
 
-	printf("n-byte mode for %d bytes\n", 8*iterations);
-	rand_test_distribution_n(rand, occurrences, 8*iterations);
+	printf("n-byte mode for %d bytes\n", 8 * iterations);
+	rand_test_distribution_n(rand, occurrences, 8 * iterations);
 	printf("    Statistical distance from uniform: %12.10f\n", OQS_RAND_test_statistical_distance_from_uniform(occurrences));
 
 	OQS_RAND_free(rand);


### PR DESCRIPTION

Memory leak was caused by a possible partial allocation of the arrays in
`oqs_kex_rlwe_bcns15_fft_ctx`.

Allocate fixed size arrays in the `oqs_kex_rlwe_bcns15_fft_ctx` struct
rather then calling an initialization function afterwords. Also specify
fixed array sizes in functions where possible.
