### PR TITLE
Fixed Windows Crypto API rand call on uninitialized machines.

### DIFF
--- a/src/rand_urandom_chacha20/rand_urandom_chacha20.c
+++ b/src/rand_urandom_chacha20/rand_urandom_chacha20.c
@@ -64,9 +64,9 @@ static OQS_RAND_urandom_chacha20_ctx *OQS_RAND_urandom_chacha20_ctx_new() {
 	if (rand_ctx == NULL) {
 		goto err;
 	}
-#if defined(WINDOWS)	
+#if defined(WINDOWS)
 	if (!CryptAcquireContext(&hCryptProv, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT) ||
-		!CryptGenRandom(hCryptProv, 32, rand_ctx->key)) {
+	    !CryptGenRandom(hCryptProv, 32, rand_ctx->key)) {
 		goto err;
 	}
 #else


### PR DESCRIPTION
I added the CRYPT_VERIFYCONTEXT flag to tell CAPI we won't need access to a key container in the following uses of the requested context. This fixes an error on machines without an initialized key container for the current user.