### PR TITLE
Add named parameters to OQS_KEX constructor.

### DIFF
--- a/src/kex/kex.c
+++ b/src/kex/kex.c
@@ -5,9 +5,9 @@
 #include <oqs/kex_rlwe_bcns15.h>
 #endif
 
-OQS_KEX *OQS_KEX_new(OQS_RAND *rand, const uint8_t *seed, const size_t seed_len) {
+OQS_KEX *OQS_KEX_new(OQS_RAND *rand, const uint8_t *seed, const size_t seed_len, const char *named_parameters) {
 #if defined(OQS_KEX_DEFAULT_BCNS15)
-	return OQS_KEX_rlwe_bcns15_new(rand, seed, seed_len);
+	return OQS_KEX_rlwe_bcns15_new(rand, seed, seed_len, named_parameters);
 #else
 #error "No default KEX method defined."
 #endif

--- a/src/kex/kex.h
+++ b/src/kex/kex.h
@@ -41,7 +41,22 @@ typedef struct OQS_KEX {
 	uint16_t estimated_quantum_security;
 
 	/**
-	 * Opaque pointer for passing around user specific data
+	 * An instance-specific seed, if any.
+	 */
+	const uint8_t *seed;
+
+	/**
+	 * Size of instance-specific seed, if any.
+	 */
+	size_t seed_len;
+
+	/**
+	 * Named parameters for this key exchange method instance, if any.
+	 */
+	const char *named_parameters;
+
+	/**
+	 * Opaque pointer for passing around instance-specific data
 	 */
 	void *params;
 
@@ -57,6 +72,7 @@ typedef struct OQS_KEX {
 	 * @param alice_priv       Alice's private key
 	 * @param alice_msg        Alice's public key
 	 * @param alice_msg_len    Alice's public key length
+	 * @return                 1 on success, or 0 on failure
 	 */
 	int (*alice_0)(OQS_KEX *k, void **alive_priv, uint8_t **alice_msg, size_t *alice_msg_len);
 
@@ -70,6 +86,7 @@ typedef struct OQS_KEX {
 	 * @param bob_msg_len      Bob's public key length
 	 * @param key              Shared key
 	 * @param key_len          Shared key length
+	 * @return                 1 on success, or 0 on failure
 	 */
 	int (*bob)(OQS_KEX *k, const uint8_t *alice_msg, const size_t alice_msg_len, uint8_t **bob_msg, size_t *bob_msg_len, uint8_t **key, size_t *key_len);
 
@@ -82,6 +99,7 @@ typedef struct OQS_KEX {
 	 * @param bob_msg_len      Bob's public key length
 	 * @param key              Shared key
 	 * @param key_len          Shared key length
+	 * @return                 1 on success, or 0 on failure
 	 */
 	int (*alice_1)(OQS_KEX *k, const void *alice_priv, const uint8_t *bob_msg, const size_t bob_msg_len, uint8_t **key, size_t *key_len);
 
@@ -102,7 +120,16 @@ typedef struct OQS_KEX {
 
 } OQS_KEX;
 
-OQS_KEX *OQS_KEX_new(OQS_RAND *rand, const uint8_t *seed, const size_t seed_len);
+/**
+ * Allocate a new key exchange object.
+ *
+ * @param rand               Random number generator.
+ * @param seed               An instance-specific seed, if any, or NULL.
+ * @param seed_len           The length of seed, or 0.
+ * @param named_parameters   Name or description of method-specific parameters to use for this instance (as a NULL-terminated C string), if any, or NULL.
+ * @return                   The object on success, or NULL on failure.
+ */
+OQS_KEX *OQS_KEX_new(OQS_RAND *rand, const uint8_t *seed, const size_t seed_len, const char *named_parameters);
 
 int OQS_KEX_alice_0(OQS_KEX *k, void **alice_priv, uint8_t **alice_msg, size_t *alice_msg_len);
 int OQS_KEX_bob(OQS_KEX *k, const uint8_t *alice_msg, const size_t alice_msg_len, uint8_t **bob_msg, size_t *bob_msg_len, uint8_t **key, size_t *key_len);

--- a/src/kex/test_kex.c
+++ b/src/kex/test_kex.c
@@ -15,7 +15,7 @@
 	printf("\n"); \
 }
 
-static int kex_test_correctness(OQS_RAND *rand, OQS_KEX * (*new_method)(OQS_RAND *, const uint8_t *, const size_t), int print, unsigned long occurrences[256]) {
+static int kex_test_correctness(OQS_RAND *rand, OQS_KEX * (*new_method)(OQS_RAND *, const uint8_t *, const size_t, const char *), const uint8_t *seed, const size_t seed_len, const char *named_parameters, const int print, unsigned long occurrences[256]) {
 
 	OQS_KEX *kex = NULL;
 	int rc;
@@ -32,7 +32,7 @@ static int kex_test_correctness(OQS_RAND *rand, OQS_KEX * (*new_method)(OQS_RAND
 	size_t bob_key_len;
 
 	/* setup KEX */
-	kex = new_method(rand, NULL, 0);
+	kex = new_method(rand, seed, seed_len, named_parameters);
 	if (kex == NULL) {
 		goto err;
 	}
@@ -114,7 +114,7 @@ cleanup:
 
 }
 
-static int kex_test_correctness_wrapper(OQS_RAND *rand, OQS_KEX * (*new_method)(OQS_RAND *, const uint8_t *, const size_t), int iterations) {
+static int kex_test_correctness_wrapper(OQS_RAND *rand, OQS_KEX * (*new_method)(OQS_RAND *, const uint8_t *, const size_t, const char *), const uint8_t *seed, const size_t seed_len, const char *named_parameters, int iterations) {
 
 	OQS_KEX *kex = NULL;
 	int ret;
@@ -124,20 +124,20 @@ static int kex_test_correctness_wrapper(OQS_RAND *rand, OQS_KEX * (*new_method)(
 		occurrences[i] = 0;
 	}
 
-	ret = kex_test_correctness(rand, new_method, 1, occurrences);
+	ret = kex_test_correctness(rand, new_method, seed, seed_len, named_parameters, 1, occurrences);
 	if (ret != 1) goto err;
 
 	/* setup KEX */
-	kex = new_method(rand, NULL, 0);
+	kex = new_method(rand, seed, seed_len, named_parameters);
 	if (kex == NULL) {
 		goto err;
 	}
 
 	printf("================================================================================\n");
-	printf("Testing correctness and randomness of key exchange method %s for %d iterations\n", kex->method_name, iterations);
+	printf("Testing correctness and randomness of key exchange method %s (params=%s) for %d iterations\n", kex->method_name, named_parameters, iterations);
 	printf("================================================================================\n");
 	for (int i = 0; i < iterations; i++) {
-		ret = kex_test_correctness(rand, new_method, 0, occurrences);
+		ret = kex_test_correctness(rand, new_method, seed, seed_len, named_parameters, 0, occurrences);
 		if (ret != 1) goto err;
 	}
 	printf("All session keys matched.\n");
@@ -167,7 +167,7 @@ int main() {
 		goto err;
 	}
 
-	ret = kex_test_correctness_wrapper(rand, &OQS_KEX_new, KEX_TEST_ITERATIONS);
+	ret = kex_test_correctness_wrapper(rand, &OQS_KEX_new, NULL, 0, NULL, KEX_TEST_ITERATIONS);
 	if (ret != 1) {
 		goto err;
 	}

--- a/src/kex_rlwe_bcns15/kex_rlwe_bcns15.c
+++ b/src/kex_rlwe_bcns15/kex_rlwe_bcns15.c
@@ -13,7 +13,7 @@
 
 #include "rlwe_a.h"
 
-OQS_KEX *OQS_KEX_rlwe_bcns15_new(OQS_RAND *rand, UNUSED const uint8_t *seed, UNUSED const size_t seed_len) {
+OQS_KEX *OQS_KEX_rlwe_bcns15_new(OQS_RAND *rand, UNUSED const uint8_t *seed, UNUSED const size_t seed_len, UNUSED const char *named_parameters) {
 
 	OQS_KEX *k = malloc(sizeof(OQS_KEX));
 	if (k == NULL) {
@@ -28,6 +28,9 @@ OQS_KEX *OQS_KEX_rlwe_bcns15_new(OQS_RAND *rand, UNUSED const uint8_t *seed, UNU
 	k->method_name = strdup("RLWE BCNS15");
 	k->estimated_classical_security = 163;
 	k->estimated_quantum_security = 76;
+	k->seed = NULL;
+	k->seed_len = 0;
+	k->named_parameters = NULL;
 	k->rand = rand;
 	k->params = NULL;
 	k->alice_0 = &OQS_KEX_rlwe_bcns15_alice_0;

--- a/src/kex_rlwe_bcns15/kex_rlwe_bcns15.h
+++ b/src/kex_rlwe_bcns15/kex_rlwe_bcns15.h
@@ -12,7 +12,7 @@
 #include <oqs/kex.h>
 #include <oqs/rand.h>
 
-OQS_KEX *OQS_KEX_rlwe_bcns15_new(OQS_RAND *rand, const uint8_t *seed, const size_t seed_len);
+OQS_KEX *OQS_KEX_rlwe_bcns15_new(OQS_RAND *rand, const uint8_t *seed, const size_t seed_len, const char *named_parameters);
 
 int OQS_KEX_rlwe_bcns15_alice_0(OQS_KEX *k, void **alice_priv, uint8_t **alice_msg, size_t *alice_msg_len);
 int OQS_KEX_rlwe_bcns15_bob(OQS_KEX *k, const uint8_t *alice_msg, const size_t alice_msg_len, uint8_t **bob_msg, size_t *bob_msg_len, uint8_t **key, size_t *key_len);


### PR DESCRIPTION
This will allow key exchange modules to support a variety of security levels using the same interface, specified via an optional named_parameters argument.