### PR TITLE
Comment-only fixes to cross-compiling toolchain files

### DIFF
--- a/.CMake/toolchain_rasppi.cmake
+++ b/.CMake/toolchain_rasppi.cmake
@@ -1,5 +1,5 @@
 # apt install gcc-8-arm-linux-gnueabihf
-# cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain-rasppi.cmake -DUSE_OPENSSL=OFF ..
+# cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_rasppi.cmake -DUSE_OPENSSL=OFF ..
 
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR arm)

--- a/.CMake/toolchain_windows-amd64.cmake
+++ b/.CMake/toolchain_windows-amd64.cmake
@@ -1,3 +1,4 @@
+# apt install gcc-mingw-w64
 # cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_windows-amd64.cmake ..
 
 set(CMAKE_SYSTEM_NAME Windows)


### PR DESCRIPTION
Correct typo of filename in Raspberry Pi toolchain file so the command can be directly copied and pasted to use.
Add a comment to the Windows toolchain to indicate the necessary package to install to get the necessary cross-compilers, as is already done for the Raspberry Pi toolchain file.