### PR TITLE
vsoftco refactor #ifdef WINDOWS

### DIFF
--- a/VisualStudio/oqs/oqs.vcxproj
+++ b/VisualStudio/oqs/oqs.vcxproj
@@ -226,7 +226,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>inline=__inline;ENABLE_SIG_PICNIC;PICNIC_STATIC;PICNIC_STATIC_DEFINE;PICNIC_EXPORTPICNIC_EXPORT=DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;AES_DISABLE_NI;OQS_RAND_DEFAULT_URANDOM_CHACHA20;OQS_KEX_DEFAULT_BCNS15;CONSTANT_TIME;WINDOWS;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>inline=__inline;ENABLE_SIG_PICNIC;PICNIC_STATIC;PICNIC_STATIC_DEFINE;PICNIC_EXPORTPICNIC_EXPORT=DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;AES_DISABLE_NI;OQS_RAND_DEFAULT_URANDOM_CHACHA20;OQS_KEX_DEFAULT_BCNS15;CONSTANT_TIME;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -266,7 +266,7 @@ msbuild  /t:Rebuild /p:Configuration=Release "$(SolutionDir)..\src\sig_picnic\ex
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>inline=__inline;ENABLE_SIG_PICNIC;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;AES_DISABLE_NI;OQS_RAND_DEFAULT_URANDOM_CHACHA20;OQS_KEX_DEFAULT_BCNS15;CONSTANT_TIME;WINDOWS;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>inline=__inline;ENABLE_SIG_PICNIC;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;AES_DISABLE_NI;OQS_RAND_DEFAULT_URANDOM_CHACHA20;OQS_KEX_DEFAULT_BCNS15;CONSTANT_TIME;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -307,7 +307,7 @@ msbuild  /t:Rebuild /p:Configuration=Release "$(SolutionDir)..\src\sig_picnic\ex
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>inline=__inline;ENABLE_KEX_LWE_FRODO;ENABLE_KEX_NTRU;ENABLE_KEX_RLWE_MSRLN16;ENABLE_KEX_RLWE_NEWHOPE;ENABLE_KEX_SIDH_MSR;ENABLE_SIG_PICNIC;PICNIC_STATIC;PICNIC_STATIC_DEFINE;PICNIC_EXPORTPICNIC_EXPORT=_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;OQS_RAND_DEFAULT_URANDOM_CHACHA20;OQS_KEX_DEFAULT_BCNS15;CONSTANT_TIME;WINDOWS;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>inline=__inline;ENABLE_KEX_LWE_FRODO;ENABLE_KEX_NTRU;ENABLE_KEX_RLWE_MSRLN16;ENABLE_KEX_RLWE_NEWHOPE;ENABLE_KEX_SIDH_MSR;ENABLE_SIG_PICNIC;PICNIC_STATIC;PICNIC_STATIC_DEFINE;PICNIC_EXPORTPICNIC_EXPORT=_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;OQS_RAND_DEFAULT_URANDOM_CHACHA20;OQS_KEX_DEFAULT_BCNS15;CONSTANT_TIME;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -351,7 +351,7 @@ msbuild  /t:Rebuild /p:Configuration=Release "$(SolutionDir)..\src\sig_picnic\ex
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>inline=__inline;ENABLE_KEX_LWE_FRODO;ENABLE_KEX_NTRU;ENABLE_KEX_RLWE_MSRLN16;ENABLE_KEX_RLWE_NEWHOPE;ENABLE_KEX_SIDH_MSR;ENABLE_SIG_PICNIC;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;OQS_RAND_DEFAULT_URANDOM_CHACHA20;OQS_KEX_DEFAULT_BCNS15;CONSTANT_TIME;WINDOWS;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>inline=__inline;ENABLE_KEX_LWE_FRODO;ENABLE_KEX_NTRU;ENABLE_KEX_RLWE_MSRLN16;ENABLE_KEX_RLWE_NEWHOPE;ENABLE_KEX_SIDH_MSR;ENABLE_SIG_PICNIC;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;OQS_RAND_DEFAULT_URANDOM_CHACHA20;OQS_KEX_DEFAULT_BCNS15;CONSTANT_TIME;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -399,7 +399,7 @@ msbuild  /t:Rebuild /p:Configuration=Release "$(SolutionDir)..\src\sig_picnic\ex
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>inline=__inline;ENABLE_SIG_PICNIC;PICNIC_STATIC;PICNIC_STATIC_DEFINE;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;AES_DISABLE_NI;OQS_RAND_DEFAULT_URANDOM_CHACHA20;OQS_KEX_DEFAULT_BCNS15;CONSTANT_TIME;WINDOWS;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>inline=__inline;ENABLE_SIG_PICNIC;PICNIC_STATIC;PICNIC_STATIC_DEFINE;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;AES_DISABLE_NI;OQS_RAND_DEFAULT_URANDOM_CHACHA20;OQS_KEX_DEFAULT_BCNS15;CONSTANT_TIME;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -443,7 +443,7 @@ msbuild  /t:Rebuild /p:Configuration=Release "$(SolutionDir)..\src\sig_picnic\ex
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>inline=__inline;ENABLE_SIG_PICNIC;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;AES_DISABLE_NI;OQS_RAND_DEFAULT_URANDOM_CHACHA20;OQS_KEX_DEFAULT_BCNS15;CONSTANT_TIME;WINDOWS;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>inline=__inline;ENABLE_SIG_PICNIC;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;AES_DISABLE_NI;OQS_RAND_DEFAULT_URANDOM_CHACHA20;OQS_KEX_DEFAULT_BCNS15;CONSTANT_TIME;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -488,7 +488,7 @@ msbuild  /t:Rebuild /p:Configuration=Release "$(SolutionDir)..\src\sig_picnic\ex
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>inline=__inline;ENABLE_KEX_LWE_FRODO;ENABLE_KEX_NTRU;ENABLE_KEX_RLWE_MSRLN16;ENABLE_KEX_RLWE_NEWHOPE;ENABLE_KEX_SIDH_MSR;ENABLE_SIG_PICNIC;PICNIC_STATIC;PICNIC_STATIC_DEFINE;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;OQS_RAND_DEFAULT_URANDOM_CHACHA20;OQS_KEX_DEFAULT_BCNS15;CONSTANT_TIME;WINDOWS;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>inline=__inline;ENABLE_KEX_LWE_FRODO;ENABLE_KEX_NTRU;ENABLE_KEX_RLWE_MSRLN16;ENABLE_KEX_RLWE_NEWHOPE;ENABLE_KEX_SIDH_MSR;ENABLE_SIG_PICNIC;PICNIC_STATIC;PICNIC_STATIC_DEFINE;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;OQS_RAND_DEFAULT_URANDOM_CHACHA20;OQS_KEX_DEFAULT_BCNS15;CONSTANT_TIME;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -536,7 +536,7 @@ msbuild  /t:Rebuild /p:Configuration=Release "$(SolutionDir)..\src\sig_picnic\ex
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>inline=__inline;ENABLE_KEX_LWE_FRODO;ENABLE_KEX_NTRU;ENABLE_KEX_RLWE_MSRLN16;ENABLE_KEX_RLWE_NEWHOPE;ENABLE_KEX_SIDH_MSR;ENABLE_SIG_PICNIC;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;OQS_RAND_DEFAULT_URANDOM_CHACHA20;OQS_KEX_DEFAULT_BCNS15;CONSTANT_TIME;WINDOWS;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>inline=__inline;ENABLE_KEX_LWE_FRODO;ENABLE_KEX_NTRU;ENABLE_KEX_RLWE_MSRLN16;ENABLE_KEX_RLWE_NEWHOPE;ENABLE_KEX_SIDH_MSR;ENABLE_SIG_PICNIC;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;OQS_RAND_DEFAULT_URANDOM_CHACHA20;OQS_KEX_DEFAULT_BCNS15;CONSTANT_TIME;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>

