### PR TITLE
Fix unknown pseudo-op: .global under macOS

### DIFF
--- a/src/kex_rlwe_msrln16/AMD64/error_asm.S
+++ b/src/kex_rlwe_msrln16/AMD64/error_asm.S
@@ -24,7 +24,7 @@
 //  Error sampling from psi_12
 //  Operation: c [reg_p2] <- sampling(a) [reg_p1]
 //*********************************************************************** 
-.global oqs_rlwe_msrln16_error_sampling_asm
+.globl oqs_rlwe_msrln16_error_sampling_asm
 oqs_rlwe_msrln16_error_sampling_asm:  
   vmovdqu    ymm7, ONE32x 
   movq       r11, 384
@@ -141,7 +141,7 @@ loop1b:
 //  Operation: c [reg_p2] <- function(a) [reg_p1]
 //             [reg_p3] points to random bits
 //*********************************************************************** 
-.global oqs_rlwe_msrln16_helprec_asm
+.globl oqs_rlwe_msrln16_helprec_asm
 oqs_rlwe_msrln16_helprec_asm:  
   vmovdqu    ymm8, ONE8x 
   movq       r11, 256
@@ -331,7 +331,7 @@ loop2:
 //  Reconciliation function
 //  Operation: c [reg_p3] <- function(a [reg_p1], b [reg_p2])
 //*********************************************************************** 
-.global oqs_rlwe_msrln16_rec_asm
+.globl oqs_rlwe_msrln16_rec_asm
 oqs_rlwe_msrln16_rec_asm:  
   vpxor      ymm12, ymm12, ymm12 
   vmovdqu    ymm15, PRIME8x   

--- a/src/kex_rlwe_msrln16/AMD64/ntt_x64_asm.S
+++ b/src/kex_rlwe_msrln16/AMD64/ntt_x64_asm.S
@@ -25,7 +25,7 @@
 //             [reg_p2] points to table and 
 //             reg_p3 contains parameter n
 //*********************************************************************** 
-.global oqs_rlwe_msrln16_NTT_CT_std2rev_12289_asm
+.globl oqs_rlwe_msrln16_NTT_CT_std2rev_12289_asm
 oqs_rlwe_msrln16_NTT_CT_std2rev_12289_asm:
   push       r12
   push       r13
@@ -355,7 +355,7 @@ loop8:
 //             reg_p3 and reg_p4 point to constants for scaling and
 //             reg_p5 contains parameter n
 //*********************************************************************** 
-.global oqs_rlwe_msrln16_INTT_GS_rev2std_12289_asm
+.globl oqs_rlwe_msrln16_INTT_GS_rev2std_12289_asm
 oqs_rlwe_msrln16_INTT_GS_rev2std_12289_asm:
   push       r12
   push       r13
@@ -776,7 +776,7 @@ loop9b:
 //  Operation: d [reg_p4] <- a [reg_p1] * b [reg_p2] + c [reg_p3]
 //             reg_p5 contains parameter n
 //*********************************************************************** 
-.global oqs_rlwe_msrln16_pmuladd_asm
+.globl oqs_rlwe_msrln16_pmuladd_asm
 oqs_rlwe_msrln16_pmuladd_asm:
   vmovdqu    ymm5, PERM0246
   vmovdqu    ymm6, MASK12x8 
@@ -817,7 +817,7 @@ lazo2:
 //  Operation: c [reg_p3] <- a [reg_p1] * b [reg_p2]
 //             reg_p4 contains parameter n
 //*********************************************************************** 
-.global oqs_rlwe_msrln16_pmul_asm
+.globl oqs_rlwe_msrln16_pmul_asm
 oqs_rlwe_msrln16_pmul_asm: 
   vmovdqu    ymm5, PERM0246
   vmovdqu    ymm6, MASK12x8 
@@ -856,7 +856,7 @@ lazo3:
 //  Operation: c [reg_p1] <- a [reg_p1]
 //             reg_p2 contains parameter n
 //*********************************************************************** 
