### PR TITLE
Fix nightly qtesla failure on gcc5

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -140,7 +140,7 @@ def available_use_options_by_name():
     with open(os.path.join('include', 'oqs', 'oqsconfig.h')) as fh:
         for line in fh:
             if line.startswith("#define USE_") and line.endswith("1\n"):
-                option_name = line.split(' ')[1][len("USE_"):-1]
+                option_name = line.split(' ')[1][len("USE_"):]
                 enabled_use_options.append(option_name)
     return enabled_use_options
 

--- a/tests/test_kat.py
+++ b/tests/test_kat.py
@@ -28,10 +28,11 @@ def test_sig(sig_name):
     )
     output = output.replace("\r\n", "\n")
     kats = []
+    avx2_aes_enabled = helpers.is_use_option_enabled_by_name('AVX2_INSTRUCTIONS') and helpers.is_use_option_enabled_by_name('AES_INSTRUCTIONS')
     for filename in os.listdir(os.path.join('tests', 'KATs', 'sig')):
         if filename.startswith(sig_name + '.') and filename.endswith('.kat'):
             # qtesla's avx2 implementation uses an optimized sampling method that results in different KAT values; we use the correct one (if avx2/aes instructions are available)
-            if not sig_name.startswith('qTesla') or not ((bool(helpers.is_use_option_enabled_by_name('AVX2_INSTRUCTIONS')) & bool(helpers.is_use_option_enabled_by_name('AES_INSTRUCTIONS'))) ^ bool('avx2' in filename)):
+            if not (sig_name.startswith('qTesla')) or any([avx2_aes_enabled and 'avx2' in filename, not avx2_aes_enabled and not 'avx2' in filename]):
                 with open(os.path.join('tests', 'KATs', 'sig', filename), 'r') as myfile:
                     kats.append(myfile.read())
     assert(output in kats)

--- a/tests/test_kat.py
+++ b/tests/test_kat.py
@@ -30,8 +30,8 @@ def test_sig(sig_name):
     kats = []
     for filename in os.listdir(os.path.join('tests', 'KATs', 'sig')):
         if filename.startswith(sig_name + '.') and filename.endswith('.kat'):
-            # qtesla's avx2 implementation uses an optimized sampling method that results in different KAT values; we use the correct one
-            if not sig_name.startswith('qTesla') or not (bool(helpers.is_use_option_enabled_by_name('AVX2_INSTRUCTION')) ^ bool('avx2' in filename)):
+            # qtesla's avx2 implementation uses an optimized sampling method that results in different KAT values; we use the correct one (if avx2/aes instructions are available)
+            if not sig_name.startswith('qTesla') or not ((bool(helpers.is_use_option_enabled_by_name('AVX2_INSTRUCTION')) and bool(helpers.is_use_option_enabled_by_name('AES_INSTRUCTIONS'))) ^ bool('avx2' in filename)):
                 with open(os.path.join('tests', 'KATs', 'sig', filename), 'r') as myfile:
                     kats.append(myfile.read())
     assert(output in kats)

--- a/tests/test_kat.py
+++ b/tests/test_kat.py
@@ -31,7 +31,7 @@ def test_sig(sig_name):
     for filename in os.listdir(os.path.join('tests', 'KATs', 'sig')):
         if filename.startswith(sig_name + '.') and filename.endswith('.kat'):
             # qtesla's avx2 implementation uses an optimized sampling method that results in different KAT values; we use the correct one (if avx2/aes instructions are available)
-            if not sig_name.startswith('qTesla') or not ((bool(helpers.is_use_option_enabled_by_name('AVX2_INSTRUCTION')) & bool(helpers.is_use_option_enabled_by_name('AES_INSTRUCTIONS'))) ^ bool('avx2' in filename)):
+            if not sig_name.startswith('qTesla') or not ((bool(helpers.is_use_option_enabled_by_name('AVX2_INSTRUCTIONS')) & bool(helpers.is_use_option_enabled_by_name('AES_INSTRUCTIONS'))) ^ bool('avx2' in filename)):
                 with open(os.path.join('tests', 'KATs', 'sig', filename), 'r') as myfile:
                     kats.append(myfile.read())
     assert(output in kats)

--- a/tests/test_kat.py
+++ b/tests/test_kat.py
@@ -31,7 +31,7 @@ def test_sig(sig_name):
     for filename in os.listdir(os.path.join('tests', 'KATs', 'sig')):
         if filename.startswith(sig_name + '.') and filename.endswith('.kat'):
             # qtesla's avx2 implementation uses an optimized sampling method that results in different KAT values; we use the correct one (if avx2/aes instructions are available)
-            if not sig_name.startswith('qTesla') or not ((bool(helpers.is_use_option_enabled_by_name('AVX2_INSTRUCTION')) and bool(helpers.is_use_option_enabled_by_name('AES_INSTRUCTIONS'))) ^ bool('avx2' in filename)):
+            if not sig_name.startswith('qTesla') or not ((bool(helpers.is_use_option_enabled_by_name('AVX2_INSTRUCTION')) & bool(helpers.is_use_option_enabled_by_name('AES_INSTRUCTIONS'))) ^ bool('avx2' in filename)):
                 with open(os.path.join('tests', 'KATs', 'sig', filename), 'r') as myfile:
                     kats.append(myfile.read())
     assert(output in kats)


### PR DESCRIPTION
Changed test_kat.py test to also check for AES instructions when branching for qtesla AVX2 KAT file; both are required for avx2 optimization. The travis VM using gcc5 had support for avx2 but not aes, therefore defaulting to the non-optimized code but comparing with avx2 KATs.

Fixes issue #572. 