### PR TITLE
Update Readme with Ubuntu commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ You need to install autoconf, automake and libtool:
 
 	brew install autoconf automake libtool
 	
+### Install dependencies for Ubuntu
+
+You need to install autoconf, automake and libtool:
+
+	sudo apt install autoconf automake libtool
+	
 ### Building	
 
 To build, clone or download the source from GitHub, then simply type:
@@ -68,6 +74,14 @@ To run the tests, simply type:
 To run benchmarks, run
 
 	./test_kex --bench
+	
+To run benchmark only on some ciphers, run
+
+	./test_kex --help
+	
+to list the availanle ciphers and then run e.g.
+	
+	./test_kex --bench code_mcbits ntru
 	
 ### Additional build options
 
@@ -115,9 +129,13 @@ To install the library on macOS:
 
 	brew install libsodium
 
+To install the library on Ubuntu:
+
+	sudo apt install libsodium-dev
+
 To build with `kex_code_mcbits ` enabled:
 
-	./configure --enable-libsodium
+	./configure --enable-mcbits
 	make clean
 	make
 	

--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ To run benchmark only on some ciphers, run
 
 	./test_kex --help
 	
-to list the availanle ciphers and then run e.g.
+to list the available ciphers and then run e.g.
 	
-	./test_kex --bench code_mcbits ntru
+	./test_kex --bench rlwe_bcns15 rlwe_newhope
+
 	
 ### Additional build options
 


### PR DESCRIPTION
I've built the library on Ubuntu 16.04 and here are the commands to install the dependencies.

I've also found a small mistake in the Readme: to build with kex_code_mcbits enabled the command is not `./configure --enable-libsodium` but `./configure --enable-mcbits`.