### PR TITLE
Use C code for BIKE on macOS

### DIFF
--- a/src/kem/bike/Makefile.am
+++ b/src/kem/bike/Makefile.am
@@ -18,28 +18,28 @@ COMMON_CSRCS += $(BIKE_DIR)/utilities.c $(BIKE_DIR)/aes_ctr_prf.c $(BIKE_DIR)/er
 COMMON_CSRCS += $(BIKE_DIR)/gf2x_mul.c 
 
 if ON_DARWIN
-  COMMON_CSRCS += $(BIKE_DIR)/sampling_portable.c $(BIKE_DIR)/converts_portable.c
-  COMMON_FLAGS += -DPORTABLE
+COMMON_CSRCS += $(BIKE_DIR)/sampling_portable.c $(BIKE_DIR)/converts_portable.c
+COMMON_FLAGS += -DPORTABLE
 else
-  if USE_AVX512F_INSTRUCTIONS
-    COMMON_CSRCS += $(BIKE_DIR)/converts.S $(BIKE_DIR)/red.S $(BIKE_DIR)/secure_decode_avx512.S
-    COMMON_CSRCS += $(BIKE_DIR)/sampling_avx512.S $(BIKE_DIR)/gf_mul.S $(BIKE_DIR)/gf_add.S 
-    COMMON_FLAGS += -DAVX512
-  else
-  if USE_AVX2_INSTRUCTIONS
-    COMMON_CSRCS += $(BIKE_DIR)/converts.S $(BIKE_DIR)/red.S $(BIKE_DIR)/secure_decode_avx2.S
-    COMMON_CSRCS += $(BIKE_DIR)/sampling_avx2.S $(BIKE_DIR)/gf_mul.S $(BIKE_DIR)/gf_add.S 
-    COMMON_FLAGS += -DAVX2
-  else
-    COMMON_CSRCS += $(BIKE_DIR)/sampling_portable.c $(BIKE_DIR)/converts_portable.c
-    COMMON_FLAGS += -DPORTABLE
-  endif
-  endif
+if USE_AVX512F_INSTRUCTIONS
+COMMON_CSRCS += $(BIKE_DIR)/converts.S $(BIKE_DIR)/red.S $(BIKE_DIR)/secure_decode_avx512.S
+COMMON_CSRCS += $(BIKE_DIR)/sampling_avx512.S $(BIKE_DIR)/gf_mul.S $(BIKE_DIR)/gf_add.S 
+COMMON_FLAGS += -DAVX512
+else
+if USE_AVX2_INSTRUCTIONS
+COMMON_CSRCS += $(BIKE_DIR)/converts.S $(BIKE_DIR)/red.S $(BIKE_DIR)/secure_decode_avx2.S
+COMMON_CSRCS += $(BIKE_DIR)/sampling_avx2.S $(BIKE_DIR)/gf_mul.S $(BIKE_DIR)/gf_add.S 
+COMMON_FLAGS += -DAVX2
+else
+COMMON_CSRCS += $(BIKE_DIR)/sampling_portable.c $(BIKE_DIR)/converts_portable.c
+COMMON_FLAGS += -DPORTABLE
+endif
+endif
 endif
 
 if USE_OPENSSL
-  COMMON_CSRCS += $(BIKE_DIR)/openssl_utils.c
-  COMMON_FLAGS += -DUSE_OPENSSL
+COMMON_CSRCS += $(BIKE_DIR)/openssl_utils.c
+COMMON_FLAGS += -DUSE_OPENSSL
 endif
 
 libkembike_la_CFLAGS = $(COMMON_FLAGS)

--- a/src/kem/bike/Makefile.am
+++ b/src/kem/bike/Makefile.am
@@ -17,19 +17,24 @@ COMMON_CSRCS += $(BIKE_DIR)/parallel_hash.c $(BIKE_DIR)/secure_decode_portable.c
 COMMON_CSRCS += $(BIKE_DIR)/utilities.c $(BIKE_DIR)/aes_ctr_prf.c $(BIKE_DIR)/error.c
 COMMON_CSRCS += $(BIKE_DIR)/gf2x_mul.c 
 
-if USE_AVX512F_INSTRUCTIONS
-  COMMON_CSRCS += $(BIKE_DIR)/converts.S $(BIKE_DIR)/red.S $(BIKE_DIR)/secure_decode_avx512.S
-  COMMON_CSRCS += $(BIKE_DIR)/sampling_avx512.S $(BIKE_DIR)/gf_mul.S $(BIKE_DIR)/gf_add.S 
-  COMMON_FLAGS += -DAVX512
-else
-if USE_AVX2_INSTRUCTIONS
-  COMMON_CSRCS += $(BIKE_DIR)/converts.S $(BIKE_DIR)/red.S $(BIKE_DIR)/secure_decode_avx2.S
-  COMMON_CSRCS += $(BIKE_DIR)/sampling_avx2.S $(BIKE_DIR)/gf_mul.S $(BIKE_DIR)/gf_add.S 
-  COMMON_FLAGS += -DAVX2
-else
+if ON_DARWIN
   COMMON_CSRCS += $(BIKE_DIR)/sampling_portable.c $(BIKE_DIR)/converts_portable.c
   COMMON_FLAGS += -DPORTABLE
-endif
+else
+  if USE_AVX512F_INSTRUCTIONS
+    COMMON_CSRCS += $(BIKE_DIR)/converts.S $(BIKE_DIR)/red.S $(BIKE_DIR)/secure_decode_avx512.S
+    COMMON_CSRCS += $(BIKE_DIR)/sampling_avx512.S $(BIKE_DIR)/gf_mul.S $(BIKE_DIR)/gf_add.S 
+    COMMON_FLAGS += -DAVX512
+  else
+  if USE_AVX2_INSTRUCTIONS
+    COMMON_CSRCS += $(BIKE_DIR)/converts.S $(BIKE_DIR)/red.S $(BIKE_DIR)/secure_decode_avx2.S
+    COMMON_CSRCS += $(BIKE_DIR)/sampling_avx2.S $(BIKE_DIR)/gf_mul.S $(BIKE_DIR)/gf_add.S 
+    COMMON_FLAGS += -DAVX2
+  else
+    COMMON_CSRCS += $(BIKE_DIR)/sampling_portable.c $(BIKE_DIR)/converts_portable.c
+    COMMON_FLAGS += -DPORTABLE
+  endif
+  endif
 endif
 
 if USE_OPENSSL


### PR DESCRIPTION
Compilation of the new BIKE code failed on my Mac.  The problem seems to be that the assembly code uses directives that aren't present in Mach-O binaries.  Examples of the error messages below.  Initial fix is just to switch to having BIKE use only C code on macOS.  This was missed by the Travis continuous integration tests because those host machines don't support AVX2 instructions, so the C code as being used anyway on them.

```
additional/converts.S:83:1: error: unknown directive
.hidden OQS_KEM_bike1_l1_cpa_convert_to_redundant_rep
^
additional/converts.S:84:1: error: unknown directive
.type OQS_KEM_bike1_l1_cpa_convert_to_redundant_rep,@function
^
additional/converts.S:177:1: error: unknown directive
.size OQS_KEM_bike1_l1_cpa_convert_to_redundant_rep,.-OQS_KEM_bike1_l1_cpa_convert_to_redundant_rep
^
```