### PR TITLE
Try changing algorithm identifiers to strings

### DIFF
--- a/.travis/algorithm-datasheets-check.sh
+++ b/.travis/algorithm-datasheets-check.sh
@@ -9,7 +9,7 @@ PRINT_RED="tput setaf 1"
 PRINT_RESET="tput sgr 0"
 
 # get the list of KEMs from the list of algorithm identifiers in enum OQS_KEM_alg_name in src/kem/kem.h
-KEMS=`grep '\tOQS_KEM_alg_' src/kem/kem.h | grep -v 'default' | grep -v 'last' | sed -e 's/OQS_KEM_alg_//' | sed -e 's/ =.*//' | tr -d '[:blank:]'`
+KEMS=`grep 'define OQS_KEM_alg_' src/kem/kem.h | grep -v 'default' | sed -e 's/^[^"]*"//' | sed -e 's/".*$//' | tr -d '[:blank:]'`
 
 RET=0
 for kem in ${KEMS}; do
@@ -26,7 +26,7 @@ done
 if [[ "${RET}" == "0" ]];
 then
 	${PRINT_GREEN}
-	echo "Algorithm datasheet present for all KEMs in enum OQS_KEM_alg_name in src/kem/kem.h.";
+	echo "Algorithm datasheet present for all KEMs #defined in src/kem/kem.h.";
 	${PRINT_RESET}
 fi
 

--- a/docs/algorithms/kem_frodokem.md
+++ b/docs/algorithms/kem_frodokem.md
@@ -15,12 +15,12 @@ Summary
 Parameter sets
 --------------
 
-| Parameter set       |   OQS algorithm name  | Security model | Claimed NIST security level | Public key size (bytes) | Secret key size (bytes) | Ciphertext size (bytes) | Shared secret size (bytes) |
-|---------------------|:---------------------:|:--------------:|:---------------------------:|:-----------------------:|:-----------------------:|:-----------------------:|:--------------------------:|
-| FrodoKEM-640-AES    |   `frodokem_640_aes`  |     IND-CCA    |              1              |           9616          |          19872          |           9736          |             16             |
-| FrodoKEM-640-cSHAKE | `frodokem_640_cshake` |     IND-CCA    |              1              |           9616          |          19872          |           9736          |             16             |
-| FrodoKEM-976-AES    |   `frodokem_976_aes`  |     IND-CCA    |              3              |          15632          |          31272          |          15768          |             24             |
-| FrodoKEM-976-cSHAKE | `frodokem_976_cshake` |     IND-CCA    |              3              |          15632          |          31272          |          15768          |             24             |
+| Parameter set       | Security model | Claimed NIST security level | Public key size (bytes) | Secret key size (bytes) | Ciphertext size (bytes) | Shared secret size (bytes) |
+|---------------------|:--------------:|:---------------------------:|:-----------------------:|:-----------------------:|:-----------------------:|:--------------------------:|
+| FrodoKEM-640-AES    |     IND-CCA    |              1              |           9616          |          19872          |           9736          |             16             |
+| FrodoKEM-640-cSHAKE |     IND-CCA    |              1              |           9616          |          19872          |           9736          |             16             |
+| FrodoKEM-976-AES    |     IND-CCA    |              3              |          15632          |          31272          |          15768          |             24             |
+| FrodoKEM-976-cSHAKE |     IND-CCA    |              3              |          15632          |          31272          |          15768          |             24             |
 
 Implementation
 --------------

--- a/docs/algorithms/kem_kyber.md
+++ b/docs/algorithms/kem_kyber.md
@@ -15,11 +15,11 @@ Summary
 Parameter sets
 --------------
 
-| Parameter set | OQS algorithm name | Security model | Claimed NIST security level | Public key size (bytes) | Secret key size (bytes) | Ciphertext size (bytes) | Shared secret size (bytes) |
-|---------------|:------------------:|:--------------:|:---------------------------:|:-----------------------:|:-----------------------:|:-----------------------:|:--------------------------:|
-| Kyber-512     |     `kyber512`     |     IND-CCA    |              1              |           736           |           1632          |           800           |             32             |
-| Kyber-768     |     `kyber768`     |     IND-CCA    |              3              |           1088          |           2400          |           1152          |             32             |
-| Kyber-1024    |     `kyber1024`    |     IND-CCA    |              5              |           1440          |           3168          |           1504          |             32             |
+| Parameter set | Security model | Claimed NIST security level | Public key size (bytes) | Secret key size (bytes) | Ciphertext size (bytes) | Shared secret size (bytes) |
+|---------------|:--------------:|:---------------------------:|:-----------------------:|:-----------------------:|:-----------------------:|:--------------------------:|
+| Kyber512      |     IND-CCA    |              1              |           736           |           1632          |           800           |             32             |
+| Kyber768      |     IND-CCA    |              3              |           1088          |           2400          |           1152          |             32             |
+| Kyber1024     |     IND-CCA    |              5              |           1440          |           3168          |           1504          |             32             |
 
 Implementation
 --------------

