### PR TITLE
Reworked search for executable files in tests

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -112,16 +112,18 @@ def filtered_test(func):
     return wrapper
 
 def path_to_executable(program_name):
+    path = "."
     if sys.platform.startswith("win"):
         if 'APPVEYOR_BUILD_FOLDER' not in os.environ: os.environ['APPVEYOR_BUILD_FOLDER'] = "."
-        return os.path.join(
-            os.environ['APPVEYOR_BUILD_FOLDER'],
-            'build',
-            'tests',
-            program_name + ".EXE"
-        )
-    else:
-        return os.path.join("build", "tests", program_name)
+        path = os.path.join(path, os.environ['APPVEYOR_BUILD_FOLDER'])
+    path = os.path.join(path, "build", "tests")
+    for executable in [
+        os.path.join(path, program_name),
+        os.path.join(path, program_name + ".EXE"),
+        os.path.join(path, program_name + ".exe")]:
+            if os.path.isfile(executable):
+                return executable
+    assert False, "Unable to find executable file {}".format(program_name)
 
 def available_use_options_by_name():
     enabled_use_options = []


### PR DESCRIPTION
I'm sorry, this patch was supposed to be included in my last pull request https://github.com/open-quantum-safe/liboqs/pull/610. Without it, tests do not pass when cross-compiling on Linux. Mingw-w64 builds executables with the ".EXE" extension, which is not expected by the script that runs the tests.