### PR TITLE
Add algorithm version strings and details to NIST branch 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ libkeccak:
 liboqs: libkeccak headers $(OBJECTS) $(UPSTREAMS)
 	$(RM) -f liboqs.a
 	ar rcs liboqs.a `find .objs -name '*.a'` `find .objs -name '*.o'`
-	gcc -shared -o liboqs.so `find .objs -name '*.a'` `find .objs -name '*.o'` -lcrypto
+	gcc -shared -o liboqs.so `find .objs -name '*.a'` `find .objs -name '*.o'` -L$(OPENSSL_LIB_DIR) -lcrypto
 
 TEST_PROGRAMS=test_kem test_kem_shared test_sig test_sig_shared
 $(TEST_PROGRAMS): liboqs

--- a/docs/algorithms/kem_BIG_QUAKE.md
+++ b/docs/algorithms/kem_BIG_QUAKE.md
@@ -24,7 +24,7 @@ Parameter sets
 Implementation
 --------------
 
-- **Source of implementation:**  https://bigquake.inria.fr/
+- **Source of implementation:**  https://bigquake.inria.fr/files/2018/03/BIGQUAKE-source.tar.gz (reference implementation)
 - **License:** Public domain
 - **Language:** C
 - **Constant-time:** Yes

--- a/docs/algorithms/kem_frodokem.md
+++ b/docs/algorithms/kem_frodokem.md
@@ -25,7 +25,7 @@ Parameter sets
 Implementation
 --------------
 
-- **Source of implementation:** https://github.com/Microsoft/PQCrypto-LWEKE
+- **Source of implementation:** https://github.com/Microsoft/PQCrypto-LWEKE/commit/47da00a91270b6f103232314eef0b891b83bfd3b
 - **License:** MIT License
 - **Language:** C
 - **Constant-time:** Yes

--- a/docs/algorithms/kem_kyber.md
+++ b/docs/algorithms/kem_kyber.md
@@ -24,7 +24,7 @@ Parameter sets
 Implementation
 --------------
 
-- **Source of implementation:** https://github.com/pq-crystals/liboqs
+- **Source of implementation:** https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/CRYSTALS_Kyber.zip (optimized variant)
 - **License:** Public domain
 - **Language:** C
 - **Constant-time:** Yes

--- a/docs/algorithms/kem_ledakem.md
+++ b/docs/algorithms/kem_ledakem.md
@@ -30,7 +30,7 @@ Parameter sets
 Implementation
 --------------
 
-- **Source of implementation:** https://github.com/LEDAcrypt/LEDAkem
+- **Source of implementation:** https://github.com/LEDAcrypt/LEDAkem, the nist-branch upstream code is a near match to the sumbission: https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/LEDAkem.zip
 - **License:** MIT License
 - **Language:** C
 - **Constant-time:** Yes

--- a/docs/algorithms/kem_lima.md
+++ b/docs/algorithms/kem_lima.md
@@ -27,7 +27,7 @@ Parameter sets
 Implementation
 --------------
 
-- **Source of implementation:** https://lima-pq.github.io/ optimized implementation
+- **Source of implementation:** https://lima-pq.github.io/ optimized implementation   (commit: c660c24db8ddbdce097a2bb19059c6896ef1c27c)
 - **License:** Public domain
 - **Language:** C
 - **Constant-time:** Unknown

--- a/docs/algorithms/sig_picnic.md
+++ b/docs/algorithms/sig_picnic.md
@@ -27,7 +27,8 @@ Parameter sets
 Implementation
 --------------
 
-- **Source of implementation:** The code in liboqs is related to the submitted version https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/Picnic.zip
+- **Source of implementation:** https://github.com/IAIK/Picnic
+- **Implementation version:** https://github.com/IAIK/Picnic/commit/423b5da7036ac3b090d50bdff1e9a8ea34e37d11
 - **License:** MIT License
 - **Language:** C
 - **Constant-time:** Yes

--- a/docs/algorithms/sig_picnic.md
+++ b/docs/algorithms/sig_picnic.md
@@ -9,7 +9,7 @@ Summary
 - **Main cryptographic assumption**: hash function security (ROM/QROM), key recovery attacks on the lowMC block cipher
 - **NIST submission URL**: https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/Picnic.zip
 - **Submitters (to NIST competition)**: Greg Zaverucha, Melissa Chase, David Derler, Steven Goldfeder, Claudio Orlandi, Sebastian Ramacher, Christian Rechberger, Daniel Slamanig
