### PR TITLE
limit Win-testing to mb-* branches; add ibmr attribution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,16 @@ workflows:
   version: 2
   build:
     jobs:
-      - win-shared
+      - win-static:
+          filters:  
+            branches:
+              only:  
+                - /mb-.*/
+      - win-shared:
+          filters:  
+            branches:
+              only:  
+                - /mb-.*/
       - centos-7-amd64
       - centos-8-amd64
       - debian-buster-amd64
@@ -235,7 +244,6 @@ workflows:
       - debian-buster-armhf
       - debian-buster-armel
       - macOS
-      - win-static
       - ubuntu-bionic-x86_64-gcc7
       - ubuntu-bionic-x86_64-gcc7-noopenssl
       - ubuntu-bionic-x86_64-gcc7-shared

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ liboqs includes some third party libraries or modules that are licensed differen
 
 ## Acknowledgements
 
-Various companies, including Amazon Web Services, evolutionQ, Microsoft Research, and Cisco Systems, have dedicated programmer time to contribute source code to OQS. [Various people](CONTRIBUTORS) have contributed source code to liboqs.
+Various companies, including Amazon Web Services, evolutionQ, Microsoft Research, Cisco Systems, and IBM Research have dedicated programmer time to contribute source code to OQS. [Various people](CONTRIBUTORS) have contributed source code to liboqs.
 
 Financial support for the development of Open Quantum Safe has been provided by Amazon Web Services and the Tutte Institute for Mathematics and Computing.
 Research projects which developed specific components of OQS have been supported by various research grants, including funding from the Natural Sciences and Engineering Research Council of Canada (NSERC); see the source papers for funding acknowledgments.


### PR DESCRIPTION
As workaround enable CCI-Win testing only on mb-* tagged branches (Thanks @dstebila for the suggestion) + added IBM Research attribution