### PR TITLE
Adding prettyprint check to Travis

### DIFF
--- a/.travis-style-check.sh
+++ b/.travis-style-check.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ $(make prettyprint | grep Formatted) ]]; 
+then 
+	tput setaf 1;
+	echo "Code does not adhere to the project standards. Run \"make prettyprint\".";
+	exit 1;
+else 
+	tput setaf 2;
+	echo "Code adheres to the project standards.";
+	exit 0;
+fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ matrix:
         - ubuntu-toolchain-r-test
         packages:
         - gcc-4.8
+    before_install:
+      - wget http://downloads.sourceforge.net/project/astyle/astyle/astyle%202.05.1/astyle_2.05.1_linux.tar.gz
+      - tar xzf astyle_2.05.1_linux.tar.gz
+      - cd astyle/build/gcc && make && export PATH=$(pwd)/bin:$PATH && cd ../../../
   - os: linux
     compiler: gcc
     env: CC_OQS=gcc-4.9
@@ -21,6 +25,10 @@ matrix:
         - ubuntu-toolchain-r-test
         packages:
         - gcc-4.9
+    before_install:
+      - wget http://downloads.sourceforge.net/project/astyle/astyle/astyle%202.05.1/astyle_2.05.1_linux.tar.gz
+      - tar xzf astyle_2.05.1_linux.tar.gz
+      - cd astyle/build/gcc && make && export PATH=$(pwd)/bin:$PATH && cd ../../../
   - os: linux
     compiler: gcc
     env: CC_OQS=gcc-5
@@ -30,6 +38,10 @@ matrix:
         - ubuntu-toolchain-r-test
         packages:
         - gcc-5
+    before_install:
+      - wget http://downloads.sourceforge.net/project/astyle/astyle/astyle%202.05.1/astyle_2.05.1_linux.tar.gz
+      - tar xzf astyle_2.05.1_linux.tar.gz
+      - cd astyle/build/gcc && make && export PATH=$(pwd)/bin:$PATH && cd ../../../
   - os: linux
     compiler: gcc
     env: CC_OQS=gcc-6
@@ -39,11 +51,17 @@ matrix:
         - ubuntu-toolchain-r-test
         packages:
         - gcc-6
+    before_install:
+      - wget http://downloads.sourceforge.net/project/astyle/astyle/astyle%202.05.1/astyle_2.05.1_linux.tar.gz
+      - tar xzf astyle_2.05.1_linux.tar.gz
+      - cd astyle/build/gcc && make && export PATH=$(pwd)/bin:$PATH && cd ../../../
   - os: osx
     compiler: clang
     env: CC_OQS=clang
-  
+    before_install:
+      - brew install astyle  
 
 script:
   - make
   - make check
+  - bash .travis-style-check.sh 

--- a/src/kex/kex.h
+++ b/src/kex/kex.h
@@ -12,9 +12,9 @@
 #include <oqs/rand.h>
 
 enum OQS_KEX_alg_name {
-    OQS_KEX_alg_default,
-    OQS_KEX_alg_rlwe_bcns15,
-    OQS_KEX_alg_rlwe_newhope,
+	OQS_KEX_alg_default,
+	OQS_KEX_alg_rlwe_bcns15,
+	OQS_KEX_alg_rlwe_newhope,
 };
 
 typedef struct OQS_KEX OQS_KEX;

--- a/src/rand/rand.h
+++ b/src/rand/rand.h
@@ -10,8 +10,8 @@
 #include <stdint.h>
 
 enum OQS_RAND_alg_name {
-    OQS_RAND_alg_default,
-    OQS_RAND_alg_urandom_chacha20,
+	OQS_RAND_alg_default,
+	OQS_RAND_alg_urandom_chacha20,
 };
 
 typedef struct OQS_RAND OQS_RAND;


### PR DESCRIPTION
I added a check on travis to verify that 
```
make prettyprint
```
was run before pushing in the PRs. The tests successfully catched the fact that `make prettyprint` in `master` [should have been run](https://travis-ci.org/tlepoint/liboqs/builds/168086027), and the second commit makes the [checks all green](https://travis-ci.org/tlepoint/liboqs/builds/168086535).

Note that I could not use the astyle package in Ubuntu 12.04 (that is used in Travis): it is an old version of astyle which (1) does not have the same output behavior, and (2) does not behave the same.