--- a/VisualStudio/test_kex/test_kex.vcxproj
+++ b/VisualStudio/test_kex/test_kex.vcxproj
@@ -161,7 +161,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WINDOWS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -180,7 +180,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WINDOWS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -199,7 +199,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WINDOWS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;ENABLE_KEX_LWE_FRODO;ENABLE_KEX_NTRU;ENABLE_KEX_RLWE_MSRLN16;ENABLE_KEX_RLWE_NEWHOPE;ENABLE_KEX_SIDH_MSR;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;ENABLE_KEX_LWE_FRODO;ENABLE_KEX_NTRU;ENABLE_KEX_RLWE_MSRLN16;ENABLE_KEX_RLWE_NEWHOPE;ENABLE_KEX_SIDH_MSR;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -219,7 +219,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WINDOWS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;ENABLE_KEX_LWE_FRODO;ENABLE_KEX_NTRU;ENABLE_KEX_RLWE_MSRLN16;ENABLE_KEX_RLWE_NEWHOPE;ENABLE_KEX_SIDH_MSR;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;ENABLE_KEX_LWE_FRODO;ENABLE_KEX_NTRU;ENABLE_KEX_RLWE_MSRLN16;ENABLE_KEX_RLWE_NEWHOPE;ENABLE_KEX_SIDH_MSR;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -241,7 +241,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WINDOWS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -264,7 +264,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WINDOWS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -287,7 +287,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WINDOWS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;ENABLE_KEX_LWE_FRODO;ENABLE_KEX_NTRU;ENABLE_KEX_RLWE_MSRLN16;ENABLE_KEX_RLWE_NEWHOPE;ENABLE_KEX_SIDH_MSR;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;ENABLE_KEX_LWE_FRODO;ENABLE_KEX_NTRU;ENABLE_KEX_RLWE_MSRLN16;ENABLE_KEX_RLWE_NEWHOPE;ENABLE_KEX_SIDH_MSR;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -311,7 +311,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WINDOWS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;ENABLE_KEX_LWE_FRODO;ENABLE_KEX_NTRU;ENABLE_KEX_RLWE_MSRLN16;ENABLE_KEX_RLWE_NEWHOPE;ENABLE_KEX_SIDH_MSR;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT;ENABLE_KEX_LWE_FRODO;ENABLE_KEX_NTRU;ENABLE_KEX_RLWE_MSRLN16;ENABLE_KEX_RLWE_NEWHOPE;ENABLE_KEX_SIDH_MSR;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>

