### PR TITLE
Fixed detection processor architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR
     set(ARCH "x86_64")
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "AMD64")
     # cmake reports AMD64 on Windows, but we might be building for 32-bit.
-    if(CMAKE_CL_64)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
         set(ARCH "x86_64")
     else()
         set(ARCH "x86")


### PR DESCRIPTION
CMAKE_CL_64 is discouraged and causes errors when building through Mingw-w64 on Windows