### PR TITLE
Use OpenSSL's EVP_MD_CTX_new and _free

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,50 +66,28 @@ jobs:
     environment:
       ARCH: armel
       CONFIGURE_ARGS: --disable-sig-sphincs --disable-sig-qtesla # sig-sphincs exhausts memory on CircleCI servers; qTesla fails on armel
-  ubuntu-xenial-x86_64-gcc49:
-    <<: *oqsjob
-    environment:
-      IMAGE: dstebila/liboqs:ubuntu-xenial-x86_64-0.1.0
-      CC: gcc-4.9
-      CONFIGURE_ARGS: --disable-sig-picnic 
-  ubuntu-xenial-x86_64-gcc5:
-    <<: *oqsjob
-    environment:
-      IMAGE: dstebila/liboqs:ubuntu-xenial-x86_64-0.1.0
-      CC: gcc-5
-  ubuntu-xenial-x86_64-gcc6:
-    <<: *oqsjob
-    environment:
-      IMAGE: dstebila/liboqs:ubuntu-xenial-x86_64-0.1.0
-      CC: gcc-6
-  ubuntu-xenial-x86_64-gcc7:
-    <<: *oqsjob
-    environment:
-      IMAGE: dstebila/liboqs:ubuntu-xenial-x86_64-0.1.0
-      CC: gcc-7
-  ubuntu-xenial-x86_64-gcc8:
-    <<: *oqsjob
-    environment:
-      IMAGE: dstebila/liboqs:ubuntu-xenial-x86_64-0.1.0
-      CC: gcc-8
-  ubuntu-xenial-x86_64-gcc8-noopenssl:
-    <<: *oqsjob
-    environment:
-      IMAGE: dstebila/liboqs:ubuntu-xenial-x86_64-0.1.0
-      CC: gcc-8
-      CONFIGURE_ARGS: --without-openssl
-  ubuntu-xenial-x86_64-gcc8-noshared:
-    <<: *oqsjob
-    environment:
-      IMAGE: dstebila/liboqs:ubuntu-xenial-x86_64-0.1.0
-      CC: gcc-8
-      CONFIGURE_ARGS: --disable-shared 
   ubuntu-bionic-x86_64-gcc7:
     <<: *oqsjob
     environment:
-      IMAGE: dstebila/liboqs:ubuntu-bionic-x86_64-0.1.0
+      IMAGE: openquantumsafe/ubuntu-bionic-x86_64:latest
       CC: gcc-7
-      SKIP_TESTS: style
+  ubuntu-bionic-x86_64-gcc7-noopenssl:
+    <<: *oqsjob
+    environment:
+      IMAGE: openquantumsafe/ubuntu-bionic-x86_64:latest
+      CC: gcc-7
+      CONFIGURE_ARGS: --without-openssl
+  ubuntu-bionic-x86_64-gcc7-noshared:
+    <<: *oqsjob
+    environment:
+      IMAGE: openquantumsafe/ubuntu-bionic-x86_64:latest
+      CC: gcc-7
+      CONFIGURE_ARGS: --disable-shared 
+  ubuntu-bionic-x86_64-gcc8:
+    <<: *oqsjob
+    environment:
+      IMAGE: openquantumsafe/ubuntu-bionic-x86_64:latest
+      CC: gcc-8
   centos-7:
     <<: *oqsjob
     environment:
@@ -129,10 +107,9 @@ workflows:
       - centos-7
       - centos-8
       - debian-buster-amd64
-      - ubuntu-xenial-x86_64-gcc8
-      - ubuntu-xenial-x86_64-gcc8-noopenssl
-      - ubuntu-xenial-x86_64-gcc8-noshared
       - ubuntu-bionic-x86_64-gcc7
+      - ubuntu-bionic-x86_64-gcc7-noopenssl
+      - ubuntu-bionic-x86_64-gcc7-noshared
   nightly:
     triggers:
       - schedule:
@@ -142,15 +119,13 @@ workflows:
               only:
                 - master
     jobs:
+      - centos-7
+      - centos-8
       - debian-buster-amd64
       - debian-buster-aarch64
       - debian-buster-armhf
       - debian-buster-armel
-      - ubuntu-xenial-x86_64-gcc49
-      - ubuntu-xenial-x86_64-gcc5
-      - ubuntu-xenial-x86_64-gcc6
-      - ubuntu-xenial-x86_64-gcc7
-      - ubuntu-xenial-x86_64-gcc8
-      - ubuntu-xenial-x86_64-gcc8-noopenssl
-      - ubuntu-xenial-x86_64-gcc8-noshared
       - ubuntu-bionic-x86_64-gcc7