-- **Submitters' website**: https://microsoft.github.io/Picnic/
+- **Submitters' website**: https://microsoft.github.io/Picnic/ and https://github.com/IAIK/Picnic
 - **Added to liboqs by**: Christian Paquin
 
 Parameter sets
@@ -27,7 +27,7 @@ Parameter sets
 Implementation
 --------------
 
-- **Source of implementation:** https://github.com/IAIK/Picnic
+- **Source of implementation:** The code in liboqs is related to the submitted version https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/Picnic.zip
 - **License:** MIT License
 - **Language:** C
 - **Constant-time:** Yes

--- a/docs/algorithms/sig_qtesla.md
+++ b/docs/algorithms/sig_qtesla.md
@@ -28,6 +28,7 @@ Implementation
 --------------
 
 - **Source of implementation:** https://github.com/qtesla/qTesla
+- **Implementation version:** https://github.com/qtesla/qTesla/commit/5e921da989b9b44aba95f63d9c28927d518f630c
 - **License:** public domain
 - **Language:** C
 - **Constant-time:** Yes

--- a/src/kem/BIG_QUAKE/kem_BIGQUAKE.c
+++ b/src/kem/BIG_QUAKE/kem_BIGQUAKE.c
@@ -11,6 +11,7 @@ OQS_KEM *OQS_KEM_BIG_QUAKE_1_new() {
 		return NULL;
 	}
 	kem->method_name = "BIG_QUAKE_1";
+	kem->alg_version = "https://bigquake.inria.fr/files/2018/03/BIGQUAKE-source.tar.gz";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -38,6 +39,7 @@ OQS_KEM *OQS_KEM_BIG_QUAKE_3_new() {
 		return NULL;
 	}
 	kem->method_name = "BIG_QUAKE_3";
+	kem->alg_version = "https://bigquake.inria.fr/files/2018/03/BIGQUAKE-source.tar.gz";
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = true;
@@ -65,6 +67,7 @@ OQS_KEM *OQS_KEM_BIG_QUAKE_5_new() {
 		return NULL;
 	}
 	kem->method_name = "BIG_QUAKE_5";
+	kem->alg_version = "https://bigquake.inria.fr/files/2018/03/BIGQUAKE-source.tar.gz";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = true;

--- a/src/kem/bike/kem_bike.c
+++ b/src/kem/bike/kem_bike.c
@@ -4,6 +4,9 @@
 
 #ifdef OQS_ENABLE_KEM_bike1_l1
 
