### PR TITLE
Fix opened message length to match NIST/SUPERCOP/Nacl conventions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,21 +59,23 @@ ifeq ($(arch), "x64")
   CFLAGS+= -arch x86_64
 endif
 
-BINUTILS_VER=$(shell ld -v | grep -o "[0-9][0-9]*.[0-9][0-9]*")
-ifneq (,$(BINUTILS_VER))
-  ifeq ($(shell expr $(BINUTILS_VER) \>= 2.26), 1)
-    SUPPORTED_BINUTILS=1
-    export SUPPORTED_BINUTILS
-    CFLAGS+=-DSUPPORTED_BINUTILS=1
-  endif
+ifeq ($(DETECTED_OS), Linux)
+  BINUTILS_VER=$(shell ld -v | grep -o "[0-9][0-9]*.[0-9][0-9]*")
+  ifneq (,$(BINUTILS_VER))
+    ifeq ($(shell expr $(BINUTILS_VER) \>= 2.26), 1)
+      SUPPORTED_BINUTILS=1
+      export SUPPORTED_BINUTILS
+      CFLAGS+=-DSUPPORTED_BINUTILS=1
+    endif
 
-  #Allow AVX optimizations only if a relevant binutils is being in use.
-  ifneq (,$(AVX512_SUPPORT))
-    CFLAGS+=-DAVX512
-  else ifneq (,$(AVX2_SUPPORT))
-    CFLAGS+=-DAVX2
-  else ifneq (,$(AVX_SUPPORT))
-    CFLAGS+=-DAVX
+    #Allow AVX optimizations only if a relevant binutils is being in use.
+    ifneq (,$(AVX512_SUPPORT))
+      CFLAGS+=-DAVX512
+    else ifneq (,$(AVX2_SUPPORT))
+      CFLAGS+=-DAVX2
+    else ifneq (,$(AVX_SUPPORT))
+      CFLAGS+=-DAVX
+    endif
   endif
 endif
 

