### PR TITLE
KEX memory benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ to list the available ciphers and then run e.g.
 	./test_kex --bench rlwe_bcns15 rlwe_newhope
 
 
-Memory benchmarks
------------------
+#### Memory benchmarks
 
 To run one or more ciphers only once use `--mem-bench`, which is suitable for memory usage profiling:
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,19 @@ to list the available ciphers and then run e.g.
 
 	./test_kex --bench rlwe_bcns15 rlwe_newhope
 
+
+Memory benchmarks
+-----------------
+
+To run one or more ciphers only once use `--mem-bench`, which is suitable for memory usage profiling:
+
+	./test_kex --mem-bench ntru
+
+You may also get instant memory usage results of an algorithm (e.g. ntru) by running [valgrind's massif tool](http://valgrind.org/docs/manual/ms-manual.html) by running
+
+	./kex_bench_memory.sh ntru
+
+
 ### Additional build options
 
 #### Building with OpenSSL algorithms enabled:

--- a/bench-memory.sh
+++ b/bench-memory.sh
@@ -3,6 +3,7 @@
 DEFAULT_TMP_DIR=/tmp
 TMP_DIR=$DEFAULT_TMP_DIR
 ALGORITHMS=""
+ROOT_DIR=`dirname $0`
 
 #parse arguments
 for arg in "$@"
@@ -26,7 +27,7 @@ Usage: $0 [OPTION]... ALGORITHM
   --tmp-dir=DIR       temporary directory [default: $DEFAULT_TMP_DIR]
     ALGORITHM         algorithm to test
 
-Example usage: $0 
+Example usage: $0 ntru
 
 EOF
   exit 0
@@ -40,7 +41,7 @@ TMP_FILE_NAME="oqs_mem_bench"
 TMP_FILE_PATH=$TMP_DIR/$TMP_FILE_NAME
 
 rm -f $TMP_FILE_PATH
-valgrind --tool=massif --massif-out-file=$TMP_FILE_PATH ./test_kex -m $ALGORITHMS
+valgrind --tool=massif --massif-out-file=$TMP_FILE_PATH $ROOT_DIR/test_kex -m $ALGORITHMS
 ms_print $TMP_FILE_PATH
 rm -f $TMP_FILE_PATH
 

--- a/bench-memory.sh
+++ b/bench-memory.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+DEFAULT_TMP_DIR=/tmp
+TMP_DIR=$DEFAULT_TMP_DIR
+ALGORITHMS=""
+
+#parse arguments
+for arg in "$@"
+do
+  case $arg in
+    -tmp-dir=*|-t=*)
+      TMP_DIR="${arg#*=}"
+      shift
+      ;;
+    *)
+      ALGORITHMS="$ALGORITHMS $arg"
+      ;;
+  esac
+done
+
+
+function print_help {
+cat << EOF
+Usage: $0 [OPTION]... ALGORITHM
+
+  --tmp-dir=DIR       temporary directory [default: $DEFAULT_TMP_DIR]
+    ALGORITHM         algorithm to test
+
+Example usage: $0 
+
+EOF
+  exit 0
+}
+
+if [[ ! -d $TMP_DIR ]]; then
+  print_help
+fi
+
+TMP_FILE_NAME="oqs_mem_bench"
+TMP_FILE_PATH=$TMP_DIR/$TMP_FILE_NAME
+
+rm -f $TMP_FILE_PATH
+valgrind --tool=massif --massif-out-file=$TMP_FILE_PATH ./test_kex -m $ALGORITHMS
+ms_print $TMP_FILE_PATH
+rm -f $TMP_FILE_PATH
+
+
+

--- a/kex_bench_memory.sh
+++ b/kex_bench_memory.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 
+# This script outputs kex memory benchmarks using valgrind
+
 DEFAULT_TMP_DIR=/tmp
 TMP_DIR=$DEFAULT_TMP_DIR
 ALGORITHMS=""
 ROOT_DIR=`dirname $0`
+TEST_KEX_CMD=$ROOT_DIR/test_kex
+
+#check for installed programs
+for prog in valgrind ms_print $TEST_KEX_CMD
+do
+  command -v $prog >/dev/null 2>&1 || { echo >&2 "Command $prog was not found.  Aborting."; exit 1; }
+done
+
 
 #parse arguments
 for arg in "$@"
