### PR TITLE
Covscan defect fix

### DIFF
--- a/.travis-tests.sh
+++ b/.travis-tests.sh
@@ -55,12 +55,9 @@ if [[ ${ENABLE_KEX_SIDH_CLN16} == 0 ]];then
   enable_disable_str+=" --disable-kex-sidh-cln16"
 fi
 
-if [[ ${USE_PICNIC} == 1 ]];then
-  enable_disable_str+=" --enable-picnic"
-  ./download-and-setup-picnic.sh
-  if [[ ! -z "${M4RI_DIR// }" ]];then
-     enable_disable_str+=" --with-m4ri-dir=${M4RI_DIR}"
-  fi
+./download-and-setup-picnic.sh
+if [[ ! -z "${M4RI_DIR// }" ]];then
+  enable_disable_str+=" --with-m4ri-dir=${M4RI_DIR}"
 fi
 
 ./configure --enable-silent-rules ${enable_disable_str}
@@ -69,11 +66,5 @@ make
 make test
 
 for f in $(ls .travis/*-check.sh); do
-  if [[ ${USE_PICNIC} == 1 ]];then
-  if [[ ! "$f" == ".travis/global-namespace-check.sh" ]];then
     bash $f;
-  fi
-else
-  bash $f;
-fi
 done

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,16 +50,12 @@ if USE_SIDH_IQC
 liboqs_la_LIBADD += src/kex_sidh_iqc_ref/libsidhiqc.la
 endif
 
-if USE_PICNIC
-liboqs_la_LIBADD += src/sig_picnic/libpicnic.la
-endif
+#liboqs_la_LIBADD += src/sig_picnic/libpicnic.la
 
 noinst_bin_PROGRAMS = test_rand test_kex test_aes
 
-if USE_PICNIC
 if USE_OPENSSL
-noinst_bin_PROGRAMS += pp_matrices test_sig
-endif
+#noinst_bin_PROGRAMS += pp_matrices test_sig
 endif
 
 noinst_bindir=$(prefix)/tests
@@ -77,20 +73,18 @@ if USE_SIDH_IQC
 test_kex_LDADD += -L$(GMP_DIR)/lib -lgmp
 endif
 
-if USE_PICNIC
 if USE_OPENSSL
-test_sig_LDADD =  liboqs.la -lm
-test_sig_SOURCES = src/sig/test_sig.c
-test_sig_CPPFLAGS = -I${OPENSSL_DIR}/include -I./include
-test_sig_CPPFLAGS += $(AM_CPPFLAGS)
-test_sig_LDADD += -L${OPENSSL_DIR}/lib -lssl -lcrypto
+#test_sig_LDADD =  liboqs.la -lm
+#test_sig_SOURCES = src/sig/test_sig.c
+#test_sig_CPPFLAGS = -I${OPENSSL_DIR}/include -I./include
+#test_sig_CPPFLAGS += $(AM_CPPFLAGS)
+#test_sig_LDADD += -L${OPENSSL_DIR}/lib -lssl -lcrypto
 
-pp_matrices_LDADD =  liboqs.la -lm
-pp_matrices_SOURCES = src/sig_picnic/external/Picnic-master/preprocessMatrices.c
-pp_matrices_CPPFLAGS = -std=c99 -I${OPENSSL_DIR}/include -I${M4RI_DIR}/include/m4ri -I./include
+#pp_matrices_LDADD =  liboqs.la -lm
+#pp_matrices_SOURCES = src/sig_picnic/external/Picnic-master/preprocessMatrices.c
+#pp_matrices_CPPFLAGS = -std=c99 -I${OPENSSL_DIR}/include -I${M4RI_DIR}/include/m4ri -I./include
 #pp_matrices_CPPFLAGS += $(AM_CPPFLAGS)
-pp_matrices_LDADD += -L${OPENSSL_DIR}/lib -L${M4RI_DIR}/lib -lssl -lcrypto -lm4ri
-endif
+#pp_matrices_LDADD += -L${OPENSSL_DIR}/lib -L${M4RI_DIR}/lib -lssl -lcrypto -lm4ri
 endif
 
 test_aes_LDADD =  liboqs.la -lm
@@ -120,12 +114,10 @@ test: clean-tests
 	./test_kex --quiet
 	./test_rand --quiet
 	./test_aes
-if USE_PICNIC
 if USE_OPENSSL
-	mkdir -p precomputed_data
-	./pp_matrices
-	./test_sig
-endif
+#	mkdir -p precomputed_data
+#	./pp_matrices
+#	./test_sig
 endif
 
 
@@ -147,10 +139,8 @@ links:
 	cp -f src/kex_sidh_cln16/kex_sidh_cln16.h include/oqs
 	cp -f src/kex_mlwe_kyber/kex_mlwe_kyber.h include/oqs
 	cp -f src/sig/sig.h include/oqs
-if USE_PICNIC
 if USE_OPENSSL
 	cp -f src/sig_picnic/external/Picnic-master/picnic.h include/oqs
-endif
 endif
 	$(LN_S) -f .libs/liboqs.a
 if USE_MCBITS
@@ -160,9 +150,7 @@ if USE_SIDH_IQC
 	cp -f src/kex_sidh_iqc_ref/kex_sidh_iqc_ref.h include/oqs
 	$(LN_S) -f src/kex_sidh_iqc_ref/sample_params
 endif
-if USE_PICNIC
 	$(LN_S) -f ../../src/sig_picnic/sig_picnic.h include/oqs
-endif
 
 clean-local:
 	rm -f liboqs.a
@@ -172,12 +160,10 @@ if USE_SIDH_IQC
 endif
 clean-tests:
 	rm -f test_kex test_rand test_aes
-if USE_PICNIC
 if USE_OPENSSL
-	rm -f test_sig
-	rm -f pp_matrices
-	rm -rf precomputed_data
-endif
+#	rm -f test_sig
+#	rm -f pp_matrices
+#	rm -rf precomputed_data
 endif
 
 prettyprint:

--- a/configure.ac
+++ b/configure.ac
@@ -99,10 +99,6 @@ ARG_ENABL_SET([kex-code-mcbits], [enable KEX-CODE-MCBITS.])
 AM_CONDITIONAL([kex_code_mcbits], [test "x$kex_code_mcbits" = xtrue])
 AM_CONDITIONAL([USE_MCBITS], [test "x$kex_code_mcbits" = xtrue])
 
-ARG_ENABL_SET([picnic], [enable PICNIC.])
-AM_CONDITIONAL([picnic], [test "x$picnic" = xtrue])
-AM_CONDITIONAL([USE_PICNIC], [test "x$picnic" = xtrue])
-
 ARG_ENABL_SET([kex-sidh-iqc-ref], [enable KEX-SIDH-IQC-REF.])
 AM_CONDITIONAL([kex_sidh_iqc_ref], [test "x$kex_sidh_iqc_ref" = xtrue])
 AM_CONDITIONAL([USE_SIDH_IQC], [test "x$kex_sidh_iqc_ref" = xtrue])
@@ -239,11 +235,6 @@ if test x"$kex_sidh_iqc_ref" = x"true"; then
   SRCDIR=${SRCDIR}" src/kex_sidh_iqc_ref"
 fi
 
-if test x"$picnic" = x"true"; then
-  AM_CPPFLAGS=${AM_CPPFLAGS}" -DENABLE_PICNIC"
-  SRCDIR=${SRCDIR}" src/sig_picnic"
-fi
-
 AC_SUBST(AM_CPPFLAGS)
 AC_SUBST(AM_CFLAGS)
 AC_SUBST(SRCDIR)
@@ -257,7 +248,6 @@ AC_SUBST(USE_KEX_MLWE_KYBER)
 AC_SUBST(USE_KEX_RLWE_MSRLN16)
 AC_SUBST(USE_KEX_RLWE_NEWHOPE)
 AC_SUBST(USE_KEX_SIDH_CLN16)
-AC_SUBST(USE_PICNIC)
 AC_SUBST(ON_DARWIN)
 AC_SUBST(X86_64)
 

--- a/src/kex_lwe_frodo/lwe_noise.c
+++ b/src/kex_lwe_frodo/lwe_noise.c
@@ -36,7 +36,7 @@ static void lwe_sample_n_inverse_8(uint16_t *s, const size_t n, const uint8_t *c
 		uint8_t sign = rndvec[i] & 0x1; // pick the least significant bit
 
 		// No need to compare with the last value.
-		for (size_t j = 0; j < cdf_table_len - 1; j++) {
+		for (int64_t j = 0; j < (int64_t)(cdf_table_len - 1); j++) {
 			// Constant time comparison: 1 if cdf_table[j] < rnd, 0 otherwise.
 			// Critically uses the fact that cdf_table[j] and rnd fit in 7 bits.
 			sample += (uint8_t)(cdf_table[j] - rnd) >> 7;

--- a/src/kex_ntru/ntru_crypto_ntru_encrypt.c
+++ b/src/kex_ntru/ntru_crypto_ntru_encrypt.c
@@ -887,7 +887,7 @@ ntru_crypto_ntru_encrypt_keygen(
 		total_polys += 2; /* ringel_buf{1,2} */
 	}
 
