### PR TITLE
-march=native compiler optimization added for qTesla, NewHope and Kyber

### DIFF
--- a/src/kem/crystals-kyber/Makefile
+++ b/src/kem/crystals-kyber/Makefile
@@ -39,7 +39,7 @@ OBJS_KEM_KYBER512_CCA_KEM=$(SRCS_KEM_KYBER512_CCA_KEM:.c=.o)
 TO_CLEAN+=$(OBJS_KEM_KYBER512_CCA_KEM)
 
 src/kem/crystals-kyber/upstream/Optimized_Implementation/crypto_kem/kyber512/%.o: src/kem/crystals-kyber/upstream/Optimized_Implementation/crypto_kem/kyber512/%.c
-	$(CC) -c -fPIC -O3 -std=c99 -o $@ $< -I$(OPENSSL_INCLUDE_DIR)
+	$(CC) -c -fPIC -O3 -std=c99 -march=native -o $@ $< -I$(OPENSSL_INCLUDE_DIR)
 
 kem_kyber512_upstream: $(OBJS_KEM_KYBER512_CCA_KEM)
 	bash scripts/collect_objects.sh kem_kyber512 $(OBJS_KEM_KYBER512_CCA_KEM)
@@ -65,7 +65,7 @@ OBJS_KEM_KYBER768_CCA_KEM=$(SRCS_KEM_KYBER768_CCA_KEM:.c=.o)
 TO_CLEAN+=$(OBJS_KEM_KYBER768_CCA_KEM)
 
 src/kem/crystals-kyber/upstream/Optimized_Implementation/crypto_kem/kyber768/%.o: src/kem/crystals-kyber/upstream/Optimized_Implementation/crypto_kem/kyber768/%.c
-	$(CC) -c -fPIC -O3 -std=c99 -o $@ $< -I$(OPENSSL_INCLUDE_DIR)
+	$(CC) -c -fPIC -O3 -std=c99 -march=native -o $@ $< -I$(OPENSSL_INCLUDE_DIR)
 
 kem_kyber768_upstream: $(OBJS_KEM_KYBER768_CCA_KEM)
 	bash scripts/collect_objects.sh kem_kyber768 $(OBJS_KEM_KYBER768_CCA_KEM)
@@ -91,7 +91,7 @@ OBJS_KEM_KYBER1024_CCA_KEM=$(SRCS_KEM_KYBER1024_CCA_KEM:.c=.o)
 TO_CLEAN+=$(OBJS_KEM_KYBER1024_CCA_KEM)
 
 src/kem/crystals-kyber/upstream/Optimized_Implementation/crypto_kem/kyber1024/%.o: src/kem/crystals-kyber/upstream/Optimized_Implementation/crypto_kem/kyber1024/%.c
-	$(CC) -c -fPIC -O3 -std=c99 -o $@ $< -I$(OPENSSL_INCLUDE_DIR)
+	$(CC) -c -fPIC -O3 -std=c99 -march=native -o $@ $< -I$(OPENSSL_INCLUDE_DIR)
 
 kem_kyber1024_usptream: $(OBJS_KEM_KYBER1024_CCA_KEM)
 	bash scripts/collect_objects.sh kem_kyber1024 $(OBJS_KEM_KYBER1024_CCA_KEM)

--- a/src/kem/newhopenist/Makefile
+++ b/src/kem/newhopenist/Makefile
@@ -28,7 +28,7 @@ OBJS_KEM_NEWHOPE_512_CCA_KEM=$(SRCS_KEM_NEWHOPE_512_CCA_KEM:.c=.o)
 TO_CLEAN+= $(OBJS_KEM_NEWHOPE_512_CCA_KEM)
 
 src/kem/newhopenist/upstream/Optimized_Implementation/crypto_kem/newhope512cca/%.o: src/kem/newhopenist/upstream/Optimized_Implementation/crypto_kem/newhope512cca/%.c
-	$(CC) -c -fPIC -O3 -std=c99 -o $@ $< -I$(OPENSSL_INCLUDE_DIR)
+	$(CC) -c -fPIC -O3 -std=c99 -march=native -o $@ $< -I$(OPENSSL_INCLUDE_DIR)
 
 kem_newhope_512_cca_kem_upstream: $(OBJS_KEM_NEWHOPE_512_CCA_KEM)
 	bash scripts/collect_objects.sh kem_newhope_512_cca_kem $(OBJS_KEM_NEWHOPE_512_CCA_KEM)
@@ -45,7 +45,7 @@ OBJS_KEM_NEWHOPE_1024_CCA_KEM=$(SRCS_KEM_NEWHOPE_1024_CCA_KEM:.c=.o)
 TO_CLEAN+= $(OBJS_KEM_NEWHOPE_1024_CCA_KEM)
 
 src/kem/newhopenist/upstream/Optimized_Implementation/crypto_kem/newhope1024cca/%.o: src/kem/newhopenist/upstream/Optimized_Implementation/crypto_kem/newhope1024cca/%.c
