### PR TITLE
Harmonized example_sig with example_kem.

### DIFF
--- a/tests/example_sig.c
+++ b/tests/example_sig.c
@@ -1,3 +1,10 @@
+/*
+ * example_sig.c
+ *
+ * Minimal example of using a post-quantum signature implemented in liboqs.
+ *
+*/
+
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -6,6 +13,13 @@
 #include <oqs/oqs.h>
 
 #define MESSAGE_LEN 50
+
+/* Cleaning up memory etc */
+void cleanup_stack(uint8_t *secret_key, size_t secret_key_len);
+
+void cleanup_heap(uint8_t *public_key, uint8_t *secret_key,
+                  uint8_t *message, uint8_t *signature,
+                  OQS_SIG *sig);
 
 /* This function gives an example of the signing operations
  * using only compile-time macros and allocating variables
@@ -25,7 +39,6 @@ static OQS_STATUS example_stack(void) {
 #ifdef OQS_ENABLE_SIG_qTesla_p_I
 
 	OQS_STATUS rc;
-	OQS_STATUS ret = OQS_ERROR;
 
 	uint8_t public_key[OQS_SIG_qTesla_p_I_length_public_key];
 	uint8_t secret_key[OQS_SIG_qTesla_p_I_length_secret_key];
@@ -34,35 +47,33 @@ static OQS_STATUS example_stack(void) {
 	size_t message_len = MESSAGE_LEN;
 	size_t signature_len;
 
+	// let's create a random test message to sign
 	OQS_randombytes(message, message_len);
 
 	rc = OQS_SIG_qTesla_p_I_keypair(public_key, secret_key);
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_SIG_qTesla_p_I_keypair failed!\n");
-		goto err;
+		cleanup_stack(secret_key, OQS_SIG_qTesla_p_I_length_secret_key);
+		return OQS_ERROR;
 	}
 	rc = OQS_SIG_qTesla_p_I_sign(signature, &signature_len, message, message_len, secret_key);
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_SIG_qTesla_p_I_sign failed!\n");
-		goto err;
+		cleanup_stack(secret_key, OQS_SIG_qTesla_p_I_length_secret_key);
+		return OQS_ERROR;
 	}
 	rc = OQS_SIG_qTesla_p_I_verify(message, message_len, signature, signature_len, public_key);
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_SIG_qTesla_p_I_verify failed!\n");
-		goto err;
+		cleanup_stack(secret_key, OQS_SIG_qTesla_p_I_length_secret_key);
+		return OQS_ERROR;
 	}
 	printf("[example_stack] OQS_SIG_qTesla_p_I operations completed.\n");
-	ret = OQS_SUCCESS; // success!
-	goto cleanup;
 
-err:
-	ret = OQS_ERROR;
-
-cleanup:
-	OQS_MEM_cleanse(secret_key, OQS_SIG_qTesla_p_I_length_secret_key);
-	return ret;
+	return OQS_SUCCESS; // success!
 
 #else
+
 	printf("[example_stack] OQS_SIG_qTesla_p_I was not enabled at compile-time.\n");
 	return OQS_ERROR;
 
@@ -87,7 +98,6 @@ static OQS_STATUS example_heap(void) {
 	size_t message_len = MESSAGE_LEN;
 	size_t signature_len;
 	OQS_STATUS rc;
-	OQS_STATUS ret = OQS_ERROR;
 
 	sig = OQS_SIG_new(OQS_SIG_alg_qTesla_p_I);
 	if (sig == NULL) {
@@ -101,47 +111,56 @@ static OQS_STATUS example_heap(void) {
 	signature = malloc(sig->length_signature);
 	if ((public_key == NULL) || (secret_key == NULL) || (message == NULL) || (signature == NULL)) {
 		fprintf(stderr, "ERROR: malloc failed!\n");
-		goto err;
+		cleanup_heap(public_key, secret_key, message, signature, sig);
+		return OQS_ERROR;
 	}
 
+	// let's create a random test message to sign
 	OQS_randombytes(message, message_len);
 
 	rc = OQS_SIG_keypair(sig, public_key, secret_key);
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_SIG_keypair failed!\n");
-		goto err;
+		cleanup_heap(public_key, secret_key, message, signature, sig);
+		return OQS_ERROR;
 	}
 	rc = OQS_SIG_sign(sig, signature, &signature_len, message, message_len, secret_key);
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_SIG_sign failed!\n");
-		goto err;
+		cleanup_heap(public_key, secret_key, message, signature, sig);
+		return OQS_ERROR;
 	}
 	rc = OQS_SIG_verify(sig, message, message_len, signature, signature_len, public_key);
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_SIG_verify failed!\n");
-		goto err;
+		cleanup_heap(public_key, secret_key, message, signature, sig);
+		return OQS_ERROR;
 	}
 
 	printf("[example_heap]  OQS_SIG_qTesla_p_I operations completed.\n");
-	ret = OQS_SUCCESS; // success
-	goto cleanup;
+	return OQS_SUCCESS; // success
+}
 
-err:
-	ret = OQS_ERROR;
+int main(void) {
+	if (example_stack() == OQS_SUCCESS && example_heap() == OQS_SUCCESS) {
+		return EXIT_SUCCESS;
+	} else {
+		return EXIT_FAILURE;
+	}
+}
 
-cleanup:
+void cleanup_stack(uint8_t *secret_key, size_t secret_key_len) {
+	OQS_MEM_cleanse(secret_key, secret_key_len);
+}
+
+void cleanup_heap(uint8_t *public_key, uint8_t *secret_key,
+                  uint8_t *message, uint8_t *signature,
+                  OQS_SIG *sig) {
 	if (sig != NULL) {
 		OQS_MEM_secure_free(secret_key, sig->length_secret_key);
 	}
 	OQS_MEM_insecure_free(public_key);
-	OQS_MEM_insecure_free(signature);
 	OQS_MEM_insecure_free(message);
+	OQS_MEM_insecure_free(signature);
 	OQS_SIG_free(sig);
-
-	return ret;
-}
-
-int main(void) {
-	example_stack();
-	example_heap();
 }

--- a/tests/example_sig.c
+++ b/tests/example_sig.c
@@ -26,9 +26,9 @@ void cleanup_heap(uint8_t *public_key, uint8_t *secret_key,
  * statically on the stack, calling a specific algorithm's functions
  * directly.
  *
- * The macros OQS_SIG_qTesla_p_I_length_* and the functions OQS_SIG_qTesla_p_I_*
- * are only defined if the algorithm qTesla-p-I was enabled at compile-time
- * which must be checked using the OQS_ENABLE_SIG_qTesla_p_I macro.
+ * The macros OQS_SIG_dilithium_2_length_* and the functions OQS_SIG_dilithium_2_*
+ * are only defined if the algorithm dilithium_2 was enabled at compile-time
+ * which must be checked using the OQS_ENABLE_SIG_dilithium_2 macro.
  *
  * <oqs/oqsconfig.h>, which is included in <oqs/oqs.h>, contains macros
  * indicating which algorithms were enabled when this instance of liboqs
@@ -36,45 +36,45 @@ void cleanup_heap(uint8_t *public_key, uint8_t *secret_key,
  */
 static OQS_STATUS example_stack(void) {
 
-#ifdef OQS_ENABLE_SIG_qTesla_p_I
+#ifdef OQS_ENABLE_SIG_dilithium_2
 
 	OQS_STATUS rc;
 
-	uint8_t public_key[OQS_SIG_qTesla_p_I_length_public_key];
-	uint8_t secret_key[OQS_SIG_qTesla_p_I_length_secret_key];
+	uint8_t public_key[OQS_SIG_dilithium_2_length_public_key];
+	uint8_t secret_key[OQS_SIG_dilithium_2_length_secret_key];
 	uint8_t message[MESSAGE_LEN];
-	uint8_t signature[OQS_SIG_qTesla_p_I_length_signature];
+	uint8_t signature[OQS_SIG_dilithium_2_length_signature];
 	size_t message_len = MESSAGE_LEN;
 	size_t signature_len;
 
 	// let's create a random test message to sign
 	OQS_randombytes(message, message_len);
 
-	rc = OQS_SIG_qTesla_p_I_keypair(public_key, secret_key);
+	rc = OQS_SIG_dilithium_2_keypair(public_key, secret_key);
 	if (rc != OQS_SUCCESS) {
-		fprintf(stderr, "ERROR: OQS_SIG_qTesla_p_I_keypair failed!\n");
-		cleanup_stack(secret_key, OQS_SIG_qTesla_p_I_length_secret_key);
+		fprintf(stderr, "ERROR: OQS_SIG_dilithium_2_keypair failed!\n");
+		cleanup_stack(secret_key, OQS_SIG_dilithium_2_length_secret_key);
 		return OQS_ERROR;
 	}
-	rc = OQS_SIG_qTesla_p_I_sign(signature, &signature_len, message, message_len, secret_key);
+	rc = OQS_SIG_dilithium_2_sign(signature, &signature_len, message, message_len, secret_key);
 	if (rc != OQS_SUCCESS) {
-		fprintf(stderr, "ERROR: OQS_SIG_qTesla_p_I_sign failed!\n");
-		cleanup_stack(secret_key, OQS_SIG_qTesla_p_I_length_secret_key);
+		fprintf(stderr, "ERROR: OQS_SIG_dilithium_2_sign failed!\n");
+		cleanup_stack(secret_key, OQS_SIG_dilithium_2_length_secret_key);
 		return OQS_ERROR;
 	}
-	rc = OQS_SIG_qTesla_p_I_verify(message, message_len, signature, signature_len, public_key);
+	rc = OQS_SIG_dilithium_2_verify(message, message_len, signature, signature_len, public_key);
 	if (rc != OQS_SUCCESS) {
-		fprintf(stderr, "ERROR: OQS_SIG_qTesla_p_I_verify failed!\n");
-		cleanup_stack(secret_key, OQS_SIG_qTesla_p_I_length_secret_key);
+		fprintf(stderr, "ERROR: OQS_SIG_dilithium_2_verify failed!\n");
+		cleanup_stack(secret_key, OQS_SIG_dilithium_2_length_secret_key);
 		return OQS_ERROR;
 	}
-	printf("[example_stack] OQS_SIG_qTesla_p_I operations completed.\n");
+	printf("[example_stack] OQS_SIG_dilithium_2 operations completed.\n");
 
 	return OQS_SUCCESS; // success!
 
 #else
 
-	printf("[example_stack] OQS_SIG_qTesla_p_I was not enabled at compile-time.\n");
+	printf("[example_stack] OQS_SIG_dilithium_2 was not enabled at compile-time.\n");
 	return OQS_ERROR;
 
 #endif
@@ -99,9 +99,9 @@ static OQS_STATUS example_heap(void) {
 	size_t signature_len;
 	OQS_STATUS rc;
 
-	sig = OQS_SIG_new(OQS_SIG_alg_qTesla_p_I);
+	sig = OQS_SIG_new(OQS_SIG_alg_dilithium_2);
 	if (sig == NULL) {
-		printf("[example_heap]  OQS_SIG_alg_qTesla_p_I was not enabled at compile-time.\n");
+		printf("[example_heap]  OQS_SIG_alg_dilithium_2 was not enabled at compile-time.\n");
 		return OQS_ERROR;
 	}
 
@@ -137,7 +137,7 @@ static OQS_STATUS example_heap(void) {
 		return OQS_ERROR;
 	}
 
-	printf("[example_heap]  OQS_SIG_qTesla_p_I operations completed.\n");
+	printf("[example_heap]  OQS_SIG_dilithium_2 operations completed.\n");
 	return OQS_SUCCESS; // success
 }
 


### PR DESCRIPTION
Ported latest example_kex changes to example_sig. In particular, example_sig now returns failure correctly.