### PR TITLE
Don't rely on bashism in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ docs: headers
 	doxygen docs/.Doxyfile
 
 install-noshared:
-	@if [[ $(PREFIX) == "usr_local" ]] ; then echo "Installing to `pwd`/$(PREFIX). Override by running 'make install PREFIX=<destination>'."; fi
+	@if [ "$(PREFIX)" == "usr_local" ] ; then echo "Installing to `pwd`/$(PREFIX). Override by running 'make install PREFIX=<destination>'."; fi
 	mkdir -p $(PREFIX_INCLUDE)
 	mkdir -p $(PREFIX_LIB)
 	$(RM) -r $(PREFIX_INCLUDE)/oqs


### PR DESCRIPTION
`/bin/sh` doesn't necessarily understand `[[`. 

```
root@18a2f0f4f26e:/# /bin/sh
# [[
/bin/sh: 1: [[: not found
```