--- a/VisualStudio/test_rand/test_rand.vcxproj
+++ b/VisualStudio/test_rand/test_rand.vcxproj
@@ -164,7 +164,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions);WINDOWS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -183,7 +183,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions);WINDOWS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -202,7 +202,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions); WINDOWS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -222,7 +222,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions); WINDOWS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -244,7 +244,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);WINDOWS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -267,7 +267,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions);WINDOWS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -290,7 +290,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions); WINDOWS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -314,7 +314,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions); WINDOWS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>

--- a/VisualStudio/test_sig/test_sig.vcxproj
+++ b/VisualStudio/test_sig/test_sig.vcxproj
@@ -164,7 +164,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>ENABLE_SIG_PICNIC;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WINDOWS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ENABLE_SIG_PICNIC;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <SDLCheck>true</SDLCheck>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -189,7 +189,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>ENABLE_SIG_PICNIC;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WINDOWS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ENABLE_SIG_PICNIC;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <SDLCheck>true</SDLCheck>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -212,7 +212,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>ENABLE_SIG_PICNIC;_CRT_SECURE_NO_WARNINGS;WINDOWS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ENABLE_SIG_PICNIC;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <SDLCheck>true</SDLCheck>
     </ClCompile>
@@ -232,7 +232,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>ENABLE_SIG_PICNIC;_CRT_SECURE_NO_WARNINGS;WINDOWS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ENABLE_SIG_PICNIC;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <SDLCheck>true</SDLCheck>
     </ClCompile>
@@ -252,7 +252,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>ENABLE_SIG_PICNIC;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WINDOWS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ENABLE_SIG_PICNIC;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <SDLCheck>true</SDLCheck>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -273,7 +273,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>ENABLE_SIG_PICNIC;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;WINDOWS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ENABLE_SIG_PICNIC;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <SDLCheck>true</SDLCheck>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -296,7 +296,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>ENABLE_SIG_PICNIC;_CRT_SECURE_NO_WARNINGS;WINDOWS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ENABLE_SIG_PICNIC;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <SDLCheck>true</SDLCheck>
     </ClCompile>
