### PR TITLE
Removed the OQS_RAND object from the sig API

### DIFF
--- a/src/sig/sig.c
+++ b/src/sig/sig.c
@@ -9,16 +9,11 @@
 #include <oqs/sig_qtesla.h>
 #endif
 
-OQS_API OQS_SIG *OQS_SIG_new(OQS_RAND *rand, enum OQS_SIG_algid algid) {
-	if (rand == NULL) {
-		return NULL;
-	}
-
+OQS_API OQS_SIG *OQS_SIG_new(enum OQS_SIG_algid algid) {
 	OQS_SIG *s = malloc(sizeof(OQS_SIG));
 	if (s == NULL) {
 		return NULL;
 	}
-	s->rand = rand;
 
 	switch (algid) {
 #ifdef ENABLE_SIG_PICNIC

--- a/src/sig/sig.h
+++ b/src/sig/sig.h
@@ -11,7 +11,6 @@
 #include <stdint.h>
 
 #include <oqs/common.h>
-#include <oqs/rand.h>
 
 #if defined(_WIN32)
 #include <oqs/winconfig.h>
@@ -49,11 +48,6 @@ typedef struct OQS_SIG OQS_SIG; // so the code below compiles...
  * OQS signature object
  */
 struct OQS_SIG {
-
-	/**
-	 * PRNG
-	 */
-	OQS_RAND *rand;
 
 	/**
 	 * Specifies the name of the signature method
@@ -142,11 +136,10 @@ struct OQS_SIG {
 /**
  * Instantiate a new signature object.
  *
- * @param rand               The random number generator.
  * @param algid              The id of the signature algorithm to be instantiated.
  * @return                   A new signature object on success, or NULL on failure.
  */
-OQS_API OQS_SIG *OQS_SIG_new(OQS_RAND *rand, enum OQS_SIG_algid algid);
+OQS_API OQS_SIG *OQS_SIG_new(enum OQS_SIG_algid algid);
 
 /**
  * Generates a new signature key pair.
@@ -185,7 +178,6 @@ OQS_API OQS_STATUS OQS_SIG_verify(const OQS_SIG *s, const uint8_t *pub, const ui
 
 /**
  * Frees the signature object, de-initializing the underlying library code.
- * Does NOT free the rand object passed to OQS_SIG_new.
  * @param s          The signature object.
  */
 OQS_API void OQS_SIG_free(OQS_SIG *s);

--- a/src/sig_picnic/external/picnic.c
+++ b/src/sig_picnic/external/picnic.c
@@ -15,11 +15,10 @@
 
 #include <stdlib.h>
 #include <string.h>
-
+#include <oqs/rand.h>
 #include "io.h"
 #include "lowmc.h"
 #include "picnic_impl.h"
-#include <oqs/rand.h>
 
 const picnic_instance_t* picnic_instance_get(picnic_params_t param) {
   return oqs_sig_picnic_get_instance(param);
@@ -53,7 +52,7 @@ size_t PICNIC_CALLING_CONVENTION picnic_get_public_key_size(picnic_params_t para
 }
 
 int PICNIC_CALLING_CONVENTION picnic_keygen(picnic_params_t param, picnic_publickey_t* pk,
-                                            picnic_privatekey_t* sk, OQS_RAND* rand) {
+                                            picnic_privatekey_t* sk) {
 
   if (!pk || !sk) {
     return -1;
@@ -74,9 +73,9 @@ int PICNIC_CALLING_CONVENTION picnic_keygen(picnic_params_t param, picnic_public
   // generate private key
   sk->data[0] = param;
   // random secret key
-  OQS_RAND_n(rand, sk_sk, input_size);
+  OQS_randombytes(sk_sk, input_size);
   // random plain text
-  OQS_RAND_n(rand, pk_pt, output_size);
+  OQS_randombytes(pk_pt, output_size);
   // encrypt plaintext under secret key
   if (picnic_sk_to_pk(sk, pk)) {
     return -1;

--- a/src/sig_picnic/external/picnic.h
+++ b/src/sig_picnic/external/picnic.h
@@ -29,7 +29,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <oqs/rand.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -105,7 +104,7 @@ picnic_get_param_name(picnic_params_t parameters);
  */
 PICNIC_EXPORT int PICNIC_CALLING_CONVENTION picnic_keygen(picnic_params_t parameters,
                                                           picnic_publickey_t* pk,
-                                                          picnic_privatekey_t* sk, OQS_RAND* rand);
+                                                          picnic_privatekey_t* sk);
 
 /**
  * Signature function.

--- a/src/sig_picnic/sig_picnic.c
+++ b/src/sig_picnic/sig_picnic.c
@@ -4,7 +4,6 @@
 
 #include <string.h>
 #include <oqs/common.h>
-#include <oqs/rand.h>
 #include "sig_picnic.h"
 #include "external/picnic.h"
 
@@ -117,7 +116,7 @@ OQS_STATUS OQS_SIG_picnic_keygen(const OQS_SIG *s, uint8_t *priv, uint8_t *pub) 
 	picnic_publickey_t pk;
 	picnic_privatekey_t sk;
 	picnic_params_t parameters = ((PICNIC_CTX *) s->ctx)->params;
-	int ret = picnic_keygen(parameters, &pk, &sk, s->rand);
+	int ret = picnic_keygen(parameters, &pk, &sk);
 	if (ret != 0) { // DO NOT modify this return code to OQS_SUCCESS/OQS_ERROR
 		return OQS_ERROR;
 	}

--- a/src/sig_qtesla/external/qTESLA_I.c
+++ b/src/sig_qtesla/external/qTESLA_I.c
@@ -879,12 +879,12 @@ static void sparse_mul32(poly prod, const int32_t *pk, const uint32_t pos_list[P
 
 #include "qTESLA_api.c"
 
-int oqs_qTESLA_I_crypto_sign_keypair(OQS_RAND *rand, unsigned char *pk, unsigned char *sk) {
-	return crypto_sign_keypair(rand, pk, sk);
+int oqs_qTESLA_I_crypto_sign_keypair(unsigned char *pk, unsigned char *sk) {
+	return crypto_sign_keypair(pk, sk);
 }
 
-int oqs_qTESLA_I_crypto_sign(OQS_RAND *rand, unsigned char *sm, unsigned long long *smlen, const unsigned char *m, unsigned long long mlen, const unsigned char *sk) {
-	return crypto_sign(rand, sm, smlen, m, mlen, sk);
+int oqs_qTESLA_I_crypto_sign(unsigned char *sm, unsigned long long *smlen, const unsigned char *m, unsigned long long mlen, const unsigned char *sk) {
+	return crypto_sign(sm, smlen, m, mlen, sk);
 }
 
 int oqs_qTESLA_I_crypto_verify(unsigned char *m, unsigned long long mlen, const unsigned char *sm, unsigned long long smlen, const unsigned char *pk) {

--- a/src/sig_qtesla/external/qTESLA_I.h
+++ b/src/sig_qtesla/external/qTESLA_I.h
@@ -1,12 +1,8 @@
-#include <oqs/rand.h>
-
 int oqs_qTESLA_I_crypto_sign_keypair(
-    OQS_RAND *rand,
     unsigned char *,
     unsigned char *);
 
 int oqs_qTESLA_I_crypto_sign(
-    OQS_RAND *rand,
     unsigned char *, unsigned long long *,
     const unsigned char *, unsigned long long,
     const unsigned char *);

--- a/src/sig_qtesla/external/qTESLA_III_size.c
+++ b/src/sig_qtesla/external/qTESLA_III_size.c
@@ -958,12 +958,12 @@ static void sparse_mul32(poly prod, const int32_t *pk, const uint32_t pos_list[P
 
 #include "qTESLA_api.c"
 
-int oqs_qTESLA_III_size_crypto_sign_keypair(OQS_RAND *rand, unsigned char *pk, unsigned char *sk) {
-	return crypto_sign_keypair(rand, pk, sk);
+int oqs_qTESLA_III_size_crypto_sign_keypair(unsigned char *pk, unsigned char *sk) {
+	return crypto_sign_keypair(pk, sk);
 }
 
-int oqs_qTESLA_III_size_crypto_sign(OQS_RAND *rand, unsigned char *sm, unsigned long long *smlen, const unsigned char *m, unsigned long long mlen, const unsigned char *sk) {
-	return crypto_sign(rand, sm, smlen, m, mlen, sk);
+int oqs_qTESLA_III_size_crypto_sign(unsigned char *sm, unsigned long long *smlen, const unsigned char *m, unsigned long long mlen, const unsigned char *sk) {
+	return crypto_sign(sm, smlen, m, mlen, sk);
 }
 
 int oqs_qTESLA_III_size_crypto_verify(unsigned char *m, unsigned long long mlen, const unsigned char *sm, unsigned long long smlen, const unsigned char *pk) {

--- a/src/sig_qtesla/external/qTESLA_III_size.h
+++ b/src/sig_qtesla/external/qTESLA_III_size.h
@@ -1,12 +1,8 @@
-#include <oqs/rand.h>
-
 int oqs_qTESLA_III_size_crypto_sign_keypair(
-    OQS_RAND *rand,
     unsigned char *,
     unsigned char *);
 
 int oqs_qTESLA_III_size_crypto_sign(
-    OQS_RAND *rand,
     unsigned char *, unsigned long long *,
     const unsigned char *, unsigned long long,
     const unsigned char *);

--- a/src/sig_qtesla/external/qTESLA_III_speed.c
+++ b/src/sig_qtesla/external/qTESLA_III_speed.c
@@ -884,12 +884,12 @@ static void sparse_mul32(poly prod, const int32_t *pk, const uint32_t pos_list[P
 
 #include "qTESLA_api.c"
 
-int oqs_qTESLA_III_speed_crypto_sign_keypair(OQS_RAND *rand, unsigned char *pk, unsigned char *sk) {
-	return crypto_sign_keypair(rand, pk, sk);
+int oqs_qTESLA_III_speed_crypto_sign_keypair(unsigned char *pk, unsigned char *sk) {
+	return crypto_sign_keypair(pk, sk);
 }
 
-int oqs_qTESLA_III_speed_crypto_sign(OQS_RAND *rand, unsigned char *sm, unsigned long long *smlen, const unsigned char *m, unsigned long long mlen, const unsigned char *sk) {
-	return crypto_sign(rand, sm, smlen, m, mlen, sk);
+int oqs_qTESLA_III_speed_crypto_sign(unsigned char *sm, unsigned long long *smlen, const unsigned char *m, unsigned long long mlen, const unsigned char *sk) {
+	return crypto_sign(sm, smlen, m, mlen, sk);
 }
 
 int oqs_qTESLA_III_speed_crypto_verify(unsigned char *m, unsigned long long mlen, const unsigned char *sm, unsigned long long smlen, const unsigned char *pk) {

--- a/src/sig_qtesla/external/qTESLA_III_speed.h
+++ b/src/sig_qtesla/external/qTESLA_III_speed.h
@@ -1,12 +1,8 @@
-#include <oqs/rand.h>
-
 int oqs_qTESLA_III_speed_crypto_sign_keypair(
-    OQS_RAND *rand,
     unsigned char *,
     unsigned char *);
 
 int oqs_qTESLA_III_speed_crypto_sign(
-    OQS_RAND *rand,
     unsigned char *, unsigned long long *,
     const unsigned char *, unsigned long long,
     const unsigned char *);

--- a/src/sig_qtesla/external/qTESLA_api.c
+++ b/src/sig_qtesla/external/qTESLA_api.c
@@ -9,7 +9,7 @@
 *              - unsigned char *sk: secret key
 * Returns:     0 for successful execution
 **********************************************************/
-static int crypto_sign_keypair(OQS_RAND *rand, unsigned char *pk, unsigned char *sk) {
+static int crypto_sign_keypair(unsigned char *pk, unsigned char *sk) {
 	unsigned char randomness[CRYPTO_RANDOMBYTES], randomness_extended[4 * CRYPTO_SEEDBYTES];
 	poly s, e, a, t;
 	int nonce = 0; // Initialize domain separator for error and secret polynomials
@@ -18,7 +18,7 @@ static int crypto_sign_keypair(OQS_RAND *rand, unsigned char *pk, unsigned char 
 #endif
 
 	// Get randomness_extended <- seed_e, seed_s, seed_a, seed_y
-	OQS_RAND_n(rand, randomness, CRYPTO_RANDOMBYTES);
+	OQS_randombytes(randomness, CRYPTO_RANDOMBYTES);
 	if (strcmp(CRYPTO_ALGNAME, "qTesla-I") == 0) {
 		OQS_SHA3_shake128(randomness_extended, 4 * CRYPTO_SEEDBYTES, randomness, CRYPTO_RANDOMBYTES);
 	} else /* III-size, III-speed */ {
@@ -66,7 +66,7 @@ static int crypto_sign_keypair(OQS_RAND *rand, unsigned char *pk, unsigned char 
 *              - unsigned long long *smlen: signature length*
 * Returns:     0 for successful execution
 ***************************************************************/
-static int crypto_sign(OQS_RAND *rand, unsigned char *sm, unsigned long long *smlen, const unsigned char *m, unsigned long long mlen, const unsigned char *sk) {
+static int crypto_sign(unsigned char *sm, unsigned long long *smlen, const unsigned char *m, unsigned long long mlen, const unsigned char *sk) {
 	unsigned char c[CRYPTO_C_BYTES], randomness[CRYPTO_SEEDBYTES], randomness_input[CRYPTO_RANDOMBYTES + CRYPTO_SEEDBYTES + mlen];
 	uint32_t pos_list[PARAM_W];
 	int16_t sign_list[PARAM_W];
@@ -79,7 +79,7 @@ static int crypto_sign(OQS_RAND *rand, unsigned char *sm, unsigned long long *sm
 #endif
 
 	// Get H(seed_y, r, m) to sample y
-	OQS_RAND_n(rand, randomness_input + CRYPTO_RANDOMBYTES, CRYPTO_RANDOMBYTES);
+	OQS_randombytes(randomness_input + CRYPTO_RANDOMBYTES, CRYPTO_RANDOMBYTES);
 	memcpy(randomness_input, &sk[CRYPTO_SECRETKEYBYTES - CRYPTO_SEEDBYTES], CRYPTO_SEEDBYTES);
 	memcpy(randomness_input + CRYPTO_RANDOMBYTES + CRYPTO_SEEDBYTES, m, mlen);
 	if (strcmp(CRYPTO_ALGNAME, "qTesla-I") == 0) {

--- a/src/sig_qtesla/sig_qtesla.c
+++ b/src/sig_qtesla/sig_qtesla.c
@@ -4,7 +4,6 @@
 
 #include <string.h>
 #include <oqs/common.h>
-#include <oqs/rand.h>
 #include "sig_qtesla.h"
 #include "external/qTESLA_I.h"
 #include "external/qTESLA_III_size.h"
@@ -62,15 +61,15 @@ OQS_STATUS OQS_SIG_qTESLA_keygen(const OQS_SIG *s, uint8_t *priv, uint8_t *pub) 
 	}
 
 	if (strcmp(s->method_name, qTESLA_I_name) == 0) {
-		if (oqs_qTESLA_I_crypto_sign_keypair(s->rand, pub, priv) != 0) {
+		if (oqs_qTESLA_I_crypto_sign_keypair(pub, priv) != 0) {
 			return OQS_ERROR;
 		}
 	} else if (strcmp(s->method_name, qTESLA_III_size_name) == 0) {
-		if (oqs_qTESLA_III_size_crypto_sign_keypair(s->rand, pub, priv) != 0) {
+		if (oqs_qTESLA_III_size_crypto_sign_keypair(pub, priv) != 0) {
 			return OQS_ERROR;
 		}
 	} else if (strcmp(s->method_name, qTESLA_III_speed_name) == 0) {
-		if (oqs_qTESLA_III_speed_crypto_sign_keypair(s->rand, pub, priv) != 0) {
+		if (oqs_qTESLA_III_speed_crypto_sign_keypair(pub, priv) != 0) {
 			return OQS_ERROR;
 		}
 	} else {
@@ -85,15 +84,15 @@ OQS_STATUS OQS_SIG_qTESLA_sign(const OQS_SIG *s, const uint8_t *priv, const uint
 	}
 
 	if (strcmp(s->method_name, qTESLA_I_name) == 0) {
-		if (oqs_qTESLA_I_crypto_sign(s->rand, sig, (unsigned long long *) sig_len, msg, (unsigned long long) msg_len, priv) != 0) {
+		if (oqs_qTESLA_I_crypto_sign(sig, (unsigned long long *) sig_len, msg, (unsigned long long) msg_len, priv) != 0) {
 			return OQS_ERROR;
 		}
 	} else if (strcmp(s->method_name, qTESLA_III_size_name) == 0) {
-		if (oqs_qTESLA_III_size_crypto_sign(s->rand, sig, (unsigned long long *) sig_len, msg, (unsigned long long) msg_len, priv) != 0) {
+		if (oqs_qTESLA_III_size_crypto_sign(sig, (unsigned long long *) sig_len, msg, (unsigned long long) msg_len, priv) != 0) {
 			return OQS_ERROR;
 		}
 	} else if (strcmp(s->method_name, qTESLA_III_speed_name) == 0) {
-		if (oqs_qTESLA_III_speed_crypto_sign(s->rand, sig, (unsigned long long *) sig_len, msg, (unsigned long long) msg_len, priv) != 0) {
+		if (oqs_qTESLA_III_speed_crypto_sign(sig, (unsigned long long *) sig_len, msg, (unsigned long long) msg_len, priv) != 0) {
 			return OQS_ERROR;
 		}
 	} else {

--- a/src/sig_qtesla/sig_qtesla.h
+++ b/src/sig_qtesla/sig_qtesla.h
@@ -11,7 +11,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <oqs/common.h>
-#include <oqs/rand.h>
 
 OQS_STATUS OQS_SIG_qTESLA_get(OQS_SIG *sig, enum OQS_SIG_algid algid);
 OQS_STATUS OQS_SIG_qTESLA_keygen(const OQS_SIG *s, uint8_t *priv, uint8_t *pub);

--- a/tests/minimal_sig_oqs.c
+++ b/tests/minimal_sig_oqs.c
@@ -11,7 +11,7 @@
 
 /* Cleaning up memory etc */
 void cleanup(uint8_t *msg, size_t msg_len, uint8_t *sig, size_t sig_len,
-             uint8_t *pub, uint8_t *priv, OQS_SIG *s, OQS_RAND *rnd);
+             uint8_t *pub, uint8_t *priv, OQS_SIG *s);
 
 #ifdef ENABLE_SIG_PICNIC
 int main(void) {
@@ -25,24 +25,14 @@ int main(void) {
 	enum OQS_SIG_algid alg_name = OQS_SIG_default; // Algorithm name
 	// Equivalent to OQS_SIG_picnic_L1_FS
 
-	OQS_RAND *rnd = NULL; // Source of randomness
 	OQS_SIG *s = NULL;    // OQS_SIG structure
 
-	/* Setup the source of randomness */
-	rnd = OQS_RAND_new(OQS_RAND_alg_urandom_chacha20);
-	if (rnd == NULL) {
-		eprintf("ERROR: Setting up the randomness source!\n");
-		cleanup(msg, msg_len, sig, sig_len, pub, priv, s, rnd);
-
-		return EXIT_FAILURE;
-	}
-
 	/* Populate the OQS_SIG structure, here's where liboqs sets up
-     * the specific details of the selected SIG implementation */
-	s = OQS_SIG_new(rnd, alg_name);
+	 * the specific details of the selected SIG implementation */
+	s = OQS_SIG_new(alg_name);
 	if (s == NULL) {
 		eprintf("ERROR: OQS_SIG_new failed!\n");
-		cleanup(msg, msg_len, sig, sig_len, pub, priv, s, rnd);
+		cleanup(msg, msg_len, sig, sig_len, pub, priv, s);
 
 		return EXIT_FAILURE;
 	}
@@ -56,7 +46,7 @@ int main(void) {
 	priv = malloc(s->priv_key_len);
 	if (priv == NULL) {
 		eprintf("ERROR: priv malloc failed!\n");
-		cleanup(msg, msg_len, sig, sig_len, pub, priv, s, rnd);
+		cleanup(msg, msg_len, sig, sig_len, pub, priv, s);
 
 		return EXIT_FAILURE;
 	}
@@ -65,7 +55,7 @@ int main(void) {
 	pub = malloc(s->pub_key_len);
 	if (pub == NULL) {
 		eprintf("ERROR: pub malloc failed!\n");
-		cleanup(msg, msg_len, sig, sig_len, pub, priv, s, rnd);
+		cleanup(msg, msg_len, sig, sig_len, pub, priv, s);
 
 		return EXIT_FAILURE;
 	}
@@ -74,7 +64,7 @@ int main(void) {
 	OQS_STATUS success = OQS_SIG_keygen(s, priv, pub);
 	if (success != OQS_SUCCESS) {
 		eprintf("ERROR: OQS_SIG_keygen failed!\n");
-		cleanup(msg, msg_len, sig, sig_len, pub, priv, s, rnd);
+		cleanup(msg, msg_len, sig, sig_len, pub, priv, s);
 
 		return EXIT_FAILURE;
 	}
@@ -87,13 +77,13 @@ int main(void) {
 	msg = malloc(msg_len);
 	if (msg == NULL) {
 		eprintf("ERROR: msg malloc failed!\n");
-		cleanup(msg, msg_len, sig, sig_len, pub, priv, s, rnd);
+		cleanup(msg, msg_len, sig, sig_len, pub, priv, s);
 
 		return EXIT_FAILURE;
 	}
 
 	/* Generates a random message to sign */
-	OQS_RAND_n(rnd, msg, msg_len);
+	OQS_randombytes(msg, msg_len);
 	OQS_print_hex_string("Message", msg, msg_len);
 
 	/* Allocates memory for the signature */
@@ -101,7 +91,7 @@ int main(void) {
 	sig = malloc(sig_len);
 	if (sig == NULL) {
 		eprintf("ERROR: sig malloc failed!\n");
-		cleanup(msg, msg_len, sig, sig_len, pub, priv, s, rnd);
+		cleanup(msg, msg_len, sig, sig_len, pub, priv, s);
 
 		return EXIT_FAILURE;
 	}
@@ -110,7 +100,7 @@ int main(void) {
 	success = OQS_SIG_sign(s, priv, msg, msg_len, sig, &sig_len);
 	if (success != OQS_SUCCESS) {
 		eprintf("ERROR: OQS_SIG_sign failed!\n");
-		cleanup(msg, msg_len, sig, sig_len, pub, priv, s, rnd);
+		cleanup(msg, msg_len, sig, sig_len, pub, priv, s);
 
 		return EXIT_FAILURE;
 	}
@@ -124,14 +114,14 @@ int main(void) {
 	success = OQS_SIG_verify(s, pub, msg, msg_len, sig, sig_len);
 	if (success != OQS_SUCCESS) {
 		eprintf("ERROR: OQS_SIG_verify failed!\n");
-		cleanup(msg, msg_len, sig, sig_len, pub, priv, s, rnd);
+		cleanup(msg, msg_len, sig, sig_len, pub, priv, s);
 
 		return EXIT_FAILURE;
 	}
 
 	/* Success and clean-up */
 	printf("Signature is valid.\n");
-	cleanup(msg, msg_len, sig, sig_len, pub, priv, s, rnd);
+	cleanup(msg, msg_len, sig, sig_len, pub, priv, s);
 
 	return EXIT_SUCCESS;
 }
@@ -144,11 +134,10 @@ int main(void) {
 
 /* Cleaning up memory etc */
 void cleanup(uint8_t *msg, size_t msg_len, uint8_t *sig, size_t sig_len,
-             uint8_t *pub, uint8_t *priv, OQS_SIG *s, OQS_RAND *rnd) {
+             uint8_t *pub, uint8_t *priv, OQS_SIG *s) {
 	OQS_MEM_secure_free(msg, msg_len);
 	OQS_MEM_secure_free(sig, sig_len);
 	OQS_MEM_secure_free(pub, s->pub_key_len);
 	OQS_MEM_secure_free(priv, s->priv_key_len);
 	OQS_SIG_free(s);
-	OQS_RAND_free(rnd);
 }


### PR DESCRIPTION
Removed the OQS_RAND object from the sig API to harmonize with the KEM API (c.f., issue #374)