### PR TITLE
Initialize out-parameters to NULL

### DIFF
--- a/src/kex_code_mcbits/kex_code_mcbits.c
+++ b/src/kex_code_mcbits/kex_code_mcbits.c
@@ -49,6 +49,9 @@ int OQS_KEX_code_mcbits_alice_0(UNUSED OQS_KEX *k, void **alice_priv, uint8_t **
 
 	int ret;
 
+	*alice_priv = NULL;
+	*alice_msg = NULL;
+
 	/* allocate public/private key pair */
 	*alice_msg = malloc(CRYPTO_PUBLICKEYBYTES);
 	*alice_msg_len = CRYPTO_PUBLICKEYBYTES;
@@ -83,6 +86,9 @@ int OQS_KEX_code_mcbits_bob(UNUSED OQS_KEX *k, const uint8_t *alice_msg, UNUSED 
 
 	int ret;
 
+	*bob_msg = NULL;
+	*key = NULL;
+
 	/* allocate message and session key */
 	*bob_msg = malloc(CRYPTO_BYTES + 32);
 	if (*bob_msg == NULL) {
@@ -112,6 +118,8 @@ cleanup:
 int OQS_KEX_code_mcbits_alice_1(UNUSED OQS_KEX *k, const void *alice_priv, const uint8_t *bob_msg, UNUSED const size_t bob_msg_len, uint8_t **key, size_t *key_len) {
 
 	int ret;
+
+	*key = NULL;
 
 	/* allocate session key */
 	*key = malloc(32);

--- a/src/kex_lwe_frodo/kex_lwe_frodo_macrify.c
+++ b/src/kex_lwe_frodo/kex_lwe_frodo_macrify.c
@@ -13,7 +13,7 @@ OQS_KEX *MACRIFY(OQS_KEX_lwe_frodo_new)(OQS_RAND *rand, const uint8_t *seed, con
 
 	k = malloc(sizeof(OQS_KEX));
 	if (k == NULL) {
-		goto err;
+		return NULL;
 	}
 	k->named_parameters = NULL;
 	k->method_name = NULL;

--- a/src/kex_lwe_frodo/kex_lwe_frodo_macrify.c
+++ b/src/kex_lwe_frodo/kex_lwe_frodo_macrify.c
@@ -13,7 +13,7 @@ OQS_KEX *MACRIFY(OQS_KEX_lwe_frodo_new)(OQS_RAND *rand, const uint8_t *seed, con
 
 	k = malloc(sizeof(OQS_KEX));
 	if (k == NULL) {
-		return NULL;
+		goto err;
 	}
 	k->named_parameters = NULL;
 	k->method_name = NULL;

--- a/src/kex_mlwe_kyber/kex_mlwe_kyber.c
+++ b/src/kex_mlwe_kyber/kex_mlwe_kyber.c
@@ -48,6 +48,9 @@ int OQS_KEX_mlwe_kyber_alice_0(UNUSED OQS_KEX *k, void **alice_priv, uint8_t **a
 
 	int ret;
 
+	*alice_priv = NULL;
+	*alice_msg = NULL;
+
 	/* allocate public/private key pair */
 	*alice_msg = malloc(KYBER_PUBLICKEYBYTES);
 	if (*alice_msg == NULL) {
@@ -80,6 +83,9 @@ cleanup:
 int OQS_KEX_mlwe_kyber_bob(UNUSED OQS_KEX *k, const uint8_t *alice_msg, const size_t alice_msg_len, uint8_t **bob_msg, size_t *bob_msg_len, uint8_t **key, size_t *key_len) {
 
 	int ret;
+
+	*bob_msg = NULL;
+	*key = NULL;
 
 	if (alice_msg_len != KYBER_PUBLICKEYBYTES) {
 		goto err;
@@ -118,6 +124,8 @@ cleanup:
 int OQS_KEX_mlwe_kyber_alice_1(UNUSED OQS_KEX *k, const void *alice_priv, const uint8_t *bob_msg, const size_t bob_msg_len, uint8_t **key, size_t *key_len) {
 
 	int ret;
+
+	*key = NULL;
 
 	if (bob_msg_len != KYBER_BYTES) {
 		goto err;

--- a/src/kex_ntru/kex_ntru.c
+++ b/src/kex_ntru/kex_ntru.c
@@ -90,6 +90,7 @@ int OQS_KEX_ntru_alice_0(UNUSED OQS_KEX *k, void **alice_priv, uint8_t **alice_m
 	ntru_alice_priv = malloc(sizeof(OQS_KEX_ntru_alice_priv));
 	if (ntru_alice_priv == NULL)
 		goto err;
+	ntru_alice_priv->priv_key = NULL;
 	*alice_priv = ntru_alice_priv;
 
 	/* calculate length of public/private keys */
@@ -119,7 +120,7 @@ int OQS_KEX_ntru_alice_0(UNUSED OQS_KEX *k, void **alice_priv, uint8_t **alice_m
 
 err:
 	ret = 0;
-	if (ntru_alice_priv != NULL && ntru_alice_priv->priv_key != NULL)
+	if (ntru_alice_priv != NULL)
 		free(ntru_alice_priv->priv_key);
 	free(ntru_alice_priv);
 	*alice_priv = NULL;

--- a/src/kex_ntru/kex_ntru.c
+++ b/src/kex_ntru/kex_ntru.c
@@ -120,7 +120,7 @@ int OQS_KEX_ntru_alice_0(UNUSED OQS_KEX *k, void **alice_priv, uint8_t **alice_m
 err:
 	ret = 0;
 	if (ntru_alice_priv != NULL && ntru_alice_priv->priv_key != NULL)
-		 free(ntru_alice_priv->priv_key);
+		free(ntru_alice_priv->priv_key);
 	free(ntru_alice_priv);
 	*alice_priv = NULL;
 	free(*alice_msg);

--- a/src/kex_ntru/kex_ntru.c
+++ b/src/kex_ntru/kex_ntru.c
@@ -78,10 +78,13 @@ int OQS_KEX_ntru_alice_0(UNUSED OQS_KEX *k, void **alice_priv, uint8_t **alice_m
 	DRBG_HANDLE drbg;
 	OQS_KEX_ntru_alice_priv *ntru_alice_priv = NULL;
 
+	*alice_priv = NULL;
+	*alice_msg = NULL;
+
 	/* initialize NTRU DRBG */
 	rc = ntru_crypto_drbg_instantiate(256, (uint8_t *) "OQS Alice", strlen("OQS Alice"), (ENTROPY_FN) &get_entropy_from_dev_urandom, &drbg);
 	if (rc != DRBG_OK)
-		goto err;
+		return 0;
 
 	/* allocate private key */
 	ntru_alice_priv = malloc(sizeof(OQS_KEX_ntru_alice_priv));
@@ -116,10 +119,12 @@ int OQS_KEX_ntru_alice_0(UNUSED OQS_KEX *k, void **alice_priv, uint8_t **alice_m
 
 err:
 	ret = 0;
-	if (ntru_alice_priv != NULL)
-		free(ntru_alice_priv->priv_key);
+	if (ntru_alice_priv != NULL && ntru_alice_priv->priv_key != NULL)
+		 free(ntru_alice_priv->priv_key);
 	free(ntru_alice_priv);
+	*alice_priv = NULL;
 	free(*alice_msg);
+	*alice_msg = NULL;
 cleanup:
 	ntru_crypto_drbg_uninstantiate(drbg);
 
@@ -138,7 +143,7 @@ int OQS_KEX_ntru_bob(OQS_KEX *k, const uint8_t *alice_msg, const size_t alice_ms
 	/* initialize NTRU DRBG */
 	rc = ntru_crypto_drbg_instantiate(256, (uint8_t *) "OQS Bob", strlen("OQS Bob"), (ENTROPY_FN) &get_entropy_from_dev_urandom, &drbg);
 	if (rc != DRBG_OK)
-		goto err;
+		return 0;
 
 	/* generate random session key */
 	*key_len = 256 / 8;
@@ -170,8 +175,10 @@ int OQS_KEX_ntru_bob(OQS_KEX *k, const uint8_t *alice_msg, const size_t alice_ms
 
 err:
 	ret = 0;
-	free(key);
-	free(bob_msg);
+	free(*bob_msg);
+	*bob_msg = NULL;
+	free(*key);
+	*key = NULL;
 cleanup:
 	ntru_crypto_drbg_uninstantiate(drbg);
 
@@ -210,7 +217,8 @@ int OQS_KEX_ntru_alice_1(UNUSED OQS_KEX *k, const void *alice_priv, const uint8_
 
 err:
 	ret = 0;
-	free(key);
+	free(*key);
+	*key = NULL;
 cleanup:
 
 	return ret;

--- a/src/kex_rlwe_bcns15/kex_rlwe_bcns15.c
+++ b/src/kex_rlwe_bcns15/kex_rlwe_bcns15.c
@@ -85,6 +85,7 @@ err:
 	ret = 0;
 	free(alice_msg_32);
 	OQS_MEM_secure_free(*alice_priv, 1024 * sizeof(uint32_t));
+	*alice_priv = NULL;
 
 cleanup:
 	return ret;
@@ -134,6 +135,7 @@ int OQS_KEX_rlwe_bcns15_bob(OQS_KEX *k, const uint8_t *alice_msg, const size_t a
 err:
 	ret = 0;
 	free(*bob_msg);
+	*bob_msg = NULL;
 	OQS_MEM_secure_free(key_64, 16 * sizeof(uint64_t));
 
 cleanup:

--- a/src/kex_rlwe_msrln16/kex_rlwe_msrln16.c
+++ b/src/kex_rlwe_msrln16/kex_rlwe_msrln16.c
@@ -75,7 +75,9 @@ int OQS_KEX_rlwe_msrln16_alice_0(OQS_KEX *k, void **alice_priv, uint8_t **alice_
 err:
 	ret = 0;
 	free(*alice_msg);
+	*alice_msg = NULL;
 	free(*alice_priv);
+	*alice_priv = NULL;
 
 cleanup:
 	return ret;
@@ -113,7 +115,9 @@ int OQS_KEX_rlwe_msrln16_bob(OQS_KEX *k, const uint8_t *alice_msg, const size_t 
 err:
 	ret = 0;
 	free(*bob_msg);
+	*bob_msg = NULL;
 	free(*key);
+	*key = NULL;
 
 cleanup:
 
@@ -147,6 +151,7 @@ int OQS_KEX_rlwe_msrln16_alice_1(UNUSED OQS_KEX *k, const void *alice_priv, cons
 err:
 	ret = 0;
 	free(*key);
+	*key = NULL;
 
 cleanup:
 

--- a/src/kex_rlwe_newhope/kex_rlwe_newhope.c
+++ b/src/kex_rlwe_newhope/kex_rlwe_newhope.c
@@ -48,6 +48,9 @@ int OQS_KEX_rlwe_newhope_alice_0(UNUSED OQS_KEX *k, void **alice_priv, uint8_t *
 
 	int ret;
 
+	*alice_priv = NULL;
+	*alice_msg = NULL;
+
 	/* allocate public/private key pair */
 	*alice_msg = malloc(NEWHOPE_SENDABYTES);
 	if (*alice_msg == NULL) {
@@ -80,6 +83,9 @@ cleanup:
 int OQS_KEX_rlwe_newhope_bob(UNUSED OQS_KEX *k, const uint8_t *alice_msg, const size_t alice_msg_len, uint8_t **bob_msg, size_t *bob_msg_len, uint8_t **key, size_t *key_len) {
 
 	int ret;
+
+	*bob_msg = NULL;
+	*key = NULL;
 
 	if (alice_msg_len != NEWHOPE_SENDABYTES) {
 		goto err;
@@ -118,6 +124,8 @@ cleanup:
 int OQS_KEX_rlwe_newhope_alice_1(UNUSED OQS_KEX *k, const void *alice_priv, const uint8_t *bob_msg, const size_t bob_msg_len, uint8_t **key, size_t *key_len) {
 
 	int ret;
+
+	*key = NULL;
 
 	if (bob_msg_len != NEWHOPE_SENDBBYTES) {
 		goto err;

--- a/src/kex_sidh_cln16/kex_sidh_cln16.c
+++ b/src/kex_sidh_cln16/kex_sidh_cln16.c
@@ -82,8 +82,9 @@ int OQS_KEX_sidh_cln16_alice_0(OQS_KEX *k, void **alice_priv, uint8_t **alice_ms
 	uint8_t *alice_tmp_pub = NULL;
 
 	if (!k || !alice_priv || !alice_msg || !alice_msg_len) {
-		return NULL;
+		return 0;
 	}
+
 	int compressed = isCompressed(k->named_parameters);
 	*alice_priv = NULL;
 	/* alice_msg is alice's public key */
@@ -126,17 +127,14 @@ int OQS_KEX_sidh_cln16_alice_0(OQS_KEX *k, void **alice_priv, uint8_t **alice_ms
 
 err:
 	ret = 0;
-	if (alice_msg && *alice_msg) {
-		free(*alice_msg);
-	}
-	if (alice_priv && *alice_priv) {
-		free(*alice_priv);
-	}
+	free(*alice_msg);
+	*alice_msg = NULL;
+	free(*alice_priv);
+	*alice_priv = NULL;
 
 cleanup:
-	if (alice_tmp_pub) {
-		free(alice_tmp_pub);
-	}
+	free(alice_tmp_pub);
+
 	return ret;
 }
 
@@ -144,16 +142,18 @@ int OQS_KEX_sidh_cln16_bob(OQS_KEX *k, const uint8_t *alice_msg, const size_t al
 
 	int ret;
 	uint8_t *bob_priv = NULL;
-	*bob_msg = NULL;
-	*key = NULL;
 	// non-compressed public key
 	uint8_t *bob_tmp_pub = NULL;
 	// decompression values
 	unsigned char *R = NULL, *A = NULL;
 
 	if (!k || !alice_msg || !bob_msg || !bob_msg_len || !key || !key_len) {
-		return NULL;
+		return 0;
 	}
+
+	*bob_msg = NULL;
+	*key = NULL;
+
 	int compressed = isCompressed(k->named_parameters);
 
 	if (compressed) {
@@ -225,26 +225,17 @@ int OQS_KEX_sidh_cln16_bob(OQS_KEX *k, const uint8_t *alice_msg, const size_t al
 
 err:
 	ret = 0;
-	if (bob_msg && *bob_msg) {
-		free(*bob_msg);
-	}
-	if (key && *key) {
-		free(*key);
-	}
+	free(*bob_msg);
+	*bob_msg = NULL;
+	free(*key);
+	*key = NULL;
 
 cleanup:
-	if (bob_tmp_pub) {
-		free(bob_tmp_pub);
-	}
-	if (bob_priv) {
-		free(bob_priv);
-	}
-	if (A) {
-		free(A);
-	}
-	if (R) {
-		free(R);
-	}
+	free(bob_tmp_pub);
+	free(bob_priv);
+	free(A);
+	free(R);
+
 	return ret;
 }
 
@@ -255,8 +246,11 @@ int OQS_KEX_sidh_cln16_alice_1(OQS_KEX *k, const void *alice_priv, const uint8_t
 	unsigned char *R = NULL, *A = NULL;
 
 	if (!k || !alice_priv || !bob_msg || !key || !key_len) {
-		return NULL;
+		return 0;
 	}
+
+	*key = NULL;
+
 	int compressed = isCompressed(k->named_parameters);
 
 	*key = malloc(SIDH_SHAREDKEY_LEN);
@@ -296,17 +290,12 @@ int OQS_KEX_sidh_cln16_alice_1(OQS_KEX *k, const void *alice_priv, const uint8_t
 
 err:
 	ret = 0;
-	if (key) {
-		free(*key);
-	}
+	free(*key);
+	*key = NULL;
 
 cleanup:
-	if (A) {
-		free(A);
-	}
-	if (R) {
-		free(R);
-	}
+	free(A);
+	free(R);
 
 	return ret;
 }


### PR DESCRIPTION
This changeset mainly adds code to consistently initialize out-parameters to NULL. This is important so we don't call free() on any invalid pointers in the failure path.

I also added code that clears out-parameters on failure, where such code was not already in place. It's generally considered good manners to not leak invalid pointers, even when returning an error code.

SIDH IQC REF has not been reviewed for this changeset since it doesn't consider failures at all, and would need a larger restructuring to get up to par.