@@ -320,7 +320,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>ENABLE_SIG_PICNIC;_CRT_SECURE_NO_WARNINGS;WINDOWS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ENABLE_SIG_PICNIC;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)include</AdditionalIncludeDirectories>
       <SDLCheck>true</SDLCheck>
     </ClCompile>

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -4,12 +4,12 @@
 #include <stdio.h>
 #include <string.h>
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #include <windows.h>
 #endif
 
 void OQS_MEM_cleanse(void *ptr, size_t len) {
-#if defined(WINDOWS)
+#if defined(_WIN32)
 	SecureZeroMemory(ptr, len);
 #elif defined(HAVE_MEMSET_S)
 	if (0U < len && memset_s(ptr, (rsize_t) len, 0, (rsize_t) len) != 0) {

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -4,9 +4,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef int OQS_STATUS;
-#define OQS_SUCCESS 0
-#define OQS_ERROR -1
+typedef enum {OQS_SUCCESS=0, OQS_ERROR=-1} OQS_STATUS;
 
 /* Displays hexadecimal strings */
 void OQS_print_hex_string(const char *label, uint8_t *str, size_t len);

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 
 typedef enum { OQS_ERROR = -1,
-               OQS_SUCCESS = 0 } OQS_STATUS;
+	           OQS_SUCCESS = 0 } OQS_STATUS;
 
 /* Displays hexadecimal strings */
 void OQS_print_hex_string(const char *label, uint8_t *str, size_t len);

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -4,7 +4,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef enum {OQS_ERROR=-1,OQS_SUCCESS=0} OQS_STATUS;
+typedef enum { OQS_ERROR = -1,
+	           OQS_SUCCESS = 0 } OQS_STATUS;
 
 /* Displays hexadecimal strings */
 void OQS_print_hex_string(const char *label, uint8_t *str, size_t len);

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 
 typedef enum { OQS_ERROR = -1,
-	           OQS_SUCCESS = 0 } OQS_STATUS;
+               OQS_SUCCESS = 0 } OQS_STATUS;
 
 /* Displays hexadecimal strings */
 void OQS_print_hex_string(const char *label, uint8_t *str, size_t len);

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef enum {OQS_SUCCESS=0, OQS_ERROR=-1} OQS_STATUS;
+typedef enum {OQS_ERROR=-1,OQS_SUCCESS=0} OQS_STATUS;
 
 /* Displays hexadecimal strings */
 void OQS_print_hex_string(const char *label, uint8_t *str, size_t len);

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -24,7 +24,7 @@ void OQS_MEM_secure_free(void *ptr, size_t len);
 #define eprintf(...) fprintf(stderr, __VA_ARGS__);
 #endif
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #define UNUSED
 // __attribute__ not supported in VS
 #else

--- a/src/common/oqs.h
+++ b/src/common/oqs.h
@@ -8,7 +8,7 @@
 #include <oqs/sha3.h>
 #include <oqs/sig.h>
 
-#if !defined(WINDOWS)
+#if !defined(_WIN32)
 #include <oqs/config.h>
 #endif
 

--- a/src/crypto/rand/rand.c
+++ b/src/crypto/rand/rand.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <math.h>
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #include <windows.h>
 #include <Wincrypt.h>
 #else
@@ -50,7 +50,7 @@ void OQS_RAND_free(OQS_RAND *r) {
 	}
 }
 
-#if !defined(WINDOWS)
+#if !defined(_WIN32)
 /* For some reason specifying inline results in a build error */
 inline
 #endif
