### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ test-results
 
 # IDEs
 .idea
+
+# CMake
+build/


### PR DESCRIPTION
So we don't get bothered by cmake builds (assuming we build in 'build' as it is customarily for CMake)