### PR TITLE
Update CMakeLists.txt C flags for Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,10 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb3")
     else()
-        include(.CMake/cpu-extensions.cmake)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -fomit-frame-pointer -march=native")
+        if (NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
+           include(.CMake/cpu-extensions.cmake)
+           set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -fomit-frame-pointer -march=native")
+        endif()
     endif()
 endif()
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang" OR


### PR DESCRIPTION
Run options which break Android build only if the target system is not Android