-	$(CC) -c -fPIC -O3 -std=c99 -o $@ $< -I$(OPENSSL_INCLUDE_DIR)
+	$(CC) -c -fPIC -O3 -std=c99 -march=native -o $@ $< -I$(OPENSSL_INCLUDE_DIR)
 
 kem_newhope_1024_cca_kem_upstream: $(OBJS_KEM_NEWHOPE_1024_CCA_KEM)
 	bash scripts/collect_objects.sh kem_newhope_1024_cca_kem $(OBJS_KEM_NEWHOPE_1024_CCA_KEM)

--- a/src/sig/qtesla/Makefile
+++ b/src/sig/qtesla/Makefile
@@ -24,7 +24,7 @@ OBJS_SIG_QTESLA_I=$(SRCS_SIG_QTESLA_I:.c=.o)
 TO_CLEAN+= $(OBJS_SIG_QTESLA_I)
 
 src/sig/qtesla/upstream/Reference_implementation/qTesla_I/%.o: src/sig/qtesla/upstream/Reference_implementation/qTesla_I/%.c
-	$(CC) -c -fPIC -O3 -std=c99 -o $@ $<
+	$(CC) -c -fPIC -O3 -std=c99 -march=native -o $@ $<
 
 sig_qTESLA_I_upstream: $(OBJS_SIG_QTESLA_I)
 	bash scripts/collect_objects.sh sig_qTESLA_I $(OBJS_SIG_QTESLA_I)
@@ -41,7 +41,7 @@ OBJS_SIG_QTESLA_III_SIZE=$(SRCS_SIG_QTESLA_III_SIZE:.c=.o)
 TO_CLEAN+= $(OBJS_SIG_QTESLA_III_SIZE)
 
 src/sig/qtesla/upstream/Reference_implementation/qTesla_III_size/%.o: src/sig/qtesla/upstream/Reference_implementation/qTesla_III_size/%.c
-	$(CC) -c -fPIC -O3 -std=c99 -o $@ $<
+	$(CC) -c -fPIC -O3 -std=c99 -march=native -o $@ $<
 
 sig_qTESLA_III_size_upstream: $(OBJS_SIG_QTESLA_III_SIZE)
 	bash scripts/collect_objects.sh sig_qTESLA_III_size $(OBJS_SIG_QTESLA_III_SIZE)
@@ -58,7 +58,7 @@ OBJS_SIG_QTESLA_III_SPEED=$(SRCS_SIG_QTESLA_III_SPEED:.c=.o)
 TO_CLEAN+= $(OBJS_SIG_QTESLA_III_SPEED)
 
 src/sig/qtesla/upstream/Reference_implementation/qTesla_III_speed/%.o: src/sig/qtesla/upstream/Reference_implementation/qTesla_III_speed/%.c
-	$(CC) -c -fPIC -O3 -std=c99 -o $@ $<
+	$(CC) -c -fPIC -O3 -std=c99 -march=native -o $@ $<
 
 sig_qTESLA_III_speed_upstream: $(OBJS_SIG_QTESLA_III_SPEED)
 	bash scripts/collect_objects.sh sig_qTESLA_III_speed $(OBJS_SIG_QTESLA_III_SPEED)
@@ -75,7 +75,7 @@ OBJS_SIG_QTESLA_P_I=$(SRCS_SIG_QTESLA_P_I:.c=.o)
 TO_CLEAN+= $(OBJS_SIG_QTESLA_P_I)
 
 src/sig/qtesla/upstream/Reference_implementation/qTesla_p_I/%.o: src/sig/qtesla/upstream/Reference_implementation/qTesla_p_I/%.c
-	$(CC) -c -fPIC -O3 -std=c99 -o $@ $<
+	$(CC) -c -fPIC -O3 -std=c99 -march=native -o $@ $<
 
 sig_qTESLA_p_I_upstream: $(OBJS_SIG_QTESLA_P_I)
 	bash scripts/collect_objects.sh sig_qTESLA_p_I $(OBJS_SIG_QTESLA_P_I)
@@ -92,7 +92,7 @@ OBJS_SIG_QTESLA_P_III=$(SRCS_SIG_QTESLA_P_III:.c=.o)
 TO_CLEAN+= $(OBJS_SIG_QTESLA_P_III)
 
 src/sig/qtesla/upstream/Reference_implementation/qTesla_p_III/%.o: src/sig/qtesla/upstream/Reference_implementation/qTesla_p_III/%.c
-	$(CC) -c -fPIC -O3 -std=c99 -o $@ $<
+	$(CC) -c -fPIC -O3 -std=c99 -march=native -o $@ $<
 
 sig_qTESLA_p_III_upstream: $(OBJS_SIG_QTESLA_P_III)
 	bash scripts/collect_objects.sh sig_qTESLA_p_III $(OBJS_SIG_QTESLA_P_III)


### PR DESCRIPTION
I have added -march=native compiler flag to Makefiles in qTesla, NewHope, and Kyber subdirectories. It has noticable effect on qTesla and NewHope, but it seems that Kyber has similar results with or without the flag.

