### PR TITLE
Refactor BIKE renaming macros

### DIFF
--- a/src/common/common.h
+++ b/src/common/common.h
@@ -125,4 +125,30 @@ void OQS_MEM_insecure_free(void *ptr);
  */
 #define OQS_API __attribute__((visibility("default")))
 
+/** Internal macro used for function renaming. */
+#define PASTER(x, y) x##_##y
+
+/** Internal macro used for function renaming. */
+#define EVALUATOR(x, y) PASTER(x, y)
+
+/**
+ * Used for renaming functions.
+ *
+ * Some implementations are structured so that binaries for multiple parameter
+ * sets are generated from the same source code but with different macros set.
+ * This causes problems when trying to assemble a single binary.
+ *
+ * To apply this technique to an implementation, do the following in that
+ * implementation's directory:
+ * 1. Define the appropriate prefix as a compiler flag -DFUNC_PREFIX=whatever
+ *    in Makefile.am
+ * 2. Create a functions_renaming.h file that uses RENAME_FUNC_NAME to combine
+ *    the specified prefix with a basename.
+ * 3. include "functions_renaming.h" in all files in that subdirectory that
+ *    need to have their functions renamed during compilation.
+ *
+ * See src/kem/bike for an example usage.
+ */
+#define RENAME_FUNC_NAME(fname) EVALUATOR(FUNC_PREFIX, fname)
+
 #endif // __OQS_COMMON_H

--- a/src/kem/bike/Makefile.am
+++ b/src/kem/bike/Makefile.am
@@ -1,5 +1,5 @@
 AUTOMAKE_OPTIONS = foreign
-noinst_LTLIBRARIES  = libkembike.la 
+noinst_LTLIBRARIES  = libkembike.la
 noinst_LTLIBRARIES += libkembike1_l1.la libkembike1_l3.la libkembike1_l5.la
 noinst_LTLIBRARIES += libkembike2_l1.la libkembike2_l3.la libkembike2_l5.la
 noinst_LTLIBRARIES += libkembike3_l1.la libkembike3_l3.la libkembike3_l5.la
@@ -8,9 +8,9 @@ libkembike_la_LIBADD = libkembike1_l1.la libkembike1_l3.la libkembike1_l5.la
 libkembike_la_LIBADD += libkembike2_l1.la libkembike2_l3.la libkembike2_l5.la
 libkembike_la_LIBADD += libkembike3_l1.la libkembike3_l3.la libkembike3_l5.la
 
-libkembike_la_SOURCES = kem_bike.c 
+libkembike_la_SOURCES = kem_bike.c
 
-COMMON_FLAGS = $(AM_CFLAGS) -include functions_renaming.h
+COMMON_FLAGS = $(AM_CFLAGS)
 libkembike_la_CFLAGS = $(COMMON_FLAGS)
 
 #When AVX2 is supported also AVX512 is supported and we can use the additional implementation.
@@ -20,8 +20,8 @@ else
   BIKE_SRC_DIR=ref/
 endif
 
-COMMON_CSRCS = $(BIKE_SRC_DIR)/kem.c $(BIKE_SRC_DIR)/aes_ctr_prf.c $(BIKE_SRC_DIR)/parallel_hash.c 
-COMMON_CSRCS += $(BIKE_SRC_DIR)/sampling.c $(BIKE_SRC_DIR)/utilities.c $(BIKE_SRC_DIR)/decode.c 
+COMMON_CSRCS = $(BIKE_SRC_DIR)/kem.c $(BIKE_SRC_DIR)/aes_ctr_prf.c $(BIKE_SRC_DIR)/parallel_hash.c
+COMMON_CSRCS += $(BIKE_SRC_DIR)/sampling.c $(BIKE_SRC_DIR)/utilities.c $(BIKE_SRC_DIR)/decode.c
 
 if BIKE_ADDITIONAL_IMPL
   COMMON_CSRCS += $(BIKE_SRC_DIR)/aes.c $(BIKE_SRC_DIR)/sha.c
@@ -30,7 +30,7 @@ if BIKE_ADDITIONAL_IMPL
   COMMON_CSRCS += $(BIKE_SRC_DIR)/sha384_update_mb.S $(BIKE_SRC_DIR)/red.S
   COMMON_CSRCS += $(BIKE_SRC_DIR)/sampling_x86_64.S  $(BIKE_SRC_DIR)/decode_x86_64.S
 else
-  COMMON_CSRCS += $(BIKE_SRC_DIR)/conversions.c 
+  COMMON_CSRCS += $(BIKE_SRC_DIR)/conversions.c
 endif
 
 libkembike1_l1_la_SOURCES = $(COMMON_CSRCS)

--- a/src/kem/bike/functions_renaming.h
+++ b/src/kem/bike/functions_renaming.h
@@ -32,12 +32,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
-#ifndef __FUNCTIONS_RENAMING_H_INCLUDED__
-#define __FUNCTIONS_RENAMING_H_INCLUDED__
-
-#define PASTER(x, y) x##_##y
-#define EVALUATOR(x, y) PASTER(x, y)
-#define RENAME_FUNC_NAME(fname) EVALUATOR(FUNC_PREFIX, fname)
+#include <oqs/common.h>
 
 #define keypair RENAME_FUNC_NAME(keypair)
 #define decaps RENAME_FUNC_NAME(decaps)
@@ -85,5 +80,3 @@
 #define find_error1 RENAME_FUNC_NAME(find_error1)
 #define find_error2 RENAME_FUNC_NAME(find_error2)
 #define compute_counter_of_unsat RENAME_FUNC_NAME(compute_counter_of_unsat)
-
-#endif //__FUNCTIONS_RENAMING_H_INCLUDED__

--- a/src/kem/bike/ref/aes_ctr_prf.c
+++ b/src/kem/bike/ref/aes_ctr_prf.c
@@ -31,6 +31,7 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+#include "../functions_renaming.h"
 #include "aes_ctr_prf.h"
 #include "string.h"
 #include "stdio.h"

--- a/src/kem/bike/ref/aes_ctr_prf.h
+++ b/src/kem/bike/ref/aes_ctr_prf.h
@@ -35,6 +35,7 @@
 #ifndef __AES_CTR_REF_H_INCLUDED__
 #define __AES_CTR_REF_H_INCLUDED__
 
+#include "../functions_renaming.h"
 #include "types.h"
 #include "oqs/common.h"
 #include "openssl/aes.h"

--- a/src/kem/bike/ref/conversions.c
+++ b/src/kem/bike/ref/conversions.c
@@ -32,6 +32,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
+ #include "../functions_renaming.h"
 #include "types.h"
 
 //////////////////////////////////////////

