### PR TITLE
Add quiet and bench options for test_kex.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ docs: links
 
 check: links tests
 	./test_kex --quiet
-	./test_rand
+	./test_rand --quiet
 	./test_aes
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ docs: links
 	doxygen
 
 check: links tests
-	./test_kex
+	./test_kex --quiet
 	./test_rand
 	./test_aes
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ To run the tests, simply type:
 
 	make check
 
+To run benchmarks, run
+
+	./test_kex --bench
+
 ### Windows
 
 Windows binaries can be generated using the Visual Studio solution in the VisualStudio folder.

--- a/src/crypto/aes/test_aes.c
+++ b/src/crypto/aes/test_aes.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -43,7 +44,6 @@ static int test_aes128_correctness_c(OQS_RAND *rand) {
 		printf("\n");
 		print_bytes(decrypted, 16);
 		printf("\n");
-		return EXIT_FAILURE;
 		return EXIT_FAILURE;
 	}
 }
@@ -210,8 +210,28 @@ static void speed_aes128_ossl(OQS_RAND *rand) {
 }
 #endif
 
-int main() {
+int main(int argc, char **argv) {
 	int ret;
+	bool bench = false;
+
+	for (int i = 1; i < argc; i++) {
+		if (argv[i][0] == '-') {
+			if (strcmp(argv[i], "--bench") == 0 || strcmp(argv[i], "-b") == 0  ) {
+				bench = true;
+			} else {
+				printf("Usage: ./test_rand [options]\n");
+				printf("\nOptions:\n");
+				printf("  --bench, -b\n");
+				printf("    Run benchmarks\n");
+				if ((strcmp(argv[i], "-h") == 0) || (strcmp(argv[i], "-help") == 0) || (strcmp(argv[i], "--help") == 0)) {
+					return EXIT_SUCCESS;
+				} else {
+					return EXIT_FAILURE;
+				}
+			}
+		}
+	}
+
 	printf("=== test_aes correctness ===\n");
 	OQS_RAND *rand = OQS_RAND_new(OQS_RAND_alg_default);
 	if (rand == NULL) {
@@ -231,16 +251,20 @@ int main() {
 	TEST_REPEATEDLY(test_aes128_ecb_correctness_ossl(rand));
 #endif
 	printf("Tests passed.\n\n");
-	printf("=== test_aes performance ===\n");
-	PRINT_TIMER_HEADER
-	speed_aes128_c(rand);
+
+	if (bench) {
+		printf("=== test_aes performance ===\n");
+		PRINT_TIMER_HEADER
+		speed_aes128_c(rand);
 #ifndef AES_DISABLE_NI
-	speed_aes128_ni(rand);
+		speed_aes128_ni(rand);
 #endif
 #ifdef USE_OPENSSL
-	speed_aes128_ossl(rand);
+		speed_aes128_ossl(rand);
 #endif
-	PRINT_TIMER_FOOTER
+		PRINT_TIMER_FOOTER
+	}
+	
 	ret = EXIT_SUCCESS;
 	goto cleanup;
 err:

--- a/src/crypto/rand/test_rand.c
+++ b/src/crypto/rand/test_rand.c
@@ -1,6 +1,8 @@
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <inttypes.h>
 
 #include <oqs/rand.h>
@@ -70,7 +72,7 @@ static int rand_test_distribution_n(OQS_RAND *rand, unsigned long occurrences[25
 	printf("\n"); \
 }
 
-static int rand_test_distribution_wrapper(enum OQS_RAND_alg_name alg_name, int iterations) {
+static int rand_test_distribution_wrapper(enum OQS_RAND_alg_name alg_name, int iterations, bool quiet) {
 
 	OQS_RAND *rand = OQS_RAND_new(alg_name);
 	if (rand == NULL) {
@@ -78,31 +80,33 @@ static int rand_test_distribution_wrapper(enum OQS_RAND_alg_name alg_name, int i
 		return 0;
 	}
 
-	printf("================================================================================\n");
-	printf("Sample outputs of PRNG %s\n", rand->method_name);
-	printf("================================================================================\n");
+	if (!quiet) {
+		printf("================================================================================\n");
+		printf("Sample outputs of PRNG %s\n", rand->method_name);
+		printf("================================================================================\n");
 
-	uint8_t x[256];
-	OQS_RAND_n(rand, x, 256);
-	PRINT_HEX_STRING("OQS_RAND_n, n = 256", x, 256)
+		uint8_t x[256];
+		OQS_RAND_n(rand, x, 256);
+		PRINT_HEX_STRING("OQS_RAND_n, n = 256", x, 256)
 
-	uint8_t y8 = OQS_RAND_8(rand);
-	PRINT_HEX_STRING("OQS_RAND_8", (uint8_t *) &y8, sizeof(y8));
-	y8 = OQS_RAND_8(rand);
-	PRINT_HEX_STRING("OQS_RAND_8", (uint8_t *) &y8, sizeof(y8));
+		uint8_t y8 = OQS_RAND_8(rand);
+		PRINT_HEX_STRING("OQS_RAND_8", (uint8_t *) &y8, sizeof(y8));
+		y8 = OQS_RAND_8(rand);
+		PRINT_HEX_STRING("OQS_RAND_8", (uint8_t *) &y8, sizeof(y8));
 
-	uint32_t y32 = OQS_RAND_32(rand);
-	PRINT_HEX_STRING("OQS_RAND_32", (uint8_t *) &y32, sizeof(y32));
-	y32 = OQS_RAND_32(rand);
-	PRINT_HEX_STRING("OQS_RAND_32", (uint8_t *) &y32, sizeof(y32));
+		uint32_t y32 = OQS_RAND_32(rand);
+		PRINT_HEX_STRING("OQS_RAND_32", (uint8_t *) &y32, sizeof(y32));
+		y32 = OQS_RAND_32(rand);
+		PRINT_HEX_STRING("OQS_RAND_32", (uint8_t *) &y32, sizeof(y32));
 
-	uint64_t y64 = OQS_RAND_64(rand);
-	PRINT_HEX_STRING("OQS_RAND_64", (uint8_t *) &y64, sizeof(y64));
-	y64 = OQS_RAND_64(rand);
-	PRINT_HEX_STRING("OQS_RAND_64", (uint8_t *) &y64, sizeof(y64));
+		uint64_t y64 = OQS_RAND_64(rand);
+		PRINT_HEX_STRING("OQS_RAND_64", (uint8_t *) &y64, sizeof(y64));
+		y64 = OQS_RAND_64(rand);
+		PRINT_HEX_STRING("OQS_RAND_64", (uint8_t *) &y64, sizeof(y64));
 
-	OQS_RAND_n(rand, x, 256);
-	PRINT_HEX_STRING("OQS_RAND_n, n = 256", x, 256)
+		OQS_RAND_n(rand, x, 256);
+		PRINT_HEX_STRING("OQS_RAND_n, n = 256", x, 256)
+	}
 
 	printf("================================================================================\n");
 	printf("Testing distribution of PRNG %s\n", rand->method_name);
@@ -147,13 +151,33 @@ static int rand_test_distribution_wrapper(enum OQS_RAND_alg_name alg_name, int i
 
 }
 
-int main() {
+int main(int argc, char **argv) {
 
 	int success;
+	bool quiet = false;
+
+	for (int i = 1; i < argc; i++) {
+		if (argv[i][0] == '-') {
+			if ( strcmp(argv[i], "--quiet") == 0
+			            || strcmp(argv[i], "-q") == 0  ) {
+				quiet = true;
+			} else {
+				printf("Usage: ./test_rand [options]\n");
+				printf("\nOptions:\n");
+				printf("  --quiet, -q\n");
+				printf("    Less verbose output\n");
+				if ((strcmp(argv[i], "-h") == 0) || (strcmp(argv[i], "-help") == 0) || (strcmp(argv[i], "--help") == 0)) {
+					return EXIT_SUCCESS;
+				} else {
+					return EXIT_FAILURE;
+				}
+			}
+		}
+	}
 
 	size_t rand_testcases_len = sizeof(rand_testcases) / sizeof(struct rand_testcase);
 	for (size_t i = 0; i < rand_testcases_len; i++) {
-		success = rand_test_distribution_wrapper(rand_testcases[i].alg_name, RAND_TEST_ITERATIONS);
+		success = rand_test_distribution_wrapper(rand_testcases[i].alg_name, RAND_TEST_ITERATIONS, quiet);
 		if (success != 1) {
 			goto err;
 		}

--- a/src/kex/test_kex.c
+++ b/src/kex/test_kex.c
@@ -140,7 +140,7 @@ cleanup:
 
 }
 
-static int kex_test_correctness_wrapper(OQS_RAND *rand, enum OQS_KEX_alg_name alg_name, const uint8_t *seed, const size_t seed_len, const char *named_parameters, int iterations) {
+static int kex_test_correctness_wrapper(OQS_RAND *rand, enum OQS_KEX_alg_name alg_name, const uint8_t *seed, const size_t seed_len, const char *named_parameters, int iterations, bool quiet) {
 	OQS_KEX *kex = NULL;
 	int ret;
 
@@ -148,8 +148,11 @@ static int kex_test_correctness_wrapper(OQS_RAND *rand, enum OQS_KEX_alg_name al
 	for (int i = 0; i < 256; i++) {
 		occurrences[i] = 0;
 	}
-
-	ret = kex_test_correctness(rand, alg_name, seed, seed_len, named_parameters, 1, occurrences);
+	if (quiet) {
+		ret = kex_test_correctness(rand, alg_name, seed, seed_len, named_parameters, 0, occurrences);
+	} else {
+		ret = kex_test_correctness(rand, alg_name, seed, seed_len, named_parameters, 1, occurrences);
+	}
 	if (ret != 1) {
 		goto err;
 	}
@@ -252,19 +255,35 @@ int main(int argc, char **argv) {
 
 	int success = 1;
 	bool run_all = true;
+	bool quiet = false;
+	bool bench = false;
 	size_t kex_testcases_len = sizeof(kex_testcases) / sizeof(struct kex_testcase);
-
-	if (argc > 1) {
-		if ((strcmp(argv[1], "-h") == 0) || (strcmp(argv[1], "-help") == 0) || (strcmp(argv[1], "--help") == 0)) {
-			printf("Usage: ./test_kex [algorithms]\n\n");
-			printf("algorithms:\n");
-			for (size_t i = 0; i < kex_testcases_len; i++) {
-				printf("  %s\n", kex_testcases[i].id);
+	for (int i = 1; i < argc; i++) {
+		if (argv[i][0] == '-') {
+			if ((strcmp(argv[i], "-h") == 0)
+			        || (strcmp(argv[i], "-help") == 0)
+			        || (strcmp(argv[i], "--help") == 0)) {
+				printf("Usage: ./test_kex [options] [algorithms]\n");
+				printf("\nOptions:\n");
+				printf("  --quiet, -q\n");
+				printf("    Less verbose output\n");
+				printf("  --bench, -b\n");
+				printf("    Run benchmarks\n");
+				printf("\nalgorithms:\n");
+				for (size_t i = 0; i < kex_testcases_len; i++) {
+					printf("  %s\n", kex_testcases[i].id);
+				}
+				return EXIT_SUCCESS;
+			} else if ( strcmp(argv[i], "--quiet") == 0
+			            || strcmp(argv[i], "-q") == 0  ) {
+				quiet = true;
+			} else if ( strcmp(argv[i], "--bench") == 0
+			            || strcmp(argv[i], "-b") == 0  ) {
+				bench = true;
 			}
-			return EXIT_SUCCESS;
-		}
-		run_all = false;
-		for (int i = 1; i < argc; i++) {
+
+		} else {
+			run_all = false;
 			for (size_t j = 0; j < kex_testcases_len; j++) {
 				if (strcmp(argv[i], kex_testcases[j].id) == 0) {
 					kex_testcases[j].run = 1;
@@ -286,20 +305,22 @@ int main(int argc, char **argv) {
 				// SIDH is slower than the other schemes, so we reduce the number of runs
 				num_iter = KEX_TEST_ITERATIONS / 10;
 			}
-			success = kex_test_correctness_wrapper(rand, kex_testcases[i].alg_name, kex_testcases[i].seed, kex_testcases[i].seed_len, kex_testcases[i].named_parameters, num_iter);
+			success = kex_test_correctness_wrapper(rand, kex_testcases[i].alg_name, kex_testcases[i].seed, kex_testcases[i].seed_len, kex_testcases[i].named_parameters, num_iter, quiet);
 		}
 		if (success != 1) {
 			goto err;
 		}
 	}
 
-	PRINT_TIMER_HEADER
-	for (size_t i = 0; i < kex_testcases_len; i++) {
-		if (run_all || kex_testcases[i].run == 1) {
-			kex_bench_wrapper(rand, kex_testcases[i].alg_name, kex_testcases[i].seed, kex_testcases[i].seed_len, kex_testcases[i].named_parameters, KEX_BENCH_SECONDS);
+	if (bench) {
+		PRINT_TIMER_HEADER
+		for (size_t i = 0; i < kex_testcases_len; i++) {
+			if (run_all || kex_testcases[i].run == 1) {
+				kex_bench_wrapper(rand, kex_testcases[i].alg_name, kex_testcases[i].seed, kex_testcases[i].seed_len, kex_testcases[i].named_parameters, KEX_BENCH_SECONDS);
+			}
 		}
+		PRINT_TIMER_FOOTER
 	}
-	PRINT_TIMER_FOOTER
 
 	success = 1;
 	goto cleanup;


### PR DESCRIPTION
The quiet option does disables the printing of keys in the output.

Benchmarking is now turned off by default unless the bench option is passed to test_kex.