### PR TITLE
Fixes for scan-build and make.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ check: links tests
 	./test_aes
 
 clean:
-	rm -rf docs objs include
+	rm -rf docs/doxygen objs include
 	rm -f test_rand test_kex test_aes liboqs.a
 	find . -name .DS_Store -type f -delete
 

--- a/docs/Algorithm data sheets/kex_rlwe_bcns15.md
+++ b/docs/Algorithm data sheets/kex_rlwe_bcns15.md
@@ -60,7 +60,8 @@ Implementation
 - Correctness: covered by test harness `test_kex`
 - Statistics of shared secrets: covered by test harness `test_kex`
 	- statistical distance from uniform over 100 iterations: 0.0561185025
-- Static analysis: none
+- Static analysis:
+	- `scan_build`
 
 **Runtime:**
 


### PR DESCRIPTION
Clang scan-build does not like it when `malloc` uses `sizeof` for its input and the type does not match the variable it is assigned to. For example `uint8_t = malloc(10*sizeof(uint64_t)`.  This is because writing the wrong type is a common source of errors. 

I changed the code to reflect this and we can now run `scan-build` over our entire build with no errors or warnings reported.

I also made `make clean` not delete the algorithms data sheet folder.