### PR TITLE
Add -g3 debug information to ASAN builds

### DIFF
--- a/.CMake/sanitizers.cmake
+++ b/.CMake/sanitizers.cmake
@@ -30,7 +30,7 @@ function(append value)
 endfunction()
 
 if(USE_SANITIZER)
-  append("-fno-omit-frame-pointer" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+  append("-fno-omit-frame-pointer -g3" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
 
   if(UNIX)
 


### PR DESCRIPTION
This should help track where it's crashing.

Not entirely sure on how CMake manages flags, might be a better way to handle this.