### PR TITLE
Compiling BIKE without AVX512-BW fix

### DIFF
--- a/config/ax_check_x86_features.m4
+++ b/config/ax_check_x86_features.m4
@@ -74,4 +74,16 @@ AC_DEFUN([AX_CHECK_X86_FEATURES],
   m4_ifval([$1],[$1],
     [CFLAGS="$CFLAGS $X86_FEATURE_CFLAGS"])
   $2
+
+  #Liboqs requires avx512f/bw/dq to run AVX512 code
+  AM_COND_IF([USE_AVX512F_INSTRUCTIONS],
+    [AM_COND_IF([USE_AVX512BW_INSTRUCTIONS],
+      [AM_COND_IF([USE_AVX512DQ_INSTRUCTIONS],
+        [use_avx512_all=yes],
+        [use_avx512_all=no])],
+      [use_avx512_all=no])],
+    [use_avx512_all=no])
+
+  AM_CONDITIONAL(USE_AVX512_INSTRUCTIONS, [test x$use_avx512_all = xyes])
 ])
+

--- a/config/features.m4
+++ b/config/features.m4
@@ -48,9 +48,6 @@ AC_DEFUN([CONFIG_FEATURES],
 [
   CONFIG_FEATURE_FLAGS
 
-  # Default is set to false, will be changed upon demand
-  AM_CONDITIONAL([BIKE_ADDITIONAL_IMPL], [false])
-
   AM_COND_IF([ENABLE_KEM_BIKE], [
     AC_DEFINE(OQS_ENABLE_KEM_bike1_l1_cpa, 1, "Define to 1 when BIKE1-L1-CPA enabled")
     AC_DEFINE(OQS_ENABLE_KEM_bike1_l3_cpa, 1, "Define to 1 when BIKE1-L3-CPA enabled")

--- a/src/kem/bike/Makefile.am
+++ b/src/kem/bike/Makefile.am
@@ -21,7 +21,7 @@ if ON_DARWIN
 COMMON_CSRCS += $(BIKE_DIR)/sampling_portable.c $(BIKE_DIR)/secure_decode_portable.c 
 COMMON_FLAGS += -DPORTABLE
 else
-if USE_AVX512F_INSTRUCTIONS
+if USE_AVX512_INSTRUCTIONS
 COMMON_CSRCS += $(BIKE_DIR)/red.S $(BIKE_DIR)/secure_decode_avx512.c
 COMMON_CSRCS += $(BIKE_DIR)/sampling_avx512.S $(BIKE_DIR)/gf_mul.S 
 COMMON_FLAGS += -DAVX512

--- a/src/kem/bike/additional/secure_decode_avx2.c
+++ b/src/kem/bike/additional/secure_decode_avx2.c
@@ -37,6 +37,7 @@
 
 #define R_YMM_HALF_LOG2 UPTOPOW2(R_YMM / 2)
 
+_INLINE_
 void rotate256_big(OUT syndrome_t *out, IN const syndrome_t *in, IN size_t ymm_num) {
 	// For preventing overflows (comparison in bytes)
 	bike_static_assert(sizeof(*out) > (YMM_SIZE * (R_YMM + (2 * R_YMM_HALF_LOG2))),


### PR DESCRIPTION
This PR addresses issue: https://github.com/open-quantum-safe/liboqs/issues/590

GCC-5 supports AVX512-F but not AVX512-BW that is required by BIKE. Added a new macro USE_AVX512_INSTRUCTIONS that is true only when the compiler supports AVX512-F/BW/DQ.