--- a/docs/algorithms/kem_newhopenist.md
+++ b/docs/algorithms/kem_newhopenist.md
@@ -15,10 +15,10 @@ Summary
 Parameter sets
 --------------
 
-| Parameter set       |   OQS algorithm name   | Security model | Claimed NIST security level | Public key size (bytes) | Secret key size (bytes) | Ciphertext size (bytes) | Shared secret size (bytes) |
-|---------------------|:----------------------:|:--------------:|:---------------------------:|:-----------------------:|:-----------------------:|:-----------------------:|:--------------------------:|
-| NewHope512-CCA-KEM  |  `newhope_512_cca_kem` |     IND-CCA    |              1              |           928           |           1888          |           1120          |             32             |
-| NewHope1024-CCA-KEM | `newhope_1024_cca_kem` |     IND-CCA    |              5              |           1824          |           3680           |           2208          |             32             |
+| Parameter set       | Security model | Claimed NIST security level | Public key size (bytes) | Secret key size (bytes) | Ciphertext size (bytes) | Shared secret size (bytes) |
+|---------------------|:--------------:|:---------------------------:|:-----------------------:|:-----------------------:|:-----------------------:|:--------------------------:|
+| NewHope512-CCA-KEM  |     IND-CCA    |              1              |           928           |           1888          |           1120          |             32             |
+| NewHope1024-CCA-KEM |     IND-CCA    |              5              |           1824          |           3680          |           2208          |             32             |
 
 Implementation
 --------------

