### PR TITLE
Moved winconfig to oqs include dir

### DIFF
--- a/VisualStudio/oqs/oqs.vcxproj
+++ b/VisualStudio/oqs/oqs.vcxproj
@@ -238,6 +238,7 @@
     <PreBuildEvent>
       <Command>mkdir "$(SolutionDir)include\oqs"
 del /Q "$(SolutionDir)include\oqs\*.*"
+copy "$(SolutionDir)winconfig.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\common\oqs.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\common\common.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\crypto\aes\aes.h" "$(SolutionDir)include\oqs\"
@@ -276,6 +277,7 @@ copy "$(SolutionDir)..\src\sig_picnic\sig_picnic.h" "$(SolutionDir)include\oqs\"
     <PreBuildEvent>
       <Command>mkdir "$(SolutionDir)include\oqs"
 del /Q "$(SolutionDir)include\oqs\*.*"
+copy "$(SolutionDir)winconfig.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\common\oqs.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\common\common.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\crypto\aes\aes.h" "$(SolutionDir)include\oqs\"
@@ -314,6 +316,7 @@ copy "$(SolutionDir)..\src\sig_picnic\sig_picnic.h" "$(SolutionDir)include\oqs\"
     <PreBuildEvent>
       <Command>mkdir "$(SolutionDir)include\oqs"
 del /Q "$(SolutionDir)include\oqs\*.*"
+copy "$(SolutionDir)winconfig.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\common\oqs.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\common\common.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\crypto\aes\aes.h" "$(SolutionDir)include\oqs\"
@@ -360,6 +363,7 @@ msbuild  /t:Rebuild /p:Configuration=Release;Platform=x64 "$(SolutionDir)..\src\
     <PreBuildEvent>
       <Command>mkdir "$(SolutionDir)include\oqs"
 del /Q "$(SolutionDir)include\oqs\*.*"
+copy "$(SolutionDir)winconfig.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\common\oqs.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\common\common.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\crypto\aes\aes.h" "$(SolutionDir)include\oqs\"
@@ -407,6 +411,7 @@ msbuild  /t:Rebuild /p:Configuration=Release;Platform=x64 "$(SolutionDir)..\src\
     <PreBuildEvent>
       <Command>mkdir "$(SolutionDir)include\oqs"
 del /Q "$(SolutionDir)include\oqs\*.*"
+copy "$(SolutionDir)winconfig.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\common\oqs.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\common\common.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\crypto\aes\aes.h" "$(SolutionDir)include\oqs\"
@@ -449,6 +454,7 @@ copy "$(SolutionDir)..\src\sig_picnic\sig_picnic.h" "$(SolutionDir)include\oqs\"
     <PreBuildEvent>
       <Command>mkdir "$(SolutionDir)include\oqs"
 del /Q "$(SolutionDir)include\oqs\*.*"
+copy "$(SolutionDir)winconfig.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\common\oqs.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\common\common.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\crypto\aes\aes.h" "$(SolutionDir)include\oqs\"
@@ -491,6 +497,7 @@ copy "$(SolutionDir)..\src\sig_picnic\sig_picnic.h" "$(SolutionDir)include\oqs\"
     <PreBuildEvent>
       <Command>mkdir "$(SolutionDir)include\oqs"
 del /Q "$(SolutionDir)include\oqs\*.*"
+copy "$(SolutionDir)winconfig.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\common\oqs.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\common\common.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\crypto\aes\aes.h" "$(SolutionDir)include\oqs\"
@@ -541,6 +548,7 @@ msbuild  /t:Rebuild /p:Configuration=Release;Platform=x64 "$(SolutionDir)..\src\
     <PreBuildEvent>
       <Command>mkdir "$(SolutionDir)include\oqs"
 del /Q "$(SolutionDir)include\oqs\*.*"
+copy "$(SolutionDir)winconfig.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\common\oqs.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\common\common.h" "$(SolutionDir)include\oqs\"
 copy "$(SolutionDir)..\src\crypto\aes\aes.h" "$(SolutionDir)include\oqs\"

--- a/src/common/oqs.h
+++ b/src/common/oqs.h
@@ -9,7 +9,7 @@
 #include <oqs/sig.h>
 
 #if defined(_WIN32)
-#include "..\winconfig.h"
+#include <oqs/winconfig.h>
 #else
 #include <oqs/config.h>
 #endif

--- a/src/kex/kex.h
+++ b/src/kex/kex.h
@@ -13,7 +13,7 @@
 #include <oqs/rand.h>
 
 #if defined(_WIN32)
-#include "..\winconfig.h"
+#include <oqs/winconfig.h>
 #else
 #include <oqs/config.h>
 #endif

--- a/src/sig/sig.h
+++ b/src/sig/sig.h
@@ -13,7 +13,7 @@
 #include <oqs/rand.h>
 
 #if defined(_WIN32)
-#include "..\winconfig.h"
+#include <oqs/winconfig.h>
 #else
 #include <oqs/config.h>
 #endif


### PR DESCRIPTION
Moved winconfig to oqs include dir in VS pre-build steps, so it can be used by downstream projects (e.g., OpenSSL). Changed references to <oqs/winconfig.h>.