### PR TITLE
generic optimized build type added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -Wall -Wextra -Wpedantic -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wstrict-prototypes -Wshadow -Wformat-security -Wwrite-strings")
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb3")
+    elseif(CMAKE_BUILD_TYPE STREQUAL "Generic")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -fomit-frame-pointer ")
     else()
         include(.CMake/cpu-extensions.cmake)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -fomit-frame-pointer -march=native")


### PR DESCRIPTION
The proposed build type "Generic" generates a variant that can run on Intel CPUs regardless of feature set _and_ is O3 compiled. For the time being, arguably the best docker-build target for execution on all x86_64s (incl. CPU-heterogeneous CI environments): When doing TLS-handshake perf tests (openssl s_time), often, AVX2-enabled code executed _slower_ than non-optimised code... Did you encounter this too? Possibly relevant reference: https://blog.cloudflare.com/on-the-dangers-of-intels-frequency-scaling/ 