### PR TITLE
Explicitly set the picnic sig_len value before calling the picnic API

### DIFF
--- a/src/sig/picnic/sig_picnic.c
+++ b/src/sig/picnic/sig_picnic.c
@@ -31,6 +31,18 @@ static size_t PUB_KEY_LEN[] = {
     PICNIC_PUBLIC_KEY_SIZE(Picnic2_L3_FS),
     PICNIC_PUBLIC_KEY_SIZE(Picnic2_L5_FS),
 };
+static size_t SIG_LEN[] = {
+    0,
+    PICNIC_SIGNATURE_SIZE(Picnic_L1_FS),
+    PICNIC_SIGNATURE_SIZE(Picnic_L1_UR),
+    PICNIC_SIGNATURE_SIZE(Picnic_L3_FS),
+    PICNIC_SIGNATURE_SIZE(Picnic_L3_UR),
+    PICNIC_SIGNATURE_SIZE(Picnic_L5_FS),
+    PICNIC_SIGNATURE_SIZE(Picnic_L5_UR),
+    PICNIC_SIGNATURE_SIZE(Picnic2_L1_FS),
+    PICNIC_SIGNATURE_SIZE(Picnic2_L3_FS),
+    PICNIC_SIGNATURE_SIZE(Picnic2_L5_FS),
+};
 
 static OQS_STATUS common_picnic_keypair(picnic_params_t parameters, uint8_t *priv, uint8_t *pub) {
 	if (priv == NULL || pub == NULL) {
@@ -63,6 +75,9 @@ static OQS_STATUS common_picnic_sign(picnic_params_t parameters, const uint8_t *
 		return OQS_ERROR;
 	}
 	picnic_privatekey_t sk;
+	// picnic2's signature code checks that the sig_len value is large enough, but the OQS
+	// API treats this as an output parameters, so we set it here
+	*sig_len = SIG_LEN[parameters];
 	// deserialize the private key
 	if (picnic_read_private_key(&sk, priv, PRIV_KEY_LEN[parameters]) != 0) {
 		return OQS_ERROR;

--- a/tests/test_sig.c
+++ b/tests/test_sig.c
@@ -32,7 +32,6 @@ static OQS_STATUS sig_test_correctness(const char *method_name) {
 	secret_key = malloc(sig->length_secret_key);
 	message = malloc(message_len);
 	signature = malloc(sig->length_signature);
-	signature_len = sig->length_signature;
 
 	if ((public_key == NULL) || (secret_key == NULL) || (message == NULL) || (signature == NULL)) {
 		fprintf(stderr, "ERROR: malloc failed\n");


### PR DESCRIPTION
The picnic2 code checks that the sig_len value is large enough before serializing the signature, but OQS treats this value as an output variable, so I explicitly set it before calling the low-level picnic2 API.

I also removed now superfluous code from the unit test to achieve the same thing (that was added when picnic2 was integrated).

This should unblock [OpenSSL's PR102](https://github.com/open-quantum-safe/openssl/pull/102), adding picnic2 as an auth method.
