### PR TITLE
Link main liboqs library to OpenSSL when enabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,9 @@ endif
 if ENABLE_KEM_KYBER
 liboqs_la_LIBADD += src/kem/kyber/libkemkyber.la
 endif
+if USE_OPENSSL
+liboqs_la_LIBADD += -L${OPENSSL_DIR}/lib -lcrypto
+endif
 
 oqsconfigh:
 	grep OQS_ config.h > src/oqsconfig.h

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -26,15 +26,3 @@ test_kem_LDADD        = ${LIB_FLAGS}
 test_sha3_LDADD       = ${LIB_FLAGS}
 test_sig_LDADD        = ${LIB_FLAGS}
 kat_kem_LDADD         = ${LIB_FLAGS}
-
-if USE_OPENSSL
-example_kem_LDADD     += -L$(OPENSSL_DIR)/lib -lcrypto
-example_sig_LDADD     += -L$(OPENSSL_DIR)/lib -lcrypto
-speed_kem_LDADD       += -L$(OPENSSL_DIR)/lib -lcrypto
-speed_sig_LDADD       += -L$(OPENSSL_DIR)/lib -lcrypto
-test_aes_LDADD        += -L$(OPENSSL_DIR)/lib -lcrypto
-test_kem_LDADD        += -L$(OPENSSL_DIR)/lib -lcrypto
-test_sha3_LDADD       += -L$(OPENSSL_DIR)/lib -lcrypto
-test_sig_LDADD        += -L$(OPENSSL_DIR)/lib -lcrypto
-kat_kem_LDADD         += -L$(OPENSSL_DIR)/lib -lcrypto
-endif


### PR DESCRIPTION
This adds the correct linker instructions when OpenSSL is enabled. It also removes the now-redundant linker instructions when building the tests.

Fixes #485.