### PR TITLE
Switch automake to using check for test programs that aren't installed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,8 +76,7 @@ installheader_HEADERS=config.h \
 	src/kem/sike/kem_sike.h \
 	src/sig/sig.h
 
-test: clean-tests
-	make
+test: check
 	tests/example_kem
 	tests/test_kem
 	tests/test_kex --quiet

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Windows binaries can be generated using the Visual Studio solution in the `Visua
 
 Builds are tested using the Appveyor continuous integration system on Windows Server 2016 (Visual Studio 2017).  Our developers also test builds periodically on Windows 10.
 
-- [Build status using Appveyor continuous integration system:](https://ci.appveyor.com/project/dstebila/liboqs) [![Build status image](https://ci.appveyor.com/api/projects/status/9d2ts78x88r8wnii/branch/master?svg=true)](https://ci.appveyor.com/project/dstebila/liboqs/branch/master)
+- [Build status using Appveyor continuous integration system:](https://ci.appveyor.com/project/dstebila/liboqs) ![Build status image](https://ci.appveyor.com/api/projects/status/9d2ts78x88r8wnii/branch/master?svg=true)
 
 The supported schemes are defined in the projects' `winconfig.h` file.
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,12 +1,11 @@
 AUTOMAKE_OPTIONS = foreign
-noinst_bin_PROGRAMS = example_kem speed_kem test_kem \
+check_PROGRAMS = example_kem speed_kem test_kem \
                       minimal_kex_oqs test_kex \
                       test_sig \
                       test_aes test_rand test_sha3
 if ENABLE_SIG_PICNIC
-noinst_bin_PROGRAMS += minimal_sig_oqs
+check_PROGRAMS += minimal_sig_oqs
 endif
-noinst_bindir = .
 
 example_kem_SOURCES     = example_kem.c
 speed_kem_SOURCES       = speed_kem.c


### PR DESCRIPTION
A previous change broke `make install`.  I looked into how to handle test programs, and rather than using our own `noinst_binPROGRAMS`, apparently automake has a built-in type `check_PROGRAMS`, so I switched to using that.