### PR TITLE
Centos testing added

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,13 @@ version: 2
         command: autoreconf -i && ./configure --enable-silent-rules ${CONFIGURE_ARGS}
     - run: 
         name: Build
-        command: make -j && make check
+        command: source ~/.bashrc && make -j && make check
     - run:
         name: Run tests
         command: mkdir -p test-results/pytest && python3 -m pytest --verbose --junitxml=test-results/pytest/results.xml --numprocesses=auto
     - store_test_results: # Note that this command will fail when running CircleCI locally, that is expected behaviour
+        path: test-results
+    - store_artifacts: 
         path: test-results
 
 .emulatedjob: &emulatedjob
@@ -39,6 +41,8 @@ version: 2
           python3 -m pytest --verbose --junitxml=test-results/pytest/results.xml --numprocesses=auto
           "
     - store_test_results:
+        path: test-results
+    - store_artifacts: 
         path: test-results
 
 jobs:
@@ -106,11 +110,24 @@ jobs:
       IMAGE: dstebila/liboqs:ubuntu-bionic-x86_64-0.1.0
       CC: gcc-7
       SKIP_TESTS: style
+  centos-7:
+    <<: *oqsjob
+    environment:
+      IMAGE: openqsafe/ci-centos-7
+      CONFIGURE_ARGS: --with-openssl=/usr/local/ssl 
+      SKIP_TESTS: style
+  centos-8:
+    <<: *oqsjob
+    environment:
+      IMAGE: openqsafe/ci-centos-8
+      SKIP_TESTS: style
 
 workflows:
   version: 2
   build:
     jobs:
+      - centos-7
+      - centos-8
       - debian-buster-amd64
       - ubuntu-xenial-x86_64-gcc8
       - ubuntu-xenial-x86_64-gcc8-noopenssl


### PR DESCRIPTION
Added testing as per [this discussion](https://github.com/baentsch/testing/wiki/Docker-image-goals) for Centos7 & 8. Arguably testing should only be nightly (iff some code changed) --> Moving new targets `centos-7` and `centos-8` down to the nightly section suggested (as would be testing target configs only either at check-in/`build` _or_ `nightly`).