### PR TITLE
Too early to make

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ To build, first clone or download the source from GitHub:
 	git clone https://github.com/open-quantum-safe/liboqs.git
 	cd liboqs
 	git checkout master
-	make
 
 Run the build system:
 


### PR DESCRIPTION
Should not `make` before configuring the build.