### PR TITLE
Added .cache to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ src/oqsconfig.h
 __pycache__
 test-results
 .pytest_cache
+.cache
 
 # IDEs
 .idea


### PR DESCRIPTION
Added .cache (created by python test framework) to .gitignore. The cache is deleted after a successful run of the tests, but not if there is an error; its presence later prevents the test_style.py test to pass and therefore blocks commits.