### PR TITLE
Disabled qtesla avx2 optimizations on darwin

### DIFF
--- a/src/sig/qtesla/Makefile.am
+++ b/src/sig/qtesla/Makefile.am
@@ -20,6 +20,9 @@ endif # ARM
 endif # X86_64
 endif # X86
 
+if ON_DARWIN
+QTESLA_FLAGS += -Iportable
+else
 if USE_AVX2_INSTRUCTIONS
 if USE_AES_INSTRUCTIONS
 QTESLA_FLAGS += -DWITH_AVX2 -Iavx2
@@ -30,6 +33,7 @@ endif # USE_AES_INSTRUCTIONS
 else
 QTESLA_FLAGS += -Iportable
 endif # USE_AVX2_INSTRUCTIONS
+endif # ON_DARWIN
 
 libqtesla_la_CFLAGS = $(AM_CFLAGS) $(QTESLA_FLAGS)
 

--- a/src/sig/qtesla/avx2/config.h
+++ b/src/sig/qtesla/avx2/config.h
@@ -11,10 +11,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-// Definition of operating system
-
-#define OS_LINUX 1
-#define OS_TARGET OS_LINUX
+// Definition of operating system (removed in OQS)
 
 // Definition of compiler (removed in OQS)
 

--- a/src/sig/qtesla/portable/config.h
+++ b/src/sig/qtesla/portable/config.h
@@ -11,16 +11,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-// Definition of operating system
-
-#define OS_WIN 1
-#define OS_LINUX 2
-
-#if defined(_WIN32) // Microsoft Windows OS
-#define OS_TARGET OS_WIN
-#else
-#define OS_TARGET OS_LINUX // default to Linux
-#endif
+// Definition of operating system (removed in OQS)
 
 // Definition of compiler (removed in OQS)
 

--- a/tests/test_kat.py
+++ b/tests/test_kat.py
@@ -2,6 +2,7 @@ import helpers
 import os
 import os.path
 import pytest
+import platform
 
 @helpers.filtered_test
 @pytest.mark.parametrize('kem_name', helpers.available_kems_by_name())
@@ -28,11 +29,11 @@ def test_sig(sig_name):
     )
     output = output.replace("\r\n", "\n")
     kats = []
-    avx2_aes_enabled = helpers.is_use_option_enabled_by_name('AVX2_INSTRUCTIONS') and helpers.is_use_option_enabled_by_name('AES_INSTRUCTIONS')
+    avx2_aes_enabled_on_linux = helpers.is_use_option_enabled_by_name('AVX2_INSTRUCTIONS') and helpers.is_use_option_enabled_by_name('AES_INSTRUCTIONS') and platform.system() == 'Linux'
     for filename in os.listdir(os.path.join('tests', 'KATs', 'sig')):
         if filename.startswith(sig_name + '.') and filename.endswith('.kat'):
             # qtesla's avx2 implementation uses an optimized sampling method that results in different KAT values; we use the correct one (if avx2/aes instructions are available)
-            if not (sig_name.startswith('qTesla')) or any([avx2_aes_enabled and 'avx2' in filename, not avx2_aes_enabled and not 'avx2' in filename]):
+            if not (sig_name.startswith('qTesla')) or any([avx2_aes_enabled_on_linux and 'avx2' in filename, not avx2_aes_enabled_on_linux and not 'avx2' in filename]):
                 with open(os.path.join('tests', 'KATs', 'sig', filename), 'r') as myfile:
                     kats.append(myfile.read())
     assert(output in kats)


### PR DESCRIPTION
qtesla's avx2 assembly only targets linux, so this PR disables the optimization on darwin.

Addresses issue #571.