### PR TITLE
Fix typo in picnic.

### DIFF
--- a/src/sig/picnic/external/endian_compat.h
+++ b/src/sig/picnic/external/endian_compat.h
@@ -33,7 +33,7 @@ static inline uint32_t ATTR_CONST bswap32(uint32_t x) {
          ((x & 0x000000ff) << 24);
 }
 
-static inline uint64_t AATR_CONST bswap64(uint64_t x) {
+static inline uint64_t ATTR_CONST bswap64(uint64_t x) {
   return ((x & UINT64_C(0xff00000000000000)) >> 56) | ((x & UINT64_C(0x00ff000000000000)) >> 40) |
          ((x & UINT64_C(0x0000ff0000000000)) >> 24) | ((x & UINT64_C(0x000000ff00000000)) >> 8) |
          ((x & UINT64_C(0x00000000ff000000)) << 8) | ((x & UINT64_C(0x0000000000ff0000)) << 24) |


### PR DESCRIPTION
Fix typo in picnic algorithm.
AATR_CONST should be ATTR_CONST.