--- a/src/kem/crystals-kyber/kem_kyber.c
+++ b/src/kem/crystals-kyber/kem_kyber.c
@@ -10,7 +10,7 @@ OQS_KEM *OQS_KEM_kyber512_new() {
 	if (kem == NULL) {
 		return NULL;
 	}
-	kem->method_name = "Kyber512";
+	kem->method_name = OQS_KEM_alg_kyber512;
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -37,7 +37,7 @@ OQS_KEM *OQS_KEM_kyber768_new() {
 	if (kem == NULL) {
 		return NULL;
 	}
-	kem->method_name = "Kyber768";
+	kem->method_name = OQS_KEM_alg_kyber768;
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -64,7 +64,7 @@ OQS_KEM *OQS_KEM_kyber1024_new() {
 	if (kem == NULL) {
 		return NULL;
 	}
-	kem->method_name = "Kyber1024";
+	kem->method_name = OQS_KEM_alg_kyber1024;
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;

--- a/src/kem/frodokem/kem_frodokem.c
+++ b/src/kem/frodokem/kem_frodokem.c
@@ -10,7 +10,7 @@ OQS_KEM *OQS_KEM_frodokem_640_aes_new() {
 	if (kem == NULL) {
 		return NULL;
 	}
-	kem->method_name = "FrodoKEM-640-AES";
+	kem->method_name = OQS_KEM_alg_frodokem_640_aes;
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -37,7 +37,7 @@ OQS_KEM *OQS_KEM_frodokem_976_aes_new() {
 	if (kem == NULL) {
 		return NULL;
 	}
-	kem->method_name = "FrodoKEM-976-AES";
+	kem->method_name = OQS_KEM_alg_frodokem_976_aes;
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = true;
@@ -64,7 +64,7 @@ OQS_KEM *OQS_KEM_frodokem_640_cshake_new() {
 	if (kem == NULL) {
 		return NULL;
 	}
-	kem->method_name = "FrodoKEM-640-CSHAKE";
+	kem->method_name = OQS_KEM_alg_frodokem_640_cshake;
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -91,7 +91,7 @@ OQS_KEM *OQS_KEM_frodokem_976_cshake_new() {
 	if (kem == NULL) {
 		return NULL;
 	}
-	kem->method_name = "FrodoKEM-976-CSHAKE";
+	kem->method_name = OQS_KEM_alg_frodokem_976_cshake;
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = true;

--- a/src/kem/kem.c
+++ b/src/kem/kem.c
@@ -5,17 +5,17 @@
 #include <oqs/oqs.h>
 
 // EDIT-WHEN-ADDING-KEM
-char *OQS_KEM_algs[OQS_KEM_algs_length] = { OQS_KEM_alg_default, OQS_KEM_alg_frodokem_640_aes, OQS_KEM_alg_frodokem_976_aes, OQS_KEM_alg_frodokem_640_cshake, OQS_KEM_alg_frodokem_976_cshake, OQS_KEM_alg_newhope_512_cca_kem, OQS_KEM_alg_newhope_1024_cca_kem, OQS_KEM_alg_kyber512, OQS_KEM_alg_kyber768, OQS_KEM_alg_kyber1024 };
+char *OQS_KEM_algs[OQS_KEM_algs_length] = {OQS_KEM_alg_default, OQS_KEM_alg_frodokem_640_aes, OQS_KEM_alg_frodokem_976_aes, OQS_KEM_alg_frodokem_640_cshake, OQS_KEM_alg_frodokem_976_cshake, OQS_KEM_alg_newhope_512_cca_kem, OQS_KEM_alg_newhope_1024_cca_kem, OQS_KEM_alg_kyber512, OQS_KEM_alg_kyber768, OQS_KEM_alg_kyber1024};
 
 OQS_KEM *OQS_KEM_new(const char *method_name) {
 	if (0 == strcasecmp(method_name, OQS_KEM_alg_default)) {
 		return OQS_KEM_new(OQS_KEM_DEFAULT);
 	} else if (0 == strcasecmp(method_name, OQS_KEM_alg_frodokem_640_aes)) {
-		#ifdef OQS_ENABLE_KEM_frodokem_640_aes
+#ifdef OQS_ENABLE_KEM_frodokem_640_aes
 		return OQS_KEM_frodokem_640_aes_new();
-		#else
+#else
 		return NULL;
-		#endif
+#endif
 	} else if (0 == strcasecmp(method_name, OQS_KEM_alg_frodokem_976_aes)) {
 #ifdef OQS_ENABLE_KEM_frodokem_976_aes
 		return OQS_KEM_frodokem_976_aes_new();
@@ -64,7 +64,7 @@ OQS_KEM *OQS_KEM_new(const char *method_name) {
 #else
 		return NULL;
 #endif
-	// EDIT-WHEN-ADDING-KEM
+		// EDIT-WHEN-ADDING-KEM
 	} else {
 		return NULL;
 	}

--- a/src/kem/kem.c
+++ b/src/kem/kem.c
@@ -4,8 +4,15 @@
 
 #include <oqs/oqs.h>
 
-// EDIT-WHEN-ADDING-KEM
-char *OQS_KEM_algs[OQS_KEM_algs_length] = {OQS_KEM_alg_default, OQS_KEM_alg_frodokem_640_aes, OQS_KEM_alg_frodokem_976_aes, OQS_KEM_alg_frodokem_640_cshake, OQS_KEM_alg_frodokem_976_cshake, OQS_KEM_alg_newhope_512_cca_kem, OQS_KEM_alg_newhope_1024_cca_kem, OQS_KEM_alg_kyber512, OQS_KEM_alg_kyber768, OQS_KEM_alg_kyber1024};
+char *OQS_KEM_alg_identifier(size_t i) {
+	// EDIT-WHEN-ADDING-KEM
+	char *a[OQS_KEM_algs_length] = {OQS_KEM_alg_default, OQS_KEM_alg_frodokem_640_aes, OQS_KEM_alg_frodokem_976_aes, OQS_KEM_alg_frodokem_640_cshake, OQS_KEM_alg_frodokem_976_cshake, OQS_KEM_alg_newhope_512_cca_kem, OQS_KEM_alg_newhope_1024_cca_kem, OQS_KEM_alg_kyber512, OQS_KEM_alg_kyber768, OQS_KEM_alg_kyber1024};
+	if (i >= OQS_KEM_algs_length) {
+		return NULL;
+	} else {
+		return a[i];
+	}
+}
 
 OQS_KEM *OQS_KEM_new(const char *method_name) {
 	if (0 == strcasecmp(method_name, OQS_KEM_alg_default)) {

--- a/src/kem/kem.c
+++ b/src/kem/kem.c
@@ -1,69 +1,72 @@
 #include <assert.h>
 #include <stdlib.h>
+#include <strings.h>
 
 #include <oqs/oqs.h>
 
-OQS_KEM *OQS_KEM_new(enum OQS_KEM_alg_name alg_name) {
-	switch (alg_name) {
-	case OQS_KEM_alg_default:
+// EDIT-WHEN-ADDING-KEM
+char *OQS_KEM_algs[OQS_KEM_algs_length] = { OQS_KEM_alg_default, OQS_KEM_alg_frodokem_640_aes, OQS_KEM_alg_frodokem_976_aes, OQS_KEM_alg_frodokem_640_cshake, OQS_KEM_alg_frodokem_976_cshake, OQS_KEM_alg_newhope_512_cca_kem, OQS_KEM_alg_newhope_1024_cca_kem, OQS_KEM_alg_kyber512, OQS_KEM_alg_kyber768, OQS_KEM_alg_kyber1024 };
+
+OQS_KEM *OQS_KEM_new(const char *method_name) {
+	if (0 == strcasecmp(method_name, OQS_KEM_alg_default)) {
 		return OQS_KEM_new(OQS_KEM_DEFAULT);
-	case OQS_KEM_alg_frodokem_640_aes:
-#ifdef OQS_ENABLE_KEM_frodokem_640_aes
+	} else if (0 == strcasecmp(method_name, OQS_KEM_alg_frodokem_640_aes)) {
+		#ifdef OQS_ENABLE_KEM_frodokem_640_aes
 		return OQS_KEM_frodokem_640_aes_new();
-#else
+		#else
 		return NULL;
-#endif
-	case OQS_KEM_alg_frodokem_976_aes:
+		#endif
+	} else if (0 == strcasecmp(method_name, OQS_KEM_alg_frodokem_976_aes)) {
 #ifdef OQS_ENABLE_KEM_frodokem_976_aes
 		return OQS_KEM_frodokem_976_aes_new();
 #else
 		return NULL;
 #endif
-	case OQS_KEM_alg_frodokem_640_cshake:
+	} else if (0 == strcasecmp(method_name, OQS_KEM_alg_frodokem_640_cshake)) {
 #ifdef OQS_ENABLE_KEM_frodokem_640_cshake
 		return OQS_KEM_frodokem_640_cshake_new();
 #else
 		return NULL;
 #endif
-	case OQS_KEM_alg_frodokem_976_cshake:
+	} else if (0 == strcasecmp(method_name, OQS_KEM_alg_frodokem_976_cshake)) {
 #ifdef OQS_ENABLE_KEM_frodokem_976_cshake
 		return OQS_KEM_frodokem_976_cshake_new();
 #else
 		return NULL;
 #endif
-	case OQS_KEM_alg_newhope_512_cca_kem:
+	} else if (0 == strcasecmp(method_name, OQS_KEM_alg_newhope_512_cca_kem)) {
 #ifdef OQS_ENABLE_KEM_newhope_512_cca_kem
 		return OQS_KEM_newhope_512_cca_kem_new();
 #else
 		return NULL;
 #endif
-	case OQS_KEM_alg_newhope_1024_cca_kem:
+	} else if (0 == strcasecmp(method_name, OQS_KEM_alg_newhope_1024_cca_kem)) {
 #ifdef OQS_ENABLE_KEM_newhope_1024_cca_kem
 		return OQS_KEM_newhope_1024_cca_kem_new();
 #else
 		return NULL;
 #endif
-	case OQS_KEM_alg_kyber512:
+	} else if (0 == strcasecmp(method_name, OQS_KEM_alg_kyber512)) {
 #ifdef OQS_ENABLE_KEM_kyber512
 		return OQS_KEM_kyber512_new();
 #else
 		return NULL;
 #endif
-	case OQS_KEM_alg_kyber768:
+	} else if (0 == strcasecmp(method_name, OQS_KEM_alg_kyber768)) {
 #ifdef OQS_ENABLE_KEM_kyber768
 		return OQS_KEM_kyber768_new();
 #else
 		return NULL;
 #endif
-	case OQS_KEM_alg_kyber1024:
+	} else if (0 == strcasecmp(method_name, OQS_KEM_alg_kyber1024)) {
 #ifdef OQS_ENABLE_KEM_kyber1024
 		return OQS_KEM_kyber1024_new();
 #else
 		return NULL;
 #endif
 	// EDIT-WHEN-ADDING-KEM
-	default:
-		assert(0);
+	} else {
+		return NULL;
 	}
 }
 

--- a/src/kem/kem.h
+++ b/src/kem/kem.h
@@ -46,23 +46,19 @@
 /** Algorithm identifier for Kyber1024 KEM. */
 #define OQS_KEM_alg_kyber1024 "Kyber1024"
 // EDIT-WHEN-ADDING-KEM
-
-/**
- * Number of KEM algorithms in liboqs; equivalently the length of the OQS_KEM_algs array.
- *
- * Note that algorithm identifiers are present in this array even when the algorithm is disabled
- * at compile time.
- */
+/** Number of algorithm identifiers above. */
 #define OQS_KEM_algs_length 10
-// EDIT-WHEN-ADDING-KEM
 
 /**
- * Identifiers for available key encapsulation mechanisms in liboqs.  Used with OQS_KEM_new.
+ * Returns identifiers for available key encapsulation mechanisms in liboqs.  Used with OQS_KEM_new.
  *
- * Note that algorithm identifiers are present in this array even when the algorithm is disabled
+ * Note that algorithm identifiers are present in this list even when the algorithm is disabled
  * at compile time.
+ *
+ * @param[in] i Index of the algorithm identifier to return, 0 <= i < OQS_KEM_algs_length
+ * @return Algorithm identifier as a string, or NULL.
  */
-extern char *OQS_KEM_algs[OQS_KEM_algs_length];
+char *OQS_KEM_alg_identifier(size_t i);
 
 /**
  * Key encapsulation mechanism object

--- a/src/kem/kem.h
+++ b/src/kem/kem.h
@@ -26,25 +26,25 @@
 #include <oqs/oqs.h>
 
 /** Algorithm identifier for default KEM algorithm. */
-#define OQS_KEM_alg_default              "DEFAULT"
+#define OQS_KEM_alg_default "DEFAULT"
 /** Algorithm identifier for FrodoKEM-640-AES KEM. */
-#define OQS_KEM_alg_frodokem_640_aes     "FrodoKEM-640-AES"
+#define OQS_KEM_alg_frodokem_640_aes "FrodoKEM-640-AES"
 /** Algorithm identifier for FrodoKEM-640-cSHAKE KEM. */
-#define OQS_KEM_alg_frodokem_640_cshake  "FrodoKEM-640-cSHAKE"
+#define OQS_KEM_alg_frodokem_640_cshake "FrodoKEM-640-cSHAKE"
 /** Algorithm identifier for FrodoKEM-976-AES KEM. */
-#define OQS_KEM_alg_frodokem_976_aes     "FrodoKEM-976-AES"
+#define OQS_KEM_alg_frodokem_976_aes "FrodoKEM-976-AES"
 /** Algorithm identifier for FrodoKEM-976-cSHAKE KEM. */
-#define OQS_KEM_alg_frodokem_976_cshake  "FrodoKEM-976-cSHAKE"
+#define OQS_KEM_alg_frodokem_976_cshake "FrodoKEM-976-cSHAKE"
 /** Algorithm identifier for NewHope512-CCA-KEM KEM. */
-#define OQS_KEM_alg_newhope_512_cca_kem  "NewHope512-CCA-KEM"
+#define OQS_KEM_alg_newhope_512_cca_kem "NewHope512-CCA-KEM"
 /** Algorithm identifier for NewHope1024-CCA-KEM KEM. */
 #define OQS_KEM_alg_newhope_1024_cca_kem "NewHope1024-CCA-KEM"
 /** Algorithm identifier for Kyber512 KEM. */
-#define OQS_KEM_alg_kyber512             "Kyber512"
+#define OQS_KEM_alg_kyber512 "Kyber512"
 /** Algorithm identifier for Kyber768 KEM. */
-#define OQS_KEM_alg_kyber768             "Kyber768"
+#define OQS_KEM_alg_kyber768 "Kyber768"
 /** Algorithm identifier for Kyber1024 KEM. */
-#define OQS_KEM_alg_kyber1024            "Kyber1024"
+#define OQS_KEM_alg_kyber1024 "Kyber1024"
 // EDIT-WHEN-ADDING-KEM
 
 /**

--- a/src/kem/kem.h
+++ b/src/kem/kem.h
@@ -25,31 +25,44 @@
 
 #include <oqs/oqs.h>
 
+/** Algorithm identifier for default KEM algorithm. */
+#define OQS_KEM_alg_default              "DEFAULT"
+/** Algorithm identifier for FrodoKEM-640-AES KEM. */
+#define OQS_KEM_alg_frodokem_640_aes     "FrodoKEM-640-AES"
+/** Algorithm identifier for FrodoKEM-640-cSHAKE KEM. */
+#define OQS_KEM_alg_frodokem_640_cshake  "FrodoKEM-640-cSHAKE"
+/** Algorithm identifier for FrodoKEM-976-AES KEM. */
+#define OQS_KEM_alg_frodokem_976_aes     "FrodoKEM-976-AES"
+/** Algorithm identifier for FrodoKEM-976-cSHAKE KEM. */
+#define OQS_KEM_alg_frodokem_976_cshake  "FrodoKEM-976-cSHAKE"
+/** Algorithm identifier for NewHope512-CCA-KEM KEM. */
+#define OQS_KEM_alg_newhope_512_cca_kem  "NewHope512-CCA-KEM"
+/** Algorithm identifier for NewHope1024-CCA-KEM KEM. */
+#define OQS_KEM_alg_newhope_1024_cca_kem "NewHope1024-CCA-KEM"
+/** Algorithm identifier for Kyber512 KEM. */
+#define OQS_KEM_alg_kyber512             "Kyber512"
+/** Algorithm identifier for Kyber768 KEM. */
+#define OQS_KEM_alg_kyber768             "Kyber768"
+/** Algorithm identifier for Kyber1024 KEM. */
+#define OQS_KEM_alg_kyber1024            "Kyber1024"
+// EDIT-WHEN-ADDING-KEM
+
+/**
+ * Number of KEM algorithms in liboqs; equivalently the length of the OQS_KEM_algs array.
+ *
+ * Note that algorithm identifiers are present in this array even when the algorithm is disabled
+ * at compile time.
+ */
+#define OQS_KEM_algs_length 10
+// EDIT-WHEN-ADDING-KEM
+
 /**
  * Identifiers for available key encapsulation mechanisms in liboqs.  Used with OQS_KEM_new.
  *
- * Note that algorithm identifiers are present in this enum even when the algorithm is disabled
+ * Note that algorithm identifiers are present in this array even when the algorithm is disabled
  * at compile time.
- *
- * The order and numbers of the identifiers (except `OQS_KEM_alg_last`) should remain fixed
- * for binary compability across versions, even if an algorithm is removed.
- *
- * New algorithms should have identifiers added immediately before `OQS_KEM_alg_last`.
  */
-enum OQS_KEM_alg_name {
-	OQS_KEM_alg_default = 0,
-	OQS_KEM_alg_frodokem_640_aes = 1,
-	OQS_KEM_alg_frodokem_976_aes = 2,
-	OQS_KEM_alg_frodokem_640_cshake = 3,
-	OQS_KEM_alg_frodokem_976_cshake = 4,
-	OQS_KEM_alg_newhope_512_cca_kem = 5,
-	OQS_KEM_alg_newhope_1024_cca_kem = 6,
-	OQS_KEM_alg_kyber512 = 7,
-	OQS_KEM_alg_kyber768 = 8,
-	OQS_KEM_alg_kyber1024 = 9,
-	// EDIT-WHEN-ADDING-KEM
-	OQS_KEM_alg_last = 10
-};
+extern char *OQS_KEM_algs[OQS_KEM_algs_length];
 
 /**
  * Key encapsulation mechanism object
@@ -124,12 +137,12 @@ typedef struct OQS_KEM {
  * Consturcts an OQS_KEM object for a particular algorithm.
  *
  * Callers should always check whether the return value is `NULL`, which indicates either than an
- * invalid algorithm identifier was provided, or that the requested algorithm was disabled at compile-time.
+ * invalid algorithm name was provided, or that the requested algorithm was disabled at compile-time.
  *
- * @param[in] alg_name Identifier of the desired KEM algorithm.
+ * @param[in] method_name Name of the desired algorithm; one of the names in `OQS_KEM_algs`.
  * @return An OQS_KEM for the particular algorithm, or `NULL` if the algorithm has been disabled at compile-time.
  */
-OQS_KEM *OQS_KEM_new(enum OQS_KEM_alg_name alg_name);
+OQS_KEM *OQS_KEM_new(const char *method_name);
 
 /**
  * Keypair generation algorithm.

--- a/src/kem/newhopenist/kem_newhopenist.c
+++ b/src/kem/newhopenist/kem_newhopenist.c
@@ -10,7 +10,7 @@ OQS_KEM *OQS_KEM_newhope_512_cca_kem_new() {
 	if (kem == NULL) {
 		return NULL;
 	}
-	kem->method_name = "NewHope512-CCA-KEM";
+	kem->method_name = OQS_KEM_alg_newhope_512_cca_kem;
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -37,7 +37,7 @@ OQS_KEM *OQS_KEM_newhope_1024_cca_kem_new() {
 	if (kem == NULL) {
 		return NULL;
 	}
-	kem->method_name = "NewHope1024-CCA-KEM";
+	kem->method_name = OQS_KEM_alg_newhope_1024_cca_kem;
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = true;

--- a/src/kem/speed_kem.c
+++ b/src/kem/speed_kem.c
@@ -62,11 +62,11 @@ cleanup:
 
 OQS_STATUS printAlgs() {
 	for (size_t i = 0; i < OQS_KEM_algs_length; i++) {
-		OQS_KEM *kem = OQS_KEM_new(OQS_KEM_algs[i]);
+		OQS_KEM *kem = OQS_KEM_new(OQS_KEM_alg_identifier(i));
 		if (kem == NULL) {
-			printf("%s (disabled)\n", OQS_KEM_algs[i]);
+			printf("%s (disabled)\n", OQS_KEM_alg_identifier(i));
 		} else {
-			printf("%s\n", OQS_KEM_algs[i]);
+			printf("%s\n", OQS_KEM_alg_identifier(i));
 		}
 		OQS_KEM_free(kem);
 	}
@@ -151,7 +151,7 @@ int main(int argc, char **argv) {
 		}
 	} else {
 		for (size_t i = 0; i < OQS_KEM_algs_length; i++) {
-			rc = kem_speed_wrapper(OQS_KEM_algs[i], duration, printKemInfo);
+			rc = kem_speed_wrapper(OQS_KEM_alg_identifier(i), duration, printKemInfo);
 			if (rc != OQS_SUCCESS) {
 				ret = EXIT_FAILURE;
 			}

--- a/src/kem/speed_kem.c
+++ b/src/kem/speed_kem.c
@@ -8,7 +8,7 @@
 
 #include "../common/ds_benchmark.h"
 
-static OQS_STATUS kem_speed_wrapper(enum OQS_KEM_alg_name alg_name, int duration, bool printInfo) {
+static OQS_STATUS kem_speed_wrapper(const char *method_name, int duration, bool printInfo) {
 
 	OQS_KEM *kem = NULL;
 	uint8_t *public_key = NULL;
@@ -18,7 +18,7 @@ static OQS_STATUS kem_speed_wrapper(enum OQS_KEM_alg_name alg_name, int duration
 	uint8_t *shared_secret_d = NULL;
 	OQS_STATUS ret = OQS_ERROR;
 
-	kem = OQS_KEM_new(alg_name);
+	kem = OQS_KEM_new(method_name);
 	if (kem == NULL) {
 		return OQS_SUCCESS;
 	}
@@ -61,12 +61,13 @@ cleanup:
 }
 
 OQS_STATUS printAlgs() {
-	for (int i = OQS_KEM_alg_default; i < OQS_KEM_alg_last; i++) {
-		OQS_KEM *kem = OQS_KEM_new(i);
+	for (size_t i = 0; i < OQS_KEM_algs_length; i++) {
+		OQS_KEM *kem = OQS_KEM_new(OQS_KEM_algs[i]);
 		if (kem == NULL) {
-			return OQS_ERROR;
+			printf("%s (disabled)\n", OQS_KEM_algs[i]);
+		} else {
+			printf("%s\n", OQS_KEM_algs[i]);
 		}
-		printf("%s\n", kem->method_name);
 		OQS_KEM_free(kem);
 	}
 	return OQS_SUCCESS;
@@ -80,7 +81,8 @@ int main(int argc, char **argv) {
 	bool printUsage = false;
 	int duration = 3;
 	bool printKemInfo = false;
-	enum OQS_KEM_alg_name single_alg = OQS_KEM_alg_last;
+
+	OQS_KEM *single_kem = NULL;
 
 	for (int i = 1; i < argc; i++) {
 		if (strcmp(argv[i], "--algs") == 0) {
@@ -105,18 +107,8 @@ int main(int argc, char **argv) {
 			printKemInfo = true;
 			continue;
 		} else {
-			for (int alg_name = OQS_KEM_alg_default; alg_name < OQS_KEM_alg_last; alg_name++) {
-				OQS_KEM *kem = OQS_KEM_new(alg_name);
-				if (kem == NULL) {
-					return EXIT_FAILURE;
-				}
-				if (strcmp(argv[i], kem->method_name) == 0) {
-					single_alg = alg_name;
-				}
-				OQS_KEM_free(kem);
-			}
-			// didn't find one?
-			if (single_alg == OQS_KEM_alg_last) {
+			single_kem = OQS_KEM_new(argv[i]);
+			if (single_kem == NULL) {
 				printUsage = true;
 				break;
 			}
@@ -152,14 +144,14 @@ int main(int argc, char **argv) {
 	printf("==========\n");
 
 	PRINT_TIMER_HEADER
-	if (single_alg != OQS_KEM_alg_last) {
-		rc = kem_speed_wrapper(single_alg, duration, printKemInfo);
+	if (single_kem != NULL) {
+		rc = kem_speed_wrapper(single_kem->method_name, duration, printKemInfo);
 		if (rc != OQS_SUCCESS) {
 			ret = EXIT_FAILURE;
 		}
 	} else {
-		for (int i = OQS_KEM_alg_default; i < OQS_KEM_alg_last; i++) {
-			rc = kem_speed_wrapper(i, duration, printKemInfo);
+		for (size_t i = 0; i < OQS_KEM_algs_length; i++) {
+			rc = kem_speed_wrapper(OQS_KEM_algs[i], duration, printKemInfo);
 			if (rc != OQS_SUCCESS) {
 				ret = EXIT_FAILURE;
 			}

--- a/src/kem/test_kem.c
+++ b/src/kem/test_kem.c
@@ -5,7 +5,7 @@
 
 #include <oqs/oqs.h>
 
-static OQS_STATUS kem_test_correctness(enum OQS_KEM_alg_name alg_name) {
+static OQS_STATUS kem_test_correctness(const char *method_name) {
 
 	OQS_KEM *kem = NULL;
 	uint8_t *public_key = NULL;
@@ -16,7 +16,7 @@ static OQS_STATUS kem_test_correctness(enum OQS_KEM_alg_name alg_name) {
 	OQS_STATUS rc, ret = OQS_ERROR;
 	int rv;
 
-	kem = OQS_KEM_new(alg_name);
+	kem = OQS_KEM_new(method_name);
 	if (kem == NULL) {
 		return OQS_SUCCESS;
 	}
@@ -86,8 +86,8 @@ int main() {
 	int ret = EXIT_SUCCESS;
 	OQS_STATUS rc;
 
-	for (int i = OQS_KEM_alg_default; i < OQS_KEM_alg_last; i++) {
-		rc = kem_test_correctness(i);
+	for (size_t i = 0; i < OQS_KEM_algs_length; i++) {
+		rc = kem_test_correctness(OQS_KEM_algs[i]);
 		if (rc != OQS_SUCCESS) {
 			ret = EXIT_FAILURE;
 		}

--- a/src/kem/test_kem.c
+++ b/src/kem/test_kem.c
@@ -87,7 +87,7 @@ int main() {
 	OQS_STATUS rc;
 
 	for (size_t i = 0; i < OQS_KEM_algs_length; i++) {
-		rc = kem_test_correctness(OQS_KEM_algs[i]);
+		rc = kem_test_correctness(OQS_KEM_alg_identifier(i));
 		if (rc != OQS_SUCCESS) {
 			ret = EXIT_FAILURE;
 		}


### PR DESCRIPTION
I was using an enum for algorithm identifiers, and some code assumed that these were sequential.  Assuming sequential means that if we want to remove an algorithm, we can't have gaps. So we'd have to reassign numbers.  But then this would mean binary incompatibility between different versions of liboqs nist-branch.  We also could not have binary compatibility with liboqs master (once master gets the new KEM API) because a different order of KEMs.  So I am trying strings for algorithm identifiers.