@@ -147,7 +147,7 @@ void OQS_RAND_report_statistics(const unsigned long occurrences[256], const char
 OQS_STATUS OQS_RAND_get_system_entropy(uint8_t *buf, size_t n) {
 	OQS_STATUS result = OQS_ERROR;
 
-#if !defined(WINDOWS)
+#if !defined(_WIN32)
 	int fd = 0;
 #endif
 
@@ -155,7 +155,7 @@ OQS_STATUS OQS_RAND_get_system_entropy(uint8_t *buf, size_t n) {
 		goto err;
 	}
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 	HCRYPTPROV hCryptProv;
 	if (!CryptAcquireContext(&hCryptProv, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT) ||
 	    !CryptGenRandom(hCryptProv, (DWORD) n, buf)) {
@@ -174,7 +174,7 @@ OQS_STATUS OQS_RAND_get_system_entropy(uint8_t *buf, size_t n) {
 	result = OQS_SUCCESS;
 
 err:
-#if !defined(WINDOWS)
+#if !defined(_WIN32)
 	if (fd > 0) {
 		close(fd);
 	}

--- a/src/crypto/rand_urandom_aesctr/rand_urandom_aesctr.c
+++ b/src/crypto/rand_urandom_aesctr/rand_urandom_aesctr.c
@@ -1,5 +1,5 @@
 #include <sys/types.h>
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #include <windows.h>
 #include <Wincrypt.h>
 #else
@@ -18,7 +18,7 @@
 #include <oqs/rand.h>
 #include <oqs/rand_urandom_aesctr.h>
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #define strdup _strdup // for strdup deprecation warning
 #endif
 

--- a/src/crypto/rand_urandom_chacha20/rand_urandom_chacha20.c
+++ b/src/crypto/rand_urandom_chacha20/rand_urandom_chacha20.c
@@ -1,9 +1,9 @@
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #pragma warning(disable : 4267)
 #endif
 
 #include <sys/types.h>
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #include <windows.h>
 #include <Wincrypt.h>
 #else
@@ -21,7 +21,7 @@
 
 #include "external/chacha20.c"
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #define strdup _strdup // for strdup deprecation warning
 #endif
 

--- a/src/crypto/sha3/sha3.c
+++ b/src/crypto/sha3/sha3.c
@@ -5,7 +5,7 @@
  * from https://twitter.com/tweetfips202
  * by Gilles Van Assche, Daniel J. Bernstein, and Peter Schwabe */
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #pragma warning(disable : 4244)
 #endif
 

--- a/src/ds_benchmark.h
+++ b/src/ds_benchmark.h
@@ -86,13 +86,13 @@ PRINT_TIMER_FOOTER
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
-#if !defined(WINDOWS)
+#if !defined(_WIN32)
 #include <sys/time.h>
 #endif
 #include <math.h>
 #include <time.h>
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #include <Windows.h>
 
 int gettimeofday(struct timeval *tp, struct timezone *tzp) {
@@ -114,7 +114,7 @@ int gettimeofday(struct timeval *tp, struct timezone *tzp) {
 #endif
 
 static uint64_t rdtsc(void) {
-#if defined(WINDOWS)
+#if defined(_WIN32)
 	return __rdtsc();
 #elif defined(__aarch64__)
 	uint64_t x;

--- a/src/kex/kex.h
+++ b/src/kex/kex.h
@@ -12,7 +12,7 @@
 #include <oqs/common.h>
 #include <oqs/rand.h>
 
-#if !defined(WINDOWS)
+#if !defined(_WIN32)
 #include <oqs/config.h>
 #endif
 

--- a/src/kex/test_kex.c
+++ b/src/kex/test_kex.c
@@ -1,4 +1,4 @@
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #pragma warning(disable : 4244 4293)
 #endif
 

--- a/src/kex_code_mcbits/kex_code_mcbits.c
+++ b/src/kex_code_mcbits/kex_code_mcbits.c
@@ -2,7 +2,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#if !defined(WINDOWS)
+#if !defined(_WIN32)
 #include <strings.h>
 #include <unistd.h>
 #endif
@@ -14,7 +14,7 @@
 #include "kex_code_mcbits.h"
 #include "mcbits.h"
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #define strdup _strdup // for strdup deprecation warning
 #endif
 

--- a/src/kex_lwe_frodo/kex_lwe_frodo.c
+++ b/src/kex_lwe_frodo/kex_lwe_frodo.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
-#if !defined(WINDOWS)
+#if !defined(_WIN32)
 #include <strings.h>
 #include <unistd.h>
 #endif

--- a/src/kex_lwe_frodo/kex_lwe_frodo_macrify.c
+++ b/src/kex_lwe_frodo/kex_lwe_frodo_macrify.c
@@ -1,4 +1,4 @@
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #define strdup _strdup // for strdup deprecation warning
 #endif
 

--- a/src/kex_lwe_frodo/lwe_noise.c
+++ b/src/kex_lwe_frodo/lwe_noise.c
@@ -11,7 +11,7 @@
 
 #define RECOMMENDED_N_ARRAY_SIZE (752 * 8)
 #define RECOMMENDED_CDF_TABLE_LEN 6
-#if defined(WINDOWS)
+#if defined(_WIN32)
 // VS complains about arrays initialized with const param. On Windows,
 // we use directly the recommended value passed down from calling functions.
 // Currently there is only one set of params, so that works. Need to fix this

--- a/src/kex_ntru/kex_ntru.c
+++ b/src/kex_ntru/kex_ntru.c
@@ -1,7 +1,7 @@
 #ifndef DISABLE_NTRU_ON_WINDOWS_BY_DEFAULT
 
 #include <fcntl.h>
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #include <windows.h>
 #include <Wincrypt.h>
 #else
@@ -15,7 +15,7 @@
 
 #include <ntru_crypto.h>
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #define strdup _strdup // for strdup deprecation warning
 #endif
 

--- a/src/kex_rlwe_bcns15/kex_rlwe_bcns15.c
+++ b/src/kex_rlwe_bcns15/kex_rlwe_bcns15.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
-#if !defined(WINDOWS)
+#if !defined(_WIN32)
 #include <strings.h>
 #include <unistd.h>
 #endif
@@ -14,7 +14,7 @@
 
 #include "rlwe_a.h"
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #define strdup _strdup // for strdup deprecation warning
 #endif
 

--- a/src/kex_rlwe_bcns15/rlwe.c
+++ b/src/kex_rlwe_bcns15/rlwe.c
@@ -8,7 +8,7 @@
  * See LICENSE for complete information.
  */
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #pragma warning(disable : 4146 4244 4267)
 #endif
 

--- a/src/kex_rlwe_msrln16/kex_rlwe_msrln16.c
+++ b/src/kex_rlwe_msrln16/kex_rlwe_msrln16.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
-#if !defined(WINDOWS)
+#if !defined(_WIN32)
 #include <strings.h>
 #include <unistd.h>
 #endif
@@ -13,7 +13,7 @@
 #include "LatticeCrypto_priv.h"
 #include "kex_rlwe_msrln16.h"
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #define strdup _strdup // for strdup deprecation warning
 #endif
 

--- a/src/kex_rlwe_newhope/avx2/test/speed.c
+++ b/src/kex_rlwe_newhope/avx2/test/speed.c
@@ -49,7 +49,7 @@ static void print_results(const char *s, unsigned long long *t, size_t tlen)
 
 unsigned long long t[NTESTS];
 
-int main()
+int main(void)
 {
   poly sk_a;
   unsigned char key_a[32], key_b[32];

--- a/src/kex_rlwe_newhope/avx2/test/test_newhope.c
+++ b/src/kex_rlwe_newhope/avx2/test/test_newhope.c
@@ -112,7 +112,7 @@ int test_invalid_ciphertext()
 }
 
 
-int main(){
+int main(void){
 
   test_keys();
   test_invalid_sk_a();

--- a/src/kex_rlwe_newhope/avx2/test/test_statistical.c
+++ b/src/kex_rlwe_newhope/avx2/test/test_statistical.c
@@ -38,7 +38,7 @@ static int hamming32(const unsigned char *k)
   return r;
 }
 
-int main()
+int main(void)
 {
   poly sk_a;
   unsigned char key_b[32];

--- a/src/kex_rlwe_newhope/kex_rlwe_newhope.c
+++ b/src/kex_rlwe_newhope/kex_rlwe_newhope.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
-#if !defined(WINDOWS)
+#if !defined(_WIN32)
 #include <strings.h>
 #include <unistd.h>
 #endif
@@ -13,7 +13,7 @@
 #include "newhope.c"
 #include "params.h"
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #define strdup _strdup // for strdup deprecation warning
 #endif
 

--- a/src/kex_rlwe_newhope/params.h
+++ b/src/kex_rlwe_newhope/params.h
@@ -21,7 +21,7 @@ extern uint16_t omegas_inv_montgomery[];
 extern uint16_t psis_inv_montgomery[];
 extern uint16_t psis_bitrev_montgomery[];
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 typedef unsigned __int16 uint16_t;
 #endif
 

--- a/src/kex_rlwe_newhope/poly.c
+++ b/src/kex_rlwe_newhope/poly.c
@@ -4,7 +4,7 @@
 
 typedef struct {
 	uint16_t coeffs[PARAM_N];
-#if defined(WINDOWS)
+#if defined(_WIN32)
 } poly;
 #else
 } poly __attribute__((aligned(32)));

--- a/src/kex_sidh_msr/P503/P503_api.h
+++ b/src/kex_sidh_msr/P503/P503_api.h
@@ -9,7 +9,7 @@
 
 #include <oqs/rand.h>
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #include "../windows_undef.h"
 #endif
 

--- a/src/kex_sidh_msr/P751/P751_api.h
+++ b/src/kex_sidh_msr/P751/P751_api.h
@@ -9,7 +9,7 @@
 
 #include <oqs/rand.h>
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #include "../windows_undef.h"
 #endif
 

--- a/src/kex_sidh_msr/config.h
+++ b/src/kex_sidh_msr/config.h
@@ -22,7 +22,7 @@
 #define OS_WIN 1
 #define OS_LINUX 2
 /*
-#if defined(__WINDOWS__)        // Microsoft Windows OS
+#if defined(_WIN32)        // Microsoft Windows OS
     #define OS_TARGET OS_WIN
 #elif defined(__LINUX__)        // Linux OS
     #define OS_TARGET OS_LINUX 

--- a/src/kex_sidh_msr/kex_sidh_msr.c
+++ b/src/kex_sidh_msr/kex_sidh_msr.c
@@ -1,8 +1,8 @@
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #pragma warning(disable : 4047 4090)
 #endif
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #define UNUSED
 #else
 #define UNUSED __attribute__((unused))
@@ -10,7 +10,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#if !defined(WINDOWS)
+#if !defined(_WIN32)
 #include <strings.h>
 #include <unistd.h>
 #endif
@@ -22,7 +22,7 @@
 #include "P751/P751_api.h"
 #include "kex_sidh_msr.h"
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #define strdup _strdup // for strdup deprecation warning
 #endif
 

--- a/src/kex_sidh_msr/windows_undef.h
+++ b/src/kex_sidh_msr/windows_undef.h
@@ -3,7 +3,7 @@
  * to avoid Visual Studio errors
  */
 
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #undef OQS_SIDH_MSR_CRYPTO_SECRETKEYBYTES
 #undef OQS_SIDH_MSR_CRYPTO_PUBLICKEYBYTES
 #undef OQS_SIDH_MSR_CRYPTO_BYTES

--- a/src/sig/test_sig.c
+++ b/src/sig/test_sig.c
@@ -321,7 +321,7 @@ cleanup:
 	return (success == OQS_SUCCESS) ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 #else // !ENABLE_SIG_PICNIC
-int main() {
+int main(void) {
 	printf("No signature algorithm available. Make sure configure was run properly; see Readme.md.\n");
 	return EXIT_FAILURE;
 }

--- a/src/sig/test_sig.c
+++ b/src/sig/test_sig.c
@@ -1,4 +1,4 @@
-#if defined(WINDOWS)
+#if defined(_WIN32)
 #pragma warning(disable : 4244 4293)
 #endif
 

--- a/src/sig_picnic/external/cmake/check-simd.c
+++ b/src/sig_picnic/external/cmake/check-simd.c
@@ -39,6 +39,6 @@ void test(void) {
 }
 #endif
 
-int main() {
+int main(void) {
   test();
 }

--- a/src/sig_picnic/external/tests/api_test.c
+++ b/src/sig_picnic/external/tests/api_test.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int main() {
+int main(void) {
   unsigned char pk[CRYPTO_PUBLICKEYBYTES]          = {0};
   unsigned char sk[CRYPTO_SECRETKEYBYTES]          = {0};
   const unsigned char message[50]                  = {0};

--- a/src/sig_picnic/external/tests/bitstream_test.c
+++ b/src/sig_picnic/external/tests/bitstream_test.c
@@ -131,7 +131,7 @@ static int test_multiple_30(void) {
   return ret;
 }
 
-int main() {
+int main(void) {
   int ret = 0;
 
   int tmp = simple_test();

--- a/src/sig_picnic/external/tests/extended_picnic_test.c
+++ b/src/sig_picnic/external/tests/extended_picnic_test.c
@@ -76,7 +76,7 @@ static int picnic_test_with_read_write(picnic_params_t parameters) {
   return 0;
 }
 
-int main() {
+int main(void) {
   int ret = 0;
   for (picnic_params_t params = 1; params < PARAMETER_SET_MAX_INDEX; params++) {
     if (picnic_test_with_read_write(params)) {

--- a/src/sig_picnic/external/tests/hmac_sha256_test.c
+++ b/src/sig_picnic/external/tests/hmac_sha256_test.c
@@ -1,6 +1,6 @@
 #include "../randomness.h"
 
-int main() {
+int main(void) {
 
   unsigned int ret_val = 0;
   unsigned char dst[32];

--- a/src/sig_picnic/external/tests/hmac_sha384_test.c
+++ b/src/sig_picnic/external/tests/hmac_sha384_test.c
@@ -1,6 +1,6 @@
 #include "../randomness.h"
 
-int main() {
+int main(void) {
 
   unsigned int ret_val = 0;
   unsigned char dst[48];

--- a/src/sig_picnic/external/tests/hmac_sha512_test.c
+++ b/src/sig_picnic/external/tests/hmac_sha512_test.c
@@ -1,6 +1,6 @@
 #include "../randomness.h"
 
-int main() {
+int main(void) {
 
   unsigned int ret_val = 0;
   unsigned char dst[64];

--- a/src/sig_picnic/external/tests/kdf_shake256_test.c
+++ b/src/sig_picnic/external/tests/kdf_shake256_test.c
@@ -1,6 +1,6 @@
 #include "../kdf_shake.h"
 
-int main() {
+int main(void) {
   const uint8_t key[] = {0xab, 0xcd};
 
   kdf_shake_t ctx;

--- a/src/sig_picnic/external/tests/lowmc_test.c
+++ b/src/sig_picnic/external/tests/lowmc_test.c
@@ -148,7 +148,7 @@ static const struct {
 
 static const size_t num_tests = sizeof(tests) / sizeof(tests[0]);
 
-int main() {
+int main(void) {
   int ret = 0;
   for (size_t s = 0; s < num_str_tests; ++s) {
     const int t = lowmc_enc_str(str_tests[s].param, str_tests[s].key, str_tests[s].plaintext,

--- a/src/sig_picnic/external/tests/mpc_test.c
+++ b/src/sig_picnic/external/tests/mpc_test.c
@@ -86,7 +86,7 @@ void run_tests(void) {
   test_mpc_add();
 }
 
-int main() {
+int main(void) {
   run_tests();
 
   return 0;

--- a/src/sig_picnic/external/tests/mzd_test.c
+++ b/src/sig_picnic/external/tests/mzd_test.c
@@ -429,7 +429,7 @@ static void test_mzd_shift(void) {
 #endif
 }
 
-int main() {
+int main(void) {
   test_mzd_local_equal();
   test_mzd_mul();
   test_mzd_mul_avx();

--- a/src/sig_picnic/external/tests/picnic_test.c
+++ b/src/sig_picnic/external/tests/picnic_test.c
@@ -58,7 +58,7 @@ static int picnic_sign_verify(const picnic_params_t param) {
   return ret;
 }
 
-int main() {
+int main(void) {
   int ret = 0;
   for (unsigned int param = Picnic_L1_FS; param < PARAMETER_SET_MAX_INDEX; ++param) {
     printf("testing: %d ... ", param);

--- a/src/sig_picnic/external/tools/example.c
+++ b/src/sig_picnic/external/tools/example.c
@@ -127,7 +127,7 @@ int picnicExample(picnic_params_t parameters) {
   return 0;
 }
 
-int main() {
+int main(void) {
   for (picnic_params_t params = 1; params < PARAMETER_SET_MAX_INDEX; params++) {
     picnicExample(params);
   }


### PR DESCRIPTION
Summary:

1. Got rid of code that was using `#if defined(WINDOWS)` as it's not portable, used `#if defined(_WIN32)` instead. Before refactoring, we manually added `WINDOWS` as a pre-processor define in VS build. There's no need, `_WIN32` is automatically defined under VS (on both 32bit and 64bit platforms) and this refactoring relies on the later.

2. Use an `enum` for `OQS_STATUS` instead of #define's, much more type-safe.

3. Also, changed signatures from `int main()` to `int main(void)` to make it C-standard compliant.

4. make prettyprint