### PR TITLE
Add support for building on OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ You need to install the following packages using brew (or a package manager of y
 
 	brew install autoconf automake libtool openssl wget
 
+### Install dependencies for OpenBSD
+
+You need to install the following packages using pkg_add:
+
+	pkg_add automake libtool
+
+On OpenBSD you have to explicitly set the environment variables `AUTOCONF_VERSION` and 
+`AUTOMAKE_VERSION` to a version installed on your system.
+
+	export AUTOCONF_VERSION=`ls -1 /usr/local/bin/autoreconf-* | sort | tail -n 1 | cut -d'-' -f2`
+	export AUTOMAKE_VERSION=`ls -1 /usr/local/bin/automake-* | sort | tail -n 1 | cut -d'-' -f2`
+
+
 ### Building
 
 To build, first clone or download the source from GitHub:

--- a/config/detect_host_and_cpu.m4
+++ b/config/detect_host_and_cpu.m4
@@ -16,6 +16,9 @@ AC_DEFUN([DETECT_HOST_AND_CPU], [
     linux*)
           linux=true
           ;;
+    openbsd*)
+          openbsd=true
+          ;;
       *)
           #Default Case
           AC_MSG_ERROR([Your platform is not currently supported])
@@ -24,6 +27,7 @@ AC_DEFUN([DETECT_HOST_AND_CPU], [
 
   AM_CONDITIONAL([ON_DARWIN], [test "x$darwin" = xtrue])
   AM_CONDITIONAL([ON_LINUX], [test "x$linux" = xtrue])
+  AM_CONDITIONAL([ON_OPENBSD], [test "x$openbsd" = xtrue])
 
   # Enable assembly optimizations here
   # Appearenly asm optimizations do not work well with darwin

--- a/src/sig/picnic/external/endian_compat.h
+++ b/src/sig/picnic/external/endian_compat.h
@@ -59,9 +59,15 @@ static inline uint64_t AATR_CONST bswap64(uint64_t x) {
 #endif
 #endif
 
-/* OS X / OpenBSD */
-#if defined(__APPLE__) || defined(__OpenBSD__)
+/* OS X */
+#if defined(__APPLE__)
 #include <machine/endian.h>
+#endif
+
+/* OpenBSD */
+#if defined(__OpenBSD__)
+#include <machine/endian.h>
+#define HAVE_HOSTSWAP
 #endif
 
 /* other BSDs */


### PR DESCRIPTION
See title. I added some additional instructions in the Readme that explain the OpenBSD specific steps in the build process.
The changes to picnic were necessary to prevent a double definition error.

One thing that would be nice to have, that i haven't figured out how to do right (since I'm not too familiar with automake) would be setting the default compiler to clang for OpenBSD.
OpenBSD's gcc is based on an old version that does not support several of the newer compilation flags used in the build process and thus can not build this project.