+// TODO: can't reliably provide a BIKE base version as code included in libOQS
+//       doesn't match the NIST PQ submission zip, or the BIKE website.
+
 OQS_KEM *OQS_KEM_bike1_l1_new() {
 
 	OQS_KEM *kem = malloc(sizeof(OQS_KEM));
@@ -11,6 +14,7 @@ OQS_KEM *OQS_KEM_bike1_l1_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike1_l1;
+	kem->alg_version = "TODO";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = false;
@@ -38,6 +42,7 @@ OQS_KEM *OQS_KEM_bike1_l3_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike1_l3;
+	kem->alg_version = "TODO";
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = false;
@@ -65,6 +70,7 @@ OQS_KEM *OQS_KEM_bike1_l5_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike1_l5;
+	kem->alg_version = "TODO";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = false;
@@ -92,6 +98,7 @@ OQS_KEM *OQS_KEM_bike2_l1_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike2_l1;
+	kem->alg_version = "TODO";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = false;
@@ -119,6 +126,7 @@ OQS_KEM *OQS_KEM_bike2_l3_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike2_l3;
+	kem->alg_version = "TODO";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = false;
@@ -146,6 +154,7 @@ OQS_KEM *OQS_KEM_bike2_l5_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike2_l5;
+	kem->alg_version = "TODO";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = false;
@@ -173,6 +182,7 @@ OQS_KEM *OQS_KEM_bike3_l1_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike3_l1;
+	kem->alg_version = "TODO";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = false;
@@ -200,6 +210,7 @@ OQS_KEM *OQS_KEM_bike3_l3_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike3_l3;
+	kem->alg_version = "TODO";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = false;
@@ -227,6 +238,7 @@ OQS_KEM *OQS_KEM_bike3_l5_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike3_l5;
+	kem->alg_version = "TODO";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = false;

--- a/src/kem/bike/kem_bike.c
+++ b/src/kem/bike/kem_bike.c
@@ -4,9 +4,6 @@
 
 #ifdef OQS_ENABLE_KEM_bike1_l1
 
-// TODO: can't reliably provide a BIKE base version as code included in libOQS
-//       doesn't match the NIST PQ submission zip, or the BIKE website.
-
 OQS_KEM *OQS_KEM_bike1_l1_new() {
 
 	OQS_KEM *kem = malloc(sizeof(OQS_KEM));
@@ -14,7 +11,11 @@ OQS_KEM *OQS_KEM_bike1_l1_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike1_l1;
-	kem->alg_version = "TODO";
+#if defined(ADDITIONAL_IMPL)
+	kem->alg_version = "Additional - 05/23/2018";
+#else
+	kem->alg_version = "Reference - 06/29/2018";
+#endif
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = false;
@@ -42,7 +43,11 @@ OQS_KEM *OQS_KEM_bike1_l3_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike1_l3;
-	kem->alg_version = "TODO";
+#if defined(ADDITIONAL_IMPL)
+	kem->alg_version = "Additional - 05/23/2018";
+#else
+	kem->alg_version = "Reference - 06/29/2018";
+#endif
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = false;
@@ -70,7 +75,11 @@ OQS_KEM *OQS_KEM_bike1_l5_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike1_l5;
-	kem->alg_version = "TODO";
+#if defined(ADDITIONAL_IMPL)
+	kem->alg_version = "Additional - 05/23/2018";
+#else
+	kem->alg_version = "Reference - 06/29/2018";
+#endif
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = false;
@@ -98,7 +107,11 @@ OQS_KEM *OQS_KEM_bike2_l1_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike2_l1;
-	kem->alg_version = "TODO";
+#if defined(ADDITIONAL_IMPL)
+	kem->alg_version = "Additional - 05/23/2018";
+#else
+	kem->alg_version = "Reference - 06/29/2018";
+#endif
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = false;
@@ -126,7 +139,11 @@ OQS_KEM *OQS_KEM_bike2_l3_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike2_l3;
-	kem->alg_version = "TODO";
+#if defined(ADDITIONAL_IMPL)
+	kem->alg_version = "Additional - 05/23/2018";
+#else
+	kem->alg_version = "Reference - 06/29/2018";
+#endif
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = false;
@@ -154,7 +171,11 @@ OQS_KEM *OQS_KEM_bike2_l5_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike2_l5;
-	kem->alg_version = "TODO";
+#if defined(ADDITIONAL_IMPL)
+	kem->alg_version = "Additional - 05/23/2018";
+#else
+	kem->alg_version = "Reference - 06/29/2018";
+#endif
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = false;
@@ -182,7 +203,11 @@ OQS_KEM *OQS_KEM_bike3_l1_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike3_l1;
-	kem->alg_version = "TODO";
+#if defined(ADDITIONAL_IMPL)
+	kem->alg_version = "Additional - 05/23/2018";
+#else
+	kem->alg_version = "Reference - 06/29/2018";
+#endif
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = false;
@@ -210,7 +235,11 @@ OQS_KEM *OQS_KEM_bike3_l3_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike3_l3;
-	kem->alg_version = "TODO";
+#if defined(ADDITIONAL_IMPL)
+	kem->alg_version = "Additional - 05/23/2018";
+#else
+	kem->alg_version = "Reference - 06/29/2018";
+#endif
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = false;
@@ -238,7 +267,11 @@ OQS_KEM *OQS_KEM_bike3_l5_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_bike3_l5;
-	kem->alg_version = "TODO";
+#if defined(ADDITIONAL_IMPL)
+	kem->alg_version = "Additional - 05/23/2018";
+#else
+	kem->alg_version = "Reference - 06/29/2018";
+#endif
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = false;

--- a/src/kem/crystals-kyber/kem_kyber.c
+++ b/src/kem/crystals-kyber/kem_kyber.c
@@ -11,6 +11,7 @@ OQS_KEM *OQS_KEM_kyber512_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_kyber512;
+	kem->alg_version = "https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/CRYSTALS_Kyber.zip";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -38,6 +39,7 @@ OQS_KEM *OQS_KEM_kyber768_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_kyber768;
+	kem->alg_version = "https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/CRYSTALS_Kyber.zip";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -65,6 +67,7 @@ OQS_KEM *OQS_KEM_kyber1024_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_kyber1024;
+	kem->alg_version = "https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/CRYSTALS_Kyber.zip";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;

--- a/src/kem/frodokem/kem_frodokem.c
+++ b/src/kem/frodokem/kem_frodokem.c
@@ -11,6 +11,7 @@ OQS_KEM *OQS_KEM_frodokem_640_aes_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_frodokem_640_aes;
+	kem->alg_version = "https://github.com/Microsoft/PQCrypto-LWEKE/commit/47da00a91270b6f103232314eef0b891b83bfd3b";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -38,6 +39,7 @@ OQS_KEM *OQS_KEM_frodokem_976_aes_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_frodokem_976_aes;
+	kem->alg_version = "https://github.com/Microsoft/PQCrypto-LWEKE/commit/47da00a91270b6f103232314eef0b891b83bfd3b";
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = true;
@@ -65,6 +67,7 @@ OQS_KEM *OQS_KEM_frodokem_640_cshake_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_frodokem_640_cshake;
+	kem->alg_version = "https://github.com/Microsoft/PQCrypto-LWEKE/commit/47da00a91270b6f103232314eef0b891b83bfd3b";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -92,6 +95,7 @@ OQS_KEM *OQS_KEM_frodokem_976_cshake_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_frodokem_976_cshake;
+	kem->alg_version = "https://github.com/Microsoft/PQCrypto-LWEKE/commit/47da00a91270b6f103232314eef0b891b83bfd3b";
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = true;

--- a/src/kem/kem.h
+++ b/src/kem/kem.h
@@ -141,6 +141,14 @@ typedef struct OQS_KEM {
 	/** Printable string representing the name of the key encapsulation mechanism. */
 	const char *method_name;
 
+	/**
+	 * Printable string representing the version of the cryptographic algorithm.
+	 *
+	 * Implementations with the same method_name and same alg_version will be interoperable.
+	 * See README.md for information about algorithm compatibility.
+	 */
+	const char *alg_version;
+
 	/** The NIST security level (1, 2, 3, 4, 5) claimed in this algorithm's original NIST submission. */
 	uint8_t claimed_nist_level;
 

--- a/src/kem/ledakem/kem_ledakem.c
+++ b/src/kem/ledakem/kem_ledakem.c
@@ -14,6 +14,7 @@ OQS_KEM *OQS_KEM_ledakem_C1_N02_new() {
 	kem->ind_cca = true;
 
 	kem->method_name = "LEDAKEM_C1_N02";
+	kem->alg_version = "https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/LEDAkem.zip";
 	kem->length_public_key = OQS_KEM_ledakem_C1_N02_length_public_key;
 	kem->length_secret_key = OQS_KEM_ledakem_C1_N02_length_secret_key;
 	kem->length_ciphertext = OQS_KEM_ledakem_C1_N02_length_ciphertext;
@@ -39,6 +40,7 @@ OQS_KEM *OQS_KEM_ledakem_C1_N03_new() {
 	kem->ind_cca = true;
 
 	kem->method_name = "LEDAKEM_C1_N03";
+	kem->alg_version = "https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/LEDAkem.zip";
 	kem->length_public_key = OQS_KEM_ledakem_C1_N03_length_public_key;
 	kem->length_secret_key = OQS_KEM_ledakem_C1_N03_length_secret_key;
 	kem->length_ciphertext = OQS_KEM_ledakem_C1_N03_length_ciphertext;
@@ -64,6 +66,7 @@ OQS_KEM *OQS_KEM_ledakem_C1_N04_new() {
 	kem->ind_cca = true;
 
 	kem->method_name = "LEDAKEM_C1_N04";
+	kem->alg_version = "https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/LEDAkem.zip";
 	kem->length_public_key = OQS_KEM_ledakem_C1_N04_length_public_key;
 	kem->length_secret_key = OQS_KEM_ledakem_C1_N04_length_secret_key;
 	kem->length_ciphertext = OQS_KEM_ledakem_C1_N04_length_ciphertext;
@@ -89,6 +92,7 @@ OQS_KEM *OQS_KEM_ledakem_C3_N02_new() {
 	kem->ind_cca = true;
 
 	kem->method_name = "LEDAKEM_C3_N02";
+	kem->alg_version = "https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/LEDAkem.zip";
 	kem->length_public_key = OQS_KEM_ledakem_C3_N02_length_public_key;
 	kem->length_secret_key = OQS_KEM_ledakem_C3_N02_length_secret_key;
 	kem->length_ciphertext = OQS_KEM_ledakem_C3_N02_length_ciphertext;
@@ -114,6 +118,7 @@ OQS_KEM *OQS_KEM_ledakem_C3_N03_new() {
 	kem->ind_cca = true;
 
 	kem->method_name = "LEDAKEM_C3_N03";
+	kem->alg_version = "https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/LEDAkem.zip";
 	kem->length_public_key = OQS_KEM_ledakem_C3_N03_length_public_key;
 	kem->length_secret_key = OQS_KEM_ledakem_C3_N03_length_secret_key;
 	kem->length_ciphertext = OQS_KEM_ledakem_C3_N03_length_ciphertext;
@@ -139,6 +144,7 @@ OQS_KEM *OQS_KEM_ledakem_C3_N04_new() {
 	kem->ind_cca = true;
 
 	kem->method_name = "LEDAKEM_C3_N04";
+	kem->alg_version = "https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/LEDAkem.zip";
 	kem->length_public_key = OQS_KEM_ledakem_C3_N04_length_public_key;
 	kem->length_secret_key = OQS_KEM_ledakem_C3_N04_length_secret_key;
 	kem->length_ciphertext = OQS_KEM_ledakem_C3_N04_length_ciphertext;
@@ -164,6 +170,7 @@ OQS_KEM *OQS_KEM_ledakem_C5_N02_new() {
 	kem->ind_cca = true;
 
 	kem->method_name = "LEDAKEM_C5_N02";
+	kem->alg_version = "https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/LEDAkem.zip";
 	kem->length_public_key = OQS_KEM_ledakem_C5_N02_length_public_key;
 	kem->length_secret_key = OQS_KEM_ledakem_C5_N02_length_secret_key;
 	kem->length_ciphertext = OQS_KEM_ledakem_C5_N02_length_ciphertext;
@@ -189,6 +196,7 @@ OQS_KEM *OQS_KEM_ledakem_C5_N03_new() {
 	kem->ind_cca = true;
 
 	kem->method_name = "LEDAKEM_C5_N03";
+	kem->alg_version = "https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/LEDAkem.zip";
 	kem->length_public_key = OQS_KEM_ledakem_C5_N03_length_public_key;
 	kem->length_secret_key = OQS_KEM_ledakem_C5_N03_length_secret_key;
 	kem->length_ciphertext = OQS_KEM_ledakem_C5_N03_length_ciphertext;
@@ -214,6 +222,7 @@ OQS_KEM *OQS_KEM_ledakem_C5_N04_new() {
 	kem->ind_cca = true;
 
 	kem->method_name = "LEDAKEM_C5_N04";
+	kem->alg_version = "https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/LEDAkem.zip";
 	kem->length_public_key = OQS_KEM_ledakem_C5_N04_length_public_key;
 	kem->length_secret_key = OQS_KEM_ledakem_C5_N04_length_secret_key;
 	kem->length_ciphertext = OQS_KEM_ledakem_C5_N04_length_ciphertext;

--- a/src/kem/lima/kem_lima.c
+++ b/src/kem/lima/kem_lima.c
@@ -11,6 +11,7 @@ OQS_KEM *OQS_KEM_lima_2p_1024_cca_kem_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_lima_2p_1024_cca_kem;
+	kem->alg_version = "https://github.com/lima-pq/optimized-implementation/tree/c660c24db8ddbdce097a2bb19059c6896ef1c27c";
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = true;
@@ -38,6 +39,7 @@ OQS_KEM *OQS_KEM_lima_2p_2048_cca_kem_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_lima_2p_2048_cca_kem;
+	kem->alg_version = "https://github.com/lima-pq/optimized-implementation/tree/c660c24db8ddbdce097a2bb19059c6896ef1c27c";
 
 	kem->claimed_nist_level = 4;
 	kem->ind_cca = true;
@@ -65,6 +67,7 @@ OQS_KEM *OQS_KEM_lima_sp_1018_cca_kem_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_lima_sp_1018_cca_kem;
+	kem->alg_version = "https://github.com/lima-pq/optimized-implementation/tree/c660c24db8ddbdce097a2bb19059c6896ef1c27c";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -92,6 +95,7 @@ OQS_KEM *OQS_KEM_lima_sp_1306_cca_kem_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_lima_sp_1306_cca_kem;
+	kem->alg_version = "https://github.com/lima-pq/optimized-implementation/tree/c660c24db8ddbdce097a2bb19059c6896ef1c27c";
 
 	kem->claimed_nist_level = 2;
 	kem->ind_cca = true;
@@ -119,6 +123,7 @@ OQS_KEM *OQS_KEM_lima_sp_1822_cca_kem_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_lima_sp_1822_cca_kem;
+	kem->alg_version = "https://github.com/lima-pq/optimized-implementation/tree/c660c24db8ddbdce097a2bb19059c6896ef1c27c";
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = true;
@@ -146,6 +151,7 @@ OQS_KEM *OQS_KEM_lima_sp_2062_cca_kem_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_lima_sp_2062_cca_kem;
+	kem->alg_version = "https://github.com/lima-pq/optimized-implementation/tree/c660c24db8ddbdce097a2bb19059c6896ef1c27c";
 
 	kem->claimed_nist_level = 4;
 	kem->ind_cca = true;

--- a/src/kem/newhopenist/kem_newhopenist.c
+++ b/src/kem/newhopenist/kem_newhopenist.c
@@ -11,6 +11,7 @@ OQS_KEM *OQS_KEM_newhope_512_cca_kem_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_newhope_512_cca_kem;
+	kem->alg_version = "https://newhopecrypto.org/data/NewHope_2017_12_21.zip";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -38,6 +39,7 @@ OQS_KEM *OQS_KEM_newhope_1024_cca_kem_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_newhope_1024_cca_kem;
+	kem->alg_version = "https://newhopecrypto.org/data/NewHope_2017_12_21.zip";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = true;

--- a/src/kem/saber/kem_saber.c
+++ b/src/kem/saber/kem_saber.c
@@ -11,6 +11,7 @@ OQS_KEM *OQS_KEM_saber_light_saber_kem_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_saber_light_saber_kem;
+	kem->alg_version = "https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/SABER.zip";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -38,6 +39,7 @@ OQS_KEM *OQS_KEM_saber_saber_kem_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_saber_saber_kem;
+	kem->alg_version = "https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/SABER.zip";
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = true;
@@ -65,6 +67,7 @@ OQS_KEM *OQS_KEM_saber_fire_saber_kem_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_saber_fire_saber_kem;
+	kem->alg_version = "https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/SABER.zip";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = true;

--- a/src/kem/sike/kem_sike.c
+++ b/src/kem/sike/kem_sike.c
@@ -11,6 +11,7 @@ OQS_KEM *OQS_KEM_sike_p503_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sike_p503;
+	kem->alg_version = "https://github.com/Microsoft/PQCrypto-SIDH/tree/77044b76181eb61c744ac8eb7ddc7a8fe72f6919";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -38,6 +39,7 @@ OQS_KEM *OQS_KEM_sike_p751_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sike_p751;
+	kem->alg_version = "https://github.com/Microsoft/PQCrypto-SIDH/tree/77044b76181eb61c744ac8eb7ddc7a8fe72f6919";
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = true;

--- a/src/kem/titanium/kem_titanium.c
+++ b/src/kem/titanium/kem_titanium.c
@@ -11,6 +11,7 @@ OQS_KEM *OQS_KEM_titanium_cca_std_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_titanium_cca_std_kem;
+	kem->alg_version = "https://github.com/raykzhao/Titanium/tree/a7547ad486e7220e1d9ffac7a76fe260dfa36cc3";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -39,6 +40,7 @@ OQS_KEM *OQS_KEM_titanium_cca_hi_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_titanium_cca_hi_kem;
+	kem->alg_version = "https://github.com/raykzhao/Titanium/tree/a7547ad486e7220e1d9ffac7a76fe260dfa36cc3";
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = true;
@@ -66,6 +68,7 @@ OQS_KEM *OQS_KEM_titanium_cca_med_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_titanium_cca_med_kem;
+	kem->alg_version = "https://github.com/raykzhao/Titanium/tree/a7547ad486e7220e1d9ffac7a76fe260dfa36cc3";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -93,6 +96,7 @@ OQS_KEM *OQS_KEM_titanium_cca_super_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_titanium_cca_super_kem;
+	kem->alg_version = "https://github.com/raykzhao/Titanium/tree/a7547ad486e7220e1d9ffac7a76fe260dfa36cc3";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = true;

--- a/src/sig/crystals-dilithium/sig_dilithium.c
+++ b/src/sig/crystals-dilithium/sig_dilithium.c
@@ -2,6 +2,9 @@
 
 #include <oqs/sig_dilithium.h>
 
+// TODO: can't reliably provide a base version as code included in libOQS
+//       doesn't match the NIST PQ submission zip or their github version.
+
 #ifdef OQS_ENABLE_SIG_Dilithium_II_medium
 
 OQS_SIG *OQS_SIG_Dilithium_II_medium_new() {
@@ -11,6 +14,7 @@ OQS_SIG *OQS_SIG_Dilithium_II_medium_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_Dilithium_II_medium;
+	sig->alg_version = "TODO";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -37,6 +41,7 @@ OQS_SIG *OQS_SIG_Dilithium_III_recommended_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_Dilithium_III_recommended;
+	sig->alg_version = "TODO";
 
 	sig->claimed_nist_level = 2;
 	sig->euf_cma = true;
@@ -63,6 +68,7 @@ OQS_SIG *OQS_SIG_Dilithium_IV_very_high_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_Dilithium_IV_very_high;
+	sig->alg_version = "TODO";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;

--- a/src/sig/picnic/sig_picnic.c
+++ b/src/sig/picnic/sig_picnic.c
@@ -4,6 +4,9 @@
 
 #ifdef OQS_ENABLE_SIG_picnic_L1_FS
 
+// TODO: can't reliably provide a Picnic base version as code included in libOQS
+//       doesn't match the NIST PQ submission zip or their website.
+
 OQS_SIG *OQS_SIG_picnic_L1_FS_new() {
 
 	OQS_SIG *sig = malloc(sizeof(OQS_SIG));
@@ -11,6 +14,7 @@ OQS_SIG *OQS_SIG_picnic_L1_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_FS;
+	sig->alg_version = "TODO";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -37,6 +41,7 @@ OQS_SIG *OQS_SIG_picnic_L1_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_UR;
+	sig->alg_version = "TODO";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -63,6 +68,7 @@ OQS_SIG *OQS_SIG_picnic_L3_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_FS;
+	sig->alg_version = "TODO";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -89,6 +95,7 @@ OQS_SIG *OQS_SIG_picnic_L3_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_UR;
+	sig->alg_version = "TODO";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -115,6 +122,7 @@ OQS_SIG *OQS_SIG_picnic_L5_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_FS;
+	sig->alg_version = "TODO";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -141,6 +149,7 @@ OQS_SIG *OQS_SIG_picnic_L5_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_UR;
+	sig->alg_version = "TODO";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;

--- a/src/sig/picnic/sig_picnic.c
+++ b/src/sig/picnic/sig_picnic.c
@@ -4,9 +4,6 @@
 
 #ifdef OQS_ENABLE_SIG_picnic_L1_FS
 
-// TODO: can't reliably provide a Picnic base version as code included in libOQS
-//       doesn't match the NIST PQ submission zip or their website.
-
 OQS_SIG *OQS_SIG_picnic_L1_FS_new() {
 
 	OQS_SIG *sig = malloc(sizeof(OQS_SIG));

--- a/src/sig/picnic/sig_picnic.c
+++ b/src/sig/picnic/sig_picnic.c
@@ -14,7 +14,7 @@ OQS_SIG *OQS_SIG_picnic_L1_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_FS;
-	sig->alg_version = "TODO";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/423b5da7036ac3b090d50bdff1e9a8ea34e37d11";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -41,7 +41,7 @@ OQS_SIG *OQS_SIG_picnic_L1_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_UR;
-	sig->alg_version = "TODO";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/423b5da7036ac3b090d50bdff1e9a8ea34e37d11";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -68,7 +68,7 @@ OQS_SIG *OQS_SIG_picnic_L3_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_FS;
-	sig->alg_version = "TODO";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/423b5da7036ac3b090d50bdff1e9a8ea34e37d11";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -95,7 +95,7 @@ OQS_SIG *OQS_SIG_picnic_L3_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_UR;
-	sig->alg_version = "TODO";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/423b5da7036ac3b090d50bdff1e9a8ea34e37d11";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -122,7 +122,7 @@ OQS_SIG *OQS_SIG_picnic_L5_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_FS;
-	sig->alg_version = "TODO";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/423b5da7036ac3b090d50bdff1e9a8ea34e37d11";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -149,7 +149,7 @@ OQS_SIG *OQS_SIG_picnic_L5_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_UR;
-	sig->alg_version = "TODO";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/423b5da7036ac3b090d50bdff1e9a8ea34e37d11";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;

--- a/src/sig/qtesla/sig_qtesla.c
+++ b/src/sig/qtesla/sig_qtesla.c
@@ -2,9 +2,6 @@
 
 #include <oqs/sig_qtesla.h>
 
-// TODO: can't reliably provide a qTESLA base version as code included in libOQS
-//       doesn't match the NIST PQ submission zip or their website.
-
 #ifdef OQS_ENABLE_SIG_qTESLA_I
 
 OQS_SIG *OQS_SIG_qTESLA_I_new() {

--- a/src/sig/qtesla/sig_qtesla.c
+++ b/src/sig/qtesla/sig_qtesla.c
@@ -2,6 +2,9 @@
 
 #include <oqs/sig_qtesla.h>
 
+// TODO: can't reliably provide a qTESLA base version as code included in libOQS
+//       doesn't match the NIST PQ submission zip or their website.
+
 #ifdef OQS_ENABLE_SIG_qTESLA_I
 
 OQS_SIG *OQS_SIG_qTESLA_I_new() {
@@ -11,6 +14,7 @@ OQS_SIG *OQS_SIG_qTESLA_I_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_qTESLA_I;
+	sig->alg_version = "TODO";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -37,6 +41,7 @@ OQS_SIG *OQS_SIG_qTESLA_III_size_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_qTESLA_III_size;
+	sig->alg_version = "TODO";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -63,6 +68,7 @@ OQS_SIG *OQS_SIG_qTESLA_III_speed_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_qTESLA_III_speed;
+	sig->alg_version = "TODO";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -89,6 +95,7 @@ OQS_SIG *OQS_SIG_qTESLA_p_I_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_qTESLA_p_I;
+	sig->alg_version = "TODO";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -115,6 +122,7 @@ OQS_SIG *OQS_SIG_qTESLA_p_III_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_qTESLA_p_III;
+	sig->alg_version = "TODO";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;

--- a/src/sig/qtesla/sig_qtesla.c
+++ b/src/sig/qtesla/sig_qtesla.c
@@ -14,7 +14,7 @@ OQS_SIG *OQS_SIG_qTESLA_I_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_qTESLA_I;
-	sig->alg_version = "TODO";
+	sig->alg_version = "https://github.com/qtesla/qTesla/commit/5e921da989b9b44aba95f63d9c28927d518f630c";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -41,7 +41,7 @@ OQS_SIG *OQS_SIG_qTESLA_III_size_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_qTESLA_III_size;
-	sig->alg_version = "TODO";
+	sig->alg_version = "https://github.com/qtesla/qTesla/commit/5e921da989b9b44aba95f63d9c28927d518f630c";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -68,7 +68,7 @@ OQS_SIG *OQS_SIG_qTESLA_III_speed_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_qTESLA_III_speed;
-	sig->alg_version = "TODO";
+	sig->alg_version = "https://github.com/qtesla/qTesla/commit/5e921da989b9b44aba95f63d9c28927d518f630c";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -95,7 +95,7 @@ OQS_SIG *OQS_SIG_qTESLA_p_I_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_qTESLA_p_I;
-	sig->alg_version = "TODO";
+	sig->alg_version = "https://github.com/qtesla/qTesla/commit/5e921da989b9b44aba95f63d9c28927d518f630c";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -122,7 +122,7 @@ OQS_SIG *OQS_SIG_qTESLA_p_III_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_qTESLA_p_III;
-	sig->alg_version = "TODO";
+	sig->alg_version = "https://github.com/qtesla/qTesla/commit/5e921da989b9b44aba95f63d9c28927d518f630c";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;

--- a/src/sig/sig.h
+++ b/src/sig/sig.h
@@ -79,6 +79,14 @@ typedef struct OQS_SIG {
 	/** Printable string representing the name of the signature scheme. */
 	const char *method_name;
 
+	/**
+	 * Printable string representing the version of the cryptographic algorithm.
+	 *
+	 * Implementations with the same method_name and same alg_version will be interoperable.
+	 * See README.md for information about algorithm compatibility.
+	 */
+	const char *alg_version;
+
 	/** The NIST security level (1, 2, 3, 4, 5) claimed in this algorithm's original NIST submission. */
 	uint8_t claimed_nist_level;
 


### PR DESCRIPTION
Added version string attribute for KEMs and SIGs.

Added unique version details for most KEM algorithms, where the upstream code could be explicitly matched to a version on GitHub, the NIST PQ site, or the algorithm web page.

Stubbed out the SIG versions, but could not specify versions. The SIG code in liboqs was different to the repos or files provided online.