### PR TITLE
Removing non-namespaced global symbols from Kyber

### DIFF
--- a/src/kex_mlwe_kyber/indcpa.c
+++ b/src/kex_mlwe_kyber/indcpa.c
@@ -39,7 +39,7 @@ static void unpack_sk(polyvec *sk, const unsigned char *packedsk) {
 #define gen_at(A, B) gen_matrix(A, B, 1)
 
 /* Generate entry a_{i,j} of matrix A as Parse(SHAKE128(seed|i|j)) */
-void gen_matrix(polyvec *a, const unsigned char *seed, int transposed) //XXX: Not static for benchmarking
+static void gen_matrix(polyvec *a, const unsigned char *seed, int transposed) //XXX: Not static for benchmarking
 {
 	unsigned int pos = 0, ctr;
 	uint16_t val;
@@ -77,7 +77,7 @@ void gen_matrix(polyvec *a, const unsigned char *seed, int transposed) //XXX: No
 	}
 }
 
-void indcpa_keypair(unsigned char *pk,
+static void indcpa_keypair(unsigned char *pk,
                     unsigned char *sk, OQS_RAND *rand) {
 	polyvec a[KYBER_D], e, pkpv, skpv;
 	unsigned char seed[KYBER_SEEDBYTES];
@@ -110,7 +110,7 @@ void indcpa_keypair(unsigned char *pk,
 	pack_pk(pk, &pkpv, seed);
 }
 
-void indcpa_enc(unsigned char *c,
+static void indcpa_enc(unsigned char *c,
                 const unsigned char *m,
                 const unsigned char *pk,
                 const unsigned char *coins) {
@@ -156,7 +156,7 @@ void indcpa_enc(unsigned char *c,
 	pack_ciphertext(c, &bp, &v);
 }
 
-void indcpa_dec(unsigned char *m,
+static void indcpa_dec(unsigned char *m,
                 const unsigned char *c,
                 const unsigned char *sk) {
 	polyvec bp, skpv;

--- a/src/kex_mlwe_kyber/indcpa.c
+++ b/src/kex_mlwe_kyber/indcpa.c
@@ -78,7 +78,7 @@ static void gen_matrix(polyvec *a, const unsigned char *seed, int transposed) //
 }
 
 static void indcpa_keypair(unsigned char *pk,
-                    unsigned char *sk, OQS_RAND *rand) {
+                           unsigned char *sk, OQS_RAND *rand) {
 	polyvec a[KYBER_D], e, pkpv, skpv;
 	unsigned char seed[KYBER_SEEDBYTES];
 	unsigned char noiseseed[KYBER_COINBYTES];
@@ -111,9 +111,9 @@ static void indcpa_keypair(unsigned char *pk,
 }
 
 static void indcpa_enc(unsigned char *c,
-                const unsigned char *m,
-                const unsigned char *pk,
-                const unsigned char *coins) {
+                       const unsigned char *m,
+                       const unsigned char *pk,
+                       const unsigned char *coins) {
 	polyvec sp, pkpv, ep, at[KYBER_D], bp;
 	poly v, k, epp;
 	unsigned char seed[KYBER_SEEDBYTES];
@@ -157,8 +157,8 @@ static void indcpa_enc(unsigned char *c,
 }
 
 static void indcpa_dec(unsigned char *m,
-                const unsigned char *c,
-                const unsigned char *sk) {
+                       const unsigned char *c,
+                       const unsigned char *sk) {
 	polyvec bp, skpv;
 	poly v, mp;
 	size_t i;

--- a/src/kex_mlwe_kyber/ntt.c
+++ b/src/kex_mlwe_kyber/ntt.c
@@ -19,7 +19,7 @@ static uint16_t bitrev_table[KYBER_N] = {
     15, 143, 79, 207, 47, 175, 111, 239, 31, 159, 95, 223, 63, 191, 127, 255,
 };
 
-void bitrev_vector(uint16_t *poly) {
+static void bitrev_vector(uint16_t *poly) {
 	unsigned int i, r;
 	uint16_t tmp;
 
@@ -33,7 +33,7 @@ void bitrev_vector(uint16_t *poly) {
 	}
 }
 
-void mul_coefficients(uint16_t *poly, const uint16_t *factors) {
+static void mul_coefficients(uint16_t *poly, const uint16_t *factors) {
 	unsigned int i;
 
 	for (i = 0; i < KYBER_N; i++)
@@ -41,7 +41,7 @@ void mul_coefficients(uint16_t *poly, const uint16_t *factors) {
 }
 
 /* GS_bo_to_no; omegas need to be in Montgomery domain */
-void ntt(uint16_t *a, const uint16_t *omega) {
+static void ntt(uint16_t *a, const uint16_t *omega) {
 	int start, j, jTwiddle, level;
 	uint16_t temp, W;
 	uint32_t t;

--- a/src/kex_mlwe_kyber/poly.c
+++ b/src/kex_mlwe_kyber/poly.c
@@ -14,7 +14,7 @@ static uint32_t load_littleendian(const unsigned char *x) {
 	return x[0] | (((uint32_t) x[1]) << 8) | (((uint32_t) x[2]) << 16) | (((uint32_t) x[3]) << 24);
 }
 
-void cbd(poly *r, const unsigned char *buf) {
+static void cbd(poly *r, const unsigned char *buf) {
 #if KYBER_K != 4
 #error "poly_getnoise in poly.c only supports k=4"
 #endif
@@ -45,7 +45,7 @@ void cbd(poly *r, const unsigned char *buf) {
 }
 /* end cbd.c */
 
-void poly_compress(unsigned char *r, const poly *a) {
+static void poly_compress(unsigned char *r, const poly *a) {
 	uint32_t t[8];
 	unsigned int i, j, k = 0;
 
@@ -60,7 +60,7 @@ void poly_compress(unsigned char *r, const poly *a) {
 	}
 }
 
-void poly_decompress(poly *r, const unsigned char *a) {
+static void poly_decompress(poly *r, const unsigned char *a) {
 	unsigned int i;
 	for (i = 0; i < KYBER_N; i += 8) {
 		r->coeffs[i + 0] = (((a[0] & 7) * KYBER_Q) + 4) >> 3;
@@ -75,7 +75,7 @@ void poly_decompress(poly *r, const unsigned char *a) {
 	}
 }
 
-void poly_tobytes(unsigned char *r, const poly *a) {
+static void poly_tobytes(unsigned char *r, const poly *a) {
 	int i, j;
 	uint16_t t[8];
 
@@ -99,7 +99,7 @@ void poly_tobytes(unsigned char *r, const poly *a) {
 	}
 }
 
-void poly_frombytes(poly *r, const unsigned char *a) {
+static void poly_frombytes(poly *r, const unsigned char *a) {
 	int i;
 	for (i = 0; i < KYBER_N / 8; i++) {
 		r->coeffs[8 * i + 0] = a[13 * i + 0] | (((uint16_t) a[13 * i + 1] & 0x1f) << 8);
@@ -113,7 +113,7 @@ void poly_frombytes(poly *r, const unsigned char *a) {
 	}
 }
 
-void poly_getnoise(poly *r, const unsigned char *seed, unsigned char nonce) {
+static void poly_getnoise(poly *r, const unsigned char *seed, unsigned char nonce) {
 	unsigned char buf[KYBER_N];
 
 	OQS_SHA3_cshake128_simple(buf, KYBER_N, nonce, seed, KYBER_NOISESEEDBYTES);
@@ -121,30 +121,30 @@ void poly_getnoise(poly *r, const unsigned char *seed, unsigned char nonce) {
 	cbd(r, buf);
 }
 
-void poly_ntt(poly *r) {
+static void poly_ntt(poly *r) {
 	mul_coefficients(r->coeffs, oqs_kex_mlwe_kyber_psis_bitrev_montgomery);
 	ntt(r->coeffs, oqs_kex_mlwe_kyber_omegas_montgomery);
 }
 
-void poly_invntt(poly *r) {
+static void poly_invntt(poly *r) {
 	bitrev_vector(r->coeffs);
 	ntt(r->coeffs, oqs_kex_mlwe_kyber_omegas_inv_bitrev_montgomery);
 	mul_coefficients(r->coeffs, oqs_kex_mlwe_kyber_psis_inv_montgomery);
 }
 
-void poly_add(poly *r, const poly *a, const poly *b) {
+static void poly_add(poly *r, const poly *a, const poly *b) {
 	int i;
 	for (i = 0; i < KYBER_N; i++)
 		r->coeffs[i] = barrett_reduce(a->coeffs[i] + b->coeffs[i]);
 }
 
-void poly_sub(poly *r, const poly *a, const poly *b) {
+static void poly_sub(poly *r, const poly *a, const poly *b) {
 	int i;
 	for (i = 0; i < KYBER_N; i++)
 		r->coeffs[i] = barrett_reduce(a->coeffs[i] + 3 * KYBER_Q - b->coeffs[i]);
 }
 
-void poly_frommsg(poly *r, const unsigned char msg[KYBER_SHAREDKEYBYTES]) {
+static void poly_frommsg(poly *r, const unsigned char msg[KYBER_SHAREDKEYBYTES]) {
 	uint16_t i, j, mask;
 
 	for (i = 0; i < KYBER_SHAREDKEYBYTES; i++) {
@@ -155,7 +155,7 @@ void poly_frommsg(poly *r, const unsigned char msg[KYBER_SHAREDKEYBYTES]) {
 	}
 }
 
-void poly_tomsg(unsigned char msg[KYBER_SHAREDKEYBYTES], const poly *a) {
+static void poly_tomsg(unsigned char msg[KYBER_SHAREDKEYBYTES], const poly *a) {
 	uint16_t t;
 	int i, j;
 

--- a/src/kex_mlwe_kyber/polyvec.c
+++ b/src/kex_mlwe_kyber/polyvec.c
@@ -9,7 +9,7 @@ typedef struct {
 #endif
 
 #if (KYBER_POLYVECCOMPRESSEDBYTES == (KYBER_D * 352))
-void polyvec_compress(unsigned char *r, const polyvec *a) {
+static void polyvec_compress(unsigned char *r, const polyvec *a) {
 	int i, j, k;
 	uint16_t t[8];
 	for (i = 0; i < KYBER_D; i++) {
@@ -33,7 +33,7 @@ void polyvec_compress(unsigned char *r, const polyvec *a) {
 	}
 }
 
-void polyvec_decompress(polyvec *r, const unsigned char *a) {
+static void polyvec_decompress(polyvec *r, const unsigned char *a) {
 	int i, j;
 	for (i = 0; i < KYBER_D; i++) {
 		for (j = 0; j < KYBER_N / 8; j++) {
@@ -52,7 +52,7 @@ void polyvec_decompress(polyvec *r, const unsigned char *a) {
 
 #elif (KYBER_POLYVECCOMPRESSEDBYTES == (KYBER_D * 320))
 
-void polyvec_compress(unsigned char *r, const polyvec *a) {
+static void polyvec_compress(unsigned char *r, const polyvec *a) {
 	int i, j, k;
 	uint16_t t[4];
 	for (i = 0; i < KYBER_D; i++) {
@@ -70,7 +70,7 @@ void polyvec_compress(unsigned char *r, const polyvec *a) {
 	}
 }
 
-void polyvec_decompress(polyvec *r, const unsigned char *a) {
+static void polyvec_decompress(polyvec *r, const unsigned char *a) {
 	int i, j;
 	for (i = 0; i < KYBER_D; i++) {
 		for (j = 0; j < KYBER_N / 4; j++) {
@@ -85,7 +85,7 @@ void polyvec_decompress(polyvec *r, const unsigned char *a) {
 
 #elif (KYBER_POLYVECCOMPRESSEDBYTES == (KYBER_D * 288))
 
-void polyvec_compress(unsigned char *r, const polyvec *a) {
+static void polyvec_compress(unsigned char *r, const polyvec *a) {
 	int i, j, k;
 	uint16_t t[8];
 	for (i = 0; i < KYBER_D; i++) {
@@ -107,7 +107,7 @@ void polyvec_compress(unsigned char *r, const polyvec *a) {
 	}
 }
 
-void polyvec_decompress(polyvec *r, const unsigned char *a) {
+static void polyvec_decompress(polyvec *r, const unsigned char *a) {
 	int i, j;
 	for (i = 0; i < KYBER_D; i++) {
 		for (j = 0; j < KYBER_N / 8; j++) {
@@ -126,7 +126,7 @@ void polyvec_decompress(polyvec *r, const unsigned char *a) {
 
 #elif (KYBER_POLYVECCOMPRESSEDBYTES == (KYBER_D * 256))
 
-void polyvec_compress(unsigned char *r, const polyvec *a) {
+static void polyvec_compress(unsigned char *r, const polyvec *a) {
 	int i, j, k;
 	uint16_t t;
 	for (i = 0; i < KYBER_D; i++) {
@@ -137,7 +137,7 @@ void polyvec_compress(unsigned char *r, const polyvec *a) {
 	}
 }
 
-void polyvec_decompress(polyvec *r, const unsigned char *a) {
+static void polyvec_decompress(polyvec *r, const unsigned char *a) {
 	int i, j;
 	for (i = 0; i < KYBER_D; i++) {
 		for (j = 0; j < KYBER_N; j++) {
@@ -151,31 +151,31 @@ void polyvec_decompress(polyvec *r, const unsigned char *a) {
 #error "Unsupported compression of polyvec"
 #endif
 
-void polyvec_tobytes(unsigned char *r, const polyvec *a) {
+static void polyvec_tobytes(unsigned char *r, const polyvec *a) {
 	int i;
 	for (i = 0; i < KYBER_D; i++)
 		poly_tobytes(r + i * KYBER_POLYBYTES, &a->vec[i]);
 }
 
-void polyvec_frombytes(polyvec *r, const unsigned char *a) {
+static void polyvec_frombytes(polyvec *r, const unsigned char *a) {
 	int i;
 	for (i = 0; i < KYBER_D; i++)
 		poly_frombytes(&r->vec[i], a + i * KYBER_POLYBYTES);
 }
 
-void polyvec_ntt(polyvec *r) {
+static void polyvec_ntt(polyvec *r) {
 	int i;
 	for (i = 0; i < KYBER_D; i++)
 		poly_ntt(&r->vec[i]);
 }
 
-void polyvec_invntt(polyvec *r) {
+static void polyvec_invntt(polyvec *r) {
 	int i;
 	for (i = 0; i < KYBER_D; i++)
 		poly_invntt(&r->vec[i]);
 }
 
-void polyvec_pointwise_acc(poly *r, const polyvec *a, const polyvec *b) {
+static void polyvec_pointwise_acc(poly *r, const polyvec *a, const polyvec *b) {
 	int i, j;
 	uint16_t t;
 	for (j = 0; j < KYBER_N; j++) {
@@ -189,7 +189,7 @@ void polyvec_pointwise_acc(poly *r, const polyvec *a, const polyvec *b) {
 	}
 }
 
-void polyvec_add(polyvec *r, const polyvec *a, const polyvec *b) {
+static void polyvec_add(polyvec *r, const polyvec *a, const polyvec *b) {
 	int i;
 	for (i = 0; i < KYBER_D; i++)
 		poly_add(&r->vec[i], &a->vec[i], &b->vec[i]);

--- a/src/kex_mlwe_kyber/reduce.c
+++ b/src/kex_mlwe_kyber/reduce.c
@@ -3,7 +3,7 @@
 static const uint32_t qinv = 7679; // -inverse_mod(q,2^18)
 static const uint32_t rlog = 18;
 
-uint16_t montgomery_reduce(uint32_t a) {
+static uint16_t montgomery_reduce(uint32_t a) {
 	uint32_t u;
 
 	u = (a * qinv);
@@ -13,7 +13,7 @@ uint16_t montgomery_reduce(uint32_t a) {
 	return a >> rlog;
 }
 
-uint16_t barrett_reduce(uint16_t a) {
+static uint16_t barrett_reduce(uint16_t a) {
 	uint32_t u;
 
 	u = a >> 13;
@@ -22,7 +22,7 @@ uint16_t barrett_reduce(uint16_t a) {
 	return a;
 }
 
-uint16_t freeze(uint16_t x) {
+static uint16_t freeze(uint16_t x) {
 	uint16_t m, r;
 	int16_t c;
 	r = barrett_reduce(x);

--- a/src/kex_mlwe_kyber/verify.c
+++ b/src/kex_mlwe_kyber/verify.c
@@ -2,7 +2,7 @@
 #include <stdint.h>
 
 /* returns 0 for equal strings, 1 for non-equal strings */
-int verify(const unsigned char *a, const unsigned char *b, size_t len) {
+static int verify(const unsigned char *a, const unsigned char *b, size_t len) {
 	uint64_t r;
 	size_t i;
 	r = 0;
@@ -15,7 +15,7 @@ int verify(const unsigned char *a, const unsigned char *b, size_t len) {
 }
 
 /* b = 1 means mov, b = 0 means don't mov*/
-void cmov(unsigned char *r, const unsigned char *x, size_t len, unsigned char b) {
+static void cmov(unsigned char *r, const unsigned char *x, size_t len, unsigned char b) {
 	size_t i;
 
 	b = -b;


### PR DESCRIPTION
Fixing #137. The output of 
```
nm -g liboqs.a | grep ' T ' | grep -E -v -i ' T [_]?[OQS|ntru_]'
```
was empty.