+      - ubuntu-bionic-x86_64-gcc7-noopenssl
+      - ubuntu-bionic-x86_64-gcc7-noshared
+      - ubuntu-bionic-x86_64-gcc8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,24 +69,24 @@ jobs:
   ubuntu-bionic-x86_64-gcc7:
     <<: *oqsjob
     environment:
-      IMAGE: openquantumsafe/ubuntu-bionic-x86_64:latest
+      IMAGE: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
       CC: gcc-7
   ubuntu-bionic-x86_64-gcc7-noopenssl:
     <<: *oqsjob
     environment:
-      IMAGE: openquantumsafe/ubuntu-bionic-x86_64:latest
+      IMAGE: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
       CC: gcc-7
       CONFIGURE_ARGS: --without-openssl
   ubuntu-bionic-x86_64-gcc7-noshared:
     <<: *oqsjob
     environment:
-      IMAGE: openquantumsafe/ubuntu-bionic-x86_64:latest
+      IMAGE: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
       CC: gcc-7
       CONFIGURE_ARGS: --disable-shared 
   ubuntu-bionic-x86_64-gcc8:
     <<: *oqsjob
     environment:
-      IMAGE: openquantumsafe/ubuntu-bionic-x86_64:latest
+      IMAGE: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
       CC: gcc-8
   centos-7:
     <<: *oqsjob

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - SKIP_TESTS=style
     - HOMEBREW_NO_AUTO_UPDATE=1
     before_install:
-    - brew install doxygen graphviz
+    - brew install doxygen graphviz openssl@1.1
     - pip3 install pytest pytest-xdist
     script:
     - autoreconf -i

