### PR TITLE
Fix build failure on Visual Studio x86

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,9 @@ version: 1.0.{build}
 
 image: Visual Studio 2017
 
-platform: x64
+platform:
+  - x86
+  - x64
 
 build:
   verbosity: minimal

--- a/src/kem/sike/config.h
+++ b/src/kem/sike/config.h
@@ -59,7 +59,7 @@ typedef uint64_t digit_t; // Unsigned 64-bit digit
 
 // Selection of generic, portable implementation
 
-#if defined(_GENERIC_)
+#if defined(_GENERIC_) || (_X86_ && OS_TARGET == OS_WIN)
 #define GENERIC_IMPLEMENTATION
 #endif
 


### PR DESCRIPTION
This fixes a build failure on Visual Studio x86 (SIKE wasn't recognizing this as a valid platform). Also adds x86 as an appveyor test platform.