@@ -41,7 +51,7 @@ TMP_FILE_NAME="oqs_mem_bench"
 TMP_FILE_PATH=$TMP_DIR/$TMP_FILE_NAME
 
 rm -f $TMP_FILE_PATH
-valgrind --tool=massif --massif-out-file=$TMP_FILE_PATH $ROOT_DIR/test_kex -m $ALGORITHMS
+valgrind --tool=massif --massif-out-file=$TMP_FILE_PATH $TEST_KEX_CMD -m $ALGORITHMS
 ms_print $TMP_FILE_PATH
 rm -f $TMP_FILE_PATH
 

--- a/src/kex/test_kex.c
+++ b/src/kex/test_kex.c
@@ -274,7 +274,6 @@ cleanup:
 	return rc;
 }
 
-
 static int kex_mem_bench_wrapper(OQS_RAND *rand, enum OQS_KEX_alg_name alg_name, const uint8_t *seed, const size_t seed_len, const char *named_parameters){
 
 	
@@ -292,7 +291,6 @@ static int kex_mem_bench_wrapper(OQS_RAND *rand, enum OQS_KEX_alg_name alg_name,
 	uint8_t *bob_key = NULL;
 	size_t bob_key_len;
 
-	//TODO: sleep between operations?
 	kex = OQS_KEX_new(rand, alg_name, seed, seed_len, named_parameters);
 	if (kex == NULL) {
 		fprintf(stderr, "new_method failed\n");
@@ -304,8 +302,6 @@ static int kex_mem_bench_wrapper(OQS_RAND *rand, enum OQS_KEX_alg_name alg_name,
 	OQS_KEX_alice_0(kex, &alice_priv, &alice_msg, &alice_msg_len);
 	OQS_KEX_bob(kex, alice_msg, alice_msg_len, &bob_msg, &bob_msg_len, &bob_key, &bob_key_len);
 	OQS_KEX_alice_1(kex, alice_priv, bob_msg, bob_msg_len, &alice_key, &alice_key_len);
-
-
 
 	rc = 1;
 	goto cleanup;

--- a/src/kex/test_kex.c
+++ b/src/kex/test_kex.c
@@ -53,7 +53,6 @@ struct kex_testcase kex_testcases[] = {
 #define KEX_TEST_ITERATIONS 100
 #define KEX_BENCH_SECONDS_DEFAULT 1
 
-
 #define PRINT_HEX_STRING(label, str, len)                        \
 	{                                                            \
 		printf("%-20s (%4zu bytes):  ", (label), (size_t)(len)); \
@@ -173,9 +172,9 @@ static int kex_test_correctness_wrapper(OQS_RAND *rand, enum OQS_KEX_alg_name al
 	for (int i = 0; i < 256; i++) {
 		occurrences[i] = 0;
 	}
-	
+
 	ret = kex_test_correctness(rand, alg_name, seed, seed_len, named_parameters, quiet ? 0 : 1, occurrences);
-	
+
 	if (ret != 1) {
 		goto err;
 	}
@@ -274,9 +273,8 @@ cleanup:
 	return rc;
 }
 
-static int kex_mem_bench_wrapper(OQS_RAND *rand, enum OQS_KEX_alg_name alg_name, const uint8_t *seed, const size_t seed_len, const char *named_parameters){
+static int kex_mem_bench_wrapper(OQS_RAND *rand, enum OQS_KEX_alg_name alg_name, const uint8_t *seed, const size_t seed_len, const char *named_parameters) {
 
-	
 	OQS_KEX *kex = NULL;
 	int rc;
 
@@ -318,11 +316,9 @@ cleanup:
 	OQS_KEX_free(kex);
 
 	return rc;
-
-
 }
 
-void print_help(){
+void print_help() {
 	printf("Usage: ./test_kex [options] [algorithms]\n");
 	printf("\nOptions:\n");
 	printf("	--quiet, -q\n");
@@ -331,8 +327,8 @@ void print_help(){
 	printf("		Run benchmarks\n");
 	printf("	--seconds -s [SECONDS]\n");
 	printf("		Number of seconds to run benchmarks (default==%d)\n", KEX_BENCH_SECONDS_DEFAULT);
-  printf("  --mem-bench\n");
-  printf("    Run memory benchmarks (run once and allocate only what is required)\n");
+	printf("  --mem-bench\n");
+	printf("    Run memory benchmarks (run once and allocate only what is required)\n");
 	printf("\nalgorithms:\n");
 	size_t kex_testcases_len = sizeof(kex_testcases) / sizeof(struct kex_testcase);
 	for (size_t i = 0; i < kex_testcases_len; i++) {
@@ -359,18 +355,18 @@ int main(int argc, char **argv) {
 			} else if (strcmp(argv[i], "--bench") == 0 || strcmp(argv[i], "-b") == 0) {
 				bench = true;
 			} else if (strcmp(argv[i], "--seconds") == 0 || strcmp(argv[i], "-s") == 0) {
-				if(++i == argc) {
+				if (++i == argc) {
 					print_help();
 					return EXIT_SUCCESS;
 				}
-				char* end;
+				char *end;
 				int kex_bench_seconds_input = strtol(argv[i], &end, 10);
-				if(kex_bench_seconds_input < 1){
+				if (kex_bench_seconds_input < 1) {
 					print_help();
 					return EXIT_SUCCESS;
 				}
 				kex_bench_seconds = kex_bench_seconds_input;
-			} else if((strcmp(argv[i], "--mem-bench") == 0 || strcmp(argv[i], "-m") == 0)){
+			} else if ((strcmp(argv[i], "--mem-bench") == 0 || strcmp(argv[i], "-m") == 0)) {
 				mem_bench = true;
 			}
 		} else {
@@ -383,19 +379,18 @@ int main(int argc, char **argv) {
 		}
 	}
 
-
 	/* setup RAND */
 	OQS_RAND *rand = OQS_RAND_new(OQS_RAND_alg_urandom_chacha20);
 	if (rand == NULL) {
 		goto err;
 	}
 
-	if(mem_bench){
+	if (mem_bench) {
 		for (size_t i = 0; i < kex_testcases_len; i++) {
 			if (run_all || kex_testcases[i].run == 1) {
 				success = kex_mem_bench_wrapper(rand, kex_testcases[i].alg_name, kex_testcases[i].seed, kex_testcases[i].seed_len, kex_testcases[i].named_parameters);
 			}
-			if(success != 1){
+			if (success != 1) {
 				goto err;
 			}
 		}

--- a/src/kex/test_kex.c
+++ b/src/kex/test_kex.c
@@ -321,18 +321,18 @@ cleanup:
 void print_help() {
 	printf("Usage: ./test_kex [options] [algorithms]\n");
 	printf("\nOptions:\n");
-	printf("	--quiet, -q\n");
-	printf("		Less verbose output\n");
-	printf("	--bench, -b\n");
-	printf("		Run benchmarks\n");
-	printf("	--seconds -s [SECONDS]\n");
-	printf("		Number of seconds to run benchmarks (default==%d)\n", KEX_BENCH_SECONDS_DEFAULT);
+	printf("  --quiet, -q\n");
+	printf("    Less verbose output\n");
+	printf("  --bench, -b\n");
+	printf("    Run benchmarks\n");
+	printf("  --seconds -s [SECONDS]\n");
+	printf("    Number of seconds to run benchmarks (default==%d)\n", KEX_BENCH_SECONDS_DEFAULT);
 	printf("  --mem-bench\n");
 	printf("    Run memory benchmarks (run once and allocate only what is required)\n");
 	printf("\nalgorithms:\n");
 	size_t kex_testcases_len = sizeof(kex_testcases) / sizeof(struct kex_testcase);
 	for (size_t i = 0; i < kex_testcases_len; i++) {
-		printf("	%s\n", kex_testcases[i].id);
+		printf("  %s\n", kex_testcases[i].id);
 	}
 }
 


### PR DESCRIPTION
Add options which enable memory usage profiling of KEX algorithms.

Changelog:
 - added `--mem-bench` option which quitly runs a test case just one
 - added `--seconds` option to specify for how long an option should be run during benchmarking
 - added `kex_memory_bench.sh` script which uses Valgrind's Massif tool to present a memory usage graph

Sponsored by [Sectra Communications](http://communications.sectra.com/)