--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ We realize some parties may want to deploy quantum-safe cryptography prior to th
 
 	On macOS, using a package manager of your choice (we've picked Homebrew):
 
-		brew install autoconf automake libtool openssl wget doxygen graphviz
+		brew install autoconf automake libtool openssl@1.1 wget doxygen graphviz
 		pip3 install pytest
+	
+	Note that, if you want liboqs to use OpenSSL for various symmetric crypto algorithms (AES, SHA-2, etc.) then you must have OpenSSL version 1.1.0 or higher.
 
 2. Get the source:
 

--- a/config/external-libraries.m4
+++ b/config/external-libraries.m4
@@ -29,7 +29,7 @@ AC_DEFUN([ADD_EXTERNAL_LIB],[
     [test "x${with_openssl}" = "xno"],
     [AC_MSG_RESULT([no])],
     [
-      AC_MSG_RESULT([${with_openssl}])
+      AC_MSG_RESULT([yes (${with_openssl})])
       # set OPENSSL_DIR based on value provided
       AC_SUBST([OPENSSL_DIR], [${with_openssl}])
     ]
@@ -40,6 +40,34 @@ AC_DEFUN([ADD_EXTERNAL_LIB],[
   AM_COND_IF(USE_OPENSSL,
     [AC_DEFINE(USE_OPENSSL, 1, [Defined to 1 if using OpenSSL in liboqs])]
   )
+
+  AS_IF(
+    [test "x${with_openssl}" != "xno"],
+    [
+      AC_MSG_CHECKING([OpenSSL version])
+      AC_LANG_PUSH([C])
+      OLDCFLAGS=${CFLAGS}
+      CFLAGS=-I${with_openssl}/include
+      OPENSSL_VERSION=`${with_openssl}/bin/openssl version -v`
+      AC_RUN_IFELSE(
+        [AC_LANG_PROGRAM(
+          [#include <openssl/opensslv.h>],
+          [
+            #if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x1010000fL
+              return 0;
+            #else
+              return 1;
+            #endif
+          ]
+        )],
+        CFLAGS=${OLDCFLAGS}
+        [AC_MSG_RESULT([ok (${OPENSSL_VERSION})])],
+        [AC_MSG_FAILURE([too old (found ${OPENSSL_VERSION}, need >= 1.1.0)])]
+      )
+      AC_LANG_POP([C])
+    ]
+  )
+
 
   AC_ARG_WITH([m4ri-dir],
     [AS_HELP_STRING(

--- a/config/external-libraries.m4
+++ b/config/external-libraries.m4
@@ -45,29 +45,15 @@ AC_DEFUN([ADD_EXTERNAL_LIB],[
     [test "x${with_openssl}" != "xno"],
     [
       AC_MSG_CHECKING([OpenSSL version])
-      AC_LANG_PUSH([C])
-      OLDCFLAGS=${CFLAGS}
-      CFLAGS=-I${with_openssl}/include
-      OPENSSL_VERSION=`${with_openssl}/bin/openssl version -v`
-      AC_RUN_IFELSE(
-        [AC_LANG_PROGRAM(
-          [#include <openssl/opensslv.h>],
-          [
-            #if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x1010000fL
-              return 0;
-            #else
-              return 1;
-            #endif
-          ]
-        )],
-        CFLAGS=${OLDCFLAGS}
+      OPENSSL_VERSION=`grep OPENSSL_VERSION_TEXT ${with_openssl}/include/openssl/opensslv.h | head -n 1 | sed -e 's/.*OpenSSL //' | sed -e 's/ .*//'`
+      OPENSSL_MAJOR_VERSION=`echo ${OPENSSL_VERSION} | cut -c 1-3`
+      AS_IF(
+        [test "x${OPENSSL_MAJOR_VERSION}" == "x1.1"],
         [AC_MSG_RESULT([ok (${OPENSSL_VERSION})])],
         [AC_MSG_FAILURE([too old (found ${OPENSSL_VERSION}, need >= 1.1.0)])]
       )
-      AC_LANG_POP([C])
     ]
   )
-
 
   AC_ARG_WITH([m4ri-dir],
     [AS_HELP_STRING(

--- a/src/crypto/sha2/sha2_ossl.c
+++ b/src/crypto/sha2/sha2_ossl.c
@@ -16,11 +16,11 @@
 static void do_hash(uint8_t *output, const uint8_t *input, size_t inplen, const EVP_MD *md) {
 	EVP_MD_CTX *mdctx;
 	unsigned int outlen;
-	mdctx = EVP_MD_CTX_create();
+	mdctx = EVP_MD_CTX_new();
 	EVP_DigestInit_ex(mdctx, md, NULL);
 	EVP_DigestUpdate(mdctx, input, inplen);
 	EVP_DigestFinal_ex(mdctx, output, &outlen);
-	EVP_MD_CTX_destroy(mdctx);
+	EVP_MD_CTX_free(mdctx);
 }
 
 void OQS_SHA2_sha256(uint8_t *output, const uint8_t *input, size_t inplen) {
@@ -46,7 +46,7 @@ void OQS_SHA2_sha256_inc_init(void **state) {
 	const EVP_MD *md = NULL;
 	md = EVP_sha256();
 	assert(md != NULL);
-	mdctx = EVP_MD_CTX_create();
+	mdctx = EVP_MD_CTX_new();
 	EVP_DigestInit_ex(mdctx, md, NULL);
 	*state = mdctx;
 }
@@ -63,7 +63,7 @@ void OQS_SHA2_sha256_inc_finalize(uint8_t *out, void *state, const uint8_t *in, 
 		EVP_DigestUpdate((EVP_MD_CTX *) state, in, inlen);
 	}
 	EVP_DigestFinal_ex((EVP_MD_CTX *) state, out, &md_len);
-	EVP_MD_CTX_destroy((EVP_MD_CTX *) state);
+	EVP_MD_CTX_free((EVP_MD_CTX *) state);
 }
 
 void OQS_SHA2_sha256_inc_destroy(void *state) {

--- a/src/crypto/sha3/sha3_ossl.c
+++ b/src/crypto/sha3/sha3_ossl.c
@@ -14,20 +14,20 @@
 static void do_hash(uint8_t *output, const uint8_t *input, size_t inplen, const EVP_MD *md) {
 	EVP_MD_CTX *mdctx;
 	unsigned int outlen;
-	mdctx = EVP_MD_CTX_create();
+	mdctx = EVP_MD_CTX_new();
 	EVP_DigestInit_ex(mdctx, md, NULL);
 	EVP_DigestUpdate(mdctx, input, inplen);
 	EVP_DigestFinal_ex(mdctx, output, &outlen);
-	EVP_MD_CTX_destroy(mdctx);
+	EVP_MD_CTX_free(mdctx);
 }
 
 static void do_xof(uint8_t *output, size_t outlen, const uint8_t *input, size_t inplen, const EVP_MD *md) {
 	EVP_MD_CTX *mdctx;
-	mdctx = EVP_MD_CTX_create();
+	mdctx = EVP_MD_CTX_new();
 	EVP_DigestInit_ex(mdctx, md, NULL);
 	EVP_DigestUpdate(mdctx, input, inplen);
 	EVP_DigestFinalXOF(mdctx, output, outlen);
-	EVP_MD_CTX_destroy(mdctx);
+	EVP_MD_CTX_free(mdctx);
 }
 
 void OQS_SHA3_sha3_256(uint8_t *output, const uint8_t *input, size_t inplen) {


### PR DESCRIPTION
Fixes #565.

Does so by requiring OpenSSL version 1.1.0 or higher.  But one of our target platforms (Ubuntu Xenial 16.04) only comes with OpenSSL 1.0.2.  So what should we do?  Require users on that platform to build OpenSSL 1.0.2 (and update our Docker images accordingly)?  Or remove that as a target platform?  Thoughts, @baentsch and @xvzcf?