--- a/src/kem/bike/ref/conversions.h
+++ b/src/kem/bike/ref/conversions.h
@@ -35,6 +35,7 @@
 #ifndef _R_CONVERSIONS_H_
 #define _R_CONVERSIONS_H_
 
+#include "../functions_renaming.h"
 int convertBinaryToByte(uint8_t *out, const uint8_t *in, uint32_t length);
 int convertByteToBinary(uint8_t *out, uint8_t *in, uint32_t length);
 void convert2compact(OUT uint32_t out[DV], IN const uint8_t in[R_BITS]);

--- a/src/kem/bike/ref/decode.c
+++ b/src/kem/bike/ref/decode.c
@@ -5,7 +5,7 @@
  * (drucker.nir@gmail.com, shay.gueron@gmail.com, rafael.misoczki@intel.com, tobias.oder@rub.de, tim.gueneysu@rub.de)
  *
  * This decoder is the decoder used by CAKE. But with the thresholds used by BIKE's decoder.
- * 
+ *
  * Permission to use this code for BIKE is granted.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -34,6 +34,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
+#include "../functions_renaming.h"
 #include "decode.h"
 #include "utilities.h"
 

--- a/src/kem/bike/ref/decode.h
+++ b/src/kem/bike/ref/decode.h
@@ -35,6 +35,7 @@
 #ifndef _R_DECAPS_H_
 #define _R_DECAPS_H_
 
+#include "../functions_renaming.h"
 #include "types.h"
 
 #define MAX_IT 10

--- a/src/kem/bike/ref/defs.h
+++ b/src/kem/bike/ref/defs.h
@@ -35,6 +35,8 @@
 #ifndef __DEFS_H_INCLUDED__
 #define __DEFS_H_INCLUDED__
 
+#include "../functions_renaming.h"
+
 ////////////////////////////////////////////
 //         BIKE main parameters
 ///////////////////////////////////////////

--- a/src/kem/bike/ref/kem.c
+++ b/src/kem/bike/ref/kem.c
@@ -32,6 +32,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
+#include "../functions_renaming.h"
+
 #include "stdio.h"
 #include "string.h"
 

--- a/src/kem/bike/ref/openssl_utils.h
+++ b/src/kem/bike/ref/openssl_utils.h
@@ -35,6 +35,7 @@
 #ifndef _OSSL_UTILITIES_H_
 #define _OSSL_UTILITIES_H_
 
+#include "../functions_renaming.h"
 #include "oqs/common.h"
 
 #include "string.h"

--- a/src/kem/bike/ref/parallel_hash.c
+++ b/src/kem/bike/ref/parallel_hash.c
@@ -32,6 +32,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
+#include "../functions_renaming.h"
 #include "parallel_hash.h"
 #include "utilities.h"
 #include "openssl/sha.h"

--- a/src/kem/bike/ref/parallel_hash.h
+++ b/src/kem/bike/ref/parallel_hash.h
@@ -35,6 +35,7 @@
 #ifndef __PARALLEL_HASH_H_INCLUDED__
 #define __PARALLEL_HASH_H_INCLUDED__
 
+#include "../functions_renaming.h"
 #include "types.h"
 
 #define SHA384_HASH_SIZE 48ULL

