### PR TITLE
OQS_SHA3_cshake128_simple4x only defined if both AES and AVX2 instructions available

### DIFF
--- a/src/sig/qtesla/Makefile.am
+++ b/src/sig/qtesla/Makefile.am
@@ -21,12 +21,15 @@ endif # X86_64
 endif # X86
 
 if USE_AVX2_INSTRUCTIONS
+if USE_AES_INSTRUCTIONS
 QTESLA_FLAGS += -DWITH_AVX2 -Iavx2
 libqtesla_la_SOURCES += avx2/poly_mul1024.S avx2/poly_mul2048.S
 else
 QTESLA_FLAGS += -Iportable
-endif
-
+endif # USE_AES_INSTRUCTIONS
+else
+QTESLA_FLAGS += -Iportable
+endif # USE_AVX2_INSTRUCTIONS
 
 libqtesla_la_CFLAGS = $(AM_CFLAGS) $(QTESLA_FLAGS)
 


### PR DESCRIPTION
Got a bunch of build failures overnight in liboqs and relying applications, related to the function `OQS_SHA3_cshake128_simple4x` not being defined.  After diagnosing, I think it's because the sha3.h file wraps `OQS_SHA3_cshake128_simple4x` in `#if defined ` demanding AVX2 and AES instructions, but the qTesla Makefile only checks for AVX2 instructions before enabling the optimized version.  And unfortunately some of our CircleCI test platforms seem to have AVX2 but not AES.  So I propose just updating the qTesla Makefile to check for AVX2 and AES.  The alternative would be to change sha3.h to only demand AVX2, but I didn't know if the source code for that implementation actually depends on AES instructions or not.