### PR TITLE
spelling fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ McBits is disabled by default in the Visual Studio build; follow these steps to 
 - Obtain the [libsodium library](https://libsodium.org); compile the static library from the Visual Studio projects.
 - Add `ENABLE_CODE_MCBITS` and `SODIUM_STATIC` to the preprocessor definitions of the `oqs` and `test_kex` projects.
 - Add the sodium "src/include" location to the "Additional Include Directories" in the oqs project C properties.
-- Add the libsodium library to the "Additional Depencies" in the `test_kex` project Linker properties.
+- Add the libsodium library to the "Additional Dependencies" in the `test_kex` project Linker properties.
 
 NTRU is disabled by default in the Visual Studio build; follow these steps to enable it:
 
 - Obtain the [NTRU library](https://github.com/NTRUOpenSourceProject/NTRUEncrypt); compile the NtruEncrypt_DLL from the Visual Studio projects.
 - Add `ENABLE_NTRU` to the preprocessor definitions of the `oqs` and `test_kex` projects.
 - Add the "NTRUEncrypt-master/include" location to the "Additional Include Directories" in the oqs project C properties.
-- Add the NtruEncrypt_DLL.lib library to the "Additional Depencies" in the `test_kex` project Linker properties.
+- Add the NtruEncrypt_DLL.lib library to the "Additional Dependencies" in the `test_kex` project Linker properties.
 
 
 Build options on Linux and macOS

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -17,7 +17,7 @@
 # DX_???_FEATURE(ON|OFF) - control the default setting fo a Doxygen feature.
 # Supported features are 'DOXYGEN' itself, 'DOT' for generating graphics,
 # 'HTML' for plain HTML, 'CHM' for compressed HTML help (for MS users), 'CHI'
-# for generating a seperate .chi file by the .chm file, and 'MAN', 'RTF',
+# for generating a separate .chi file by the .chm file, and 'MAN', 'RTF',
 # 'XML', 'PDF' and 'PS' for the appropriate output formats. The environment
 # variable DOXYGEN_PAPER_SIZE may be specified to override the default 'a4wide'
 # paper size.
@@ -248,8 +248,8 @@ DX_ARG_ABLE(chm, [generate doxygen compressed HTML help documentation],
              DX_ENV_APPEND(GENERATE_HTMLHELP, YES)],
             [DX_ENV_APPEND(GENERATE_HTMLHELP, NO)])
 
-# Seperate CHI file generation.
-DX_ARG_ABLE(chi, [generate doxygen seperate compressed HTML help index file],
+# Separate CHI file generation.
+DX_ARG_ABLE(chi, [generate doxygen separate compressed HTML help index file],
             [DX_CHECK_DEPEND(chm, 1)],
             [DX_CLEAR_DEPEND(chm, 1)],
             [],


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.