### PR TITLE
Fix macros so AES version compilation actually works

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,7 @@ CLANGFORMAT ?= clang-format-3.9
 
 SUBDIRS = ${SRCDIR} . tests
 
-BUILT_SOURCES = oqsconfigh links
+BUILT_SOURCES = links
 lib_LTLIBRARIES = liboqs.la
 liboqs_la_SOURCES =
 liboqs_la_LIBADD =  src/common/libcommon.la
@@ -55,9 +55,6 @@ if USE_OPENSSL
 liboqs_la_LIBADD += -L${OPENSSL_DIR}/lib -lcrypto
 endif
 
-oqsconfigh:
-	grep OQS_ config.h > src/oqsconfig.h
-
 installheaderdir=$(includedir)/oqs
 ##### OQS_COPY_FROM_PQCLEAN_FRAGMENT_INSTALLHEADER_START
 installheader_HEADERS= src/oqs.h \
@@ -94,9 +91,11 @@ kat: clean-kats check
 	tests/kat_kem
 	scripts/check_kats.sh
 
-links: oqsconfigh
+links:
 	$(MKDIR_P) include/oqs
 	cp -f src/oqs.h include/oqs
+	grep OQS_ config.h > src/oqsconfig.h
+	grep USE_ config.h >> src/oqsconfig.h
 	cp -f src/oqsconfig.h include/oqs
 	cp -f src/common/common.h include/oqs
 	cp -f src/common/rand.h include/oqs

--- a/src/crypto/aes/aes.c
+++ b/src/crypto/aes/aes.c
@@ -1,6 +1,6 @@
 #include <assert.h>
 
-#include <oqs/oqsconfig.h>
+#include <oqs/oqs.h>
 
 #include "aes.h"
 #include "aes_local.h"

--- a/src/crypto/aes/aes.c
+++ b/src/crypto/aes/aes.c
@@ -1,12 +1,14 @@
 #include <assert.h>
 
