### PR TITLE
Add a basic .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# see https://mirrors.edge.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+* text=auto whitespace=trailing-space
+
+*.png binary
+*.jpe?g binary


### PR DESCRIPTION
This should force the handling of trailing whitespace and newlines a bit better.

There is more that you can do, such as not allowing tabs in indentation etc, but that possibly breaks some peoples branches (I see a bunch of files having tabs at the start of lines in this repository).