### PR TITLE
OSX testing

### DIFF
--- a/.build-osx.sh
+++ b/.build-osx.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -o xtrace
+
+r=`git log --name-only --since="1 day ago" -n 2`
+if [ "x$r" == "x" ]; then 
+	echo "No checkin in the last day. No build/test required. Exiting."
+       	exit 0
+fi
+
+# New stuff found: Testing _is_ needed:
+brew update; brew unlink python@2; brew install autoconf automake libtool wget doxygen graphviz clang-format; pip3 install pytest
+autoreconf -i && ./configure ${CONFIGURE_ARGS}
+if [ $? -ne 0 ]; then
+	echo "Configure failed. Exiting."
+	exit -1
+fi
+make && make check
+if [ $? -ne 0 ]; then
+	echo "Make failed. Exiting."
+	exit -1
+fi
+sysctl -a | grep machdep.cpu; cat src/kem/sike/Makefile; ls -l tests; ./tests/example_kem
+# Test result becomes exit code for whole build
+export SKIP_TESTS=style
+mkdir -p test-results/pytest && python3 -m pytest --verbose --junitxml=test-results/pytest/results.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,16 @@ jobs:
     environment:
       IMAGE: openqsafe/ci-centos-8
       SKIP_TESTS: style
+  osx:
+    macos:
+        xcode: "11.3.0"
+    environment:
+        CONFIGURE_ARGS: --without-openssl
+    steps:
+        - checkout
+        - run:
+            name: Do All
+            command: ./.build-osx.sh
 
 workflows:
   version: 2
@@ -142,6 +152,7 @@ workflows:
               only:
                 - master
     jobs:
+      - osx
       - debian-buster-amd64
       - debian-buster-aarch64
       - debian-buster-armhf


### PR DESCRIPTION
This adds OSX testing to CircleCI testing. To limit use of OSX test cycles, tests only run at midnight on master and only if something has been checked in to master during the last day.