### PR TITLE
Fix memory leak

### DIFF
--- a/src/aes/test_aes.c
+++ b/src/aes/test_aes.c
@@ -163,7 +163,7 @@ static void speed_aes128_c(OQS_RAND *rand) {
 	OQS_RAND_n(rand, plaintext, 320);
 	TIME_OPERATION_SECONDS_CLEANUP(oqs_aes128_load_schedule_c(key, &schedule), "oqs_aes128_load_schedule_c", BENCH_DURATION, oqs_aes128_free_schedule_c(schedule));
 
-	oqs_aes128_load_schedule_c(key, &schedule);	
+	oqs_aes128_load_schedule_c(key, &schedule);
 	TIME_OPERATION_SECONDS(oqs_aes128_enc_c(plaintext, schedule, ciphertext), "oqs_aes128_enc_c", BENCH_DURATION);
 	TIME_OPERATION_SECONDS(oqs_aes128_dec_c(ciphertext, schedule, decrypted), "oqs_aes128_dec_c", BENCH_DURATION);
 	TIME_OPERATION_SECONDS(oqs_aes128_ecb_enc_c(plaintext, 320, key, ciphertext), "oqs_aes128_ecb_enc_c", BENCH_DURATION);

--- a/src/aes/test_aes.c
+++ b/src/aes/test_aes.c
@@ -161,7 +161,7 @@ static void speed_aes128_c(OQS_RAND *rand) {
 	void *schedule = NULL;
 	OQS_RAND_n(rand, key, 16);
 	OQS_RAND_n(rand, plaintext, 320);
-	TIME_OPERATION_SECONDS_CLEANUP(oqs_aes128_load_schedule_c(key, &schedule), "oqs_aes128_load_schedule_c", BENCH_DURATION, oqs_aes128_free_schedule_c(schedule));
+	TIME_OPERATION_SECONDS({ oqs_aes128_load_schedule_c(key, &schedule); oqs_aes128_free_schedule_c(schedule); }, "oqs_aes128_load_schedule_c", BENCH_DURATION);
 
 	oqs_aes128_load_schedule_c(key, &schedule);
 	TIME_OPERATION_SECONDS(oqs_aes128_enc_c(plaintext, schedule, ciphertext), "oqs_aes128_enc_c", BENCH_DURATION);
@@ -180,7 +180,7 @@ static void speed_aes128_ni(OQS_RAND *rand) {
 	void *schedule = NULL;
 	OQS_RAND_n(rand, key, 16);
 	OQS_RAND_n(rand, plaintext, 320);
-	TIME_OPERATION_SECONDS_CLEANUP(oqs_aes128_load_schedule_ni(key, &schedule), "oqs_aes128_load_schedule_ni", BENCH_DURATION, oqs_aes128_free_schedule_ni(schedule));
+	TIME_OPERATION_SECONDS({ oqs_aes128_load_schedule_ni(key, &schedule); oqs_aes128_free_schedule_ni(schedule); }, "oqs_aes128_load_schedule_ni", BENCH_DURATION);
 
 	oqs_aes128_load_schedule_ni(key, &schedule);
 	TIME_OPERATION_SECONDS(oqs_aes128_enc_ni(plaintext, schedule, ciphertext), "oqs_aes128_enc_ni", BENCH_DURATION);

--- a/src/aes/test_aes.c
+++ b/src/aes/test_aes.c
@@ -161,28 +161,35 @@ static void speed_aes128_c(OQS_RAND *rand) {
 	void *schedule = NULL;
 	OQS_RAND_n(rand, key, 16);
 	OQS_RAND_n(rand, plaintext, 320);
-	TIME_OPERATION_SECONDS(oqs_aes128_load_schedule_c(key, &schedule), "oqs_aes128_load_schedule_c", BENCH_DURATION);
+	TIME_OPERATION_SECONDS_CLEANUP(oqs_aes128_load_schedule_c(key, &schedule), "oqs_aes128_load_schedule_c", BENCH_DURATION, oqs_aes128_free_schedule_c(schedule));
+
+	oqs_aes128_load_schedule_c(key, &schedule);	
 	TIME_OPERATION_SECONDS(oqs_aes128_enc_c(plaintext, schedule, ciphertext), "oqs_aes128_enc_c", BENCH_DURATION);
 	TIME_OPERATION_SECONDS(oqs_aes128_dec_c(ciphertext, schedule, decrypted), "oqs_aes128_dec_c", BENCH_DURATION);
 	TIME_OPERATION_SECONDS(oqs_aes128_ecb_enc_c(plaintext, 320, key, ciphertext), "oqs_aes128_ecb_enc_c", BENCH_DURATION);
 	TIME_OPERATION_SECONDS(oqs_aes128_ecb_dec_c(ciphertext, 320, key, decrypted), "oqs_aes128_ecb_dec_c", BENCH_DURATION);
 	TIME_OPERATION_SECONDS(oqs_aes128_ecb_enc_sch_c(plaintext, 320, schedule, ciphertext), "oqs_aes128_ecb_enc_sch_c", BENCH_DURATION);
 	TIME_OPERATION_SECONDS(oqs_aes128_ecb_dec_sch_c(ciphertext, 320, schedule, decrypted), "oqs_aes128_ecb_dec_sch_c", BENCH_DURATION);
+	oqs_aes128_free_schedule_c(schedule);
 }
 
 #ifndef AES_DISABLE_NI
+
 static void speed_aes128_ni(OQS_RAND *rand) {
 	uint8_t key[16], plaintext[320], ciphertext[320], decrypted[320];
 	void *schedule = NULL;
 	OQS_RAND_n(rand, key, 16);
 	OQS_RAND_n(rand, plaintext, 320);
-	TIME_OPERATION_SECONDS(oqs_aes128_load_schedule_ni(key, &schedule), "oqs_aes128_load_schedule_ni", BENCH_DURATION);
+	TIME_OPERATION_SECONDS_CLEANUP(oqs_aes128_load_schedule_ni(key, &schedule), "oqs_aes128_load_schedule_ni", BENCH_DURATION, oqs_aes128_free_schedule_ni(schedule));
+
+	oqs_aes128_load_schedule_ni(key, &schedule);
 	TIME_OPERATION_SECONDS(oqs_aes128_enc_ni(plaintext, schedule, ciphertext), "oqs_aes128_enc_ni", BENCH_DURATION);
 	TIME_OPERATION_SECONDS(oqs_aes128_dec_ni(ciphertext, schedule, decrypted), "oqs_aes128_dec_ni", BENCH_DURATION);
 	TIME_OPERATION_SECONDS(oqs_aes128_ecb_enc_ni(plaintext, 320, key, ciphertext), "oqs_aes128_ecb_enc_ni", BENCH_DURATION);
 	TIME_OPERATION_SECONDS(oqs_aes128_ecb_dec_ni(ciphertext, 320, key, decrypted), "oqs_aes128_ecb_dec_ni", BENCH_DURATION);
 	TIME_OPERATION_SECONDS(oqs_aes128_ecb_enc_sch_ni(plaintext, 320, schedule, ciphertext), "oqs_aes128_ecb_enc_sch_ni", BENCH_DURATION);
 	TIME_OPERATION_SECONDS(oqs_aes128_ecb_dec_sch_ni(ciphertext, 320, schedule, decrypted), "oqs_aes128_ecb_dec_sch_ni", BENCH_DURATION);
+	oqs_aes128_free_schedule_ni(schedule);
 }
 #endif
 

--- a/src/ds_benchmark.h
+++ b/src/ds_benchmark.h
@@ -139,7 +139,9 @@ static uint64_t rdtsc(void) {
 		PRINT_TIMER_AVG(op_name) \
 	}
 
-#define TIME_OPERATION_SECONDS(op, op_name, secs) \
+#define TIME_OPERATION_SECONDS(op, op_name, secs) TIME_OPERATION_SECONDS_CLEANUP(op, op_name, secs, NULL)
+
+#define TIME_OPERATION_SECONDS_CLEANUP(op, op_name, secs, cleanop) \
 	{ \
 		DEFINE_TIMER_VARIABLES \
 		INITIALIZE_TIMER \
@@ -148,6 +150,7 @@ static uint64_t rdtsc(void) {
 			START_TIMER \
 			(op); \
 			STOP_TIMER \
+			((void)cleanop); \
 		} \
 		FINALIZE_TIMER \
 		PRINT_TIMER_AVG(op_name) \

--- a/src/ds_benchmark.h
+++ b/src/ds_benchmark.h
@@ -132,25 +132,22 @@ static uint64_t rdtsc(void) {
 		INITIALIZE_TIMER \
 		for (int i = 0; i < (it); i++) { \
 			START_TIMER \
-			(op); \
+			{ op ; } \
 			STOP_TIMER \
 		} \
 		FINALIZE_TIMER \
 		PRINT_TIMER_AVG(op_name) \
 	}
 
-#define TIME_OPERATION_SECONDS(op, op_name, secs) TIME_OPERATION_SECONDS_CLEANUP(op, op_name, secs, NULL)
-
-#define TIME_OPERATION_SECONDS_CLEANUP(op, op_name, secs, cleanop) \
+#define TIME_OPERATION_SECONDS(op, op_name, secs) \
 	{ \
 		DEFINE_TIMER_VARIABLES \
 		INITIALIZE_TIMER \
 		uint64_t _bench_time_goal_usecs = 1000000 * secs; \
 		while (_bench_time_cumulative < _bench_time_goal_usecs) { \
 			START_TIMER \
-			(op); \
+			{ op ; } \
 			STOP_TIMER \
-			((void)cleanop); \
 		} \
 		FINALIZE_TIMER \
 		PRINT_TIMER_AVG(op_name) \

--- a/src/kex/test_kex.c
+++ b/src/kex/test_kex.c
@@ -182,6 +182,16 @@ cleanup:
 
 }
 
+static void cleanup_alice_0(OQS_KEX *kex, void *alice_priv, uint8_t *alice_msg) {
+	free(alice_msg);
+	OQS_KEX_alice_priv_free(kex, alice_priv);
+}
+
+static void cleanup_bob(uint8_t *bob_msg, uint8_t *bob_key) {
+	free(bob_msg);
+	free(bob_key);
+}
+
 static int kex_bench_wrapper(OQS_RAND *rand, enum OQS_KEX_alg_name alg_name, const uint8_t *seed, const size_t seed_len, const char *named_parameters, const int seconds) {
 
 	OQS_KEX *kex = NULL;
@@ -206,9 +216,14 @@ static int kex_bench_wrapper(OQS_RAND *rand, enum OQS_KEX_alg_name alg_name, con
 	}
 	printf("%s\n", kex->method_name);
 
-	TIME_OPERATION_SECONDS(OQS_KEX_alice_0(kex, &alice_priv, &alice_msg, &alice_msg_len), "alice 0", seconds);
-	TIME_OPERATION_SECONDS(OQS_KEX_bob(kex, alice_msg, alice_msg_len, &bob_msg, &bob_msg_len, &bob_key, &bob_key_len), "bob", seconds);
-	TIME_OPERATION_SECONDS(OQS_KEX_alice_1(kex, alice_priv, bob_msg, bob_msg_len, &alice_key, &alice_key_len), "alice 1", seconds);
+	TIME_OPERATION_SECONDS_CLEANUP(OQS_KEX_alice_0(kex, &alice_priv, &alice_msg, &alice_msg_len), "alice 0", seconds, cleanup_alice_0(kex, alice_priv, alice_msg));
+
+	OQS_KEX_alice_0(kex, &alice_priv, &alice_msg, &alice_msg_len);
+	TIME_OPERATION_SECONDS_CLEANUP(OQS_KEX_bob(kex, alice_msg, alice_msg_len, &bob_msg, &bob_msg_len, &bob_key, &bob_key_len), "bob", seconds, cleanup_bob(bob_msg, bob_key));
+
+	OQS_KEX_bob(kex, alice_msg, alice_msg_len, &bob_msg, &bob_msg_len, &bob_key, &bob_key_len);
+	TIME_OPERATION_SECONDS_CLEANUP(OQS_KEX_alice_1(kex, alice_priv, bob_msg, bob_msg_len, &alice_key, &alice_key_len), "alice 1", seconds, free(alice_key));
+	alice_key = NULL;
 
 	rc = 1;
 	goto cleanup;

--- a/src/kex/test_kex.c
+++ b/src/kex/test_kex.c
@@ -216,13 +216,13 @@ static int kex_bench_wrapper(OQS_RAND *rand, enum OQS_KEX_alg_name alg_name, con
 	}
 	printf("%s\n", kex->method_name);
 
-	TIME_OPERATION_SECONDS_CLEANUP(OQS_KEX_alice_0(kex, &alice_priv, &alice_msg, &alice_msg_len), "alice 0", seconds, cleanup_alice_0(kex, alice_priv, alice_msg));
+	TIME_OPERATION_SECONDS({ OQS_KEX_alice_0(kex, &alice_priv, &alice_msg, &alice_msg_len); cleanup_alice_0(kex, alice_priv, alice_msg); }, "alice 0", seconds);
 
 	OQS_KEX_alice_0(kex, &alice_priv, &alice_msg, &alice_msg_len);
-	TIME_OPERATION_SECONDS_CLEANUP(OQS_KEX_bob(kex, alice_msg, alice_msg_len, &bob_msg, &bob_msg_len, &bob_key, &bob_key_len), "bob", seconds, cleanup_bob(bob_msg, bob_key));
+	TIME_OPERATION_SECONDS({ OQS_KEX_bob(kex, alice_msg, alice_msg_len, &bob_msg, &bob_msg_len, &bob_key, &bob_key_len); cleanup_bob(bob_msg, bob_key); }, "bob", seconds);
 
 	OQS_KEX_bob(kex, alice_msg, alice_msg_len, &bob_msg, &bob_msg_len, &bob_key, &bob_key_len);
-	TIME_OPERATION_SECONDS_CLEANUP(OQS_KEX_alice_1(kex, alice_priv, bob_msg, bob_msg_len, &alice_key, &alice_key_len), "alice 1", seconds, free(alice_key));
+	TIME_OPERATION_SECONDS({ OQS_KEX_alice_1(kex, alice_priv, bob_msg, bob_msg_len, &alice_key, &alice_key_len); free(alice_key); }, "alice 1", seconds);
 	alice_key = NULL;
 
 	rc = 1;

--- a/src/kex_lwe_frodo/kex_lwe_frodo.c
+++ b/src/kex_lwe_frodo/kex_lwe_frodo.c
@@ -379,6 +379,8 @@ void OQS_KEX_lwe_frodo_free(OQS_KEX *k) {
 		free(k->params);
 		k->params = NULL;
 	}
+	free(k->named_parameters);
+	k->named_parameters = NULL;
 	free(k->method_name);
 	k->method_name = NULL;
 	free(k);

--- a/src/kex_lwe_frodo/kex_lwe_frodo.c
+++ b/src/kex_lwe_frodo/kex_lwe_frodo.c
@@ -156,7 +156,7 @@ int OQS_KEX_lwe_frodo_alice_0(OQS_KEX *k, void **alice_priv, uint8_t **alice_msg
 	if (ret != 1) {
 		goto err;
 	}
-	oqs_kex_lwe_frodo_pack(*alice_msg, params->pub_len, b, params->n * params->nbar * sizeof(uint16_t), params->log2_q);
+	oqs_kex_lwe_frodo_pack(*alice_msg, params->pub_len, b, params->n * params->nbar, params->log2_q);
 
 	*alice_msg_len = params->pub_len;
 
@@ -245,7 +245,7 @@ int OQS_KEX_lwe_frodo_bob(OQS_KEX *k, const uint8_t *alice_msg, const size_t ali
 	if (ret != 1) {
 		goto err;
 	}
-	oqs_kex_lwe_frodo_pack(*bob_msg, params->pub_len, bprime, params->n * params->nbar * sizeof(uint16_t), params->log2_q);
+	oqs_kex_lwe_frodo_pack(*bob_msg, params->pub_len, bprime, params->n * params->nbar, params->log2_q);
 
 	/* generate E'' */
 	ret = oqs_kex_lwe_frodo_sample_n(eprimeprime, params->nbar * params->nbar, params, k->rand);

--- a/src/kex_rlwe_newhope/kex_rlwe_newhope.c
+++ b/src/kex_rlwe_newhope/kex_rlwe_newhope.c
@@ -153,6 +153,8 @@ void OQS_KEX_rlwe_newhope_alice_priv_free(UNUSED OQS_KEX *k, void *alice_priv) {
 
 void OQS_KEX_rlwe_newhope_free(OQS_KEX *k) {
 	if (k) {
+		free(k->named_parameters);
+		k->named_parameters = NULL;
 		free(k->method_name);
 		k->method_name = NULL;
 	}


### PR DESCRIPTION
Cleaned up a couple memory leaks.

The first is pretty straight forward; the named_parameters weren't being freed properly.

The second fix is for the running the speed tests; TIME_OPERATION_SECONDS was being used to time running some functions, but when those functions allocated memory, it was never cleaned up.
To fix this, I added a TIME_OPERATION_SECONDS_CLEANUP method. It is just the same as TIME_OPERATION_SECONDS, but takes an optional `cleanop` parameter that runs after each iteration.

Verified using valgrind:
valgrind --leak-check=full ./test_kex
valgrind --leak-check=full ./test_aes
valgrind --leak-check=full ./test_rand
