### PR TITLE
Expose common Keccak symbol

### DIFF
--- a/src/common/sha3/keccak4x/KeccakP-1600-times4-SIMD256.c
+++ b/src/common/sha3/keccak4x/KeccakP-1600-times4-SIMD256.c
@@ -412,7 +412,7 @@ static ALIGN(KeccakP1600times4_statesAlignment) const UINT64 KeccakF1600RoundCon
 #endif
 #include "KeccakP-1600-unrolling.macros"
 
-static void KeccakP1600times4_PermuteAll_24rounds(void *states) {
+void KeccakP1600times4_PermuteAll_24rounds(void *states) {
 	V256 *statesAsLanes = (V256 *) states;
 	declareABCDE
 #ifndef KeccakP1600times4_fullUnrolling

--- a/src/common/sha3/keccak4x/KeccakP-1600-times4-SnP.h
+++ b/src/common/sha3/keccak4x/KeccakP-1600-times4-SnP.h
@@ -34,6 +34,6 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #define KeccakP1600times4_StaticInitialize()
 #define KeccakP1600times4_AddByte(states, instanceIndex, byte, offset) \
     ((unsigned char *) (states))[(instanceIndex) *8 + ((offset) / 8) * 4 * 8 + (offset) % 8] ^= (byte)
-static void KeccakP1600times4_PermuteAll_24rounds(void *states);
+void KeccakP1600times4_PermuteAll_24rounds(void *states);
 
 #endif

--- a/src/sig/picnic/external/sha3/KeccakSpongeWidth1600times4.c
+++ b/src/sig/picnic/external/sha3/KeccakSpongeWidth1600times4.c
@@ -20,7 +20,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #define prefix oqs_sig_picnic_KeccakWidth1600times4
 #define PlSnP KeccakP1600times4
 #define PlSnP_width 1600
-#define PlSnP_Permute KeccakP1600times4_PermuteAll_24rounds
+#define PlSnP_Permute oqs_picnic_KeccakP1600times4_PermuteAll_24rounds
 #if defined(KeccakF1600times4_FastLoop_supported)
 //can we enable fastloop absorb?
 //#define PlSnP_FastLoop_Absorb KeccakF1600times4_FastLoop_Absorb

--- a/src/sig/picnic/external/sha3/armv8a-neon/KeccakP-1600-times4-SnP.h
+++ b/src/sig/picnic/external/sha3/armv8a-neon/KeccakP-1600-times4-SnP.h
@@ -36,7 +36,7 @@ void KeccakP1600times4_OverwriteWithZeroes(void *states, unsigned int instanceIn
 void KeccakP1600times4_PermuteAll_4rounds(void *states);
 void KeccakP1600times4_PermuteAll_6rounds(void *states);
 void KeccakP1600times4_PermuteAll_12rounds(void *states);
-void KeccakP1600times4_PermuteAll_24rounds(void *states);
+void oqs_picnic_KeccakP1600times4_PermuteAll_24rounds(void *states);
 void KeccakP1600times4_ExtractBytes(const void *states, unsigned int instanceIndex, unsigned char *data, unsigned int offset, unsigned int length);
 void KeccakP1600times4_ExtractLanesAll(const void *states, unsigned char *data, unsigned int laneCount, unsigned int laneOffset);
 void KeccakP1600times4_ExtractAndAddBytes(const void *states, unsigned int instanceIndex,  const unsigned char *input, unsigned char *output, unsigned int offset, unsigned int length);

--- a/src/sig/picnic/external/sha3/armv8a-neon/KeccakP-1600-times4-on1.c
+++ b/src/sig/picnic/external/sha3/armv8a-neon/KeccakP-1600-times4-on1.c
@@ -29,7 +29,7 @@ Please refer to LowLevel.build for the exact list of other files it must be comb
 #define SnP_Permute                     KeccakP1600_Permute_24rounds
 #define SnP_Permute_12rounds            KeccakP1600_Permute_12rounds
 #define SnP_Permute_Nrounds             KeccakP1600_Permute_Nrounds
-#define PlSnP_PermuteAll                KeccakP1600times4_PermuteAll_24rounds
+#define PlSnP_PermuteAll                oqs_picnic_KeccakP1600times4_PermuteAll_24rounds
 #define PlSnP_PermuteAll_12rounds       KeccakP1600times4_PermuteAll_12rounds
 #define PlSnP_PermuteAll_6rounds        KeccakP1600times4_PermuteAll_6rounds
 #define PlSnP_PermuteAll_4rounds        KeccakP1600times4_PermuteAll_4rounds

--- a/src/sig/picnic/external/sha3/avx2/KeccakP-1600-times4-SIMD256.c
+++ b/src/sig/picnic/external/sha3/avx2/KeccakP-1600-times4-SIMD256.c
@@ -815,7 +815,7 @@ static ALIGN(KeccakP1600times4_statesAlignment) const UINT64 KeccakF1600RoundCon
 #include "KeccakP-1600-unrolling.macros"
 
 ATTRIBUTE_TARGET_AVX2
-void KeccakP1600times4_PermuteAll_24rounds(void *states)
+void oqs_picnic_KeccakP1600times4_PermuteAll_24rounds(void *states)
 {
     V256 *statesAsLanes = (V256 *)states;
     declareABCDE
@@ -904,7 +904,7 @@ size_t KeccakF1600times4_FastLoop_Absorb(void *states, unsigned int laneCount, u
             Xor_In( 20 );
             #undef  Xor_In
             #undef  Xor_In4
-            KeccakP1600times4_PermuteAll_24rounds(states);
+            oqs_picnic_KeccakP1600times4_PermuteAll_24rounds(states);
             curData0 += laneOffsetSerial;
             curData1 += laneOffsetSerial;
             curData2 += laneOffsetSerial;
@@ -963,7 +963,7 @@ size_t KeccakF1600times4_FastLoop_Absorb(void *states, unsigned int laneCount, u
 
         while(dataByteLen >= (laneOffsetParallel*3 + laneCount)*8) {
             KeccakP1600times4_AddLanesAll(states, data, laneCount, laneOffsetParallel);
-            KeccakP1600times4_PermuteAll_24rounds(states);
+            oqs_picnic_KeccakP1600times4_PermuteAll_24rounds(states);
             data += laneOffsetSerial*8;
             dataByteLen -= laneOffsetSerial*8;
         }

--- a/src/sig/picnic/external/sha3/avx2/KeccakP-1600-times4-SnP.h
+++ b/src/sig/picnic/external/sha3/avx2/KeccakP-1600-times4-SnP.h
@@ -40,7 +40,7 @@ void KeccakP1600times4_OverwriteWithZeroes(void *states, unsigned int instanceIn
 void KeccakP1600times4_PermuteAll_4rounds(void *states);
 void KeccakP1600times4_PermuteAll_6rounds(void *states);
 void KeccakP1600times4_PermuteAll_12rounds(void *states);
-void KeccakP1600times4_PermuteAll_24rounds(void *states);
+void oqs_picnic_KeccakP1600times4_PermuteAll_24rounds(void *states);
 void KeccakP1600times4_ExtractBytes(const void *states, unsigned int instanceIndex, unsigned char *data, unsigned int offset, unsigned int length);
 void KeccakP1600times4_ExtractLanesAll(const void *states, unsigned char *data, unsigned int laneCount, unsigned int laneOffset);
 void KeccakP1600times4_ExtractAndAddBytes(const void *states, unsigned int instanceIndex,  const unsigned char *input, unsigned char *output, unsigned int offset, unsigned int length);

--- a/src/sig/picnic/external/sha3/opt64/KeccakP-1600-times4-SnP.h
+++ b/src/sig/picnic/external/sha3/opt64/KeccakP-1600-times4-SnP.h
@@ -36,7 +36,7 @@ void KeccakP1600times4_OverwriteWithZeroes(void *states, unsigned int instanceIn
 void KeccakP1600times4_PermuteAll_4rounds(void *states);
 void KeccakP1600times4_PermuteAll_6rounds(void *states);
 void KeccakP1600times4_PermuteAll_12rounds(void *states);
-void KeccakP1600times4_PermuteAll_24rounds(void *states);
+void oqs_picnic_KeccakP1600times4_PermuteAll_24rounds(void *states);
 void KeccakP1600times4_ExtractBytes(const void *states, unsigned int instanceIndex, unsigned char *data, unsigned int offset, unsigned int length);
 void KeccakP1600times4_ExtractLanesAll(const void *states, unsigned char *data, unsigned int laneCount, unsigned int laneOffset);
 void KeccakP1600times4_ExtractAndAddBytes(const void *states, unsigned int instanceIndex,  const unsigned char *input, unsigned char *output, unsigned int offset, unsigned int length);

--- a/src/sig/picnic/external/sha3/opt64/KeccakP-1600-times4-on1.c
+++ b/src/sig/picnic/external/sha3/opt64/KeccakP-1600-times4-on1.c
@@ -29,7 +29,7 @@ Please refer to LowLevel.build for the exact list of other files it must be comb
 #define SnP_Permute                     KeccakP1600_Permute_24rounds
 #define SnP_Permute_12rounds            KeccakP1600_Permute_12rounds
 #define SnP_Permute_Nrounds             KeccakP1600_Permute_Nrounds
-#define PlSnP_PermuteAll                KeccakP1600times4_PermuteAll_24rounds
+#define PlSnP_PermuteAll                oqs_picnic_KeccakP1600times4_PermuteAll_24rounds
 #define PlSnP_PermuteAll_12rounds       KeccakP1600times4_PermuteAll_12rounds
 #define PlSnP_PermuteAll_6rounds        KeccakP1600times4_PermuteAll_6rounds
 #define PlSnP_PermuteAll_4rounds        KeccakP1600times4_PermuteAll_4rounds


### PR DESCRIPTION
As discussed with @xvzcf. This exposes the `src/common` based Keccak used by Dilithium, Sphincs and Kyber in their AVX2 implementations and hides the Picnic variant.