### PR TITLE
Add checks to verify length of input data for McBits

### DIFF
--- a/src/kex_code_mcbits/kex_code_mcbits.c
+++ b/src/kex_code_mcbits/kex_code_mcbits.c
@@ -82,12 +82,16 @@ cleanup:
 	return ret;
 }
 
-int OQS_KEX_code_mcbits_bob(UNUSED OQS_KEX *k, const uint8_t *alice_msg, UNUSED const size_t alice_msg_len, uint8_t **bob_msg, size_t *bob_msg_len, uint8_t **key, size_t *key_len) {
+int OQS_KEX_code_mcbits_bob(UNUSED OQS_KEX *k, const uint8_t *alice_msg, const size_t alice_msg_len, uint8_t **bob_msg, size_t *bob_msg_len, uint8_t **key, size_t *key_len) {
 
 	int ret;
 
 	*bob_msg = NULL;
 	*key = NULL;
+
+	if (alice_msg_len != CRYPTO_PUBLICKEYBYTES) {
+		goto err;
+	}
 
 	/* allocate message and session key */
 	*bob_msg = malloc(CRYPTO_BYTES + 32);
@@ -115,11 +119,15 @@ cleanup:
 	return ret;
 }
 
-int OQS_KEX_code_mcbits_alice_1(UNUSED OQS_KEX *k, const void *alice_priv, const uint8_t *bob_msg, UNUSED const size_t bob_msg_len, uint8_t **key, size_t *key_len) {
+int OQS_KEX_code_mcbits_alice_1(UNUSED OQS_KEX *k, const void *alice_priv, const uint8_t *bob_msg, const size_t bob_msg_len, uint8_t **key, size_t *key_len) {
 
 	int ret;
 
 	*key = NULL;
+
+	if (bob_msg_len != (CRYPTO_BYTES + 32)) {
+		goto err;
+	}
 
 	/* allocate session key */
 	*key = malloc(32);


### PR DESCRIPTION
This change adds the bare minimum checks to ensure input data is valid. In the specific case of McBits providing too little data will result in a memcpy operation reading beyond the buffer. A similar read will typically return garbage data but could also induce a crash if it crosses into a guard page or uncommitted page.