### PR TITLE
Update PQClean implementations to have AES key schedule release

### DIFF
--- a/src/common/pqclean_shims/aes.h
+++ b/src/common/pqclean_shims/aes.h
@@ -14,16 +14,14 @@
 
 typedef void * aes128ctx;
 
-static void aes128_keyexp(aes128ctx *r, const unsigned char *key) {
-    OQS_AES128_load_schedule(key, r, 1);
-}
+#define aes128_keyexp(r, key) OQS_AES128_load_schedule((key), (r), 1);
+#define aes128_ecb(out, in, nblocks, ctx) OQS_AES128_ECB_enc_sch((in), (nblocks) * AES_BLOCKBYTES, *(ctx), (out));
+#define aes128_ctx_release(ctx) OQS_AES128_free_schedule(*(ctx));
 
-static void aes128_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, aes128ctx *ctx) {
-    OQS_AES128_ECB_enc_sch(in, nblocks * AES_BLOCKBYTES, *ctx, out);
-    OQS_AES128_free_schedule(*ctx);
-    // FIXME: PQClean AES API expects that aes128_ecb can be called multiple 
-    // times with the same key schedule, but this instantiation does not, since
-    // it frees the key schedule immediately
-}
+typedef void * aes256ctx;
+
+#define aes256_keyexp(r, key) OQS_AES256_load_schedule((key), (r), 1);
+#define aes256_ecb(out, in, nblocks, ctx) OQS_AES256_ECB_enc_sch((in), (nblocks) * AES_BLOCKBYTES, *(ctx), (out));
+#define aes256_ctx_release(ctx) OQS_AES256_free_schedule(*(ctx));
 
 #endif

--- a/src/crypto/aes/aes.c
+++ b/src/crypto/aes/aes.c
@@ -1,6 +1,6 @@
 #include <assert.h>
 
-#include <oqs/oqsconfig.h>
+#include <oqs/oqs.h>
 
 #include "aes.h"
 #include "aes_local.h"

--- a/src/kem/frodokem/pqclean_frodokem1344aes_clean/matrix_aes.c
+++ b/src/kem/frodokem/pqclean_frodokem1344aes_clean/matrix_aes.c
@@ -33,6 +33,7 @@ int PQCLEAN_FRODOKEM1344AES_CLEAN_mul_add_as_plus_e(uint16_t *out, const uint16_
     }
 
     aes128_ecb((uint8_t *) A, (uint8_t *) A, PARAMS_N * PARAMS_N * sizeof(int16_t) / AES_BLOCKBYTES, &ctx128);
+    aes128_ctx_release(&ctx128);
 
     for (i = 0; i < PARAMS_N * PARAMS_N; i++) {
         A[i] = PQCLEAN_FRODOKEM1344AES_CLEAN_LE_TO_UINT16(A[i]);
@@ -73,6 +74,7 @@ int PQCLEAN_FRODOKEM1344AES_CLEAN_mul_add_sa_plus_e(uint16_t *out, const uint16_
     }
 
     aes128_ecb((uint8_t *) A, (uint8_t *) A, PARAMS_N * PARAMS_N * sizeof(int16_t) / AES_BLOCKBYTES, &ctx128);
+    aes128_ctx_release(&ctx128);
 
     for (i = 0; i < PARAMS_N * PARAMS_N; i++) {
         A[i] = PQCLEAN_FRODOKEM1344AES_CLEAN_LE_TO_UINT16(A[i]);

--- a/src/kem/frodokem/pqclean_frodokem640aes_clean/matrix_aes.c
+++ b/src/kem/frodokem/pqclean_frodokem640aes_clean/matrix_aes.c
@@ -33,6 +33,7 @@ int PQCLEAN_FRODOKEM640AES_CLEAN_mul_add_as_plus_e(uint16_t *out, const uint16_t
     }
 
     aes128_ecb((uint8_t *) A, (uint8_t *) A, PARAMS_N * PARAMS_N * sizeof(int16_t) / AES_BLOCKBYTES, &ctx128);
+    aes128_ctx_release(&ctx128);
 
     for (i = 0; i < PARAMS_N * PARAMS_N; i++) {
         A[i] = PQCLEAN_FRODOKEM640AES_CLEAN_LE_TO_UINT16(A[i]);
@@ -73,6 +74,7 @@ int PQCLEAN_FRODOKEM640AES_CLEAN_mul_add_sa_plus_e(uint16_t *out, const uint16_t
     }
 
     aes128_ecb((uint8_t *) A, (uint8_t *) A, PARAMS_N * PARAMS_N * sizeof(int16_t) / AES_BLOCKBYTES, &ctx128);
+    aes128_ctx_release(&ctx128);
 
     for (i = 0; i < PARAMS_N * PARAMS_N; i++) {
         A[i] = PQCLEAN_FRODOKEM640AES_CLEAN_LE_TO_UINT16(A[i]);

--- a/src/kem/frodokem/pqclean_frodokem976aes_clean/matrix_aes.c
+++ b/src/kem/frodokem/pqclean_frodokem976aes_clean/matrix_aes.c
@@ -33,6 +33,7 @@ int PQCLEAN_FRODOKEM976AES_CLEAN_mul_add_as_plus_e(uint16_t *out, const uint16_t
     }
 
     aes128_ecb((uint8_t *) A, (uint8_t *) A, PARAMS_N * PARAMS_N * sizeof(int16_t) / AES_BLOCKBYTES, &ctx128);
+    aes128_ctx_release(&ctx128);
 
     for (i = 0; i < PARAMS_N * PARAMS_N; i++) {
         A[i] = PQCLEAN_FRODOKEM976AES_CLEAN_LE_TO_UINT16(A[i]);
@@ -73,6 +74,7 @@ int PQCLEAN_FRODOKEM976AES_CLEAN_mul_add_sa_plus_e(uint16_t *out, const uint16_t
     }
 
     aes128_ecb((uint8_t *) A, (uint8_t *) A, PARAMS_N * PARAMS_N * sizeof(int16_t) / AES_BLOCKBYTES, &ctx128);
+    aes128_ctx_release(&ctx128);
 
     for (i = 0; i < PARAMS_N * PARAMS_N; i++) {
         A[i] = PQCLEAN_FRODOKEM976AES_CLEAN_LE_TO_UINT16(A[i]);


### PR DESCRIPTION
liboqs has several AES implementations available to it, one of which (OpenSSL EVP) requires that the key schedule be allocated on the heap and release after use.  In particular it cannot be done on the stack (https://github.com/openssl/openssl/issues/962#issuecomment-208792020).  This patch adds a release function for the AES key schedule in the PQClean shims.

Depends on #496.