### PR TITLE
Remove superfluous extern keywords from KEMs.

### DIFF
--- a/src/kem/BIG_QUAKE/kem_BIGQUAKE.h
+++ b/src/kem/BIG_QUAKE/kem_BIGQUAKE.h
@@ -12,9 +12,9 @@
 
 OQS_KEM *OQS_KEM_BIG_QUAKE_1_new();
 
-extern OQS_STATUS OQS_KEM_BIG_QUAKE_1_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_BIG_QUAKE_1_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_BIG_QUAKE_1_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_BIG_QUAKE_1_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_BIG_QUAKE_1_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_BIG_QUAKE_1_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -27,9 +27,9 @@ extern OQS_STATUS OQS_KEM_BIG_QUAKE_1_decaps(uint8_t *shared_secret, const unsig
 
 OQS_KEM *OQS_KEM_BIG_QUAKE_3_new();
 
-extern OQS_STATUS OQS_KEM_BIG_QUAKE_3_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_BIG_QUAKE_3_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_BIG_QUAKE_3_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_BIG_QUAKE_3_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_BIG_QUAKE_3_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_BIG_QUAKE_3_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -42,9 +42,9 @@ extern OQS_STATUS OQS_KEM_BIG_QUAKE_3_decaps(uint8_t *shared_secret, const unsig
 
 OQS_KEM *OQS_KEM_BIG_QUAKE_5_new();
 
-extern OQS_STATUS OQS_KEM_BIG_QUAKE_5_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_BIG_QUAKE_5_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_BIG_QUAKE_5_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_BIG_QUAKE_5_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_BIG_QUAKE_5_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_BIG_QUAKE_5_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 

--- a/src/kem/bike/kem_bike.h
+++ b/src/kem/bike/kem_bike.h
@@ -29,14 +29,14 @@
 
 OQS_KEM *OQS_KEM_bike1_l1_new();
 
-extern OQS_STATUS OQS_KEM_bike1_l1_keypair(uint8_t *public_key,
-                                           uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_bike1_l1_encaps(uint8_t *ciphertext,
-                                          uint8_t *shared_secret,
-                                          const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_bike1_l1_decaps(uint8_t *shared_secret,
-                                          const unsigned char *ciphertext,
-                                          const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike1_l1_keypair(uint8_t *public_key,
+                                    uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike1_l1_encaps(uint8_t *ciphertext,
+                                   uint8_t *shared_secret,
+                                   const uint8_t *public_key);
+OQS_STATUS OQS_KEM_bike1_l1_decaps(uint8_t *shared_secret,
+                                   const unsigned char *ciphertext,
+                                   const uint8_t *secret_key);
 
 #endif
 
@@ -57,14 +57,14 @@ extern OQS_STATUS OQS_KEM_bike1_l1_decaps(uint8_t *shared_secret,
 
 OQS_KEM *OQS_KEM_bike1_l3_new();
 
-extern OQS_STATUS OQS_KEM_bike1_l3_keypair(uint8_t *public_key,
-                                           uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_bike1_l3_encaps(uint8_t *ciphertext,
-                                          uint8_t *shared_secret,
-                                          const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_bike1_l3_decaps(uint8_t *shared_secret,
-                                          const unsigned char *ciphertext,
-                                          const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike1_l3_keypair(uint8_t *public_key,
+                                    uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike1_l3_encaps(uint8_t *ciphertext,
+                                   uint8_t *shared_secret,
+                                   const uint8_t *public_key);
+OQS_STATUS OQS_KEM_bike1_l3_decaps(uint8_t *shared_secret,
+                                   const unsigned char *ciphertext,
+                                   const uint8_t *secret_key);
 
 #endif
 
@@ -85,14 +85,14 @@ extern OQS_STATUS OQS_KEM_bike1_l3_decaps(uint8_t *shared_secret,
 
 OQS_KEM *OQS_KEM_bike1_l5_new();
 
-extern OQS_STATUS OQS_KEM_bike1_l5_keypair(uint8_t *public_key,
-                                           uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_bike1_l5_encaps(uint8_t *ciphertext,
-                                          uint8_t *shared_secret,
-                                          const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_bike1_l5_decaps(uint8_t *shared_secret,
-                                          const unsigned char *ciphertext,
-                                          const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike1_l5_keypair(uint8_t *public_key,
+                                    uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike1_l5_encaps(uint8_t *ciphertext,
+                                   uint8_t *shared_secret,
+                                   const uint8_t *public_key);
+OQS_STATUS OQS_KEM_bike1_l5_decaps(uint8_t *shared_secret,
+                                   const unsigned char *ciphertext,
+                                   const uint8_t *secret_key);
 
 #endif
 
@@ -115,14 +115,14 @@ extern OQS_STATUS OQS_KEM_bike1_l5_decaps(uint8_t *shared_secret,
 
 OQS_KEM *OQS_KEM_bike2_l1_new();
 
-extern OQS_STATUS OQS_KEM_bike2_l1_keypair(uint8_t *public_key,
-                                           uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_bike2_l1_encaps(uint8_t *ciphertext,
-                                          uint8_t *shared_secret,
-                                          const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_bike2_l1_decaps(uint8_t *shared_secret,
-                                          const unsigned char *ciphertext,
-                                          const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike2_l1_keypair(uint8_t *public_key,
+                                    uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike2_l1_encaps(uint8_t *ciphertext,
+                                   uint8_t *shared_secret,
+                                   const uint8_t *public_key);
+OQS_STATUS OQS_KEM_bike2_l1_decaps(uint8_t *shared_secret,
+                                   const unsigned char *ciphertext,
+                                   const uint8_t *secret_key);
 
 #endif
 
@@ -146,14 +146,14 @@ extern OQS_STATUS OQS_KEM_bike2_l1_decaps(uint8_t *shared_secret,
 
 OQS_KEM *OQS_KEM_bike2_l3_new();
 
-extern OQS_STATUS OQS_KEM_bike2_l3_keypair(uint8_t *public_key,
-                                           uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_bike2_l3_encaps(uint8_t *ciphertext,
-                                          uint8_t *shared_secret,
-                                          const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_bike2_l3_decaps(uint8_t *shared_secret,
-                                          const unsigned char *ciphertext,
-                                          const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike2_l3_keypair(uint8_t *public_key,
+                                    uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike2_l3_encaps(uint8_t *ciphertext,
+                                   uint8_t *shared_secret,
+                                   const uint8_t *public_key);
+OQS_STATUS OQS_KEM_bike2_l3_decaps(uint8_t *shared_secret,
+                                   const unsigned char *ciphertext,
+                                   const uint8_t *secret_key);
 
 #endif
 
@@ -177,14 +177,14 @@ extern OQS_STATUS OQS_KEM_bike2_l3_decaps(uint8_t *shared_secret,
 
 OQS_KEM *OQS_KEM_bike2_l5_new();
 
-extern OQS_STATUS OQS_KEM_bike2_l5_keypair(uint8_t *public_key,
-                                           uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_bike2_l5_encaps(uint8_t *ciphertext,
-                                          uint8_t *shared_secret,
-                                          const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_bike2_l5_decaps(uint8_t *shared_secret,
-                                          const unsigned char *ciphertext,
-                                          const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike2_l5_keypair(uint8_t *public_key,
+                                    uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike2_l5_encaps(uint8_t *ciphertext,
+                                   uint8_t *shared_secret,
+                                   const uint8_t *public_key);
+OQS_STATUS OQS_KEM_bike2_l5_decaps(uint8_t *shared_secret,
+                                   const unsigned char *ciphertext,
+                                   const uint8_t *secret_key);
 
 #endif
 
@@ -206,14 +206,14 @@ extern OQS_STATUS OQS_KEM_bike2_l5_decaps(uint8_t *shared_secret,
 
 OQS_KEM *OQS_KEM_bike3_l1_new();
 
-extern OQS_STATUS OQS_KEM_bike3_l1_keypair(uint8_t *public_key,
-                                           uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_bike3_l1_encaps(uint8_t *ciphertext,
-                                          uint8_t *shared_secret,
-                                          const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_bike3_l1_decaps(uint8_t *shared_secret,
-                                          const unsigned char *ciphertext,
-                                          const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike3_l1_keypair(uint8_t *public_key,
+                                    uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike3_l1_encaps(uint8_t *ciphertext,
+                                   uint8_t *shared_secret,
+                                   const uint8_t *public_key);
+OQS_STATUS OQS_KEM_bike3_l1_decaps(uint8_t *shared_secret,
+                                   const unsigned char *ciphertext,
+                                   const uint8_t *secret_key);
 
 #endif
 
@@ -234,14 +234,14 @@ extern OQS_STATUS OQS_KEM_bike3_l1_decaps(uint8_t *shared_secret,
 
 OQS_KEM *OQS_KEM_bike3_l3_new();
 
-extern OQS_STATUS OQS_KEM_bike3_l3_keypair(uint8_t *public_key,
-                                           uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_bike3_l3_encaps(uint8_t *ciphertext,
-                                          uint8_t *shared_secret,
-                                          const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_bike3_l3_decaps(uint8_t *shared_secret,
-                                          const unsigned char *ciphertext,
-                                          const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike3_l3_keypair(uint8_t *public_key,
+                                    uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike3_l3_encaps(uint8_t *ciphertext,
+                                   uint8_t *shared_secret,
+                                   const uint8_t *public_key);
+OQS_STATUS OQS_KEM_bike3_l3_decaps(uint8_t *shared_secret,
+                                   const unsigned char *ciphertext,
+                                   const uint8_t *secret_key);
 
 #endif
 
@@ -262,14 +262,14 @@ extern OQS_STATUS OQS_KEM_bike3_l3_decaps(uint8_t *shared_secret,
 
 OQS_KEM *OQS_KEM_bike3_l5_new();
 
-extern OQS_STATUS OQS_KEM_bike3_l5_keypair(uint8_t *public_key,
-                                           uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_bike3_l5_encaps(uint8_t *ciphertext,
-                                          uint8_t *shared_secret,
-                                          const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_bike3_l5_decaps(uint8_t *shared_secret,
-                                          const unsigned char *ciphertext,
-                                          const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike3_l5_keypair(uint8_t *public_key,
+                                    uint8_t *secret_key);
+OQS_STATUS OQS_KEM_bike3_l5_encaps(uint8_t *ciphertext,
+                                   uint8_t *shared_secret,
+                                   const uint8_t *public_key);
+OQS_STATUS OQS_KEM_bike3_l5_decaps(uint8_t *shared_secret,
+                                   const unsigned char *ciphertext,
+                                   const uint8_t *secret_key);
 
 #endif
 

--- a/src/kem/crystals-kyber/kem_kyber.h
+++ b/src/kem/crystals-kyber/kem_kyber.h
@@ -12,9 +12,9 @@
 
 OQS_KEM *OQS_KEM_kyber512_new();
 
-extern OQS_STATUS OQS_KEM_kyber512_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_kyber512_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_kyber512_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_kyber512_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_kyber512_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_kyber512_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -27,9 +27,9 @@ extern OQS_STATUS OQS_KEM_kyber512_decaps(uint8_t *shared_secret, const unsigned
 
 OQS_KEM *OQS_KEM_kyber768_new();
 
-extern OQS_STATUS OQS_KEM_kyber768_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_kyber768_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_kyber768_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_kyber768_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_kyber768_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_kyber768_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -42,9 +42,9 @@ extern OQS_STATUS OQS_KEM_kyber768_decaps(uint8_t *shared_secret, const unsigned
 
 OQS_KEM *OQS_KEM_kyber1024_new();
 
-extern OQS_STATUS OQS_KEM_kyber1024_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_kyber1024_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_kyber1024_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_kyber1024_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_kyber1024_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_kyber1024_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 

--- a/src/kem/frodokem/kem_frodokem.h
+++ b/src/kem/frodokem/kem_frodokem.h
@@ -12,9 +12,9 @@
 
 OQS_KEM *OQS_KEM_frodokem_640_aes_new();
 
-extern OQS_STATUS OQS_KEM_frodokem_640_aes_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_frodokem_640_aes_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_frodokem_640_aes_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_frodokem_640_aes_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_frodokem_640_aes_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_frodokem_640_aes_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -27,9 +27,9 @@ extern OQS_STATUS OQS_KEM_frodokem_640_aes_decaps(uint8_t *shared_secret, const 
 
 OQS_KEM *OQS_KEM_frodokem_976_aes_new();
 
-extern OQS_STATUS OQS_KEM_frodokem_976_aes_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_frodokem_976_aes_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_frodokem_976_aes_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_frodokem_976_aes_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_frodokem_976_aes_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_frodokem_976_aes_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -42,9 +42,9 @@ extern OQS_STATUS OQS_KEM_frodokem_976_aes_decaps(uint8_t *shared_secret, const 
 
 OQS_KEM *OQS_KEM_frodokem_640_cshake_new();
 
-extern OQS_STATUS OQS_KEM_frodokem_640_cshake_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_frodokem_640_cshake_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_frodokem_640_cshake_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_frodokem_640_cshake_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_frodokem_640_cshake_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_frodokem_640_cshake_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -57,9 +57,9 @@ extern OQS_STATUS OQS_KEM_frodokem_640_cshake_decaps(uint8_t *shared_secret, con
 
 OQS_KEM *OQS_KEM_frodokem_976_cshake_new();
 
-extern OQS_STATUS OQS_KEM_frodokem_976_cshake_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_frodokem_976_cshake_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_frodokem_976_cshake_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_frodokem_976_cshake_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_frodokem_976_cshake_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_frodokem_976_cshake_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 

--- a/src/kem/ledakem/kem_ledakem.h
+++ b/src/kem/ledakem/kem_ledakem.h
@@ -11,9 +11,9 @@
 #define OQS_KEM_ledakem_C1_N02_length_shared_secret 32
 
 OQS_KEM *OQS_KEM_ledakem_C1_N02_new();
-extern OQS_STATUS OQS_KEM_ledakem_C1_N02_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_ledakem_C1_N02_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_ledakem_C1_N02_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C1_N02_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C1_N02_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_ledakem_C1_N02_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -24,9 +24,9 @@ extern OQS_STATUS OQS_KEM_ledakem_C1_N02_decaps(uint8_t *shared_secret, const un
 #define OQS_KEM_ledakem_C1_N03_length_shared_secret 32
 
 OQS_KEM *OQS_KEM_ledakem_C1_N03_new();
-extern OQS_STATUS OQS_KEM_ledakem_C1_N03_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_ledakem_C1_N03_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_ledakem_C1_N03_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C1_N03_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C1_N03_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_ledakem_C1_N03_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -38,9 +38,9 @@ extern OQS_STATUS OQS_KEM_ledakem_C1_N03_decaps(uint8_t *shared_secret, const un
 #define OQS_KEM_ledakem_C1_N04_length_shared_secret 32
 
 OQS_KEM *OQS_KEM_ledakem_C1_N04_new();
-extern OQS_STATUS OQS_KEM_ledakem_C1_N04_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_ledakem_C1_N04_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_ledakem_C1_N04_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C1_N04_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C1_N04_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_ledakem_C1_N04_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -52,9 +52,9 @@ extern OQS_STATUS OQS_KEM_ledakem_C1_N04_decaps(uint8_t *shared_secret, const un
 #define OQS_KEM_ledakem_C3_N02_length_shared_secret 48
 
 OQS_KEM *OQS_KEM_ledakem_C3_N02_new();
-extern OQS_STATUS OQS_KEM_ledakem_C3_N02_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_ledakem_C3_N02_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_ledakem_C3_N02_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C3_N02_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C3_N02_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_ledakem_C3_N02_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -66,9 +66,9 @@ extern OQS_STATUS OQS_KEM_ledakem_C3_N02_decaps(uint8_t *shared_secret, const un
 #define OQS_KEM_ledakem_C3_N03_length_shared_secret 48
 
 OQS_KEM *OQS_KEM_ledakem_C3_N03_new();
-extern OQS_STATUS OQS_KEM_ledakem_C3_N03_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_ledakem_C3_N03_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_ledakem_C3_N03_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C3_N03_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C3_N03_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_ledakem_C3_N03_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -80,9 +80,9 @@ extern OQS_STATUS OQS_KEM_ledakem_C3_N03_decaps(uint8_t *shared_secret, const un
 #define OQS_KEM_ledakem_C3_N04_length_shared_secret 48
 
 OQS_KEM *OQS_KEM_ledakem_C3_N04_new();
-extern OQS_STATUS OQS_KEM_ledakem_C3_N04_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_ledakem_C3_N04_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_ledakem_C3_N04_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C3_N04_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C3_N04_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_ledakem_C3_N04_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -94,9 +94,9 @@ extern OQS_STATUS OQS_KEM_ledakem_C3_N04_decaps(uint8_t *shared_secret, const un
 #define OQS_KEM_ledakem_C5_N02_length_shared_secret 64
 
 OQS_KEM *OQS_KEM_ledakem_C5_N02_new();
-extern OQS_STATUS OQS_KEM_ledakem_C5_N02_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_ledakem_C5_N02_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_ledakem_C5_N02_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C5_N02_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C5_N02_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_ledakem_C5_N02_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -108,9 +108,9 @@ extern OQS_STATUS OQS_KEM_ledakem_C5_N02_decaps(uint8_t *shared_secret, const un
 #define OQS_KEM_ledakem_C5_N03_length_shared_secret 64
 
 OQS_KEM *OQS_KEM_ledakem_C5_N03_new();
-extern OQS_STATUS OQS_KEM_ledakem_C5_N03_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_ledakem_C5_N03_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_ledakem_C5_N03_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C5_N03_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C5_N03_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_ledakem_C5_N03_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -122,9 +122,9 @@ extern OQS_STATUS OQS_KEM_ledakem_C5_N03_decaps(uint8_t *shared_secret, const un
 #define OQS_KEM_ledakem_C5_N04_length_shared_secret 64
 
 OQS_KEM *OQS_KEM_ledakem_C5_N04_new();
-extern OQS_STATUS OQS_KEM_ledakem_C5_N04_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_ledakem_C5_N04_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_ledakem_C5_N04_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C5_N04_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_ledakem_C5_N04_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_ledakem_C5_N04_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 

--- a/src/kem/lima/kem_lima.h
+++ b/src/kem/lima/kem_lima.h
@@ -12,9 +12,9 @@
 
 OQS_KEM *OQS_KEM_lima_2p_1024_cca_kem_new();
 
-extern OQS_STATUS OQS_KEM_lima_2p_1024_cca_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_lima_2p_1024_cca_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_lima_2p_1024_cca_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_lima_2p_1024_cca_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_lima_2p_1024_cca_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_lima_2p_1024_cca_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -27,9 +27,9 @@ extern OQS_STATUS OQS_KEM_lima_2p_1024_cca_kem_decaps(uint8_t *shared_secret, co
 
 OQS_KEM *OQS_KEM_lima_2p_2048_cca_kem_new();
 
-extern OQS_STATUS OQS_KEM_lima_2p_2048_cca_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_lima_2p_2048_cca_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_lima_2p_2048_cca_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_lima_2p_2048_cca_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_lima_2p_2048_cca_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_lima_2p_2048_cca_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -42,9 +42,9 @@ extern OQS_STATUS OQS_KEM_lima_2p_2048_cca_kem_decaps(uint8_t *shared_secret, co
 
 OQS_KEM *OQS_KEM_lima_sp_1018_cca_kem_new();
 
-extern OQS_STATUS OQS_KEM_lima_sp_1018_cca_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_lima_sp_1018_cca_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_lima_sp_1018_cca_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_lima_sp_1018_cca_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_lima_sp_1018_cca_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_lima_sp_1018_cca_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -57,9 +57,9 @@ extern OQS_STATUS OQS_KEM_lima_sp_1018_cca_kem_decaps(uint8_t *shared_secret, co
 
 OQS_KEM *OQS_KEM_lima_sp_1306_cca_kem_new();
 
-extern OQS_STATUS OQS_KEM_lima_sp_1306_cca_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_lima_sp_1306_cca_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_lima_sp_1306_cca_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_lima_sp_1306_cca_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_lima_sp_1306_cca_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_lima_sp_1306_cca_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -72,9 +72,9 @@ extern OQS_STATUS OQS_KEM_lima_sp_1306_cca_kem_decaps(uint8_t *shared_secret, co
 
 OQS_KEM *OQS_KEM_lima_sp_1822_cca_kem_new();
 
-extern OQS_STATUS OQS_KEM_lima_sp_1822_cca_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_lima_sp_1822_cca_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_lima_sp_1822_cca_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_lima_sp_1822_cca_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_lima_sp_1822_cca_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_lima_sp_1822_cca_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -87,9 +87,9 @@ extern OQS_STATUS OQS_KEM_lima_sp_1822_cca_kem_decaps(uint8_t *shared_secret, co
 
 OQS_KEM *OQS_KEM_lima_sp_2062_cca_kem_new();
 
-extern OQS_STATUS OQS_KEM_lima_sp_2062_cca_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_lima_sp_2062_cca_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_lima_sp_2062_cca_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_lima_sp_2062_cca_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_lima_sp_2062_cca_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_lima_sp_2062_cca_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 

--- a/src/kem/newhopenist/kem_newhopenist.h
+++ b/src/kem/newhopenist/kem_newhopenist.h
@@ -12,9 +12,9 @@
 
 OQS_KEM *OQS_KEM_newhope_512_cca_kem_new();
 
-extern OQS_STATUS OQS_KEM_newhope_512_cca_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_newhope_512_cca_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_newhope_512_cca_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_newhope_512_cca_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_newhope_512_cca_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_newhope_512_cca_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -27,9 +27,9 @@ extern OQS_STATUS OQS_KEM_newhope_512_cca_kem_decaps(uint8_t *shared_secret, con
 
 OQS_KEM *OQS_KEM_newhope_1024_cca_kem_new();
 
-extern OQS_STATUS OQS_KEM_newhope_1024_cca_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_newhope_1024_cca_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_newhope_1024_cca_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_newhope_1024_cca_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_newhope_1024_cca_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_newhope_1024_cca_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 

--- a/src/kem/saber/kem_saber.h
+++ b/src/kem/saber/kem_saber.h
@@ -12,9 +12,9 @@
 
 OQS_KEM *OQS_KEM_saber_light_saber_kem_new();
 
-extern OQS_STATUS OQS_KEM_saber_light_saber_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_saber_light_saber_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_saber_light_saber_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_saber_light_saber_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_saber_light_saber_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_saber_light_saber_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -27,9 +27,9 @@ extern OQS_STATUS OQS_KEM_saber_light_saber_kem_decaps(uint8_t *shared_secret, c
 
 OQS_KEM *OQS_KEM_saber_saber_kem_new();
 
-extern OQS_STATUS OQS_KEM_saber_saber_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_saber_saber_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_saber_saber_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_saber_saber_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_saber_saber_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_saber_saber_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 
@@ -42,9 +42,9 @@ extern OQS_STATUS OQS_KEM_saber_saber_kem_decaps(uint8_t *shared_secret, const u
 
 OQS_KEM *OQS_KEM_saber_fire_saber_kem_new();
 
-extern OQS_STATUS OQS_KEM_saber_fire_saber_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
-extern OQS_STATUS OQS_KEM_saber_fire_saber_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
-extern OQS_STATUS OQS_KEM_saber_fire_saber_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
+OQS_STATUS OQS_KEM_saber_fire_saber_kem_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_STATUS OQS_KEM_saber_fire_saber_kem_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_STATUS OQS_KEM_saber_fire_saber_kem_decaps(uint8_t *shared_secret, const unsigned char *ciphertext, const uint8_t *secret_key);
 
 #endif
 


### PR DESCRIPTION
Cleanup for issue: https://github.com/open-quantum-safe/liboqs/issues/357

I've left extern in the sigs for another issue/PR.