--- a/src/kem/bike/ref/sampling.c
+++ b/src/kem/bike/ref/sampling.c
@@ -32,6 +32,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
+#include "../functions_renaming.h"
 #include "sampling.h"
 
 _INLINE_ uint32_t count_ones(IN const uint8_t *a,

--- a/src/kem/bike/ref/sampling.h
+++ b/src/kem/bike/ref/sampling.h
@@ -35,6 +35,7 @@
 #ifndef _SAMPLE_H_
 #define _SAMPLE_H_
 
+#include "../functions_renaming.h"
 #include "oqs/rand.h"
 #include "openssl_utils.h"
 #include "aes_ctr_prf.h"

--- a/src/kem/bike/ref/types.h
+++ b/src/kem/bike/ref/types.h
@@ -35,6 +35,7 @@
 #ifndef __TYPES_H_INCLUDED__
 #define __TYPES_H_INCLUDED__
 
+#include "../functions_renaming.h"
 #include "defs.h"
 #include <stdint.h>
 

--- a/src/kem/bike/ref/utilities.c
+++ b/src/kem/bike/ref/utilities.c
@@ -32,6 +32,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
+#include "../functions_renaming.h"
 #include "utilities.h"
 #include "stdio.h"
 #include "openssl_utils.h"

--- a/src/kem/bike/ref/utilities.h
+++ b/src/kem/bike/ref/utilities.h
@@ -35,6 +35,7 @@
 #ifndef _UTILITIES_H_
 #define _UTILITIES_H_
 
+#include "../functions_renaming.h"
 #include "types.h"
 
 //Printing number is required only in verbose level 2 or above.

--- a/src/kem/bike/x86_64/aes.c
+++ b/src/kem/bike/x86_64/aes.c
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -9,6 +9,7 @@
 * The license is detailed in the file LICENSE.txt, and applies to this file.
 * ***************************************************************************/
 
+#include "../functions_renaming.h"
 #include "aes.h"
 #include <wmmintrin.h>
 #include <tmmintrin.h>

--- a/src/kem/bike/x86_64/aes.h
+++ b/src/kem/bike/x86_64/aes.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -12,6 +12,7 @@
 #ifndef __AES_H_INCLUDED__
 #define __AES_H_INCLUDED__
 
+#include "../functions_renaming.h"
 #include "types.h"
 
 #define AES256_KEY_SIZE 32ULL

--- a/src/kem/bike/x86_64/aes_ctr_prf.c
+++ b/src/kem/bike/x86_64/aes_ctr_prf.c
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -9,6 +9,7 @@
 * The license is detailed in the file LICENSE.txt, and applies to this file.
 * ***************************************************************************/
 
+#include "../functions_renaming.h"
 #include "aes_ctr_prf.h"
 #include "string.h"
 #include "stdio.h"

--- a/src/kem/bike/x86_64/aes_ctr_prf.h
+++ b/src/kem/bike/x86_64/aes_ctr_prf.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -12,6 +12,7 @@
 #ifndef __AES_CTR_REF_H_INCLUDED__
 #define __AES_CTR_REF_H_INCLUDED__
 
+#include "../functions_renaming.h"
 #include "types.h"
 #include "aes.h"
 

--- a/src/kem/bike/x86_64/api.h
+++ b/src/kem/bike/x86_64/api.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -12,6 +12,7 @@
 #ifndef __API_H_INCLUDED__
 #define __API_H_INCLUDED__
 
+#include "../functions_renaming.h"
 #include "types.h"
 
 #define CRYPTO_SECRETKEYBYTES sizeof(sk_t)

--- a/src/kem/bike/x86_64/bike_defs.h
+++ b/src/kem/bike/x86_64/bike_defs.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -12,6 +12,7 @@
 #ifndef __BIKE_DEFS_H_INCLUDED__
 #define __BIKE_DEFS_H_INCLUDED__
 
+#include "../functions_renaming.h"
 #include "defs.h"
 
 #if BIKE_VER > 3

--- a/src/kem/bike/x86_64/converts.S
+++ b/src/kem/bike/x86_64/converts.S
@@ -1,5 +1,5 @@
 ##############################################################################
-# Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+# Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 # Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Written by Nir Drucker and Shay Gueron
@@ -12,6 +12,7 @@
 ##############################################################################
 
 #define __ASM_FILE__
+#include "../functions_renaming.h"
 #include "defs.h"
 
 .data
@@ -30,13 +31,13 @@ SHUF_MASK:
 .byte 0x2,0x2,0x2,0x2,0x2,0x2,0x2,0x2
 .byte 0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3
 
-.text    
+.text
 
 #############################################################################################
 # convert a sequence of uint8_t elements which fully uses all 8-bits of an uint8_t element to
 # a sequence of uint8_t which uses just a single bit per byte (either 0 or 1).
-#void convert_to_redundant_rep(OUT uint8_t* out, 
-#                             IN const uint8_t * in, 
+#void convert_to_redundant_rep(OUT uint8_t* out,
+#                             IN const uint8_t * in,
 #                             IN const uint64_t length)
 
 .set out, %rdi
@@ -79,7 +80,7 @@ convert_to_redundant_rep:
     xor in_itr, in_itr
     xor out_itr, out_itr
     mov $6*4, in_next_itr
-    
+
     vmovdqu  BIT_MASK(%rip), BIT_MASK_REG
     vmovdqu  ONES_MASK(%rip), ONES
     vmovdqu  SHUF_MASK(%rip), SHUF_MASK_REG
@@ -89,23 +90,23 @@ convert_to_redundant_rep:
     .irpc i,012345
         vpbroadcastd 0x4*\i(in, in_itr, 1), DUP4_\i
     .endr
-    
+
     .irpc i,012345
         vpshufb SHUF_MASK_REG, DUP4_\i, DUP4_\i
     .endr
-    
+
     .irpc i,012345
         vpand BIT_MASK_REG, DUP4_\i, DUP4_MASKED\i
     .endr
-    
+
     .irpc i,012345
         vpcmpeqb ZERO, DUP4_MASKED\i, DUP4_MASKED\i
     .endr
-    
+
     .irpc i,012345
         vpaddb DUP4_MASKED\i, ONES, DUP4_MASKED\i
     .endr
-    
+
     .irpc i,012345
         vmovdqu DUP4_MASKED\i, YMM_SIZE*\i(out, out_itr, 1)
     .endr
@@ -157,12 +158,12 @@ convert_to_redundant_rep:
 count_ones:
     push len
     xor %rax, %rax
-    
+
     mov len, qw_itr
     mov len, len_itr
     shr $3, qw_itr
     and $0x7, len_itr
-    
+
     test qw_itr,qw_itr
     jz .co_singles_loop
 
@@ -176,10 +177,10 @@ count_ones:
 .co_singles:
     test len_itr, len_itr
     jz .end_co
-    
+
     #zero upper bits val64
     xor val64, val64
-    
+
 .co_singles_loop:
     movb -0x1(in, len, 1), val8
     popcnt val64, pop_res

--- a/src/kem/bike/x86_64/decode.c
+++ b/src/kem/bike/x86_64/decode.c
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -8,15 +8,16 @@
 *
 * The license is detailed in the file LICENSE.txt, and applies to this file.
 *
-* The optimizations are based on the description developed in the paper: 
-* N. Drucker, S. Gueron, 
-* "A toolbox for software optimization of QC-MDPC code-based cryptosystems", 
+* The optimizations are based on the description developed in the paper:
+* N. Drucker, S. Gueron,
+* "A toolbox for software optimization of QC-MDPC code-based cryptosystems",
 * ePrint (2017).
 * The decoder (in decoder/decoder.c) algorithm is the algorithm included in
 * the early submission of CAKE (due to N. Sandrier and R Misoczki).
 *
 * ***************************************************************************/
 
+#include "../functions_renaming.h"
 #include "decode.h"
 #include "stdio.h"
 #include "string.h"

--- a/src/kem/bike/x86_64/decode.h
+++ b/src/kem/bike/x86_64/decode.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -12,6 +12,7 @@
 #ifndef _R_DECAPS_H_
 #define _R_DECAPS_H_
 
+#include "../functions_renaming.h"
 #include "types.h"
 
 void split_e(OUT split_e_t *split_e, IN const e_t *e);

--- a/src/kem/bike/x86_64/decode_x86_64.S
+++ b/src/kem/bike/x86_64/decode_x86_64.S
@@ -1,5 +1,5 @@
 ##############################################################################
-# Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+# Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 # Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Written by Nir Drucker and Shay Gueron
@@ -12,13 +12,14 @@
 ##############################################################################
 
 #define __ASM_FILE__
+#include "../functions_renaming.h"
 #include "bike_defs.h"
 
 #ifdef USE_AVX512F_INSTRUCTIONS
 
 #ifdef CONSTANT_TIME
 
-.text    
+.text
 #void compute_counter_of_unsat(uint8_t unsat_counter[N_BITS],
 #                              const uint8_t s[R_BITS],
 #                              const uint64_t inv_h0_compressed[DV],
@@ -55,15 +56,15 @@
         #load position
         vbroadcastss 0x4(\inv_h_compressed, itr2, 8), mask
         mov (\inv_h_compressed, itr2, 8), tmp32
-        
+
         #adjust loop offset
-        add itr1, tmp 
+        add itr1, tmp
 
         vpandq (ZMM_SIZE*0)(s, tmp, 1), mask, %zmm16
         vpandq (ZMM_SIZE*1)(s, tmp, 1), mask, %zmm17
         vpandq (ZMM_SIZE*2)(s, tmp, 1), mask, %zmm18
         vpandq (ZMM_SIZE*3)(s, tmp, 1), mask, %zmm19
-        
+
         vpaddb %zmm0, %zmm16, %zmm0
         vpaddb %zmm1, %zmm17, %zmm1
         vpaddb %zmm2, %zmm18, %zmm2
@@ -98,7 +99,7 @@
         vpaddb %zmm13, %zmm29, %zmm13
         vpaddb %zmm14, %zmm30, %zmm14
         vpaddb %zmm15, %zmm31, %zmm15
-                
+
         inc itr2
         cmp $FAKE_DV, itr2
         jl .Linner_loop\tag
@@ -191,7 +192,7 @@ find_error1:
 .find_err1_start:
     movb (upc), val
     mov $R_BITS-1, itr
-    
+
     MASK_OR black_th black_acc
     MASK_OR gray_th gray_acc
 
@@ -200,7 +201,7 @@ find_error1:
     movb (upc, itr, 1), val
     xor   cmp_res64, cmp_res64
     rol bit
-    
+
     #Store qw after 64 iterations.
     cmp $1, bit
     jne .dont_store1
@@ -209,11 +210,11 @@ find_error1:
     movq black_acc, (black_e, qw_itr, 8)
     xorq black_acc, (e, qw_itr, 8)
     movq gray_acc, (gray_e, qw_itr, 8)
-    
+
     #Restart the acc blocks
     xor black_acc, black_acc
     xor gray_acc, gray_acc
-    
+
     inc qw_itr
 .dont_store1:
 
@@ -293,7 +294,7 @@ find_error2:
 .find_err2_start:
     movb (upc), val
     mov $R_BITS-1, itr
-    
+
     MASK_OR threshold pos_acc
 
 .find_err2_loop:
@@ -301,7 +302,7 @@ find_error2:
     movb (upc, itr, 1), val
     xor   cmp_res64, cmp_res64
     rol bit
-    
+
     #Store qw after 64 iterations.
     cmp $1, bit
     jne .dont_store2
@@ -311,7 +312,7 @@ find_error2:
     #update the error.
     xorq pos_acc, (e, qw_itr, 8)
     xorq pos_acc, pos_acc
-    
+
     inc qw_itr
 .dont_store2:
 
@@ -332,7 +333,7 @@ find_error2:
     shl  $3, qw_itr
     sub $N_EXTRA_BYTES, qw_itr
     shl $8*N_EXTRA_BYTES, pos_acc
-   
+
     #update the final values
     andq (pos_e, qw_itr, 1), pos_acc
     xorq pos_acc, (e, qw_itr, 1)
@@ -348,7 +349,7 @@ find_error2:
 #// CONSTANT_TIME
 #else
 
-.text    
+.text
 #void compute_counter_of_unsat(uint8_t unsat_counter[N_BITS],
 #                              const uint8_t s[R_BITS],
 #                              const uint64_t inv_h0_compact[DV],
@@ -385,12 +386,12 @@ find_error2:
         mov (\inv_h_compact, itr2, 4), tmp32
 
         #adjust loop offset
-        add itr1, tmp 
+        add itr1, tmp
 
         .irp ALL_ZMMS
             vpaddb (ZMM_SIZE*\i)(s, tmp, 1), %zmm\i, %zmm\i
         .endr
-        
+
         add $ALL_ZMM_SIZE, tmp
         inc itr2
         cmp $DV, itr2
@@ -474,7 +475,7 @@ recompute:
     #When there are no positions to flip do nothing.
     test numPos, numPos
     je .Lexit
-    
+
     #Allocate room on the stack.
     sub $2*ZMM_SIZE, %rsp
 
@@ -488,24 +489,24 @@ recompute:
     vmovdqu64 ZMM_SIZE*\i(h_compressed), H0\i
     vmovdqu64 ZMM_SIZE*(\i+1)(h_compressed), H1\i
     .endr
-    
+
     #initialize pos_itr
     xor pos_itr, pos_itr
-    
+
 .Lpos_loop:
     vbroadcastss (positions, pos_itr, 4), POS
-    
+
     .irp i,ZMM_INDICES
     vcmpps $_CMP_LT_OS, H0\i, POS, %k1
     vcmpps $_CMP_LT_OS, H1\i, POS, %k2
     vpsubd H0\i, POS, RES
     vpsubd H1\i, POS, RES2
-    
+
     vpaddd RES, RBITS, RES{%k1}
     vpaddd RES2, RBITS, RES2{%k2}
     vmovdqu64 RES, (%rsp)
     vmovdqu64 RES2, ZMM_SIZE(%rsp)
-    
+
     xor itr2, itr2
 .Linside_loop\i:
     mov (%rsp, itr2, 4), %eax
@@ -514,7 +515,7 @@ recompute:
     cmp $32, itr2
     jne .Linside_loop\i
     .endr
-    
+
     inc pos_itr
     cmp numPos, pos_itr
     jne .Lpos_loop
@@ -523,10 +524,10 @@ recompute:
 .Ltail:
     vmovdqu64 4*ITER_INC(h_compressed), H00
     xor pos_itr, pos_itr
-    
+
 .Lpos_tail_loop:
     vbroadcastss (positions, pos_itr, 4), POS
-    
+
     vcmpps $_CMP_LT_OS, H00, POS, %k1
     vpsubd H00, POS, RES
     vpaddd RES, RBITS, RES{%k1}
@@ -544,9 +545,9 @@ recompute:
     inc pos_itr
     cmp numPos, pos_itr
     jne .Lpos_tail_loop
-    
+
     add $2*ZMM_SIZE, %rsp
-    
+
 .Lexit:
     ret
 .size    recompute,.-recompute
@@ -560,7 +561,7 @@ recompute:
 #ifdef CONSTANT_TIME
 
 
-.text    
+.text
 #void compute_counter_of_unsat(uint8_t unsat_counter[N_BITS],
 #                              const uint8_t s[R_BITS],
 #                              const uint64_t inv_h0_compressed[DV],
@@ -598,9 +599,9 @@ recompute:
         #load position
         vbroadcastss 0x4(\inv_h_compressed, itr2, 8), mask
         mov (\inv_h_compressed, itr2, 8), tmp32
-        
+
         #adjust loop offset
-        add itr1, tmp 
+        add itr1, tmp
 
         vpand (YMM_SIZE*0)(s, tmp, 1), mask, %ymm8
         vpand (YMM_SIZE*1)(s, tmp, 1), mask, %ymm9
@@ -614,14 +615,14 @@ recompute:
         vpaddb %ymm2, %ymm10, %ymm2
         vpaddb %ymm3, %ymm11, %ymm3
         vpaddb %ymm4, %ymm12, %ymm4
-        
+
         vpand (YMM_SIZE*6)(s, tmp, 1), mask, %ymm14
         vpand (YMM_SIZE*7)(s, tmp, 1), mask, %ymm15
-        
+
         vpaddb %ymm5, %ymm13, %ymm5
         vpaddb %ymm6, %ymm14, %ymm6
         vpaddb %ymm7, %ymm15, %ymm7
-        
+
         inc itr2
         cmp $FAKE_DV, itr2
         jl .Linner_loop\tag
@@ -705,7 +706,7 @@ find_error1:
     xor qw_itr, qw_itr
     xor black_acc, black_acc
     xor gray_acc, gray_acc
-    
+
     mov $N0, n0
     mov $1, bit
     xor cmp_res64, cmp_res64
@@ -713,7 +714,7 @@ find_error1:
 .find_err1_start:
     movb (upc), val
     mov $R_BITS-1, itr
-    
+
     MASK_OR black_th black_acc
     MASK_OR gray_th gray_acc
 
@@ -722,7 +723,7 @@ find_error1:
     movb (upc, itr, 1), val
     xor   cmp_res64, cmp_res64
     rol bit
-    
+
     #Store qw after 64 iterations.
     cmp $1, bit
     jne .dont_store1
@@ -734,7 +735,7 @@ find_error1:
     #Restart the acc blocks
     xor black_acc, black_acc
     xor gray_acc, gray_acc
-    
+
     inc qw_itr
 .dont_store1:
 
@@ -814,7 +815,7 @@ find_error2:
 .find_err2_start:
     movb (upc), val
     mov $R_BITS-1, itr
-    
+
     MASK_OR threshold pos_acc
 
 .find_err2_loop:
@@ -822,7 +823,7 @@ find_error2:
     movb (upc, itr, 1), val
     xor   cmp_res64, cmp_res64
     rol bit
-    
+
     #Store qw after 64 iterations.
     cmp $1, bit
     jne .dont_store2
@@ -832,7 +833,7 @@ find_error2:
     #update the error.
     xorq pos_acc, (e, qw_itr, 8)
     xorq pos_acc, pos_acc
-    
+
     inc qw_itr
 .dont_store2:
 
@@ -853,7 +854,7 @@ find_error2:
     shl  $3, qw_itr
     sub $N_EXTRA_BYTES, qw_itr
     shl $8*N_EXTRA_BYTES, pos_acc
-   
+
     #update the final values
     andq (pos_e, qw_itr, 1), pos_acc
     xorq pos_acc, (e, qw_itr, 1)
@@ -869,7 +870,7 @@ find_error2:
 #// CONSTANT_TIME
 #else
 
-.text    
+.text
 #void compute_counter_of_unsat(uint8_t unsat_counter[N_BITS],
 #                              const uint8_t s[R_BITS],
 #                              const uint64_t inv_h0_compact[DV],
@@ -893,7 +894,7 @@ find_error2:
 .macro SUM tag inv_h_compressed res_offset
     xor itr1, itr1
     xor tmp, tmp
-    
+
 .Lloop\tag:
 
     .irp ALL_YMMS
@@ -908,12 +909,12 @@ find_error2:
         mov (\inv_h_compressed, itr2, 4), tmp32
 
         #adjust loop offset
-        add itr1, tmp 
+        add itr1, tmp
 
         .irp ALL_YMMS
             vpaddb (YMM_SIZE*\i)(s, tmp, 1), %ymm\i, %ymm\i
         .endr
-        
+
         inc itr2
         cmp $DV, itr2
         jl .Linner_loop\tag
@@ -1002,10 +1003,10 @@ recompute:
     #When there are no positions to flip do nothing.
     test numPos, numPos
     je .Lexit
-    
+
     #Allocate room on the stack.
     sub $2*YMM_SIZE, %rsp
-    
+
     #Initialize the h_compressed iterator to 0.
     xor h_itr, h_itr
 
@@ -1020,13 +1021,13 @@ recompute:
         vmovdqu YMM_SIZE*\i(h_compressed, h_itr, 4), H0\i
         vmovdqu YMM_SIZE*(\i+1)(h_compressed, h_itr, 4), H1\i
     .endr
-    
+
     #initialize pos_itr
     xor pos_itr, pos_itr
-    
+
 .Lpos_loop:
     vbroadcastss (positions, pos_itr, 4), POS
-    
+
     .irp i, YMM_INDICES
         vcmpps $_CMP_LT_OS, H0\i, POS, MASK
         vcmpps $_CMP_LT_OS, H1\i, POS, MASK2
@@ -1035,12 +1036,12 @@ recompute:
 
         vpand  MASK, RBITS, MASK
         vpand  MASK2, RBITS, MASK2
-        
+
         vpaddd RES, MASK, RES
         vpaddd RES2, MASK2, RES2
         vmovdqu RES, (%rsp)
         vmovdqu RES2, YMM_SIZE(%rsp)
-        
+
         xor itr2, itr2
 .Linside_loop\i:
         mov (%rsp, itr2, 4), %eax
@@ -1049,7 +1050,7 @@ recompute:
         cmp $16, itr2
         jne .Linside_loop\i
     .endr
-    
+
     add $1, pos_itr
     cmp numPos, pos_itr
     jne .Lpos_loop
@@ -1062,17 +1063,17 @@ recompute:
 .Ltail:
     vmovdqu YMM_SIZE*0(h_compressed, h_itr, 4), H00
     vmovdqu YMM_SIZE*1(h_compressed, h_itr, 4), H02
-    
+
     xor pos_itr, pos_itr
-    
+
 .Lpos_tail_loop:
     vbroadcastss (positions, pos_itr, 4), POS
-    
+
     vcmpps $_CMP_LT_OS, H00, POS, MASK
     vcmpps $_CMP_LT_OS, H02, POS, MASK2
     vpsubd H00, POS, RES
     vpsubd H02, POS, RES2
-    
+
     vpand  MASK, RBITS, MASK
     vpand  MASK2, RBITS, MASK2
 
@@ -1093,10 +1094,10 @@ recompute:
     inc pos_itr
     cmp numPos, pos_itr
     jne .Lpos_tail_loop
-  
+
     #Fix RSP offset.
     add $2*YMM_SIZE, %rsp
-    
+
 .Lexit:
     ret
 .size    recompute,.-recompute
@@ -1106,4 +1107,3 @@ recompute:
 
 # //USE_AVX2_INSTRUCTIONS
 #endif
-

--- a/src/kem/bike/x86_64/defs.h
+++ b/src/kem/bike/x86_64/defs.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -13,6 +13,7 @@
 #define __DEFS_H_INCLUDED__
 
 #include <oqs/config.h>
+#include "../functions_renaming.h"
 
 ////////////////////////////////////////////
 //             Basic defs

--- a/src/kem/bike/x86_64/gf2x_mul.c
+++ b/src/kem/bike/x86_64/gf2x_mul.c
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -9,6 +9,7 @@
 * The license is detailed in the file LICENSE.txt, and applies to this file.
 * ***************************************************************************/
 
+#include "../functions_renaming.h"
 #include "gf2x_mul.h"
 #include "stdlib.h"
 #include "string.h"

--- a/src/kem/bike/x86_64/gf2x_mul.h
+++ b/src/kem/bike/x86_64/gf2x_mul.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -12,6 +12,7 @@
 #ifndef _GF2MUL_H_
 #define _GF2MUL_H_
 
+#include "../functions_renaming.h"
 #include "types.h"
 
 //Found in the assembly files.

--- a/src/kem/bike/x86_64/gf_add.S
+++ b/src/kem/bike/x86_64/gf_add.S
@@ -1,5 +1,5 @@
 ##############################################################################
-# Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+# Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 # Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Written by Nir Drucker and Shay Gueron
@@ -12,9 +12,10 @@
 ##############################################################################
 
 #define __ASM_FILE__
+#include "../functions_renaming.h"
 #include "defs.h"
 
-.text    
+.text
 
 ###################################################################################
 #void gf2_add(const uint64_t *res, const uint64_t *a, const uint64_t *b, const uint64_t size)

--- a/src/kem/bike/x86_64/gf_mul.S
+++ b/src/kem/bike/x86_64/gf_mul.S
@@ -1,5 +1,5 @@
 ##############################################################################
-# Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+# Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 # Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Written by Nir Drucker and Shay Gueron
@@ -12,9 +12,10 @@
 ##############################################################################
 
 #define __ASM_FILE__
+#include "../functions_renaming.h"
 #include "defs.h"
 
-.text    
+.text
 #void gf2_mul_4x4(const uint64_t *res, const uint64_t *a, const uint64_t *b)
 
 .set res, %rdi
@@ -75,7 +76,7 @@ gf2_muladd_4x4:
       vmovdqu XMM_SIZE*\i(a), A\i
       vmovdqu XMM_SIZE*\i(b), B\i
     .endr
-          
+
     vpclmulqdq $0x00, A0, B0, X0
     vpclmulqdq $0x00, A1, B0, X1
     vpclmulqdq $0x11, A0, B0, X2
@@ -101,7 +102,7 @@ gf2_muladd_4x4:
     vmovdqu 8*1(res), XT0
     vmovdqu 8*3(res), XT1
     vmovdqu 8*5(res), XT2
-    
+
     vpclmulqdq $0x10, A0, B0, X0
     vpclmulqdq $0x01, A0, B0, X1
     vpclmulqdq $0x01, A1, B0, X2
@@ -118,22 +119,22 @@ gf2_muladd_4x4:
 
     vxorpd X0, XT0, XT0
     vxorpd X1, XT0, XT0
-    
+
     vxorpd X6, XT2, XT2
     vxorpd X7, XT2, XT2
 
     vmovdqu XT0, 8*1(res)
     vmovdqu XT1, 8*3(res)
     vmovdqu XT2, 8*5(res)
-    
+
   ret
 .size   gf2_muladd_4x4,.-gf2_muladd_4x4
 
 ########################################################################################
-# void karatzuba_add1(OUT const uint64_t *res, 
-#                     IN const uint64_t  *a, 
-#                     IN const uint64_t  *b, 
-#                     IN const uint64_t  n_half, 
+# void karatzuba_add1(OUT const uint64_t *res,
+#                     IN const uint64_t  *a,
+#                     IN const uint64_t  *b,
+#                     IN const uint64_t  n_half,
 #                              uint64_t  *alah);
 #
 #The variables alah|blbh|tmp are located on the secure buffer in that order exactly!
@@ -187,17 +188,17 @@ karatzuba_add1:
     vmovdqu (a, itr, 8),    a_wide
     vmovdqu (b, itr, 8),    b_wide
     vmovdqu (res1, itr, 8), res1_wide
-   
+
     vpxor (a_high, itr, 8), a_wide, alah_wide
     vpxor (b_high, itr, 8), b_wide, blbh_wide
     vpxor (res2, itr, 8),   res1_wide, tmp_wide
 
     #a_low + a_high
     vmovdqu alah_wide, (alah, itr, 8)
-    
+
     #b_low + b_high
     vmovdqu blbh_wide, (blbh, itr, 8)
-    
+
     #Storing res1 and res2 together in one location
     #It is used to xor out "res2|res1" in the future.
     vmovdqu tmp_wide, (tmp, itr, 8)
@@ -212,12 +213,12 @@ karatzuba_add1:
     ret
 .size karatzuba_add1,.-karatzuba_add1
 
-   
+
 #######################################################
 # void karatzuba_add2(OUT const uint64_t *res,
-#                     IN  const uint64_t *res1, 
-#                     IN  const uint64_t *res2, 
-#                     IN  const uint64_t *tmp, 
+#                     IN  const uint64_t *res1,
+#                     IN  const uint64_t *res2,
+#                     IN  const uint64_t *tmp,
 #                     IN  const uint64_t n_half);
 
 .set res,    %rdi
@@ -242,7 +243,7 @@ karatzuba_add1:
 karatzuba_add2:
 
     lea (res2, n_half, 8), res3
-    
+
     dec n_half
     xor itr, itr
     jmp .lT2
@@ -251,22 +252,21 @@ karatzuba_add2:
     vmovdqu (tmp, itr, 8), tmp_wide
     vmovdqu (res1, itr, 8), res1_wide
     vmovdqu (res2, itr, 8), res2_wide
-    
+
     vpxor (res, itr, 8), tmp_wide, res_wide
     vpxor (res3, itr, 8), tmp_wide, res3_wide
-    
+
     vpxor res_wide , res1_wide, res1_wide
     vpxor res3_wide, res2_wide, res2_wide
-    
+
     vmovdqu res1_wide, (res1, itr, 8)
     vmovdqu res2_wide, (res2, itr, 8)
 
     add $4, itr
     cmp n_half, itr
     jl .lT2
-    
+
 .Lt2_end:
-    
+
     ret
 .size karatzuba_add2,.-karatzuba_add2
-

--- a/src/kem/bike/x86_64/kem.c
+++ b/src/kem/bike/x86_64/kem.c
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -9,6 +9,7 @@
 * The license is detailed in the file LICENSE.txt, and applies to this file.
 * ***************************************************************************/
 
+#include "../functions_renaming.h"
 #include "stdio.h"
 #include "string.h"
 

--- a/src/kem/bike/x86_64/measurements.h
+++ b/src/kem/bike/x86_64/measurements.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -11,6 +11,8 @@
 
 #ifndef MEASURE_H
 #define MEASURE_H
+
+#include "../functions_renaming.h"
 
 #ifndef RDTSC
 //Less accurate measurement than with RDTSC
@@ -54,7 +56,7 @@ inline static uint64_t get_Clks(void) {
 	return ((uint64_t) lo) ^ (((uint64_t) hi) << 32);
 }
 
-/* 
+/*
    This MACRO measures the number of cycles "x" runs. This is the flow:
       1) it sets the priority to FIFO, to avoid time slicing if possible.
       2) it repeats "x" WARMUP times, in order to warm the cache.

--- a/src/kem/bike/x86_64/openssl_utils.h
+++ b/src/kem/bike/x86_64/openssl_utils.h
@@ -35,6 +35,7 @@
 #ifndef _OSSL_UTILITIES_H_
 #define _OSSL_UTILITIES_H_
 
+#include "../functions_renaming.h"
 #include "string.h"
 #include "types.h"
 #include "utilities.h"

--- a/src/kem/bike/x86_64/parallel_hash.c
+++ b/src/kem/bike/x86_64/parallel_hash.c
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -9,6 +9,7 @@
 * The license is detailed in the file LICENSE.txt, and applies to this file.
 * ***************************************************************************/
 
+#include "../functions_renaming.h"
 #include "parallel_hash.h"
 #include "utilities.h"
 #include "stdio.h"

--- a/src/kem/bike/x86_64/parallel_hash.h
+++ b/src/kem/bike/x86_64/parallel_hash.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -12,6 +12,7 @@
 #ifndef __PARALLEL_HASH_H_INCLUDED__
 #define __PARALLEL_HASH_H_INCLUDED__
 
+#include "../functions_renaming.h"
 #include "types.h"
 #include "sha.h"
 

--- a/src/kem/bike/x86_64/red.S
+++ b/src/kem/bike/x86_64/red.S
@@ -1,5 +1,5 @@
 ##############################################################################
-# Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+# Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 # Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Written by Nir Drucker and Shay Gueron
@@ -12,6 +12,7 @@
 ##############################################################################
 
 #define __ASM_FILE__
+#include "../functions_renaming.h"
 #include "bike_defs.h"
 
 .set p, %rdi
@@ -29,10 +30,10 @@ red_asm:
     vmovdqu R_QW    *0x8(p,itr,8), %ymm2
     vmovdqu (R_QW-1)*0x8(p,itr,8), %ymm3
     vmovdqu (p,itr,8), %ymm4
-    
+
     vpsllq $LAST_R_QW_TRAIL, %ymm2, %ymm2
     vpsrlq $LAST_R_QW_LEAD,  %ymm3, %ymm3
-    
+
     vpor  %ymm2, %ymm3, %ymm5
     vpxor %ymm4, %ymm5, %ymm5
     vmovdqu %ymm5, (p,itr,8)

--- a/src/kem/bike/x86_64/sampling.c
+++ b/src/kem/bike/x86_64/sampling.c
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -9,6 +9,7 @@
 * The license is detailed in the file LICENSE.txt, and applies to this file.
 * ***************************************************************************/
 
+#include "../functions_renaming.h"
 #include "sampling.h"
 #include "string.h"
 #include "assert.h"

--- a/src/kem/bike/x86_64/sampling.h
+++ b/src/kem/bike/x86_64/sampling.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -12,6 +12,7 @@
 #ifndef _SAMPLE_H_
 #define _SAMPLE_H_
 
+#include "../functions_renaming.h"
 #include "stdio.h"
 #include "aes_ctr_prf.h"
 #include "utilities.h"

--- a/src/kem/bike/x86_64/sampling_x86_64.S
+++ b/src/kem/bike/x86_64/sampling_x86_64.S
@@ -1,5 +1,5 @@
 ##############################################################################
-# Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+# Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 # Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Written by Nir Drucker and Shay Gueron
@@ -12,9 +12,10 @@
 ##############################################################################
 
 #define __ASM_FILE__
+#include "../functions_renaming.h"
 #include "bike_defs.h"
 
-.data 
+.data
 
 .align 64
 INIT_POS0:
@@ -25,8 +26,8 @@ INIT_POS1:
 DWORDS_INC:
 .long 16, 16, 16, 16, 16, 16, 16, 16
 
-.text    
-#void secure_set_bits(IN OUT uint8_t* a, 
+.text
+#void secure_set_bits(IN OUT uint8_t* a,
 #                     IN const compressed_n_t* wlist,
 #                     IN const uint32_t a_len,
 #                     IN const uint32_t weight)
@@ -90,7 +91,7 @@ DWORDS_INC:
         #copy to tmp mem in order to broadcast.
         mov dword_pos,   (%rsp)
         mov bit_mask, 0x8(%rsp)
-        
+
         #copy to wide regs.
         vpbroadcastd (%rsp), DWORD_POS\i
         vpbroadcastd 0x8(%rsp), BIT_MASK\i
@@ -116,7 +117,7 @@ secure_set_bits:
         LOAD_POS 0
         LOAD_POS 1
         LOAD_POS 2
-        
+
         xor itr, itr
 
 .align 16
@@ -199,11 +200,11 @@ secure_set_bits:
         add $2*0x20, itr
         cmp len, itr
         jl .rest_loop
-    
+
     inc w_itr
     cmp weight, w_itr
     jl .rest_wloop
-        
+
 #endif
 
 .exit:

--- a/src/kem/bike/x86_64/sha-mb.c
+++ b/src/kem/bike/x86_64/sha-mb.c
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -8,13 +8,14 @@
 *
 * The license is detailed in the file LICENSE.txt, and applies to this file.
 *
-* Multi block SHA384 AVX2/AVX512 is due to: 
-* "Multi Block (MB) SHA384 for x86_64 architectures that support 
+* Multi block SHA384 AVX2/AVX512 is due to:
+* "Multi Block (MB) SHA384 for x86_64 architectures that support
 * AVX2/AVX512 instructions set" by Shay Gueron and Regev Shemy
 * https://mta.openssl.org/pipermail/openssl-dev/2016-August/008238.html
 * See: https://mta.openssl.org/pipermail/openssl-dev/2016-August/008238.html
 * ***************************************************************************/
 
+#include "../functions_renaming.h"
 #include <string.h>
 #include <stdio.h>
 #include "sha.h"

--- a/src/kem/bike/x86_64/sha.c
+++ b/src/kem/bike/x86_64/sha.c
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -9,6 +9,7 @@
 * The license is detailed in the file LICENSE.txt, and applies to this file.
 * ***************************************************************************/
 
+#include "../functions_renaming.h"
 #include "sha.h"
 #include "utilities.h"
 #include "stdlib.h"

--- a/src/kem/bike/x86_64/sha.h
+++ b/src/kem/bike/x86_64/sha.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -12,6 +12,7 @@
 #ifndef _MB_SHA_H_
 #define _MB_SHA_H_
 
+#include "../functions_renaming.h"
 #include "types.h"
 
 #define SHA384_HASH_SIZE 48ULL

--- a/src/kem/bike/x86_64/sha384.h
+++ b/src/kem/bike/x86_64/sha384.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -12,6 +12,7 @@
 #ifndef _SHA384_H_
 #define _SHA384_H_
 
+#include "../functions_renaming.h"
 #include "types.h"
 
 #ifdef USE_AVX512F_INSTRUCTIONS

--- a/src/kem/bike/x86_64/sha384_update_mb.S
+++ b/src/kem/bike/x86_64/sha384_update_mb.S
@@ -1,17 +1,18 @@
 ##############################################################################
-# Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+# Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 # Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Written by Nir Drucker and Shay Gueron
 # AWS Cryptographic Algorithms Group
 # (ndrucker@amazon.com, gueron@amazon.com)
 #
-# Multi block SHA384 AVX2/AVX512 is due to: 
-# "Multi Block (MB) SHA384 for x86_64 architectures that support 
+# Multi block SHA384 AVX2/AVX512 is due to:
+# "Multi Block (MB) SHA384 for x86_64 architectures that support
 # AVX2/AVX512 instructions set" by Shay Gueron and Regev Shemy at
 # https://mta.openssl.org/pipermail/openssl-dev/2016-August/008238.html
 ##############################################################################
 
+#include "../functions_renaming.h"
 #include "oqs/config.h"
 
 .text
@@ -792,7 +793,7 @@ END:
 # // USE_AVX512F_INSTRUCTIONS
 #endif
 
-.data 
+.data
 
 .align 64
 and_last_block_not_256:

--- a/src/kem/bike/x86_64/types.h
+++ b/src/kem/bike/x86_64/types.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -12,6 +12,7 @@
 #ifndef __TYPES_H_INCLUDED__
 #define __TYPES_H_INCLUDED__
 
+#include "../functions_renaming.h"
 #include "bike_defs.h"
 #include "stdint.h"
 

--- a/src/kem/bike/x86_64/utilities.c
+++ b/src/kem/bike/x86_64/utilities.c
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -9,6 +9,7 @@
 * The license is detailed in the file LICENSE.txt, and applies to this file.
 * ***************************************************************************/
 
+#include "../functions_renaming.h"
 #include "utilities.h"
 #include "stdio.h"
 

--- a/src/kem/bike/x86_64/utilities.h
+++ b/src/kem/bike/x86_64/utilities.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-* Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+* Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
 * Written by Nir Drucker and Shay Gueron
@@ -12,6 +12,7 @@
 #ifndef _UTILITIES_H_
 #define _UTILITIES_H_
 
+#include "../functions_renaming.h"
 #include "types.h"
 
 #ifndef bswap_64

--- a/src/kem/bike/x86_64/vaes256_key_expansion.S
+++ b/src/kem/bike/x86_64/vaes256_key_expansion.S
@@ -1,5 +1,5 @@
 ##############################################################################
-# Additional implementation of "BIKE: Bit Flipping Key Encapsulation". 
+# Additional implementation of "BIKE: Bit Flipping Key Encapsulation".
 # Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Written by Nir Drucker and Shay Gueron
@@ -10,6 +10,8 @@
 # Based on:
 # github.com/Shay-Gueron/A-toolbox-for-software-optimization-of-QC-MDPC-code-based-cryptosystems
 ##############################################################################
+
+#include "../functions_renaming.h"
 
 .data
 
@@ -38,7 +40,7 @@ AES_256_Key_Expansion:
    vmovdqa con(%rip), %xmm0
    vmovdqa mask_256(%rip), %xmm15
    vpxor %xmm14, %xmm14, %xmm14
-   
+
    mov $6, %ax
 LOOP_256_VAES:
 
@@ -46,17 +48,17 @@ LOOP_256_VAES:
    dec %ax
 
    vpshufb     %xmm15, %xmm3, %xmm2
-   vaesenclast %xmm0,  %xmm2, %xmm2 
+   vaesenclast %xmm0,  %xmm2, %xmm2
    vpslld      $1,     %xmm0, %xmm0
    vpslldq     $4,     %xmm1, %xmm4
    vpxor       %xmm4,  %xmm1, %xmm1
-   vpslldq     $4,     %xmm4, %xmm4	   
+   vpslldq     $4,     %xmm4, %xmm4
    vpxor       %xmm4,  %xmm1, %xmm1
    vpslldq     $4,     %xmm4, %xmm4
-   vpxor       %xmm4,  %xmm1, %xmm1    
-   vpxor       %xmm2,  %xmm1, %xmm1    
+   vpxor       %xmm4,  %xmm1, %xmm1
+   vpxor       %xmm2,  %xmm1, %xmm1
    vmovdqa     %xmm1,  (ks)
-   
+
    vpshufd     $0xff,  %xmm1, %xmm2
    vaesenclast %xmm14, %xmm2, %xmm2
    vpslldq     $4,     %xmm3, %xmm4
@@ -67,19 +69,19 @@ LOOP_256_VAES:
    vpxor       %xmm4,  %xmm3, %xmm3
    vpxor       %xmm2,  %xmm3, %xmm3
    vmovdqa     %xmm3,  16(ks)
-   
+
    jne LOOP_256_VAES
-   
+
    vpshufb     %xmm15, %xmm3, %xmm2
-   vaesenclast %xmm0,  %xmm2, %xmm2 
+   vaesenclast %xmm0,  %xmm2, %xmm2
    vpslldq     $4,     %xmm1, %xmm4
    vpxor       %xmm4,  %xmm1, %xmm1
    vpslldq     $4,     %xmm4, %xmm4
    vpxor       %xmm4,  %xmm1, %xmm1
    vpslldq     $4,     %xmm4, %xmm4
-   vpxor       %xmm4,  %xmm1, %xmm1    
-   vpxor       %xmm2,  %xmm1, %xmm1    
+   vpxor       %xmm4,  %xmm1, %xmm1
+   vpxor       %xmm2,  %xmm1, %xmm1
    vmovdqa     %xmm1,  32(ks)
-   
+
    ret
 .size   AES_256_Key_Expansion,.-AES_256_Key_Expansion


### PR DESCRIPTION
As discussed, I moved the renaming macros into a common OQS header. 

I found that when I did this, the `-include functions_renaming.h` line from the Makefile caused a bunch of problems, which could be resolved by removing that from the Makefile and including it deliberately in each file.  Maybe you can find a better way.