### PR TITLE
Use of EXIT_SUCCESS and EXIT_FAILURE

### DIFF
--- a/src/kex/test_kex.c
+++ b/src/kex/test_kex.c
@@ -158,7 +158,7 @@ cleanup:
 
 int main() {
 
-	int ret;
+	int success;
 
 	/* setup RAND */
 	OQS_RAND *rand = NULL;
@@ -167,21 +167,21 @@ int main() {
 		goto err;
 	}
 
-	ret = kex_test_correctness_wrapper(rand, &OQS_KEX_new, NULL, 0, NULL, KEX_TEST_ITERATIONS);
-	if (ret != 1) {
+	success = kex_test_correctness_wrapper(rand, &OQS_KEX_new, NULL, 0, NULL, KEX_TEST_ITERATIONS);
+	if (success != 1) {
 		goto err;
 	}
 
-	ret = 1;
+	success = 1;
 	goto cleanup;
 
 err:
-	ret = 0;
+	success = 0;
 	fprintf(stderr, "ERROR!\n");
 
 cleanup:
 	OQS_RAND_free(rand);
 
-	return ret;
+	return (success == 1) ? EXIT_SUCCESS : EXIT_FAILURE;
 
 }

--- a/src/rand/test_rand.c
+++ b/src/rand/test_rand.c
@@ -137,20 +137,20 @@ static int rand_test_distribution_wrapper(OQS_RAND * (*new_method)(), int iterat
 
 int main() {
 
-	int ret;
+	int success;
 
-	ret = rand_test_distribution_wrapper(&OQS_RAND_new, RAND_TEST_ITERATIONS);
-	if (ret != 1) goto err;
+	success = rand_test_distribution_wrapper(&OQS_RAND_new, RAND_TEST_ITERATIONS);
+	if (success != 1) goto err;
 
-	ret = 1;
+	success = 1;
 	goto cleanup;
 
 err:
-	ret = 0;
+	success = 0;
 	fprintf(stderr, "ERROR!\n");
 
 cleanup:
 
-	return ret;
+	return (success == 1) ? EXIT_SUCCESS : EXIT_FAILURE;
 
 }


### PR DESCRIPTION
In order to have portable code, we should use `EXIT_SUCCESS` and `EXIT_FAILURE` that indicate success and failure of the execution from the programmers POV and are guaranteed to work on all platforms.