--- a/src/sig/example_sig.c
+++ b/src/sig/example_sig.c
@@ -32,8 +32,10 @@ static OQS_STATUS example_stack() {
 	uint8_t secret_key[OQS_SIG_qTESLA_I_length_secret_key];
 	uint8_t message[MESSAGE_LEN];
 	uint8_t signed_message[MESSAGE_LEN + OQS_SIG_qTESLA_I_length_sig_overhead];
+	uint8_t opened_message[MESSAGE_LEN + OQS_SIG_qTESLA_I_length_sig_overhead];
 	size_t message_len = MESSAGE_LEN;
 	size_t signed_message_len;
+	size_t opened_message_len;
 
 	OQS_randombytes(message, MESSAGE_LEN);
 
@@ -47,7 +49,7 @@ static OQS_STATUS example_stack() {
 		fprintf(stderr, "ERROR: OQS_SIG_qTESLA_I_sign failed!\n");
 		goto err;
 	}
-	rc = OQS_SIG_qTESLA_I_sign_open(message, &message_len, signed_message, signed_message_len, public_key);
+	rc = OQS_SIG_qTESLA_I_sign_open(opened_message, &opened_message_len, signed_message, signed_message_len, public_key);
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_SIG_qTESLA_I_sign_open failed!\n");
 		goto err;
@@ -85,8 +87,10 @@ static OQS_STATUS example_heap() {
 	uint8_t *secret_key = NULL;
 	uint8_t *message = NULL;
 	uint8_t *signed_message = NULL;
+	uint8_t *opened_message = NULL;
 	size_t message_len = 50;
 	size_t signed_message_len;
+	size_t opened_message_len;
 	OQS_STATUS rc;
 	OQS_STATUS ret = OQS_ERROR;
 
@@ -100,7 +104,8 @@ static OQS_STATUS example_heap() {
 	secret_key = malloc(sig->length_secret_key);
 	message = malloc(message_len);
 	signed_message = malloc(message_len + sig->length_sig_overhead);
-	if ((public_key == NULL) || (secret_key == NULL) || (message == NULL) || (signed_message == NULL)) {
+	opened_message = malloc(message_len + sig->length_sig_overhead);
+	if ((public_key == NULL) || (secret_key == NULL) || (message == NULL) || (signed_message == NULL) || (opened_message == NULL)) {
 		fprintf(stderr, "ERROR: malloc failed!\n");
 		goto err;
 	}
@@ -117,7 +122,7 @@ static OQS_STATUS example_heap() {
 		fprintf(stderr, "ERROR: OQS_SIG_sign failed!\n");
 		goto err;
 	}
-	rc = OQS_SIG_sign_open(sig, message, &message_len, signed_message, signed_message_len, public_key);
+	rc = OQS_SIG_sign_open(sig, opened_message, &opened_message_len, signed_message, signed_message_len, public_key);
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_SIG_sign_open failed!\n");
 		goto err;
@@ -135,6 +140,7 @@ cleanup:
 		OQS_MEM_secure_free(secret_key, sig->length_secret_key);
 	}
 	OQS_MEM_insecure_free(public_key);
+	OQS_MEM_insecure_free(opened_message);
 	OQS_MEM_insecure_free(signed_message);
 	OQS_MEM_insecure_free(message);
 	OQS_SIG_free(sig);

--- a/src/sig/kat_sig.c
+++ b/src/sig/kat_sig.c
@@ -64,7 +64,7 @@ static OQS_STATUS sig_kat(const char *method_name) {
 	fprintf(fh, "mlen = %lu\n", mlen);
 	public_key = malloc(sig->length_public_key);
 	secret_key = malloc(sig->length_secret_key);
-	message = malloc(mlen);
+	message = malloc(mlen + sig->length_sig_overhead);
 	signed_message = malloc(mlen + sig->length_sig_overhead);
 	if ((public_key == NULL) || (secret_key == NULL) || (message == NULL) || (signed_message == NULL)) {
 		fprintf(stderr, "[kat_sig] %s ERROR: malloc failed!\n", method_name);

--- a/src/sig/speed_sig.c
+++ b/src/sig/speed_sig.c
@@ -26,7 +26,7 @@ static OQS_STATUS sig_speed_wrapper(const char *method_name, int duration, bool 
 
 	public_key = malloc(sig->length_public_key);
 	secret_key = malloc(sig->length_secret_key);
-	message = malloc(message_len);
+	message = malloc(message_len + sig->length_sig_overhead);
 	signed_message = malloc(message_len + sig->length_sig_overhead);
 
 	if ((public_key == NULL) || (secret_key == NULL) || (message == NULL) || (signed_message == NULL)) {

--- a/src/sig/test_sig.c
+++ b/src/sig/test_sig.c
@@ -12,8 +12,10 @@ static OQS_STATUS sig_test_correctness(const char *method_name) {
 	uint8_t *secret_key = NULL;
 	uint8_t *message = NULL;
 	uint8_t *signed_message = NULL;
+	uint8_t *opened_message = NULL;
 	size_t message_len = 50;
 	size_t signed_message_len;
+	size_t opened_message_len;
 	OQS_STATUS rc, ret = OQS_ERROR;
 
 	sig = OQS_SIG_new(method_name);
@@ -29,8 +31,9 @@ static OQS_STATUS sig_test_correctness(const char *method_name) {
 	secret_key = malloc(sig->length_secret_key);
 	message = malloc(message_len);
 	signed_message = malloc(message_len + sig->length_sig_overhead);
+	opened_message = malloc(message_len + sig->length_sig_overhead);
 
-	if ((public_key == NULL) || (secret_key == NULL) || (message == NULL) || (signed_message == NULL)) {
+	if ((public_key == NULL) || (secret_key == NULL) || (message == NULL) || (signed_message == NULL) || (opened_message == NULL)) {
 		fprintf(stderr, "ERROR: malloc failed!\n");
 		goto err;
 	}
@@ -49,9 +52,19 @@ static OQS_STATUS sig_test_correctness(const char *method_name) {
 		goto err;
 	}
 
-	rc = OQS_SIG_sign_open(sig, message, &message_len, signed_message, signed_message_len, public_key);
+	rc = OQS_SIG_sign_open(sig, opened_message, &opened_message_len, signed_message, signed_message_len, public_key);
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_SIG_sign_open failed!\n");
+		goto err;
+	}
+
+	if (message_len != opened_message_len) {
+		fprintf(stderr, "ERROR: OQS_SIG_sign_open resulted in different opened message length\n");
+		goto err;
+	}
+
+	if (0 != memcmp(message, opened_message, opened_message_len)) {
+		fprintf(stderr, "ERROR: OQS_SIG_sign_open resulted in different opened message\n");
 		goto err;
 	}
 
@@ -75,6 +88,7 @@ cleanup:
 		OQS_MEM_secure_free(secret_key, sig->length_secret_key);
 	}
 	OQS_MEM_insecure_free(public_key);
+	OQS_MEM_insecure_free(opened_message);
 	OQS_MEM_insecure_free(signed_message);
 	OQS_MEM_insecure_free(message);
 	OQS_SIG_free(sig);


### PR DESCRIPTION
Identified by @tlepoint in #319 but doing as a separate pull request so it gets into the July snapshot release of nist-branch.  