### PR TITLE
Fixes mem leak issue in sig_picnic

### DIFF
--- a/src/sig/sig.c
+++ b/src/sig/sig.c
@@ -65,8 +65,7 @@ OQS_STATUS OQS_SIG_verify(const OQS_SIG *s, const uint8_t *pub, const uint8_t *m
 }
 
 void OQS_SIG_free(OQS_SIG *s) {
-	if (s == NULL) {
-		return;
+	if (s) {
+		s->free(s);
 	}
-	free(s);
 }

--- a/src/sig/sig.h
+++ b/src/sig/sig.h
@@ -121,6 +121,13 @@ struct OQS_SIG {
 	 */
 	OQS_STATUS(*verify)
 	(const OQS_SIG *s, const uint8_t *pub, const uint8_t *msg, const size_t msg_len, const uint8_t *sig, const size_t sig_len);
+
+	/**
+	 * Pointer to a function for freeing the allocated signature structure
+	 *
+	 * @param s                Signature structure
+	 */
+	void (*free)(OQS_SIG *s);
 };
 
 /**

--- a/src/sig_picnic/sig_picnic.c
+++ b/src/sig_picnic/sig_picnic.c
@@ -105,6 +105,7 @@ OQS_STATUS OQS_SIG_picnic_get(OQS_SIG *s, enum OQS_SIG_algid algid) {
 	s->keygen = &OQS_SIG_picnic_keygen;
 	s->sign = &OQS_SIG_picnic_sign;
 	s->verify = &OQS_SIG_picnic_verify;
+	s->free = &OQS_SIG_picnic_free;
 
 	return OQS_SUCCESS;
 }
@@ -167,4 +168,14 @@ OQS_STATUS OQS_SIG_picnic_verify(UNUSED const OQS_SIG *s, const uint8_t *pub, co
 	}
 	return OQS_SUCCESS;
 }
+
+void OQS_SIG_picnic_free(OQS_SIG *s) {
+	if (!s) {
+		return;
+	}
+	free(s->ctx);
+	s->ctx = NULL;
+	free(s);
+}
+
 #endif

--- a/src/sig_picnic/sig_picnic.c
+++ b/src/sig_picnic/sig_picnic.c
@@ -99,7 +99,7 @@ OQS_STATUS OQS_SIG_picnic_get(OQS_SIG *s, enum OQS_SIG_algid algid) {
 	}
 	// set the ctx, sizes, and API functions
 	s->ctx = pctx;
-	s->priv_key_len = (uint16_t)(PRIV_KEY_LEN[pctx->params] + PUB_KEY_LEN[pctx->params]); // priv key also contains pub key
+	s->priv_key_len = (uint16_t) PRIV_KEY_LEN[pctx->params];
 	s->pub_key_len = (uint16_t) PUB_KEY_LEN[pctx->params];
 	s->max_sig_len = (uint32_t) SIG_LEN[pctx->params];
 	s->keygen = &OQS_SIG_picnic_keygen;

--- a/src/sig_picnic/sig_picnic.h
+++ b/src/sig_picnic/sig_picnic.h
@@ -17,5 +17,6 @@ OQS_STATUS OQS_SIG_picnic_get(OQS_SIG *sig, enum OQS_SIG_algid algid);
 OQS_STATUS OQS_SIG_picnic_keygen(const OQS_SIG *s, uint8_t *priv, uint8_t *pub);
 OQS_STATUS OQS_SIG_picnic_sign(const OQS_SIG *s, const uint8_t *priv, const uint8_t *msg, const size_t msg_len, uint8_t *sig, size_t *sig_len);
 OQS_STATUS OQS_SIG_picnic_verify(const OQS_SIG *s, const uint8_t *pub, const uint8_t *msg, const size_t msg_len, const uint8_t *sig, const size_t sig_len);
+void OQS_SIG_picnic_free(OQS_SIG *s);
 #endif
 #endif


### PR DESCRIPTION
Fixes private key length (issue #227) and adds free functions to sig api to clean up internal ctx memory.