### PR TITLE
Remove residual KEX sidh_msr (#369).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,7 +110,6 @@ sample_params
 data/
 
 # Exceptions
-!/src/kex_sidh_msr/config.h
 !src/sig_picnic/external/config.h.in
 
 # Misc (master branch)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ matrix:
     compiler: gcc
     env:
     - CC_OVERRIDE=gcc
-    - ENABLE_KEX_SIDH_MSR=0
     - ENABLE_SIG_PICNIC=0
     - USE_OPENSSL=1
     - CHECK_STYLE=true

--- a/.travis/all-tests.sh
+++ b/.travis/all-tests.sh
@@ -54,10 +54,6 @@ if [[ ${ENABLE_KEX_NTRU} == 0 ]];then
 	enable_disable_str+=" --disable-kex-ntru"
 fi
 
-if [[ ${ENABLE_KEX_SIDH_MSR} == 0 ]];then
-	enable_disable_str+=" --disable-kex-sidh-msr"
-fi
-
 if [[ ${ENABLE_SIG_PICNIC} == 0 ]];then
 	enable_disable_str+=" --disable-sig-picnic"
 fi

--- a/docs/.Doxyfile
+++ b/docs/.Doxyfile
@@ -877,7 +877,6 @@ RECURSIVE              = NO
 EXCLUDE                = include/oqs/kex.h \
                          include/oqs/kex_ntru.h \
                          include/oqs/kex_code_mcbits.h \
-                         include/oqs/kex_sidh_msr.h \
                          include/oqs/rand_urandom_aesctr.h \
                          include/oqs/rand_urandom_chacha20.h
 


### PR DESCRIPTION
Removing remnants of KEX sidh_msr. The tests pass on Linux, so I'm assuming this work is OK.

 Previous work merged into master looks to have cleaned up sidh_msr references in the makefiles etc.
EDIT: windows/Vis Studio specific content still needs to be removed.