### PR TITLE
Avoid picnic macro redefinition

### DIFF
--- a/src/sig/picnic/external/oqs_picnic_macros.h
+++ b/src/sig/picnic/external/oqs_picnic_macros.h
@@ -4,7 +4,9 @@
 #include <oqs/common.h>
 
 /* avoid printing debug output */
+#ifndef NDEBUG
 #define NDEBUG
+#endif
 
 /* use OQS's free function */
 #define free OQS_MEM_insecure_free


### PR DESCRIPTION
Don't redefine NDEBUG in Picnic code; fixes warning when building cmake release build.