-.global oqs_rlwe_msrln16_two_reduce12289_asm
+.globl oqs_rlwe_msrln16_two_reduce12289_asm
 oqs_rlwe_msrln16_two_reduce12289_asm: 
   vmovdqu    ymm6, MASK12x8 
   vmovdqu    ymm7, PRIME8x
@@ -900,7 +900,7 @@ lazo4:
 //  Encoding
 //  Operation: c [reg_p2] <- a [reg_p1]
 //*********************************************************************** 
-.global oqs_rlwe_msrln16_encode_asm
+.globl oqs_rlwe_msrln16_encode_asm
 oqs_rlwe_msrln16_encode_asm: 
   vmovdqu    ymm6, MASK32 
   vmovdqu    ymm7, MASK42
@@ -939,7 +939,7 @@ lazo5:
 //  Decoding
 //  Operation: c [reg_p2] <- a [reg_p1]
 //*********************************************************************** 
-.global oqs_rlwe_msrln16_decode_asm
+.globl oqs_rlwe_msrln16_decode_asm
 oqs_rlwe_msrln16_decode_asm: 
   vmovdqu    ymm6, MASK14_1 
   vmovdqu    ymm7, MASK14_2

--- a/src/kex_sidh_cln16/AMD64/fp_x64_asm.S
+++ b/src/kex_sidh_cln16/AMD64/fp_x64_asm.S
@@ -50,7 +50,7 @@
 //  Field addition
 //  Operation: c [reg_p3] = a [reg_p1] + b [reg_p2]
 //*********************************************************************** 
-.global oqs_sidh_cln16_fpadd751_asm
+.globl oqs_sidh_cln16_fpadd751_asm
 oqs_sidh_cln16_fpadd751_asm:
   push   r12
   push   r13
@@ -191,7 +191,7 @@ oqs_sidh_cln16_fpadd751_asm:
 //  Field subtraction
 //  Operation: c [reg_p3] = a [reg_p1] - b [reg_p2]
 //*********************************************************************** 
-.global oqs_sidh_cln16_fpsub751_asm
+.globl oqs_sidh_cln16_fpsub751_asm
 oqs_sidh_cln16_fpsub751_asm:
   push   r12
   push   r13
@@ -306,7 +306,7 @@ oqs_sidh_cln16_fpsub751_asm:
 //  Operation: c [reg_p3] = a [reg_p1] * b [reg_p2]
 //  NOTE: a=c or b=c are not allowed
 //***********************************************************************
-.global oqs_sidh_cln16_mul751_asm
+.globl oqs_sidh_cln16_mul751_asm
 oqs_sidh_cln16_mul751_asm:
   push   r12
   push   r13
@@ -1249,7 +1249,7 @@ oqs_sidh_cln16_mul751_asm:
 //  Operation: c [reg_p2] = a [reg_p1]
 //  NOTE: a=c is not allowed
 //*********************************************************************** 
-.global oqs_sidh_cln16_rdc751_asm
+.globl oqs_sidh_cln16_rdc751_asm
 oqs_sidh_cln16_rdc751_asm:
   push   r12
   push   r13 
@@ -1868,7 +1868,7 @@ oqs_sidh_cln16_rdc751_asm:
 //  751-bit multiprecision addition
 //  Operation: c [reg_p3] = a [reg_p1] + b [reg_p2]
 //*********************************************************************** 
-.global oqs_sidh_cln16_mp_add751_asm
+.globl oqs_sidh_cln16_mp_add751_asm
 oqs_sidh_cln16_mp_add751_asm:
   push   r12
   push   r13
@@ -1927,7 +1927,7 @@ oqs_sidh_cln16_mp_add751_asm:
 //  2x751-bit multiprecision addition
 //  Operation: c [reg_p3] = a [reg_p1] + b [reg_p2]
 //*********************************************************************** 
-.global oqs_sidh_cln16_mp_add751x2_asm
+.globl oqs_sidh_cln16_mp_add751x2_asm
 oqs_sidh_cln16_mp_add751x2_asm:
   push   r12
   push   r13


### PR DESCRIPTION
replaced .global with .globl in all .S files due to ancient “as” tool
in macOS