+#include <oqs/oqsconfig.h>
+
 #include "aes.h"
 #include "aes_local.h"
 
 void OQS_AES128_load_schedule(const uint8_t *key, void **schedule, UNUSED int for_encryption) {
 #ifdef USE_OPENSSL
 	oqs_aes128_load_schedule_ossl(key, schedule, for_encryption);
-#elif defined(AES_ENABLE_NI)
+#elif defined(USE_AES_NI)
 	oqs_aes128_load_schedule_ni(key, schedule);
 #else
 	oqs_aes128_load_schedule_c(key, schedule);
@@ -16,7 +18,7 @@ void OQS_AES128_load_schedule(const uint8_t *key, void **schedule, UNUSED int fo
 void OQS_AES128_free_schedule(void *schedule) {
 #ifdef USE_OPENSSL
 	oqs_aes128_free_schedule_ossl(schedule);
-#elif defined(AES_ENABLE_NI)
+#elif defined(USE_AES_NI)
 	oqs_aes128_free_schedule_ni(schedule);
 #else
 	oqs_aes128_free_schedule_c(schedule);
@@ -26,7 +28,7 @@ void OQS_AES128_free_schedule(void *schedule) {
 void OQS_AES128_ECB_enc(const uint8_t *plaintext, const size_t plaintext_len, const uint8_t *key, uint8_t *ciphertext) {
 #ifdef USE_OPENSSL
 	oqs_aes128_ecb_enc_ossl(plaintext, plaintext_len, key, ciphertext);
-#elif defined(AES_ENABLE_NI)
+#elif defined(USE_AES_NI)
 	oqs_aes128_ecb_enc_ni(plaintext, plaintext_len, key, ciphertext);
 #else
 	oqs_aes128_ecb_enc_c(plaintext, plaintext_len, key, ciphertext);
@@ -36,7 +38,7 @@ void OQS_AES128_ECB_enc(const uint8_t *plaintext, const size_t plaintext_len, co
 void OQS_AES128_ECB_dec(const uint8_t *ciphertext, const size_t ciphertext_len, const uint8_t *key, uint8_t *plaintext) {
 #ifdef USE_OPENSSL
 	oqs_aes128_ecb_dec_ossl(ciphertext, ciphertext_len, key, plaintext);
-#elif defined(AES_ENABLE_NI)
+#elif defined(USE_AES_NI)
 	oqs_aes128_ecb_dec_ni(ciphertext, ciphertext_len, key, plaintext);
 #else
 	oqs_aes128_ecb_dec_c(ciphertext, ciphertext_len, key, plaintext);
@@ -46,7 +48,7 @@ void OQS_AES128_ECB_dec(const uint8_t *ciphertext, const size_t ciphertext_len, 
 void OQS_AES128_ECB_enc_sch(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext) {
 #ifdef USE_OPENSSL
 	oqs_aes128_ecb_enc_sch_ossl(plaintext, plaintext_len, schedule, ciphertext);
-#elif defined(AES_ENABLE_NI)
+#elif defined(USE_AES_NI)
 	oqs_aes128_ecb_enc_sch_ni(plaintext, plaintext_len, schedule, ciphertext);
 #else
 	oqs_aes128_ecb_enc_sch_c(plaintext, plaintext_len, schedule, ciphertext);
@@ -56,14 +58,14 @@ void OQS_AES128_ECB_enc_sch(const uint8_t *plaintext, const size_t plaintext_len
 void OQS_AES128_ECB_dec_sch(const uint8_t *ciphertext, const size_t ciphertext_len, const void *schedule, uint8_t *plaintext) {
 #ifdef USE_OPENSSL
 	oqs_aes128_ecb_dec_sch_ossl(ciphertext, ciphertext_len, schedule, plaintext);
-#elif defined(AES_ENABLE_NI)
+#elif defined(USE_AES_NI)
 	oqs_aes128_ecb_dec_sch_ni(ciphertext, ciphertext_len, schedule, plaintext);
 #else
 	oqs_aes128_ecb_dec_sch_c(ciphertext, ciphertext_len, schedule, plaintext);
 #endif
 }
 
-#ifdef AES_ENABLE_NI
+#ifdef USE_AES_NI
 void oqs_aes128_ecb_enc_ni(const uint8_t *plaintext, const size_t plaintext_len, const uint8_t *key, uint8_t *ciphertext) {
 	void *schedule = NULL;
 	oqs_aes128_load_schedule_ni(key, &schedule);
@@ -79,7 +81,7 @@ void oqs_aes128_ecb_enc_c(const uint8_t *plaintext, const size_t plaintext_len, 
 	oqs_aes128_free_schedule_c(schedule);
 }
 
-#ifdef AES_ENABLE_NI
+#ifdef USE_AES_NI
 void oqs_aes128_ecb_enc_sch_ni(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext) {
 	assert(plaintext_len % 16 == 0);
 	for (size_t block = 0; block < plaintext_len / 16; block++) {
@@ -95,7 +97,7 @@ void oqs_aes128_ecb_enc_sch_c(const uint8_t *plaintext, const size_t plaintext_l
 	}
 }
 
-#ifdef AES_ENABLE_NI
+#ifdef USE_AES_NI
 void oqs_aes128_ecb_dec_ni(const uint8_t *ciphertext, const size_t ciphertext_len, const uint8_t *key, uint8_t *plaintext) {
 	void *schedule = NULL;
 	oqs_aes128_load_schedule_ni(key, &schedule);
@@ -111,7 +113,7 @@ void oqs_aes128_ecb_dec_c(const uint8_t *ciphertext, const size_t ciphertext_len
 	oqs_aes128_free_schedule_c(schedule);
 }
 
-#ifdef AES_ENABLE_NI
+#ifdef USE_AES_NI
 void oqs_aes128_ecb_dec_sch_ni(const uint8_t *ciphertext, const size_t ciphertext_len, const void *schedule, uint8_t *plaintext) {
 	assert(ciphertext_len % 16 == 0);
 	for (size_t block = 0; block < ciphertext_len / 16; block++) {

--- a/src/crypto/aes/aes_ni.c
+++ b/src/crypto/aes/aes_ni.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <oqs/common.h>
 
-#ifndef AES_ENABLE_NI
+#ifndef USE_AES_NI
 #include <assert.h>
 void oqs_aes128_load_schedule_ni(UNUSED const uint8_t *key, UNUSED void **_schedule) {
 	assert(0);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,7 +5,10 @@ if !ENABLE_SHARED
 check_PROGRAMS += test_aes test_sha3
 endif
 
-LIB_FLAGS=../liboqs.la -lm -lcrypto
+LIB_FLAGS=../liboqs.la -lm
+if USE_OPENSSL
+LIB_FLAGS += -L${OPENSSL_DIR}/lib -lcrypto
+endif
 
 example_kem_SOURCES     = example_kem.c
 example_sig_SOURCES     = example_sig.c

--- a/tests/test_aes.c
+++ b/tests/test_aes.c
@@ -72,7 +72,7 @@ static int test_aes256_correctness_c() {
 	return EXIT_SUCCESS;
 }
 
-#ifdef AES_ENABLE_NI
+#ifdef USE_AES_NI
 static int test_aes128_correctness_ni() {
 	uint8_t derived_plaintext[16], derived_ciphertext[16];
 	void *schedule = NULL;
@@ -168,7 +168,7 @@ static void speed_aes256_c() {
 	oqs_aes256_free_schedule_c(schedule);
 }
 
-#ifdef AES_ENABLE_NI
+#ifdef USE_AES_NI
 static void speed_aes128_ni() {
 	uint8_t plaintext[16], ciphertext[16];
 	void *schedule = NULL;
@@ -253,7 +253,7 @@ int main(int argc, char **argv) {
 		return EXIT_FAILURE;
 	if (test_aes256_correctness_c() != EXIT_SUCCESS)
 		return EXIT_FAILURE;
-#ifdef AES_ENABLE_NI
+#ifdef USE_AES_NI
 	if (test_aes128_correctness_ni() != EXIT_SUCCESS)
 		return EXIT_FAILURE;
 #endif
@@ -270,7 +270,7 @@ int main(int argc, char **argv) {
 		PRINT_TIMER_HEADER
 		speed_aes128_c();
 		speed_aes256_c();
-#ifdef AES_ENABLE_NI
+#ifdef USE_AES_NI
 		speed_aes128_ni();
 #endif
 #ifdef USE_OPENSSL


### PR DESCRIPTION
While working on something else, I noticed that the options from configure to select the different AES configurations weren't actually getting used, so it was always using the plain C AES implementation even when we directed it to use the AES_NI or OpenSSL AES implementations.  This patch fixes that.