-	scratch_buf_len = total_polys * pad_deg * sizeof(uint16_t);
+	scratch_buf_len = ((size_t)(total_polys * pad_deg)) * sizeof(uint16_t);
 	scratch_buf_len += 2 * dF * sizeof(uint16_t);
 	scratch_buf = MALLOC(scratch_buf_len);
 	if (!scratch_buf) {

--- a/src/kex_sidh_cln16/SIDH_setup.c
+++ b/src/kex_sidh_cln16/SIDH_setup.c
@@ -67,9 +67,6 @@ PCurveIsogenyStruct oqs_sidh_cln16_curve_allocate(PCurveIsogenyStaticData CurveD
 	pCurveIsogeny->Montgomery_pp = (digit_t *) calloc(1, pbytes);
 	pCurveIsogeny->Montgomery_one = (digit_t *) calloc(1, pbytes);
 
-	if (oqs_sidh_cln16_is_CurveIsogenyStruct_null(pCurveIsogeny)) {
-		return NULL;
-	}
 	return pCurveIsogeny;
 }
 

--- a/src/kex_sidh_cln16/ec_isogeny.c
+++ b/src/kex_sidh_cln16/ec_isogeny.c
@@ -695,7 +695,7 @@ static void get_X_on_curve(oqs_sidh_cln16_f2elm_t A, unsigned int *r, oqs_sidh_c
 
 	oqs_sidh_cln16_fpcopy751(((oqs_sidh_cln16_felm_t *) &LIST)[(*r << 1) - 2], r1); // r1 = list[2*r-1]
 	oqs_sidh_cln16_fpcopy751(((oqs_sidh_cln16_felm_t *) &LIST)[(*r << 1) - 1], r0); // r0 = list[2*r]
-	rsq[0] = (*r) * (*r);                                                           // rsp = r^2
+	rsq[0] = (digit_t)(*r) * (*r);                                                  // rsp = r^2
 	oqs_sidh_cln16_to_mont(rsq, rsq);                                               // Converting to Montgomery representation
 	oqs_sidh_cln16_fpmul751_mont(A[1], r1, t0);                                     // t0 = A1*r1
 	oqs_sidh_cln16_fpmul751_mont(A[0], r0, v0);                                     // v0 = A0*r0

--- a/src/kex_sidh_cln16/kex_sidh_cln16.c
+++ b/src/kex_sidh_cln16/kex_sidh_cln16.c
@@ -45,7 +45,8 @@ OQS_KEX *OQS_KEX_sidh_cln16_new(OQS_RAND *rand, const char *named_parameters) {
 
 	// Curve isogeny system initialization
 	PCurveIsogenyStruct curveIsogeny = oqs_sidh_cln16_curve_allocate(&CurveIsogeny_SIDHp751);
-	if (curveIsogeny == NULL) {
+
+	if (curveIsogeny == NULL || oqs_sidh_cln16_is_CurveIsogenyStruct_null(curveIsogeny)) {
 		free(k);
 		return NULL;
 	}

--- a/src/kex_sidh_cln16/kex_sidh_cln16.c
+++ b/src/kex_sidh_cln16/kex_sidh_cln16.c
@@ -36,6 +36,9 @@ static int isCompressed(const char *named_parameters) {
 	return 0;
 }
 
+// Check if curve isogeny structure is NULL
+extern bool oqs_sidh_cln16_is_CurveIsogenyStruct_null(PCurveIsogenyStruct pCurveIsogeny);
+
 OQS_KEX *OQS_KEX_sidh_cln16_new(OQS_RAND *rand, const char *named_parameters) {
 	int compressed = isCompressed(named_parameters);
 	OQS_KEX *k = malloc(sizeof(OQS_KEX));

--- a/src/kex_sidh_cln16/kex_sidh_cln16.c
+++ b/src/kex_sidh_cln16/kex_sidh_cln16.c
@@ -48,7 +48,7 @@ OQS_KEX *OQS_KEX_sidh_cln16_new(OQS_RAND *rand, const char *named_parameters) {
 
 	if (curveIsogeny == NULL || oqs_sidh_cln16_is_CurveIsogenyStruct_null(curveIsogeny)) {
 		free(k);
-    oqs_sidh_cln16_curve_free(curveIsogeny);
+		oqs_sidh_cln16_curve_free(curveIsogeny);
 		return NULL;
 	}
 	if (oqs_sidh_cln16_curve_initialize(curveIsogeny, &CurveIsogeny_SIDHp751) != SIDH_CRYPTO_SUCCESS) {

--- a/src/kex_sidh_cln16/kex_sidh_cln16.c
+++ b/src/kex_sidh_cln16/kex_sidh_cln16.c
@@ -48,6 +48,7 @@ OQS_KEX *OQS_KEX_sidh_cln16_new(OQS_RAND *rand, const char *named_parameters) {
 
 	if (curveIsogeny == NULL || oqs_sidh_cln16_is_CurveIsogenyStruct_null(curveIsogeny)) {
 		free(k);
+    oqs_sidh_cln16_curve_free(curveIsogeny);
 		return NULL;
 	}
 	if (oqs_sidh_cln16_curve_initialize(curveIsogeny, &CurveIsogeny_SIDHp751) != SIDH_CRYPTO_SUCCESS) {


### PR DESCRIPTION
FALSE POSITIVE
-------------

CID 1411664 (#1-8 of 8): Untrusted pointer read (TAINTED_SCALAR)
src/kex_rlwe_bcns15/fft.c


Comments:
 False positive if SHA_INIT flag set.  It's always set.

CID 1458082:    (UNINIT)
/src/kex_ntru/ntru_crypto_sha256.c: 105 in ntru_crypto_sha256_digest()
/src/kex_ntru/ntru_crypto_sha256.c: 105 in ntru_crypto_sha256_digest()


Comments:
False positive if SHA_INIT flag set. It's always set.

CID 1458079:    (UNINIT)
/src/kex_ntru/ntru_crypto_sha1.c: 676 in ntru_crypto_sha1_digest()
/src/kex_ntru/ntru_crypto_sha1.c: 676 in ntru_crypto_sha1_digest()


CID 1411663 (#1 of 1): Resource leak (RESOURCE_LEAK)
/src/crypto/rand/rand.c

CID 1458078 (#1 of 1): Out-of-bounds access (ARRAY_VS_SINGLETON)
src/kex_sidh_cln16/ec_isogeny.c in oqs_sidh_cln16_phn15()

CID 1458075 (#1 of 1): Out-of-bounds access (ARRAY_VS_SINGLETON)
src/kex_sidh_cln16/ec_isogeny.c


CID 1458083 (#1 of 1): Double free (USE_AFTER_FREE)
src/kex_sidh_cln16/kex_sidh_cln16.c in OQS_KEX_sidh_cln16_alice_0()

CID 1458085 (#1 of 1): Double free (USE_AFTER_FREE)
src/kex_sidh_cln16/kex_sidh_cln16.c in OQS_KEX_sidh_cln16_bob()


Comments:
Can be a problem if the while loop just above is not entered.

CID 1458084 (#1 of 1): Division or modulo by zero (DIVIDE_BY_ZERO)
src/kex_sidh_cln16/fpx.c in oqs_sidh_cln16_inv_mod_orderA()


CID 1411660 (#7-9 of 9): Division or modulo by float zero (DIVIDE_BY_ZERO)
src/kec/test_kex.c in kex_bench_wrapper

CID 1458081 (#1 of 1): Bad bit shift operation (BAD_SHIFT)
src/kex_sidh_cln16/ec_isogeny.c in oqs_sidh_cln16_phn84()
	

CID 1411659 (#1 of 1): Bad bit shift operation (BAD_SHIFT)
src/kex_rlwe_bcns15/fft.c in nussbaumer_fft() 


FIXED
-----

CID 1458086:  Integer handling issues  (SIGN_EXTENSION)
src/kex_ntru/ntru_crypto_ntru_encrypt.c: 890 in ntru_crypto_ntru_encrypt_keygen()

CID 1458073:  Integer handling issues  (SIGN_EXTENSION)
src/kex_ntru/ntru_crypto_ntru_encrypt.c: 890 in ntru_crypto_ntru_encrypt_keygen()


If cdf_table_len is 0 then there will be a problem:

CID 1411665 (#1 of 1): Uninitialized scalar variable (UNINIT)
src/kex_lwe_frodo/lwe_noise.c


CID 1458074 (#1 of 1): Resource leak (RESOURCE_LEAK)
src/kex_sidh_cln16/kex_sidh_cln16.c

Unclear about the semantics
---------------------------

CID 1458076 (#1 of 1): Out-of-bounds read (OVERRUN)
src/kex_ntru/ntru_crypto_sha2.c

CID 1458072 (#1 of 1): Out-of-bounds read (OVERRUN)
src/kex_ntru/ntru_crypto_sha1.c

CID 1411662 (#1 of 1): Out-of-bounds read (OVERRUN)
src/crypto/rand_urandom_chacha20/rand_urandom_chacha20.c

CID 1411661 (#1 of 1): Out-of-bounds read (OVERRUN)
src/crypto/rand_urandom_aesctr/rand_urandom_aesctr.c

