### PR TITLE
Adding separate AVX2 runtime-checked common/sha3

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,11 @@
 add_subdirectory(common)
+set(_COMMON_OBJS $<TARGET_OBJECTS:common>)
+if(OQS_USE_AVX2_INSTRUCTIONS)
+add_subdirectory(common_avx2)
+set(_COMMON_OBJS ${_COMMON_OBJS} $<TARGET_OBJECTS:common_avx2>)
+endif()
+set(COMMON_OBJS ${_COMMON_OBJS} PARENT_SCOPE)
+
 
 if(OQS_ENABLE_KEM_BIKE)
     add_subdirectory(kem/bike)
@@ -75,7 +82,7 @@ add_library(oqs kem/kem.c
                 ${KEM_OBJS}
                 sig/sig.c
                 ${SIG_OBJS}
-                $<TARGET_OBJECTS:common>)
+                ${_COMMON_OBJS})
 if(DEFINED SANITIZER_LD_FLAGS)
     target_link_libraries(oqs PUBLIC ${SANITIZER_LD_FLAGS})
 endif()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -24,11 +24,6 @@ set(SHA3_IMPL sha3/sha3_c.c)
 if(OQS_USE_SHA3_OPENSSL)
     set(SHA3_IMPL ${SHA3_IMPL} sha3/sha3_ossl.c)
 endif()
-if(OQS_USE_AVX2_INSTRUCTIONS AND OQS_USE_AES_INSTRUCTIONS)
-    set(SHA3_IMPL ${SHA3_IMPL} sha3/sha3x4.c)
-    add_compile_options(-mavx2)
-    add_compile_options(-maes)
-endif()
 
 add_library(common OBJECT ${AES_IMPL}
                           ${SHA2_IMPL}

--- a/src/common/sha3/sha3_c.c
+++ b/src/common/sha3/sha3_c.c
@@ -164,8 +164,8 @@ void oqs_avx2_sha3_cshake256_inc_ctx_clone(shake256incctx *dest, const shake256i
 
 void OQS_SHA3_sha3_256_inc_init(OQS_SHA3_sha3_256_inc_ctx *state) {
 #ifdef OQS_USE_AVX2_INSTRUCTIONS
-        OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions(); \
-        if (available_cpu_extensions.AVX2_ENABLED) { \
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
 		oqs_avx2_sha3_sha3_256_inc_init((sha3_256incctx *) state);
 	} else {
 		oqs_sha3_sha3_256_inc_init((sha3_256incctx *) state);

--- a/src/common/sha3/sha3_c.c
+++ b/src/common/sha3/sha3_c.c
@@ -108,116 +108,485 @@ typedef struct {
 
 #include "fips202.c"
 
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+void oqs_avx2_sha3_sha3_256_inc_init(sha3_256incctx *state);
+void oqs_avx2_sha3_sha3_256_inc_absorb(sha3_256incctx *state, const uint8_t *input, size_t inlen);
+void oqs_avx2_sha3_sha3_256_inc_finalize(uint8_t *output, sha3_256incctx *state) ;
+void oqs_avx2_sha3_sha3_256_inc_ctx_release(sha3_256incctx *state);
+void oqs_avx2_sha3_sha3_256_inc_ctx_clone(sha3_256incctx *dest, const sha3_256incctx *src);
+void oqs_avx2_sha3_sha3_384_inc_init(sha3_384incctx *state);
+void oqs_avx2_sha3_sha3_384_inc_ctx_clone(sha3_384incctx *dest, const sha3_384incctx *src);
+void oqs_avx2_sha3_sha3_384_inc_absorb(sha3_384incctx *state, const uint8_t *input, size_t inlen);
+void oqs_avx2_sha3_sha3_384_inc_ctx_release(sha3_384incctx *state);
+void oqs_avx2_sha3_sha3_384_inc_finalize(uint8_t *output, sha3_384incctx *state) ;
+void oqs_avx2_sha3_sha3_512_inc_init(sha3_512incctx *state) ;
+void oqs_avx2_sha3_sha3_512_inc_ctx_clone(sha3_512incctx *dest, const sha3_512incctx *src);
+void oqs_avx2_sha3_sha3_512_inc_absorb(sha3_512incctx *state, const uint8_t *input, size_t inlen) ;
+void oqs_avx2_sha3_sha3_512_inc_ctx_release(sha3_512incctx *state) ;
+void oqs_avx2_sha3_sha3_512_inc_finalize(uint8_t *output, sha3_512incctx *state) ;
+void oqs_avx2_sha3_shake128_inc_init(shake128incctx *state) ;
+void oqs_avx2_sha3_shake128_inc_absorb(shake128incctx *state, const uint8_t *input, size_t inlen);
+void oqs_avx2_sha3_shake128_inc_finalize(shake128incctx *state);
+void oqs_avx2_sha3_shake128_inc_squeeze(uint8_t *output, size_t outlen, shake128incctx *state) ;
+void oqs_avx2_sha3_shake128_inc_ctx_clone(shake128incctx *dest, const shake128incctx *src) ;
+void oqs_avx2_sha3_shake128_inc_ctx_release(shake128incctx *state);
+void oqs_avx2_sha3_shake256_inc_init(shake256incctx *state) ;
+void oqs_avx2_sha3_shake256_inc_absorb(shake256incctx *state, const uint8_t *input, size_t inlen) ;
+void oqs_avx2_sha3_shake256_inc_finalize(shake256incctx *state);
+void oqs_avx2_sha3_shake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state) ;
+void oqs_avx2_sha3_shake256_inc_ctx_clone(shake256incctx *dest, const shake256incctx *src);
+void oqs_avx2_sha3_shake256_inc_ctx_release(shake256incctx *state) ;
+void oqs_avx2_sha3_shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen) ;
+void oqs_avx2_sha3_shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state);
+void oqs_avx2_sha3_shake128_ctx_clone(shake128ctx *dest, const shake128ctx *src);
+void oqs_avx2_sha3_shake128_ctx_release(shake128ctx *state);
+void oqs_avx2_sha3_shake256_absorb(shake256ctx *state, const uint8_t *input, size_t inlen) ;
+void oqs_avx2_sha3_shake256_squeezeblocks(uint8_t *output, size_t nblocks, shake256ctx *state) ;
+void oqs_avx2_sha3_shake256_ctx_clone(shake256ctx *dest, const shake256ctx *src) ;
+void oqs_avx2_sha3_shake256_ctx_release(shake256ctx *state) ;
+
+void oqs_avx2_sha3_cshake128_inc_init(shake128incctx *state, const uint8_t *name, size_t namelen, const uint8_t *cstm, size_t cstmlen) ;
+void oqs_avx2_sha3_cshake128_inc_absorb(shake128incctx *state, const uint8_t *input, size_t inlen);
+void oqs_avx2_sha3_cshake128_inc_finalize(shake128incctx *state);
+void oqs_avx2_sha3_cshake128_inc_squeeze(uint8_t *output, size_t outlen, shake128incctx *state);
+void oqs_avx2_sha3_cshake128_inc_ctx_release(shake128incctx *state);
+void oqs_avx2_sha3_cshake128_inc_ctx_clone(shake128incctx *dest, const shake128incctx *src);
+void oqs_avx2_sha3_cshake256_inc_init(shake256incctx *state, const uint8_t *name, size_t namelen, const uint8_t *cstm, size_t cstmlen);
+void oqs_avx2_sha3_cshake256_inc_absorb(shake256incctx *state, const uint8_t *input, size_t inlen);
+void oqs_avx2_sha3_cshake256_inc_finalize(shake256incctx *state);
+void oqs_avx2_sha3_cshake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state);
+void oqs_avx2_sha3_cshake256_inc_ctx_release(shake256incctx *state);
+void oqs_avx2_sha3_cshake256_inc_ctx_clone(shake256incctx *dest, const shake256incctx *src);
+
+
+#endif
+
+
 void OQS_SHA3_sha3_256_inc_init(OQS_SHA3_sha3_256_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+        OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions(); \
+        if (available_cpu_extensions.AVX2_ENABLED) { \
+		oqs_avx2_sha3_sha3_256_inc_init((sha3_256incctx *) state);
+	} else {
+		oqs_sha3_sha3_256_inc_init((sha3_256incctx *) state);
+	}
+#else
 	oqs_sha3_sha3_256_inc_init((sha3_256incctx *) state);
+#endif
 }
 void OQS_SHA3_sha3_256_inc_absorb(OQS_SHA3_sha3_256_inc_ctx *state, const uint8_t *input, size_t inlen) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_sha3_256_inc_absorb((sha3_256incctx *) state, input, inlen);
+	} else {
+		oqs_sha3_sha3_256_inc_absorb((sha3_256incctx *) state, input, inlen);
+	}
+#else
 	oqs_sha3_sha3_256_inc_absorb((sha3_256incctx *) state, input, inlen);
+#endif
 }
 void OQS_SHA3_sha3_256_inc_finalize(uint8_t *output, OQS_SHA3_sha3_256_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_sha3_256_inc_finalize(output, (sha3_256incctx *) state);
+	} else {
+		oqs_sha3_sha3_256_inc_finalize(output, (sha3_256incctx *) state);
+	}
+#else
 	oqs_sha3_sha3_256_inc_finalize(output, (sha3_256incctx *) state);
+#endif
 }
 void OQS_SHA3_sha3_256_inc_ctx_release(OQS_SHA3_sha3_256_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_sha3_256_inc_ctx_release((sha3_256incctx *) state);
+	} else {
+		oqs_sha3_sha3_256_inc_ctx_release((sha3_256incctx *) state);
+	}
+#else
 	oqs_sha3_sha3_256_inc_ctx_release((sha3_256incctx *) state);
+#endif
 }
 void OQS_SHA3_sha3_256_inc_ctx_clone(OQS_SHA3_sha3_256_inc_ctx *dest, const OQS_SHA3_sha3_256_inc_ctx *src) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_sha3_256_inc_ctx_clone((sha3_256incctx *) dest, (const sha3_256incctx *) src);
+	} else {
+		oqs_sha3_sha3_256_inc_ctx_clone((sha3_256incctx *) dest, (const sha3_256incctx *) src);
+	}
+#else
 	oqs_sha3_sha3_256_inc_ctx_clone((sha3_256incctx *) dest, (const sha3_256incctx *) src);
+#endif
 }
 
 void OQS_SHA3_sha3_384_inc_init(OQS_SHA3_sha3_384_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_sha3_384_inc_init((sha3_384incctx *) state);
+	} else {
+		oqs_sha3_sha3_384_inc_init((sha3_384incctx *) state);
+	}
+#else
 	oqs_sha3_sha3_384_inc_init((sha3_384incctx *) state);
+#endif
 }
 void OQS_SHA3_sha3_384_inc_absorb(OQS_SHA3_sha3_384_inc_ctx *state, const uint8_t *input, size_t inlen) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_sha3_384_inc_absorb((sha3_384incctx *) state, input, inlen);
+	} else {
+		oqs_sha3_sha3_384_inc_absorb((sha3_384incctx *) state, input, inlen);
+	}
+#else
 	oqs_sha3_sha3_384_inc_absorb((sha3_384incctx *) state, input, inlen);
+#endif
 }
 void OQS_SHA3_sha3_384_inc_finalize(uint8_t *output, OQS_SHA3_sha3_384_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_sha3_384_inc_finalize(output, (sha3_384incctx *) state);
+	} else {
+		oqs_sha3_sha3_384_inc_finalize(output, (sha3_384incctx *) state);
+	}
+#else
 	oqs_sha3_sha3_384_inc_finalize(output, (sha3_384incctx *) state);
+#endif
 }
 void OQS_SHA3_sha3_384_inc_ctx_release(OQS_SHA3_sha3_384_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_sha3_384_inc_ctx_release((sha3_384incctx *) state);
+	} else {
+		oqs_sha3_sha3_384_inc_ctx_release((sha3_384incctx *) state);
+	}
+#else
 	oqs_sha3_sha3_384_inc_ctx_release((sha3_384incctx *) state);
+#endif
 }
 void OQS_SHA3_sha3_384_inc_ctx_clone(OQS_SHA3_sha3_384_inc_ctx *dest, const OQS_SHA3_sha3_384_inc_ctx *src) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_sha3_384_inc_ctx_clone((sha3_384incctx *) dest, (const sha3_384incctx *) src);
+	} else {
+		oqs_sha3_sha3_384_inc_ctx_clone((sha3_384incctx *) dest, (const sha3_384incctx *) src);
+	}
+#else
 	oqs_sha3_sha3_384_inc_ctx_clone((sha3_384incctx *) dest, (const sha3_384incctx *) src);
+#endif
 }
 
 void OQS_SHA3_sha3_512_inc_init(OQS_SHA3_sha3_512_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_sha3_512_inc_init((sha3_512incctx *) state);
+	} else {
+		oqs_sha3_sha3_512_inc_init((sha3_512incctx *) state);
+	}
+#else
 	oqs_sha3_sha3_512_inc_init((sha3_512incctx *) state);
+#endif
 }
 void OQS_SHA3_sha3_512_inc_absorb(OQS_SHA3_sha3_512_inc_ctx *state, const uint8_t *input, size_t inlen) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_sha3_512_inc_absorb((sha3_512incctx *) state, input, inlen);
+	} else {
+		oqs_sha3_sha3_512_inc_absorb((sha3_512incctx *) state, input, inlen);
+	}
+#else
 	oqs_sha3_sha3_512_inc_absorb((sha3_512incctx *) state, input, inlen);
+#endif
 }
 void OQS_SHA3_sha3_512_inc_finalize(uint8_t *output, OQS_SHA3_sha3_512_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_sha3_512_inc_finalize(output, (sha3_512incctx *) state);
+	} else {
+		oqs_sha3_sha3_512_inc_finalize(output, (sha3_512incctx *) state);
+	}
+#else
 	oqs_sha3_sha3_512_inc_finalize(output, (sha3_512incctx *) state);
+#endif
 }
 void OQS_SHA3_sha3_512_inc_ctx_release(OQS_SHA3_sha3_512_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_sha3_512_inc_ctx_release((sha3_512incctx *) state);
+	} else {
+		oqs_sha3_sha3_512_inc_ctx_release((sha3_512incctx *) state);
+	}
+#else
 	oqs_sha3_sha3_512_inc_ctx_release((sha3_512incctx *) state);
+#endif
 }
 void OQS_SHA3_sha3_512_inc_ctx_clone(OQS_SHA3_sha3_512_inc_ctx *dest, const OQS_SHA3_sha3_512_inc_ctx *src) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_sha3_512_inc_ctx_clone((sha3_512incctx *) dest, (const sha3_512incctx *) src);
+	} else {
+		oqs_sha3_sha3_512_inc_ctx_clone((sha3_512incctx *) dest, (const sha3_512incctx *) src);
+	}
+#else
 	oqs_sha3_sha3_512_inc_ctx_clone((sha3_512incctx *) dest, (const sha3_512incctx *) src);
+#endif
 }
 
 void OQS_SHA3_shake128_absorb(OQS_SHA3_shake128_ctx *state, const uint8_t *input, size_t inplen) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake128_absorb((shake128ctx *) state, input, inplen);
+	} else {
+		oqs_sha3_shake128_absorb((shake128ctx *) state, input, inplen);
+	}
+#else
 	oqs_sha3_shake128_absorb((shake128ctx *) state, input, inplen);
+#endif
 }
 void OQS_SHA3_shake128_squeezeblocks(uint8_t *output, size_t nblocks, OQS_SHA3_shake128_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake128_squeezeblocks(output, nblocks, (shake128ctx *) state);
+	} else {
+		oqs_sha3_shake128_squeezeblocks(output, nblocks, (shake128ctx *) state);
+	}
+#else
 	oqs_sha3_shake128_squeezeblocks(output, nblocks, (shake128ctx *) state);
+#endif
 }
 void OQS_SHA3_shake128_ctx_release(OQS_SHA3_shake128_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake128_ctx_release((shake128ctx *) state);
+	} else {
+		oqs_sha3_shake128_ctx_release((shake128ctx *) state);
+	}
+#else
 	oqs_sha3_shake128_ctx_release((shake128ctx *) state);
+#endif
 }
 void OQS_SHA3_shake128_ctx_clone(OQS_SHA3_shake128_ctx *dest, const OQS_SHA3_shake128_ctx *src) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake128_ctx_clone((shake128ctx *) dest, (const shake128ctx *) src);
+	} else {
+		oqs_sha3_shake128_ctx_clone((shake128ctx *) dest, (const shake128ctx *) src);
+	}
+#else
 	oqs_sha3_shake128_ctx_clone((shake128ctx *) dest, (const shake128ctx *) src);
+#endif
 }
 
 void OQS_SHA3_shake128_inc_init(OQS_SHA3_shake128_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake128_inc_init((shake128incctx *) state);
+	} else {
+		oqs_sha3_shake128_inc_init((shake128incctx *) state);
+	}
+#else
 	oqs_sha3_shake128_inc_init((shake128incctx *) state);
+#endif
 }
 void OQS_SHA3_shake128_inc_absorb(OQS_SHA3_shake128_inc_ctx *state, const uint8_t *input, size_t inlen) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake128_inc_absorb((shake128incctx *) state, input, inlen);
+	} else {
+		oqs_sha3_shake128_inc_absorb((shake128incctx *) state, input, inlen);
+	}
+#else
 	oqs_sha3_shake128_inc_absorb((shake128incctx *) state, input, inlen);
+#endif
 }
 void OQS_SHA3_shake128_inc_finalize(OQS_SHA3_shake128_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake128_inc_finalize((shake128incctx *) state);
+	} else {
+		oqs_sha3_shake128_inc_finalize((shake128incctx *) state);
+	}
+#else
 	oqs_sha3_shake128_inc_finalize((shake128incctx *) state);
+#endif
 }
 void OQS_SHA3_shake128_inc_squeeze(uint8_t *output, size_t outlen, OQS_SHA3_shake128_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake128_inc_squeeze(output, outlen, (shake128incctx *) state);
+	} else {
+		oqs_sha3_shake128_inc_squeeze(output, outlen, (shake128incctx *) state);
+	}
+#else
 	oqs_sha3_shake128_inc_squeeze(output, outlen, (shake128incctx *) state);
+#endif
 }
 void OQS_SHA3_shake128_inc_ctx_release(OQS_SHA3_shake128_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake128_inc_ctx_release((shake128incctx *) state);
+	} else {
+		oqs_sha3_shake128_inc_ctx_release((shake128incctx *) state);
+	}
+#else
 	oqs_sha3_shake128_inc_ctx_release((shake128incctx *) state);
+#endif
 }
 void OQS_SHA3_shake128_inc_ctx_clone(OQS_SHA3_shake128_inc_ctx *dest, const OQS_SHA3_shake128_inc_ctx *src) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake128_inc_ctx_clone((shake128incctx *) dest, (const shake128incctx *) src);
+	} else {
+		oqs_sha3_shake128_inc_ctx_clone((shake128incctx *) dest, (const shake128incctx *) src);
+	}
+#else
 	oqs_sha3_shake128_inc_ctx_clone((shake128incctx *) dest, (const shake128incctx *) src);
+#endif
 }
 
 void OQS_SHA3_shake256_absorb(OQS_SHA3_shake256_ctx *state, const uint8_t *input, size_t inplen) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake256_absorb((shake256ctx *) state, input, inplen);
+	} else {
+		oqs_sha3_shake256_absorb((shake256ctx *) state, input, inplen);
+	}
+#else
 	oqs_sha3_shake256_absorb((shake256ctx *) state, input, inplen);
+#endif
 }
 void OQS_SHA3_shake256_squeezeblocks(uint8_t *output, size_t nblocks, OQS_SHA3_shake256_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake256_squeezeblocks(output, nblocks, (shake256ctx *) state);
+	} else {
+		oqs_sha3_shake256_squeezeblocks(output, nblocks, (shake256ctx *) state);
+	}
+#else
 	oqs_sha3_shake256_squeezeblocks(output, nblocks, (shake256ctx *) state);
+#endif
 }
 void OQS_SHA3_shake256_ctx_release(OQS_SHA3_shake256_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake256_ctx_release((shake256ctx *) state);
+	} else {
+		oqs_sha3_shake256_ctx_release((shake256ctx *) state);
+	}
+#else
 	oqs_sha3_shake256_ctx_release((shake256ctx *) state);
+#endif
 }
 void OQS_SHA3_shake256_ctx_clone(OQS_SHA3_shake256_ctx *dest, const OQS_SHA3_shake256_ctx *src) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake256_ctx_clone((shake256ctx *) dest, (const shake256ctx *) src);
+	} else {
+		oqs_sha3_shake256_ctx_clone((shake256ctx *) dest, (const shake256ctx *) src);
+	}
+#else
 	oqs_sha3_shake256_ctx_clone((shake256ctx *) dest, (const shake256ctx *) src);
+#endif
 }
 
 void OQS_SHA3_shake256_inc_init(OQS_SHA3_shake256_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake256_inc_init((shake256incctx *) state);
+	} else {
+		oqs_sha3_shake256_inc_init((shake256incctx *) state);
+	}
+#else
 	oqs_sha3_shake256_inc_init((shake256incctx *) state);
+#endif
 }
 void OQS_SHA3_shake256_inc_absorb(OQS_SHA3_shake256_inc_ctx *state, const uint8_t *input, size_t inlen) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake256_inc_absorb((shake256incctx *) state, input, inlen);
+	} else {
+		oqs_sha3_shake256_inc_absorb((shake256incctx *) state, input, inlen);
+	}
+#else
 	oqs_sha3_shake256_inc_absorb((shake256incctx *) state, input, inlen);
+#endif
 }
 void OQS_SHA3_shake256_inc_finalize(OQS_SHA3_shake256_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake256_inc_finalize((shake256incctx *) state);
+	} else {
+		oqs_sha3_shake256_inc_finalize((shake256incctx *) state);
+	}
+#else
 	oqs_sha3_shake256_inc_finalize((shake256incctx *) state);
+#endif
 }
 void OQS_SHA3_shake256_inc_squeeze(uint8_t *output, size_t outlen, OQS_SHA3_shake256_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake256_inc_squeeze(output, outlen, (shake256incctx *) state);
+	} else {
+		oqs_sha3_shake256_inc_squeeze(output, outlen, (shake256incctx *) state);
+	}
+#else
 	oqs_sha3_shake256_inc_squeeze(output, outlen, (shake256incctx *) state);
+#endif
 }
 void OQS_SHA3_shake256_inc_ctx_release(OQS_SHA3_shake256_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake256_inc_ctx_release((shake256incctx *) state);
+	} else {
+		oqs_sha3_shake256_inc_ctx_release((shake256incctx *) state);
+	}
+#else
 	oqs_sha3_shake256_inc_ctx_release((shake256incctx *) state);
+#endif
 }
 void OQS_SHA3_shake256_inc_ctx_clone(OQS_SHA3_shake256_inc_ctx *dest, const OQS_SHA3_shake256_inc_ctx *src) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_shake256_inc_ctx_clone((shake256incctx *) dest, (const shake256incctx *) src);
+	} else {
+		oqs_sha3_shake256_inc_ctx_clone((shake256incctx *) dest, (const shake256incctx *) src);
+	}
+#else
 	oqs_sha3_shake256_inc_ctx_clone((shake256incctx *) dest, (const shake256incctx *) src);
+#endif
 }
 
 #define cshake128 OQS_SHA3_cshake128
@@ -241,41 +610,149 @@ void OQS_SHA3_shake256_inc_ctx_clone(OQS_SHA3_shake256_inc_ctx *dest, const OQS_
 #include "sp800-185.c"
 
 void OQS_SHA3_cshake128_inc_init(OQS_SHA3_shake128_inc_ctx *state, const uint8_t *name, size_t namelen, const uint8_t *cstm, size_t cstmlen) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_cshake128_inc_init((shake128incctx *) state, name, namelen, cstm, cstmlen);
+	} else {
+		oqs_sha3_cshake128_inc_init((shake128incctx *) state, name, namelen, cstm, cstmlen);
+	}
+#else
 	oqs_sha3_cshake128_inc_init((shake128incctx *) state, name, namelen, cstm, cstmlen);
+#endif
 }
 void OQS_SHA3_cshake128_inc_absorb(OQS_SHA3_shake128_inc_ctx *state, const uint8_t *input, size_t inlen) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_cshake128_inc_absorb((shake128incctx *) state, input, inlen);
+	} else {
+		oqs_sha3_cshake128_inc_absorb((shake128incctx *) state, input, inlen);
+	}
+#else
 	oqs_sha3_cshake128_inc_absorb((shake128incctx *) state, input, inlen);
+#endif
 }
 void OQS_SHA3_cshake128_inc_finalize(OQS_SHA3_shake128_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_cshake128_inc_finalize((shake128incctx *) state);
+	} else {
+		oqs_sha3_cshake128_inc_finalize((shake128incctx *) state);
+	}
+#else
 	oqs_sha3_cshake128_inc_finalize((shake128incctx *) state);
+#endif
 }
 void OQS_SHA3_cshake128_inc_squeeze(uint8_t *output, size_t outlen, OQS_SHA3_shake128_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_cshake128_inc_squeeze(output, outlen, (shake128incctx *) state);
+	} else {
+		oqs_sha3_cshake128_inc_squeeze(output, outlen, (shake128incctx *) state);
+	}
+#else
 	oqs_sha3_cshake128_inc_squeeze(output, outlen, (shake128incctx *) state);
+#endif
 }
 void OQS_SHA3_cshake128_inc_ctx_release(OQS_SHA3_shake128_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_cshake128_inc_ctx_release((shake128incctx *) state);
+	} else {
+		oqs_sha3_cshake128_inc_ctx_release((shake128incctx *) state);
+	}
+#else
 	oqs_sha3_cshake128_inc_ctx_release((shake128incctx *) state);
+#endif
 }
 void OQS_SHA3_cshake128_inc_ctx_clone(OQS_SHA3_shake128_inc_ctx *dest, const OQS_SHA3_shake128_inc_ctx *src) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_cshake128_inc_ctx_clone((shake128incctx *) dest, (const shake128incctx *) src);
+	} else {
+		oqs_sha3_cshake128_inc_ctx_clone((shake128incctx *) dest, (const shake128incctx *) src);
+	}
+#else
 	oqs_sha3_cshake128_inc_ctx_clone((shake128incctx *) dest, (const shake128incctx *) src);
+#endif
 }
 
 void OQS_SHA3_cshake256_inc_init(OQS_SHA3_shake256_inc_ctx *state, const uint8_t *name, size_t namelen, const uint8_t *cstm, size_t cstmlen) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_cshake256_inc_init((shake256incctx *) state, name, namelen, cstm, cstmlen);
+	} else {
+		oqs_sha3_cshake256_inc_init((shake256incctx *) state, name, namelen, cstm, cstmlen);
+	}
+#else
 	oqs_sha3_cshake256_inc_init((shake256incctx *) state, name, namelen, cstm, cstmlen);
+#endif
 }
 void OQS_SHA3_cshake256_inc_absorb(OQS_SHA3_shake256_inc_ctx *state, const uint8_t *input, size_t inlen) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_cshake256_inc_absorb((shake256incctx *) state, input, inlen);
+	} else {
+		oqs_sha3_cshake256_inc_absorb((shake256incctx *) state, input, inlen);
+	}
+#else
 	oqs_sha3_cshake256_inc_absorb((shake256incctx *) state, input, inlen);
+#endif
 }
 void OQS_SHA3_cshake256_inc_finalize(OQS_SHA3_shake256_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_cshake256_inc_finalize((shake256incctx *) state);
+	} else {
+		oqs_sha3_cshake256_inc_finalize((shake256incctx *) state);
+	}
+#else
 	oqs_sha3_cshake256_inc_finalize((shake256incctx *) state);
+#endif
 }
 void OQS_SHA3_cshake256_inc_squeeze(uint8_t *output, size_t outlen, OQS_SHA3_shake256_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_cshake256_inc_squeeze(output, outlen, (shake256incctx *) state);
+	} else {
+		oqs_sha3_cshake256_inc_squeeze(output, outlen, (shake256incctx *) state);
+	}
+#else
 	oqs_sha3_cshake256_inc_squeeze(output, outlen, (shake256incctx *) state);
+#endif
 }
 void OQS_SHA3_cshake256_inc_ctx_release(OQS_SHA3_shake256_inc_ctx *state) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_cshake256_inc_ctx_release((shake256incctx *) state);
+	} else {
+		oqs_sha3_cshake256_inc_ctx_release((shake256incctx *) state);
+	}
+#else
 	oqs_sha3_cshake256_inc_ctx_release((shake256incctx *) state);
+#endif
 }
 void OQS_SHA3_cshake256_inc_ctx_clone(OQS_SHA3_shake256_inc_ctx *dest, const OQS_SHA3_shake256_inc_ctx *src) {
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
+	OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
+	if (available_cpu_extensions.AVX2_ENABLED) {
+		oqs_avx2_sha3_cshake256_inc_ctx_clone((shake256incctx *) dest, (const shake256incctx *) src);
+	} else {
+		oqs_sha3_cshake256_inc_ctx_clone((shake256incctx *) dest, (const shake256incctx *) src);
+	}
+#else
 	oqs_sha3_cshake256_inc_ctx_clone((shake256incctx *) dest, (const shake256incctx *) src);
+#endif
 }
 
 void OQS_SHA3_cshake128_simple(uint8_t *output, size_t outlen, uint16_t cstm, const uint8_t *input, size_t inplen) {

--- a/src/common_avx2/CMakeLists.txt
+++ b/src/common_avx2/CMakeLists.txt
@@ -1,0 +1,19 @@
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR
+   CMAKE_C_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wbad-function-cast)
+endif()
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wcast-qual)
+    add_compile_options(-Wnarrowing)
+    add_compile_options(-Wconversion)
+endif()
+
+set(SHA3_IMPL sha3/sha3_c.c)
+
+if(OQS_USE_AVX2_INSTRUCTIONS AND OQS_USE_AES_INSTRUCTIONS)
+    set(SHA3_IMPL ${SHA3_IMPL} sha3/sha3x4.c)
+    add_compile_options(-mavx2)
+    add_compile_options(-maes)
+endif()
+add_library(common_avx2 OBJECT ${SHA3_IMPL})
+

--- a/src/common_avx2/sha3/fips202.c
+++ b/src/common_avx2/sha3/fips202.c
@@ -1,0 +1,930 @@
+/* Based on the public domain implementation in
+ * crypto_hash/keccakc512/simple/ from http://bench.cr.yp.to/supercop.html
+ * by Ronny Van Keer
+ * and the public domain "TweetFips202" implementation
+ * from https://twitter.com/tweetfips202
+ * by Gilles Van Assche, Daniel J. Bernstein, and Peter Schwabe */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define PQC_SHAKEINCCTX_BYTES (sizeof(uint64_t)*26)
+#define PQC_SHAKECTX_BYTES (sizeof(uint64_t)*25)
+
+#define NROUNDS 24
+#define ROL(a, offset) (((a) << (offset)) ^ ((a) >> (64 - (offset))))
+
+/*************************************************
+ * Name:        load64
+ *
+ * Description: Load 8 bytes into uint64_t in little-endian order
+ *
+ * Arguments:   - const uint8_t *x: pointer to input byte array
+ *
+ * Returns the loaded 64-bit unsigned integer
+ **************************************************/
+static uint64_t load64(const uint8_t *x) {
+	uint64_t r = 0;
+	for (size_t i = 0; i < 8; ++i) {
+		r |= (uint64_t)x[i] << 8 * i;
+	}
+
+	return r;
+}
+
+/*************************************************
+ * Name:        store64
+ *
+ * Description: Store a 64-bit integer to a byte array in little-endian order
+ *
+ * Arguments:   - uint8_t *x: pointer to the output byte array
+ *              - uint64_t u: input 64-bit unsigned integer
+ **************************************************/
+static void store64(uint8_t *x, uint64_t u) {
+	for (size_t i = 0; i < 8; ++i) {
+		x[i] = (uint8_t) (u >> 8 * i);
+	}
+}
+
+/* Keccak round constants */
+static const uint64_t KeccakF_RoundConstants[NROUNDS] = {
+	0x0000000000000001ULL, 0x0000000000008082ULL,
+	0x800000000000808aULL, 0x8000000080008000ULL,
+	0x000000000000808bULL, 0x0000000080000001ULL,
+	0x8000000080008081ULL, 0x8000000000008009ULL,
+	0x000000000000008aULL, 0x0000000000000088ULL,
+	0x0000000080008009ULL, 0x000000008000000aULL,
+	0x000000008000808bULL, 0x800000000000008bULL,
+	0x8000000000008089ULL, 0x8000000000008003ULL,
+	0x8000000000008002ULL, 0x8000000000000080ULL,
+	0x000000000000800aULL, 0x800000008000000aULL,
+	0x8000000080008081ULL, 0x8000000000008080ULL,
+	0x0000000080000001ULL, 0x8000000080008008ULL
+};
+
+/*************************************************
+ * Name:        KeccakF1600_StatePermute
+ *
+ * Description: The Keccak F1600 Permutation
+ *
+ * Arguments:   - uint64_t *state: pointer to input/output Keccak state
+ **************************************************/
+static void KeccakF1600_StatePermute(uint64_t *state) {
+	int round;
+
+	uint64_t Aba, Abe, Abi, Abo, Abu;
+	uint64_t Aga, Age, Agi, Ago, Agu;
+	uint64_t Aka, Ake, Aki, Ako, Aku;
+	uint64_t Ama, Ame, Ami, Amo, Amu;
+	uint64_t Asa, Ase, Asi, Aso, Asu;
+	uint64_t BCa, BCe, BCi, BCo, BCu;
+	uint64_t Da, De, Di, Do, Du;
+	uint64_t Eba, Ebe, Ebi, Ebo, Ebu;
+	uint64_t Ega, Ege, Egi, Ego, Egu;
+	uint64_t Eka, Eke, Eki, Eko, Eku;
+	uint64_t Ema, Eme, Emi, Emo, Emu;
+	uint64_t Esa, Ese, Esi, Eso, Esu;
+
+	// copyFromState(A, state)
+	Aba = state[0];
+	Abe = state[1];
+	Abi = state[2];
+	Abo = state[3];
+	Abu = state[4];
+	Aga = state[5];
+	Age = state[6];
+	Agi = state[7];
+	Ago = state[8];
+	Agu = state[9];
+	Aka = state[10];
+	Ake = state[11];
+	Aki = state[12];
+	Ako = state[13];
+	Aku = state[14];
+	Ama = state[15];
+	Ame = state[16];
+	Ami = state[17];
+	Amo = state[18];
+	Amu = state[19];
+	Asa = state[20];
+	Ase = state[21];
+	Asi = state[22];
+	Aso = state[23];
+	Asu = state[24];
+
+	for (round = 0; round < NROUNDS; round += 2) {
+		//    prepareTheta
+		BCa = Aba ^ Aga ^ Aka ^ Ama ^ Asa;
+		BCe = Abe ^ Age ^ Ake ^ Ame ^ Ase;
+		BCi = Abi ^ Agi ^ Aki ^ Ami ^ Asi;
+		BCo = Abo ^ Ago ^ Ako ^ Amo ^ Aso;
+		BCu = Abu ^ Agu ^ Aku ^ Amu ^ Asu;
+
+		// thetaRhoPiChiIotaPrepareTheta(round  , A, E)
+		Da = BCu ^ ROL(BCe, 1);
+		De = BCa ^ ROL(BCi, 1);
+		Di = BCe ^ ROL(BCo, 1);
+		Do = BCi ^ ROL(BCu, 1);
+		Du = BCo ^ ROL(BCa, 1);
+
+		Aba ^= Da;
+		BCa = Aba;
+		Age ^= De;
+		BCe = ROL(Age, 44);
+		Aki ^= Di;
+		BCi = ROL(Aki, 43);
+		Amo ^= Do;
+		BCo = ROL(Amo, 21);
+		Asu ^= Du;
+		BCu = ROL(Asu, 14);
+		Eba = BCa ^ ((~BCe) & BCi);
+		Eba ^= KeccakF_RoundConstants[round];
+		Ebe = BCe ^ ((~BCi) & BCo);
+		Ebi = BCi ^ ((~BCo) & BCu);
+		Ebo = BCo ^ ((~BCu) & BCa);
+		Ebu = BCu ^ ((~BCa) & BCe);
+
+		Abo ^= Do;
+		BCa = ROL(Abo, 28);
+		Agu ^= Du;
+		BCe = ROL(Agu, 20);
+		Aka ^= Da;
+		BCi = ROL(Aka, 3);
+		Ame ^= De;
+		BCo = ROL(Ame, 45);
+		Asi ^= Di;
+		BCu = ROL(Asi, 61);
+		Ega = BCa ^ ((~BCe) & BCi);
+		Ege = BCe ^ ((~BCi) & BCo);
+		Egi = BCi ^ ((~BCo) & BCu);
+		Ego = BCo ^ ((~BCu) & BCa);
+		Egu = BCu ^ ((~BCa) & BCe);
+
+		Abe ^= De;
+		BCa = ROL(Abe, 1);
+		Agi ^= Di;
+		BCe = ROL(Agi, 6);
+		Ako ^= Do;
+		BCi = ROL(Ako, 25);
+		Amu ^= Du;
+		BCo = ROL(Amu, 8);
+		Asa ^= Da;
+		BCu = ROL(Asa, 18);
+		Eka = BCa ^ ((~BCe) & BCi);
+		Eke = BCe ^ ((~BCi) & BCo);
+		Eki = BCi ^ ((~BCo) & BCu);
+		Eko = BCo ^ ((~BCu) & BCa);
+		Eku = BCu ^ ((~BCa) & BCe);
+
+		Abu ^= Du;
+		BCa = ROL(Abu, 27);
+		Aga ^= Da;
+		BCe = ROL(Aga, 36);
+		Ake ^= De;
+		BCi = ROL(Ake, 10);
+		Ami ^= Di;
+		BCo = ROL(Ami, 15);
+		Aso ^= Do;
+		BCu = ROL(Aso, 56);
+		Ema = BCa ^ ((~BCe) & BCi);
+		Eme = BCe ^ ((~BCi) & BCo);
+		Emi = BCi ^ ((~BCo) & BCu);
+		Emo = BCo ^ ((~BCu) & BCa);
+		Emu = BCu ^ ((~BCa) & BCe);
+
+		Abi ^= Di;
+		BCa = ROL(Abi, 62);
+		Ago ^= Do;
+		BCe = ROL(Ago, 55);
+		Aku ^= Du;
+		BCi = ROL(Aku, 39);
+		Ama ^= Da;
+		BCo = ROL(Ama, 41);
+		Ase ^= De;
+		BCu = ROL(Ase, 2);
+		Esa = BCa ^ ((~BCe) & BCi);
+		Ese = BCe ^ ((~BCi) & BCo);
+		Esi = BCi ^ ((~BCo) & BCu);
+		Eso = BCo ^ ((~BCu) & BCa);
+		Esu = BCu ^ ((~BCa) & BCe);
+
+		//    prepareTheta
+		BCa = Eba ^ Ega ^ Eka ^ Ema ^ Esa;
+		BCe = Ebe ^ Ege ^ Eke ^ Eme ^ Ese;
+		BCi = Ebi ^ Egi ^ Eki ^ Emi ^ Esi;
+		BCo = Ebo ^ Ego ^ Eko ^ Emo ^ Eso;
+		BCu = Ebu ^ Egu ^ Eku ^ Emu ^ Esu;
+
+		// thetaRhoPiChiIotaPrepareTheta(round+1, E, A)
+		Da = BCu ^ ROL(BCe, 1);
+		De = BCa ^ ROL(BCi, 1);
+		Di = BCe ^ ROL(BCo, 1);
+		Do = BCi ^ ROL(BCu, 1);
+		Du = BCo ^ ROL(BCa, 1);
+
+		Eba ^= Da;
+		BCa = Eba;
+		Ege ^= De;
+		BCe = ROL(Ege, 44);
+		Eki ^= Di;
+		BCi = ROL(Eki, 43);
+		Emo ^= Do;
+		BCo = ROL(Emo, 21);
+		Esu ^= Du;
+		BCu = ROL(Esu, 14);
+		Aba = BCa ^ ((~BCe) & BCi);
+		Aba ^= KeccakF_RoundConstants[round + 1];
+		Abe = BCe ^ ((~BCi) & BCo);
+		Abi = BCi ^ ((~BCo) & BCu);
+		Abo = BCo ^ ((~BCu) & BCa);
+		Abu = BCu ^ ((~BCa) & BCe);
+
+		Ebo ^= Do;
+		BCa = ROL(Ebo, 28);
+		Egu ^= Du;
+		BCe = ROL(Egu, 20);
+		Eka ^= Da;
+		BCi = ROL(Eka, 3);
+		Eme ^= De;
+		BCo = ROL(Eme, 45);
+		Esi ^= Di;
+		BCu = ROL(Esi, 61);
+		Aga = BCa ^ ((~BCe) & BCi);
+		Age = BCe ^ ((~BCi) & BCo);
+		Agi = BCi ^ ((~BCo) & BCu);
+		Ago = BCo ^ ((~BCu) & BCa);
+		Agu = BCu ^ ((~BCa) & BCe);
+
+		Ebe ^= De;
+		BCa = ROL(Ebe, 1);
+		Egi ^= Di;
+		BCe = ROL(Egi, 6);
+		Eko ^= Do;
+		BCi = ROL(Eko, 25);
+		Emu ^= Du;
+		BCo = ROL(Emu, 8);
+		Esa ^= Da;
+		BCu = ROL(Esa, 18);
+		Aka = BCa ^ ((~BCe) & BCi);
+		Ake = BCe ^ ((~BCi) & BCo);
+		Aki = BCi ^ ((~BCo) & BCu);
+		Ako = BCo ^ ((~BCu) & BCa);
+		Aku = BCu ^ ((~BCa) & BCe);
+
+		Ebu ^= Du;
+		BCa = ROL(Ebu, 27);
+		Ega ^= Da;
+		BCe = ROL(Ega, 36);
+		Eke ^= De;
+		BCi = ROL(Eke, 10);
+		Emi ^= Di;
+		BCo = ROL(Emi, 15);
+		Eso ^= Do;
+		BCu = ROL(Eso, 56);
+		Ama = BCa ^ ((~BCe) & BCi);
+		Ame = BCe ^ ((~BCi) & BCo);
+		Ami = BCi ^ ((~BCo) & BCu);
+		Amo = BCo ^ ((~BCu) & BCa);
+		Amu = BCu ^ ((~BCa) & BCe);
+
+		Ebi ^= Di;
+		BCa = ROL(Ebi, 62);
+		Ego ^= Do;
+		BCe = ROL(Ego, 55);
+		Eku ^= Du;
+		BCi = ROL(Eku, 39);
+		Ema ^= Da;
+		BCo = ROL(Ema, 41);
+		Ese ^= De;
+		BCu = ROL(Ese, 2);
+		Asa = BCa ^ ((~BCe) & BCi);
+		Ase = BCe ^ ((~BCi) & BCo);
+		Asi = BCi ^ ((~BCo) & BCu);
+		Aso = BCo ^ ((~BCu) & BCa);
+		Asu = BCu ^ ((~BCa) & BCe);
+	}
+
+	// copyToState(state, A)
+	state[0] = Aba;
+	state[1] = Abe;
+	state[2] = Abi;
+	state[3] = Abo;
+	state[4] = Abu;
+	state[5] = Aga;
+	state[6] = Age;
+	state[7] = Agi;
+	state[8] = Ago;
+	state[9] = Agu;
+	state[10] = Aka;
+	state[11] = Ake;
+	state[12] = Aki;
+	state[13] = Ako;
+	state[14] = Aku;
+	state[15] = Ama;
+	state[16] = Ame;
+	state[17] = Ami;
+	state[18] = Amo;
+	state[19] = Amu;
+	state[20] = Asa;
+	state[21] = Ase;
+	state[22] = Asi;
+	state[23] = Aso;
+	state[24] = Asu;
+}
+
+/*************************************************
+ * Name:        keccak_absorb
+ *
+ * Description: Absorb step of Keccak;
+ *              non-incremental, starts by zeroeing the state.
+ *
+ * Arguments:   - uint64_t *s: pointer to (uninitialized) output Keccak state
+ *              - uint32_t r: rate in bytes (e.g., 168 for SHAKE128)
+ *              - const uint8_t *m: pointer to input to be absorbed into s
+ *              - size_t mlen: length of input in bytes
+ *              - uint8_t p: domain-separation byte for different
+ *                                 Keccak-derived functions
+ **************************************************/
+static void keccak_absorb(uint64_t *s, uint32_t r, const uint8_t *m,
+                          size_t mlen, uint8_t p) {
+	size_t i;
+	uint8_t t[200];
+
+	/* Zero state */
+	for (i = 0; i < 25; ++i) {
+		s[i] = 0;
+	}
+
+	while (mlen >= r) {
+		for (i = 0; i < r / 8; ++i) {
+			s[i] ^= load64(m + 8 * i);
+		}
+
+		KeccakF1600_StatePermute(s);
+		mlen -= r;
+		m += r;
+	}
+
+	for (i = 0; i < r; ++i) {
+		t[i] = 0;
+	}
+	for (i = 0; i < mlen; ++i) {
+		t[i] = m[i];
+	}
+	t[i] = p;
+	t[r - 1] |= 128;
+	for (i = 0; i < r / 8; ++i) {
+		s[i] ^= load64(t + 8 * i);
+	}
+}
+
+/*************************************************
+ * Name:        keccak_squeezeblocks
+ *
+ * Description: Squeeze step of Keccak. Squeezes full blocks of r bytes each.
+ *              Modifies the state. Can be called multiple times to keep
+ *              squeezing, i.e., is incremental.
+ *
+ * Arguments:   - uint8_t *h: pointer to output blocks
+ *              - size_t nblocks: number of blocks to be
+ *                                                squeezed (written to h)
+ *              - uint64_t *s: pointer to input/output Keccak state
+ *              - uint32_t r: rate in bytes (e.g., 168 for SHAKE128)
+ **************************************************/
+static void keccak_squeezeblocks(uint8_t *h, size_t nblocks,
+                                 uint64_t *s, uint32_t r) {
+	while (nblocks > 0) {
+		KeccakF1600_StatePermute(s);
+		for (size_t i = 0; i < (r >> 3); i++) {
+			store64(h + 8 * i, s[i]);
+		}
+		h += r;
+		nblocks--;
+	}
+}
+
+/*************************************************
+ * Name:        keccak_inc_init
+ *
+ * Description: Initializes the incremental Keccak state to zero.
+ *
+ * Arguments:   - uint64_t *s_inc: pointer to input/output incremental state
+ *                First 25 values represent Keccak state.
+ *                26th value represents either the number of absorbed bytes
+ *                that have not been permuted, or not-yet-squeezed bytes.
+ **************************************************/
+static void keccak_inc_init(uint64_t *s_inc) {
+	size_t i;
+
+	for (i = 0; i < 25; ++i) {
+		s_inc[i] = 0;
+	}
+	s_inc[25] = 0;
+}
+
+/*************************************************
+ * Name:        keccak_inc_absorb
+ *
+ * Description: Incremental keccak absorb
+ *              Preceded by keccak_inc_init, succeeded by keccak_inc_finalize
+ *
+ * Arguments:   - uint64_t *s_inc: pointer to input/output incremental state
+ *                First 25 values represent Keccak state.
+ *                26th value represents either the number of absorbed bytes
+ *                that have not been permuted, or not-yet-squeezed bytes.
+ *              - uint32_t r: rate in bytes (e.g., 168 for SHAKE128)
+ *              - const uint8_t *m: pointer to input to be absorbed into s
+ *              - size_t mlen: length of input in bytes
+ **************************************************/
+static void keccak_inc_absorb(uint64_t *s_inc, uint32_t r, const uint8_t *m,
+                              size_t mlen) {
+	size_t i;
+
+	/* Recall that s_inc[25] is the non-absorbed bytes xored into the state */
+	while (mlen + s_inc[25] >= r) {
+		for (i = 0; i < r - (uint32_t)s_inc[25]; i++) {
+			/* Take the i'th byte from message
+			   xor with the s_inc[25] + i'th byte of the state; little-endian */
+			s_inc[(s_inc[25] + i) >> 3] ^= (uint64_t)m[i] << (8 * ((s_inc[25] + i) & 0x07));
+		}
+		mlen -= (size_t)(r - s_inc[25]);
+		m += r - s_inc[25];
+		s_inc[25] = 0;
+
+		KeccakF1600_StatePermute(s_inc);
+	}
+
+	for (i = 0; i < mlen; i++) {
+		s_inc[(s_inc[25] + i) >> 3] ^= (uint64_t)m[i] << (8 * ((s_inc[25] + i) & 0x07));
+	}
+	s_inc[25] += mlen;
+}
+
+/*************************************************
+ * Name:        keccak_inc_finalize
+ *
+ * Description: Finalizes Keccak absorb phase, prepares for squeezing
+ *
+ * Arguments:   - uint64_t *s_inc: pointer to input/output incremental state
+ *                First 25 values represent Keccak state.
+ *                26th value represents either the number of absorbed bytes
+ *                that have not been permuted, or not-yet-squeezed bytes.
+ *              - uint32_t r: rate in bytes (e.g., 168 for SHAKE128)
+ *              - uint8_t p: domain-separation byte for different
+ *                                 Keccak-derived functions
+ **************************************************/
+static void keccak_inc_finalize(uint64_t *s_inc, uint32_t r, uint8_t p) {
+	/* After keccak_inc_absorb, we are guaranteed that s_inc[25] < r,
+	   so we can always use one more byte for p in the current state. */
+	s_inc[s_inc[25] >> 3] ^= (uint64_t)p << (8 * (s_inc[25] & 0x07));
+	s_inc[(r - 1) >> 3] ^= (uint64_t)128 << (8 * ((r - 1) & 0x07));
+	s_inc[25] = 0;
+}
+
+/*************************************************
+ * Name:        keccak_inc_squeeze
+ *
+ * Description: Incremental Keccak squeeze; can be called on byte-level
+ *
+ * Arguments:   - uint8_t *h: pointer to output bytes
+ *              - size_t outlen: number of bytes to be squeezed
+ *              - uint64_t *s_inc: pointer to input/output incremental state
+ *                First 25 values represent Keccak state.
+ *                26th value represents either the number of absorbed bytes
+ *                that have not been permuted, or not-yet-squeezed bytes.
+ *              - uint32_t r: rate in bytes (e.g., 168 for SHAKE128)
+ **************************************************/
+static void keccak_inc_squeeze(uint8_t *h, size_t outlen,
+                               uint64_t *s_inc, uint32_t r) {
+	size_t i;
+
+	/* First consume any bytes we still have sitting around */
+	for (i = 0; i < outlen && i < s_inc[25]; i++) {
+		/* There are s_inc[25] bytes left, so r - s_inc[25] is the first
+		   available byte. We consume from there, i.e., up to r. */
+		h[i] = (uint8_t)(s_inc[(r - s_inc[25] + i) >> 3] >> (8 * ((r - s_inc[25] + i) & 0x07)));
+	}
+	h += i;
+	outlen -= i;
+	s_inc[25] -= i;
+
+	/* Then squeeze the remaining necessary blocks */
+	while (outlen > 0) {
+		KeccakF1600_StatePermute(s_inc);
+
+		for (i = 0; i < outlen && i < r; i++) {
+			h[i] = (uint8_t)(s_inc[i >> 3] >> (8 * (i & 0x07)));
+		}
+		h += i;
+		outlen -= i;
+		s_inc[25] = r - i;
+	}
+}
+
+void shake128_inc_init(shake128incctx *state) {
+	state->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+	if (state->ctx == NULL) {
+		exit(111);
+	}
+	keccak_inc_init(state->ctx);
+}
+
+void shake128_inc_absorb(shake128incctx *state, const uint8_t *input, size_t inlen) {
+	keccak_inc_absorb(state->ctx, SHAKE128_RATE, input, inlen);
+}
+
+void shake128_inc_finalize(shake128incctx *state) {
+	keccak_inc_finalize(state->ctx, SHAKE128_RATE, 0x1F);
+}
+
+void shake128_inc_squeeze(uint8_t *output, size_t outlen, shake128incctx *state) {
+	keccak_inc_squeeze(output, outlen, state->ctx, SHAKE128_RATE);
+}
+
+void shake128_inc_ctx_clone(shake128incctx *dest, const shake128incctx *src) {
+	dest->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+	if (dest->ctx == NULL) {
+		exit(111);
+	}
+	memcpy(dest->ctx, src->ctx, PQC_SHAKEINCCTX_BYTES);
+}
+
+void shake128_inc_ctx_release(shake128incctx *state) {
+	free(state->ctx); // IGNORE free-check
+}
+
+void shake256_inc_init(shake256incctx *state) {
+	state->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+	if (state->ctx == NULL) {
+		exit(111);
+	}
+	keccak_inc_init(state->ctx);
+}
+
+void shake256_inc_absorb(shake256incctx *state, const uint8_t *input, size_t inlen) {
+	keccak_inc_absorb(state->ctx, SHAKE256_RATE, input, inlen);
+}
+
+void shake256_inc_finalize(shake256incctx *state) {
+	keccak_inc_finalize(state->ctx, SHAKE256_RATE, 0x1F);
+}
+
+void shake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state) {
+	keccak_inc_squeeze(output, outlen, state->ctx, SHAKE256_RATE);
+}
+
+void shake256_inc_ctx_clone(shake256incctx *dest, const shake256incctx *src) {
+	dest->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+	if (dest->ctx == NULL) {
+		exit(111);
+	}
+	memcpy(dest->ctx, src->ctx, PQC_SHAKEINCCTX_BYTES);
+}
+
+void shake256_inc_ctx_release(shake256incctx *state) {
+	free(state->ctx); // IGNORE free-check
+}
+
+
+/*************************************************
+ * Name:        shake128_absorb
+ *
+ * Description: Absorb step of the SHAKE128 XOF.
+ *              non-incremental, starts by zeroeing the state.
+ *
+ * Arguments:   - uint64_t *s: pointer to (uninitialized) output Keccak state
+ *              - const uint8_t *input: pointer to input to be absorbed
+ *                                            into s
+ *              - size_t inlen: length of input in bytes
+ **************************************************/
+void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen) {
+	state->ctx = malloc(PQC_SHAKECTX_BYTES);
+	if (state->ctx == NULL) {
+		exit(111);
+	}
+	keccak_absorb(state->ctx, SHAKE128_RATE, input, inlen, 0x1F);
+}
+
+/*************************************************
+ * Name:        shake128_squeezeblocks
+ *
+ * Description: Squeeze step of SHAKE128 XOF. Squeezes full blocks of
+ *              SHAKE128_RATE bytes each. Modifies the state. Can be called
+ *              multiple times to keep squeezing, i.e., is incremental.
+ *
+ * Arguments:   - uint8_t *output: pointer to output blocks
+ *              - size_t nblocks: number of blocks to be squeezed
+ *                                            (written to output)
+ *              - shake128ctx *state: pointer to input/output Keccak state
+ **************************************************/
+void shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state) {
+	keccak_squeezeblocks(output, nblocks, state->ctx, SHAKE128_RATE);
+}
+
+void shake128_ctx_clone(shake128ctx *dest, const shake128ctx *src) {
+	dest->ctx = malloc(PQC_SHAKECTX_BYTES);
+	if (dest->ctx == NULL) {
+		exit(111);
+	}
+	memcpy(dest->ctx, src->ctx, PQC_SHAKECTX_BYTES);
+}
+
+/** Release the allocated state. Call only once. */
+void shake128_ctx_release(shake128ctx *state) {
+	free(state->ctx); // IGNORE free-check
+}
+
+/*************************************************
+ * Name:        shake256_absorb
+ *
+ * Description: Absorb step of the SHAKE256 XOF.
+ *              non-incremental, starts by zeroeing the state.
+ *
+ * Arguments:   - shake256ctx *state: pointer to (uninitialized) output Keccak state
+ *              - const uint8_t *input: pointer to input to be absorbed
+ *                                            into s
+ *              - size_t inlen: length of input in bytes
+ **************************************************/
+void shake256_absorb(shake256ctx *state, const uint8_t *input, size_t inlen) {
+	state->ctx = malloc(PQC_SHAKECTX_BYTES);
+	if (state->ctx == NULL) {
+		exit(111);
+	}
+	keccak_absorb(state->ctx, SHAKE256_RATE, input, inlen, 0x1F);
+}
+
+/*************************************************
+ * Name:        shake256_squeezeblocks
+ *
+ * Description: Squeeze step of SHAKE256 XOF. Squeezes full blocks of
+ *              SHAKE256_RATE bytes each. Modifies the state. Can be called
+ *              multiple times to keep squeezing, i.e., is incremental.
+ *
+ * Arguments:   - uint8_t *output: pointer to output blocks
+ *              - size_t nblocks: number of blocks to be squeezed
+ *                                (written to output)
+ *              - shake256ctx *state: pointer to input/output Keccak state
+ **************************************************/
+void shake256_squeezeblocks(uint8_t *output, size_t nblocks, shake256ctx *state) {
+	keccak_squeezeblocks(output, nblocks, state->ctx, SHAKE256_RATE);
+}
+
+void shake256_ctx_clone(shake256ctx *dest, const shake256ctx *src) {
+	dest->ctx = malloc(PQC_SHAKECTX_BYTES);
+	if (dest->ctx == NULL) {
+		exit(111);
+	}
+	memcpy(dest->ctx, src->ctx, PQC_SHAKECTX_BYTES);
+}
+
+/** Release the allocated state. Call only once. */
+void shake256_ctx_release(shake256ctx *state) {
+	free(state->ctx); // IGNORE free-check
+}
+
+/*************************************************
+ * Name:        shake128
+ *
+ * Description: SHAKE128 XOF with non-incremental API
+ *
+ * Arguments:   - uint8_t *output: pointer to output
+ *              - size_t outlen: requested output length in bytes
+ *              - const uint8_t *input: pointer to input
+ *              - size_t inlen: length of input in bytes
+ **************************************************/
+void shake128(uint8_t *output, size_t outlen,
+              const uint8_t *input, size_t inlen) {
+	size_t nblocks = outlen / SHAKE128_RATE;
+	uint8_t t[SHAKE128_RATE];
+	shake128ctx s;
+
+	shake128_absorb(&s, input, inlen);
+	shake128_squeezeblocks(output, nblocks, &s);
+
+	output += nblocks * SHAKE128_RATE;
+	outlen -= nblocks * SHAKE128_RATE;
+
+	if (outlen) {
+		shake128_squeezeblocks(t, 1, &s);
+		for (size_t i = 0; i < outlen; ++i) {
+			output[i] = t[i];
+		}
+	}
+	shake128_ctx_release(&s);
+}
+
+/*************************************************
+ * Name:        shake256
+ *
+ * Description: SHAKE256 XOF with non-incremental API
+ *
+ * Arguments:   - uint8_t *output: pointer to output
+ *              - size_t outlen: requested output length in bytes
+ *              - const uint8_t *input: pointer to input
+ *              - size_t inlen: length of input in bytes
+ **************************************************/
+void shake256(uint8_t *output, size_t outlen,
+              const uint8_t *input, size_t inlen) {
+	size_t nblocks = outlen / SHAKE256_RATE;
+	uint8_t t[SHAKE256_RATE];
+	shake256ctx s;
+
+	shake256_absorb(&s, input, inlen);
+	shake256_squeezeblocks(output, nblocks, &s);
+
+	output += nblocks * SHAKE256_RATE;
+	outlen -= nblocks * SHAKE256_RATE;
+
+	if (outlen) {
+		shake256_squeezeblocks(t, 1, &s);
+		for (size_t i = 0; i < outlen; ++i) {
+			output[i] = t[i];
+		}
+	}
+	shake256_ctx_release(&s);
+}
+
+void sha3_256_inc_init(sha3_256incctx *state) {
+	state->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+	if (state->ctx == NULL) {
+		exit(111);
+	}
+	keccak_inc_init(state->ctx);
+}
+
+void sha3_256_inc_ctx_clone(sha3_256incctx *dest, const sha3_256incctx *src) {
+	dest->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+	if (dest->ctx == NULL) {
+		exit(111);
+	}
+	memcpy(dest->ctx, src->ctx, PQC_SHAKEINCCTX_BYTES);
+}
+
+void sha3_256_inc_ctx_release(sha3_256incctx *state) {
+	free(state->ctx); // IGNORE free-check
+}
+
+void sha3_256_inc_absorb(sha3_256incctx *state, const uint8_t *input, size_t inlen) {
+	keccak_inc_absorb(state->ctx, SHA3_256_RATE, input, inlen);
+}
+
+void sha3_256_inc_finalize(uint8_t *output, sha3_256incctx *state) {
+	uint8_t t[SHA3_256_RATE];
+	keccak_inc_finalize(state->ctx, SHA3_256_RATE, 0x06);
+
+	keccak_squeezeblocks(t, 1, state->ctx, SHA3_256_RATE);
+
+	sha3_256_inc_ctx_release(state);
+
+	for (size_t i = 0; i < 32; i++) {
+		output[i] = t[i];
+	}
+}
+
+/*************************************************
+ * Name:        sha3_256
+ *
+ * Description: SHA3-256 with non-incremental API
+ *
+ * Arguments:   - uint8_t *output:      pointer to output
+ *              - const uint8_t *input: pointer to input
+ *              - size_t inlen:   length of input in bytes
+ **************************************************/
+void sha3_256(uint8_t *output, const uint8_t *input, size_t inlen) {
+	uint64_t s[25];
+	uint8_t t[SHA3_256_RATE];
+
+	/* Absorb input */
+	keccak_absorb(s, SHA3_256_RATE, input, inlen, 0x06);
+
+	/* Squeeze output */
+	keccak_squeezeblocks(t, 1, s, SHA3_256_RATE);
+
+	for (size_t i = 0; i < 32; i++) {
+		output[i] = t[i];
+	}
+}
+
+void sha3_384_inc_init(sha3_384incctx *state) {
+	state->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+	if (state->ctx == NULL) {
+		exit(111);
+	}
+	keccak_inc_init(state->ctx);
+}
+
+void sha3_384_inc_ctx_clone(sha3_384incctx *dest, const sha3_384incctx *src) {
+	dest->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+	if (dest->ctx == NULL) {
+		exit(111);
+	}
+	memcpy(dest->ctx, src->ctx, PQC_SHAKEINCCTX_BYTES);
+}
+
+void sha3_384_inc_absorb(sha3_384incctx *state, const uint8_t *input, size_t inlen) {
+	keccak_inc_absorb(state->ctx, SHA3_384_RATE, input, inlen);
+}
+
+void sha3_384_inc_ctx_release(sha3_384incctx *state) {
+	free(state->ctx); // IGNORE free-check
+}
+
+void sha3_384_inc_finalize(uint8_t *output, sha3_384incctx *state) {
+	uint8_t t[SHA3_384_RATE];
+	keccak_inc_finalize(state->ctx, SHA3_384_RATE, 0x06);
+
+	keccak_squeezeblocks(t, 1, state->ctx, SHA3_384_RATE);
+
+	sha3_384_inc_ctx_release(state);
+
+	for (size_t i = 0; i < 48; i++) {
+		output[i] = t[i];
+	}
+}
+
+/*************************************************
+ * Name:        sha3_384
+ *
+ * Description: SHA3-256 with non-incremental API
+ *
+ * Arguments:   - uint8_t *output:      pointer to output
+ *              - const uint8_t *input: pointer to input
+ *              - size_t inlen:   length of input in bytes
+ **************************************************/
+void sha3_384(uint8_t *output, const uint8_t *input, size_t inlen) {
+	uint64_t s[25];
+	uint8_t t[SHA3_384_RATE];
+
+	/* Absorb input */
+	keccak_absorb(s, SHA3_384_RATE, input, inlen, 0x06);
+
+	/* Squeeze output */
+	keccak_squeezeblocks(t, 1, s, SHA3_384_RATE);
+
+	for (size_t i = 0; i < 48; i++) {
+		output[i] = t[i];
+	}
+}
+
+void sha3_512_inc_init(sha3_512incctx *state) {
+	state->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+	if (state->ctx == NULL) {
+		exit(111);
+	}
+	keccak_inc_init(state->ctx);
+}
+
+void sha3_512_inc_ctx_clone(sha3_512incctx *dest, const sha3_512incctx *src) {
+	dest->ctx = malloc(PQC_SHAKEINCCTX_BYTES);
+	if (dest->ctx == NULL) {
+		exit(111);
+	}
+	memcpy(dest->ctx, src->ctx, PQC_SHAKEINCCTX_BYTES);
+}
+
+void sha3_512_inc_absorb(sha3_512incctx *state, const uint8_t *input, size_t inlen) {
+	keccak_inc_absorb(state->ctx, SHA3_512_RATE, input, inlen);
+}
+
+void sha3_512_inc_ctx_release(sha3_512incctx *state) {
+	free(state->ctx); // IGNORE free-check
+}
+
+void sha3_512_inc_finalize(uint8_t *output, sha3_512incctx *state) {
+	uint8_t t[SHA3_512_RATE];
+	keccak_inc_finalize(state->ctx, SHA3_512_RATE, 0x06);
+
+	keccak_squeezeblocks(t, 1, state->ctx, SHA3_512_RATE);
+
+	sha3_512_inc_ctx_release(state);
+
+	for (size_t i = 0; i < 64; i++) {
+		output[i] = t[i];
+	}
+}
+
+/*************************************************
+ * Name:        sha3_512
+ *
+ * Description: SHA3-512 with non-incremental API
+ *
+ * Arguments:   - uint8_t *output:      pointer to output
+ *              - const uint8_t *input: pointer to input
+ *              - size_t inlen:   length of input in bytes
+ **************************************************/
+void sha3_512(uint8_t *output, const uint8_t *input, size_t inlen) {
+	uint64_t s[25];
+	uint8_t t[SHA3_512_RATE];
+
+	/* Absorb input */
+	keccak_absorb(s, SHA3_512_RATE, input, inlen, 0x06);
+
+	/* Squeeze output */
+	keccak_squeezeblocks(t, 1, s, SHA3_512_RATE);
+
+	for (size_t i = 0; i < 64; i++) {
+		output[i] = t[i];
+	}
+}

--- a/src/common_avx2/sha3/keccak4x/KeccakP-1600-times4-SIMD256.c
+++ b/src/common_avx2/sha3/keccak4x/KeccakP-1600-times4-SIMD256.c
@@ -1,0 +1,425 @@
+/*
+Implementation by the Keccak, Keyak and Ketje Teams, namely, Guido Bertoni,
+Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer, hereby
+denoted as "the implementer".
+
+For more information, feedback or questions, please refer to our websites:
+http://keccak.noekeon.org/
+http://keyak.noekeon.org/
+http://ketje.noekeon.org/
+
+To the extent possible under law, the implementer has waived all copyright
+and related or neighboring rights to the source code in this file.
+http://creativecommons.org/publicdomain/zero/1.0/
+*/
+
+/* Simplified for liboqs: remove code that wasn't used in shake128_4x */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <smmintrin.h>
+#include <wmmintrin.h>
+#include <immintrin.h>
+#include <emmintrin.h>
+#include "align.h"
+#include "KeccakP-1600-times4-SnP.h"
+#include "SIMD256-config.h"
+
+#include "brg_endian.h"
+#if (PLATFORM_BYTE_ORDER != IS_LITTLE_ENDIAN)
+#error Expecting a little-endian platform
+#endif
+
+typedef unsigned char UINT8;
+typedef unsigned long long int UINT64;
+typedef __m128i V128;
+typedef __m256i V256;
+
+#define laneIndex(instanceIndex, lanePosition) ((lanePosition) *4 + instanceIndex)
+
+#if defined(KeccakP1600times4_useAVX2)
+#define ANDnu256(a, b) _mm256_andnot_si256(a, b)
+#define CONST256(a) _mm256_load_si256((const V256 *) &(a))
+#define CONST256_64(a) _mm256_castpd_si256(_mm256_broadcast_sd((const double *) (&a)))
+#define LOAD256(a) _mm256_load_si256((const V256 *) &(a))
+#define LOAD256u(a) _mm256_loadu_si256((const V256 *) &(a))
+#define LOAD4_64(a, b, c, d) _mm256_set_epi64x((UINT64)(a), (UINT64)(b), (UINT64)(c), (UINT64)(d))
+#define ROL64in256(d, a, o) d = _mm256_or_si256(_mm256_slli_epi64(a, o), _mm256_srli_epi64(a, 64 - (o)))
+#define ROL64in256_8(d, a) d = _mm256_shuffle_epi8(a, CONST256(rho8))
+#define ROL64in256_56(d, a) d = _mm256_shuffle_epi8(a, CONST256(rho56))
+static const UINT64 rho8[4] = {0x0605040302010007, 0x0E0D0C0B0A09080F, 0x1615141312111017, 0x1E1D1C1B1A19181F};
+static const UINT64 rho56[4] = {0x0007060504030201, 0x080F0E0D0C0B0A09, 0x1017161514131211, 0x181F1E1D1C1B1A19};
+#define STORE256(a, b) _mm256_store_si256((V256 *) &(a), b)
+#define STORE256u(a, b) _mm256_storeu_si256((V256 *) &(a), b)
+#define STORE2_128(ah, al, v) _mm256_storeu2_m128d((V128 *) &(ah), (V128 *) &(al), v)
+#define XOR256(a, b) _mm256_xor_si256(a, b)
+#define XOReq256(a, b) a = _mm256_xor_si256(a, b)
+#define UNPACKL(a, b) _mm256_unpacklo_epi64((a), (b))
+#define UNPACKH(a, b) _mm256_unpackhi_epi64((a), (b))
+#define PERM128(a, b, c) (V256) _mm256_permute2f128_ps((__m256)(a), (__m256)(b), c)
+#define SHUFFLE64(a, b, c) (V256) _mm256_shuffle_pd((__m256d)(a), (__m256d)(b), c)
+
+#define UNINTLEAVE() lanesL01 = UNPACKL(lanes0, lanes1),         \
+                     lanesH01 = UNPACKH(lanes0, lanes1),         \
+                     lanesL23 = UNPACKL(lanes2, lanes3),         \
+                     lanesH23 = UNPACKH(lanes2, lanes3),         \
+                     lanes0 = PERM128(lanesL01, lanesL23, 0x20), \
+                     lanes2 = PERM128(lanesL01, lanesL23, 0x31), \
+                     lanes1 = PERM128(lanesH01, lanesH23, 0x20), \
+                     lanes3 = PERM128(lanesH01, lanesH23, 0x31)
+
+#define INTLEAVE() lanesL01 = PERM128(lanes0, lanes2, 0x20),     \
+                   lanesH01 = PERM128(lanes1, lanes3, 0x20),     \
+                   lanesL23 = PERM128(lanes0, lanes2, 0x31),     \
+                   lanesH23 = PERM128(lanes1, lanes3, 0x31),     \
+                   lanes0 = SHUFFLE64(lanesL01, lanesH01, 0x00), \
+                   lanes1 = SHUFFLE64(lanesL01, lanesH01, 0x0F), \
+                   lanes2 = SHUFFLE64(lanesL23, lanesH23, 0x00), \
+                   lanes3 = SHUFFLE64(lanesL23, lanesH23, 0x0F)
+
+#endif
+
+#define SnP_laneLengthInBytes 8
+
+#define declareABCDE              \
+    V256 Aba, Abe, Abi, Abo, Abu; \
+    V256 Aga, Age, Agi, Ago, Agu; \
+    V256 Aka, Ake, Aki, Ako, Aku; \
+    V256 Ama, Ame, Ami, Amo, Amu; \
+    V256 Asa, Ase, Asi, Aso, Asu; \
+    V256 Bba, Bbe, Bbi, Bbo, Bbu; \
+    V256 Bga, Bge, Bgi, Bgo, Bgu; \
+    V256 Bka, Bke, Bki, Bko, Bku; \
+    V256 Bma, Bme, Bmi, Bmo, Bmu; \
+    V256 Bsa, Bse, Bsi, Bso, Bsu; \
+    V256 Ca, Ce, Ci, Co, Cu;      \
+    V256 Ca1, Ce1, Ci1, Co1, Cu1; \
+    V256 Da, De, Di, Do, Du;      \
+    V256 Eba, Ebe, Ebi, Ebo, Ebu; \
+    V256 Ega, Ege, Egi, Ego, Egu; \
+    V256 Eka, Eke, Eki, Eko, Eku; \
+    V256 Ema, Eme, Emi, Emo, Emu; \
+    V256 Esa, Ese, Esi, Eso, Esu;
+
+#define prepareTheta                                              \
+    Ca = XOR256(Aba, XOR256(Aga, XOR256(Aka, XOR256(Ama, Asa)))); \
+    Ce = XOR256(Abe, XOR256(Age, XOR256(Ake, XOR256(Ame, Ase)))); \
+    Ci = XOR256(Abi, XOR256(Agi, XOR256(Aki, XOR256(Ami, Asi)))); \
+    Co = XOR256(Abo, XOR256(Ago, XOR256(Ako, XOR256(Amo, Aso)))); \
+    Cu = XOR256(Abu, XOR256(Agu, XOR256(Aku, XOR256(Amu, Asu))));
+
+/* --- Theta Rho Pi Chi Iota Prepare-theta */
+/* --- 64-bit lanes mapped to 64-bit words */
+#define thetaRhoPiChiIotaPrepareTheta(i, A, E)                  \
+    ROL64in256(Ce1, Ce, 1);                                     \
+    Da = XOR256(Cu, Ce1);                                       \
+    ROL64in256(Ci1, Ci, 1);                                     \
+    De = XOR256(Ca, Ci1);                                       \
+    ROL64in256(Co1, Co, 1);                                     \
+    Di = XOR256(Ce, Co1);                                       \
+    ROL64in256(Cu1, Cu, 1);                                     \
+    Do = XOR256(Ci, Cu1);                                       \
+    ROL64in256(Ca1, Ca, 1);                                     \
+    Du = XOR256(Co, Ca1);                                       \
+                                                                \
+    XOReq256(A##ba, Da);                                        \
+    Bba = A##ba;                                                \
+    XOReq256(A##ge, De);                                        \
+    ROL64in256(Bbe, A##ge, 44);                                 \
+    XOReq256(A##ki, Di);                                        \
+    ROL64in256(Bbi, A##ki, 43);                                 \
+    E##ba = XOR256(Bba, ANDnu256(Bbe, Bbi));                    \
+    XOReq256(E##ba, CONST256_64(KeccakF1600RoundConstants[i])); \
+    Ca = E##ba;                                                 \
+    XOReq256(A##mo, Do);                                        \
+    ROL64in256(Bbo, A##mo, 21);                                 \
+    E##be = XOR256(Bbe, ANDnu256(Bbi, Bbo));                    \
+    Ce = E##be;                                                 \
+    XOReq256(A##su, Du);                                        \
+    ROL64in256(Bbu, A##su, 14);                                 \
+    E##bi = XOR256(Bbi, ANDnu256(Bbo, Bbu));                    \
+    Ci = E##bi;                                                 \
+    E##bo = XOR256(Bbo, ANDnu256(Bbu, Bba));                    \
+    Co = E##bo;                                                 \
+    E##bu = XOR256(Bbu, ANDnu256(Bba, Bbe));                    \
+    Cu = E##bu;                                                 \
+                                                                \
+    XOReq256(A##bo, Do);                                        \
+    ROL64in256(Bga, A##bo, 28);                                 \
+    XOReq256(A##gu, Du);                                        \
+    ROL64in256(Bge, A##gu, 20);                                 \
+    XOReq256(A##ka, Da);                                        \
+    ROL64in256(Bgi, A##ka, 3);                                  \
+    E##ga = XOR256(Bga, ANDnu256(Bge, Bgi));                    \
+    XOReq256(Ca, E##ga);                                        \
+    XOReq256(A##me, De);                                        \
+    ROL64in256(Bgo, A##me, 45);                                 \
+    E##ge = XOR256(Bge, ANDnu256(Bgi, Bgo));                    \
+    XOReq256(Ce, E##ge);                                        \
+    XOReq256(A##si, Di);                                        \
+    ROL64in256(Bgu, A##si, 61);                                 \
+    E##gi = XOR256(Bgi, ANDnu256(Bgo, Bgu));                    \
+    XOReq256(Ci, E##gi);                                        \
+    E##go = XOR256(Bgo, ANDnu256(Bgu, Bga));                    \
+    XOReq256(Co, E##go);                                        \
+    E##gu = XOR256(Bgu, ANDnu256(Bga, Bge));                    \
+    XOReq256(Cu, E##gu);                                        \
+                                                                \
+    XOReq256(A##be, De);                                        \
+    ROL64in256(Bka, A##be, 1);                                  \
+    XOReq256(A##gi, Di);                                        \
+    ROL64in256(Bke, A##gi, 6);                                  \
+    XOReq256(A##ko, Do);                                        \
+    ROL64in256(Bki, A##ko, 25);                                 \
+    E##ka = XOR256(Bka, ANDnu256(Bke, Bki));                    \
+    XOReq256(Ca, E##ka);                                        \
+    XOReq256(A##mu, Du);                                        \
+    ROL64in256_8(Bko, A##mu);                                   \
+    E##ke = XOR256(Bke, ANDnu256(Bki, Bko));                    \
+    XOReq256(Ce, E##ke);                                        \
+    XOReq256(A##sa, Da);                                        \
+    ROL64in256(Bku, A##sa, 18);                                 \
+    E##ki = XOR256(Bki, ANDnu256(Bko, Bku));                    \
+    XOReq256(Ci, E##ki);                                        \
+    E##ko = XOR256(Bko, ANDnu256(Bku, Bka));                    \
+    XOReq256(Co, E##ko);                                        \
+    E##ku = XOR256(Bku, ANDnu256(Bka, Bke));                    \
+    XOReq256(Cu, E##ku);                                        \
+                                                                \
+    XOReq256(A##bu, Du);                                        \
+    ROL64in256(Bma, A##bu, 27);                                 \
+    XOReq256(A##ga, Da);                                        \
+    ROL64in256(Bme, A##ga, 36);                                 \
+    XOReq256(A##ke, De);                                        \
+    ROL64in256(Bmi, A##ke, 10);                                 \
+    E##ma = XOR256(Bma, ANDnu256(Bme, Bmi));                    \
+    XOReq256(Ca, E##ma);                                        \
+    XOReq256(A##mi, Di);                                        \
+    ROL64in256(Bmo, A##mi, 15);                                 \
+    E##me = XOR256(Bme, ANDnu256(Bmi, Bmo));                    \
+    XOReq256(Ce, E##me);                                        \
+    XOReq256(A##so, Do);                                        \
+    ROL64in256_56(Bmu, A##so);                                  \
+    E##mi = XOR256(Bmi, ANDnu256(Bmo, Bmu));                    \
+    XOReq256(Ci, E##mi);                                        \
+    E##mo = XOR256(Bmo, ANDnu256(Bmu, Bma));                    \
+    XOReq256(Co, E##mo);                                        \
+    E##mu = XOR256(Bmu, ANDnu256(Bma, Bme));                    \
+    XOReq256(Cu, E##mu);                                        \
+                                                                \
+    XOReq256(A##bi, Di);                                        \
+    ROL64in256(Bsa, A##bi, 62);                                 \
+    XOReq256(A##go, Do);                                        \
+    ROL64in256(Bse, A##go, 55);                                 \
+    XOReq256(A##ku, Du);                                        \
+    ROL64in256(Bsi, A##ku, 39);                                 \
+    E##sa = XOR256(Bsa, ANDnu256(Bse, Bsi));                    \
+    XOReq256(Ca, E##sa);                                        \
+    XOReq256(A##ma, Da);                                        \
+    ROL64in256(Bso, A##ma, 41);                                 \
+    E##se = XOR256(Bse, ANDnu256(Bsi, Bso));                    \
+    XOReq256(Ce, E##se);                                        \
+    XOReq256(A##se, De);                                        \
+    ROL64in256(Bsu, A##se, 2);                                  \
+    E##si = XOR256(Bsi, ANDnu256(Bso, Bsu));                    \
+    XOReq256(Ci, E##si);                                        \
+    E##so = XOR256(Bso, ANDnu256(Bsu, Bsa));                    \
+    XOReq256(Co, E##so);                                        \
+    E##su = XOR256(Bsu, ANDnu256(Bsa, Bse));                    \
+    XOReq256(Cu, E##su);
+
+/* --- Theta Rho Pi Chi Iota */
+/* --- 64-bit lanes mapped to 64-bit words */
+#define thetaRhoPiChiIota(i, A, E)                              \
+    ROL64in256(Ce1, Ce, 1);                                     \
+    Da = XOR256(Cu, Ce1);                                       \
+    ROL64in256(Ci1, Ci, 1);                                     \
+    De = XOR256(Ca, Ci1);                                       \
+    ROL64in256(Co1, Co, 1);                                     \
+    Di = XOR256(Ce, Co1);                                       \
+    ROL64in256(Cu1, Cu, 1);                                     \
+    Do = XOR256(Ci, Cu1);                                       \
+    ROL64in256(Ca1, Ca, 1);                                     \
+    Du = XOR256(Co, Ca1);                                       \
+                                                                \
+    XOReq256(A##ba, Da);                                        \
+    Bba = A##ba;                                                \
+    XOReq256(A##ge, De);                                        \
+    ROL64in256(Bbe, A##ge, 44);                                 \
+    XOReq256(A##ki, Di);                                        \
+    ROL64in256(Bbi, A##ki, 43);                                 \
+    E##ba = XOR256(Bba, ANDnu256(Bbe, Bbi));                    \
+    XOReq256(E##ba, CONST256_64(KeccakF1600RoundConstants[i])); \
+    XOReq256(A##mo, Do);                                        \
+    ROL64in256(Bbo, A##mo, 21);                                 \
+    E##be = XOR256(Bbe, ANDnu256(Bbi, Bbo));                    \
+    XOReq256(A##su, Du);                                        \
+    ROL64in256(Bbu, A##su, 14);                                 \
+    E##bi = XOR256(Bbi, ANDnu256(Bbo, Bbu));                    \
+    E##bo = XOR256(Bbo, ANDnu256(Bbu, Bba));                    \
+    E##bu = XOR256(Bbu, ANDnu256(Bba, Bbe));                    \
+                                                                \
+    XOReq256(A##bo, Do);                                        \
+    ROL64in256(Bga, A##bo, 28);                                 \
+    XOReq256(A##gu, Du);                                        \
+    ROL64in256(Bge, A##gu, 20);                                 \
+    XOReq256(A##ka, Da);                                        \
+    ROL64in256(Bgi, A##ka, 3);                                  \
+    E##ga = XOR256(Bga, ANDnu256(Bge, Bgi));                    \
+    XOReq256(A##me, De);                                        \
+    ROL64in256(Bgo, A##me, 45);                                 \
+    E##ge = XOR256(Bge, ANDnu256(Bgi, Bgo));                    \
+    XOReq256(A##si, Di);                                        \
+    ROL64in256(Bgu, A##si, 61);                                 \
+    E##gi = XOR256(Bgi, ANDnu256(Bgo, Bgu));                    \
+    E##go = XOR256(Bgo, ANDnu256(Bgu, Bga));                    \
+    E##gu = XOR256(Bgu, ANDnu256(Bga, Bge));                    \
+                                                                \
+    XOReq256(A##be, De);                                        \
+    ROL64in256(Bka, A##be, 1);                                  \
+    XOReq256(A##gi, Di);                                        \
+    ROL64in256(Bke, A##gi, 6);                                  \
+    XOReq256(A##ko, Do);                                        \
+    ROL64in256(Bki, A##ko, 25);                                 \
+    E##ka = XOR256(Bka, ANDnu256(Bke, Bki));                    \
+    XOReq256(A##mu, Du);                                        \
+    ROL64in256_8(Bko, A##mu);                                   \
+    E##ke = XOR256(Bke, ANDnu256(Bki, Bko));                    \
+    XOReq256(A##sa, Da);                                        \
+    ROL64in256(Bku, A##sa, 18);                                 \
+    E##ki = XOR256(Bki, ANDnu256(Bko, Bku));                    \
+    E##ko = XOR256(Bko, ANDnu256(Bku, Bka));                    \
+    E##ku = XOR256(Bku, ANDnu256(Bka, Bke));                    \
+                                                                \
+    XOReq256(A##bu, Du);                                        \
+    ROL64in256(Bma, A##bu, 27);                                 \
+    XOReq256(A##ga, Da);                                        \
+    ROL64in256(Bme, A##ga, 36);                                 \
+    XOReq256(A##ke, De);                                        \
+    ROL64in256(Bmi, A##ke, 10);                                 \
+    E##ma = XOR256(Bma, ANDnu256(Bme, Bmi));                    \
+    XOReq256(A##mi, Di);                                        \
+    ROL64in256(Bmo, A##mi, 15);                                 \
+    E##me = XOR256(Bme, ANDnu256(Bmi, Bmo));                    \
+    XOReq256(A##so, Do);                                        \
+    ROL64in256_56(Bmu, A##so);                                  \
+    E##mi = XOR256(Bmi, ANDnu256(Bmo, Bmu));                    \
+    E##mo = XOR256(Bmo, ANDnu256(Bmu, Bma));                    \
+    E##mu = XOR256(Bmu, ANDnu256(Bma, Bme));                    \
+                                                                \
+    XOReq256(A##bi, Di);                                        \
+    ROL64in256(Bsa, A##bi, 62);                                 \
+    XOReq256(A##go, Do);                                        \
+    ROL64in256(Bse, A##go, 55);                                 \
+    XOReq256(A##ku, Du);                                        \
+    ROL64in256(Bsi, A##ku, 39);                                 \
+    E##sa = XOR256(Bsa, ANDnu256(Bse, Bsi));                    \
+    XOReq256(A##ma, Da);                                        \
+    ROL64in256(Bso, A##ma, 41);                                 \
+    E##se = XOR256(Bse, ANDnu256(Bsi, Bso));                    \
+    XOReq256(A##se, De);                                        \
+    ROL64in256(Bsu, A##se, 2);                                  \
+    E##si = XOR256(Bsi, ANDnu256(Bso, Bsu));                    \
+    E##so = XOR256(Bso, ANDnu256(Bsu, Bsa));                    \
+    E##su = XOR256(Bsu, ANDnu256(Bsa, Bse));
+
+static ALIGN(KeccakP1600times4_statesAlignment) const UINT64 KeccakF1600RoundConstants[24] = {
+	0x0000000000000001ULL,
+	0x0000000000008082ULL,
+	0x800000000000808aULL,
+	0x8000000080008000ULL,
+	0x000000000000808bULL,
+	0x0000000080000001ULL,
+	0x8000000080008081ULL,
+	0x8000000000008009ULL,
+	0x000000000000008aULL,
+	0x0000000000000088ULL,
+	0x0000000080008009ULL,
+	0x000000008000000aULL,
+	0x000000008000808bULL,
+	0x800000000000008bULL,
+	0x8000000000008089ULL,
+	0x8000000000008003ULL,
+	0x8000000000008002ULL,
+	0x8000000000000080ULL,
+	0x000000000000800aULL,
+	0x800000008000000aULL,
+	0x8000000080008081ULL,
+	0x8000000000008080ULL,
+	0x0000000080000001ULL,
+	0x8000000080008008ULL
+};
+
+#define copyFromState(X, state) \
+    X##ba = LOAD256(state[0]);  \
+    X##be = LOAD256(state[1]);  \
+    X##bi = LOAD256(state[2]);  \
+    X##bo = LOAD256(state[3]);  \
+    X##bu = LOAD256(state[4]);  \
+    X##ga = LOAD256(state[5]);  \
+    X##ge = LOAD256(state[6]);  \
+    X##gi = LOAD256(state[7]);  \
+    X##go = LOAD256(state[8]);  \
+    X##gu = LOAD256(state[9]);  \
+    X##ka = LOAD256(state[10]); \
+    X##ke = LOAD256(state[11]); \
+    X##ki = LOAD256(state[12]); \
+    X##ko = LOAD256(state[13]); \
+    X##ku = LOAD256(state[14]); \
+    X##ma = LOAD256(state[15]); \
+    X##me = LOAD256(state[16]); \
+    X##mi = LOAD256(state[17]); \
+    X##mo = LOAD256(state[18]); \
+    X##mu = LOAD256(state[19]); \
+    X##sa = LOAD256(state[20]); \
+    X##se = LOAD256(state[21]); \
+    X##si = LOAD256(state[22]); \
+    X##so = LOAD256(state[23]); \
+    X##su = LOAD256(state[24]);
+
+#define copyToState(state, X)   \
+    STORE256(state[0], X##ba);  \
+    STORE256(state[1], X##be);  \
+    STORE256(state[2], X##bi);  \
+    STORE256(state[3], X##bo);  \
+    STORE256(state[4], X##bu);  \
+    STORE256(state[5], X##ga);  \
+    STORE256(state[6], X##ge);  \
+    STORE256(state[7], X##gi);  \
+    STORE256(state[8], X##go);  \
+    STORE256(state[9], X##gu);  \
+    STORE256(state[10], X##ka); \
+    STORE256(state[11], X##ke); \
+    STORE256(state[12], X##ki); \
+    STORE256(state[13], X##ko); \
+    STORE256(state[14], X##ku); \
+    STORE256(state[15], X##ma); \
+    STORE256(state[16], X##me); \
+    STORE256(state[17], X##mi); \
+    STORE256(state[18], X##mo); \
+    STORE256(state[19], X##mu); \
+    STORE256(state[20], X##sa); \
+    STORE256(state[21], X##se); \
+    STORE256(state[22], X##si); \
+    STORE256(state[23], X##so); \
+    STORE256(state[24], X##su);
+
+#ifdef KeccakP1600times4_fullUnrolling
+#define FullUnrolling
+#else
+#define Unrolling KeccakP1600times4_unrolling
+#endif
+#include "KeccakP-1600-unrolling.macros"
+
+void KeccakP1600times4_PermuteAll_24rounds(void *states) {
+	V256 *statesAsLanes = (V256 *) states;
+	declareABCDE
+#ifndef KeccakP1600times4_fullUnrolling
+	unsigned int i;
+#endif
+
+	copyFromState(A, statesAsLanes)
+	rounds24
+	copyToState(statesAsLanes, A)
+}

--- a/src/common_avx2/sha3/keccak4x/KeccakP-1600-times4-SnP.h
+++ b/src/common_avx2/sha3/keccak4x/KeccakP-1600-times4-SnP.h
@@ -1,0 +1,39 @@
+/*
+Implementation by the Keccak, Keyak and Ketje Teams, namely, Guido Bertoni,
+Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer, hereby
+denoted as "the implementer".
+
+For more information, feedback or questions, please refer to our websites:
+http://keccak.noekeon.org/
+http://keyak.noekeon.org/
+http://ketje.noekeon.org/
+
+To the extent possible under law, the implementer has waived all copyright
+and related or neighboring rights to the source code in this file.
+http://creativecommons.org/publicdomain/zero/1.0/
+*/
+
+/* Simplified for liboqs: remove code that wasn't used in shake128_4x */
+
+#ifndef _KeccakP_1600_times4_SnP_h_
+#define _KeccakP_1600_times4_SnP_h_
+
+/** For the documentation, see PlSnP-documentation.h.
+ */
+
+#include "SIMD256-config.h"
+
+#define KeccakP1600times4_implementation "256-bit SIMD implementation (" KeccakP1600times4_implementation_config ")"
+#define KeccakP1600times4_statesSizeInBytes 800
+#define KeccakP1600times4_statesAlignment 32
+#define KeccakF1600times4_FastLoop_supported
+#define KeccakP1600times4_12rounds_FastLoop_supported
+
+#include <stddef.h>
+
+#define KeccakP1600times4_StaticInitialize()
+#define KeccakP1600times4_AddByte(states, instanceIndex, byte, offset) \
+    ((unsigned char *) (states))[(instanceIndex) *8 + ((offset) / 8) * 4 * 8 + (offset) % 8] ^= (byte)
+void KeccakP1600times4_PermuteAll_24rounds(void *states);
+
+#endif

--- a/src/common_avx2/sha3/keccak4x/KeccakP-1600-unrolling.macros
+++ b/src/common_avx2/sha3/keccak4x/KeccakP-1600-unrolling.macros
@@ -1,0 +1,198 @@
+/*
+Implementation by the Keccak, Keyak and Ketje Teams, namely, Guido Bertoni,
+Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer, hereby
+denoted as "the implementer".
+
+For more information, feedback or questions, please refer to our websites:
+http://keccak.noekeon.org/
+http://keyak.noekeon.org/
+http://ketje.noekeon.org/
+
+To the extent possible under law, the implementer has waived all copyright
+and related or neighboring rights to the source code in this file.
+http://creativecommons.org/publicdomain/zero/1.0/
+*/
+
+#if (defined(FullUnrolling))
+#define rounds24 \
+    prepareTheta \
+    thetaRhoPiChiIotaPrepareTheta( 0, A, E) \
+    thetaRhoPiChiIotaPrepareTheta( 1, E, A) \
+    thetaRhoPiChiIotaPrepareTheta( 2, A, E) \
+    thetaRhoPiChiIotaPrepareTheta( 3, E, A) \
+    thetaRhoPiChiIotaPrepareTheta( 4, A, E) \
+    thetaRhoPiChiIotaPrepareTheta( 5, E, A) \
+    thetaRhoPiChiIotaPrepareTheta( 6, A, E) \
+    thetaRhoPiChiIotaPrepareTheta( 7, E, A) \
+    thetaRhoPiChiIotaPrepareTheta( 8, A, E) \
+    thetaRhoPiChiIotaPrepareTheta( 9, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(10, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(11, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(12, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(13, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(14, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(15, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(16, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(17, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(18, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(19, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(20, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(21, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(22, A, E) \
+    thetaRhoPiChiIota(23, E, A) \
+
+#define rounds12 \
+    prepareTheta \
+    thetaRhoPiChiIotaPrepareTheta(12, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(13, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(14, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(15, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(16, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(17, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(18, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(19, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(20, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(21, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(22, A, E) \
+    thetaRhoPiChiIota(23, E, A) \
+
+#elif (Unrolling == 12)
+#define rounds24 \
+    prepareTheta \
+    for(i=0; i<24; i+=12) { \
+        thetaRhoPiChiIotaPrepareTheta(i   , A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+ 1, E, A) \
+        thetaRhoPiChiIotaPrepareTheta(i+ 2, A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+ 3, E, A) \
+        thetaRhoPiChiIotaPrepareTheta(i+ 4, A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+ 5, E, A) \
+        thetaRhoPiChiIotaPrepareTheta(i+ 6, A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+ 7, E, A) \
+        thetaRhoPiChiIotaPrepareTheta(i+ 8, A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+ 9, E, A) \
+        thetaRhoPiChiIotaPrepareTheta(i+10, A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+11, E, A) \
+    } \
+
+#define rounds12 \
+    prepareTheta \
+    thetaRhoPiChiIotaPrepareTheta(12, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(13, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(14, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(15, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(16, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(17, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(18, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(19, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(20, A, E) \
+    thetaRhoPiChiIotaPrepareTheta(21, E, A) \
+    thetaRhoPiChiIotaPrepareTheta(22, A, E) \
+    thetaRhoPiChiIota(23, E, A) \
+
+#elif (Unrolling == 6)
+#define rounds24 \
+    prepareTheta \
+    for(i=0; i<24; i+=6) { \
+        thetaRhoPiChiIotaPrepareTheta(i  , A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+1, E, A) \
+        thetaRhoPiChiIotaPrepareTheta(i+2, A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+3, E, A) \
+        thetaRhoPiChiIotaPrepareTheta(i+4, A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+5, E, A) \
+    } \
+
+#define rounds12 \
+    prepareTheta \
+    for(i=12; i<24; i+=6) { \
+        thetaRhoPiChiIotaPrepareTheta(i  , A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+1, E, A) \
+        thetaRhoPiChiIotaPrepareTheta(i+2, A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+3, E, A) \
+        thetaRhoPiChiIotaPrepareTheta(i+4, A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+5, E, A) \
+    } \
+
+#elif (Unrolling == 4)
+#define rounds24 \
+    prepareTheta \
+    for(i=0; i<24; i+=4) { \
+        thetaRhoPiChiIotaPrepareTheta(i  , A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+1, E, A) \
+        thetaRhoPiChiIotaPrepareTheta(i+2, A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+3, E, A) \
+    } \
+
+#define rounds12 \
+    prepareTheta \
+    for(i=12; i<24; i+=4) { \
+        thetaRhoPiChiIotaPrepareTheta(i  , A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+1, E, A) \
+        thetaRhoPiChiIotaPrepareTheta(i+2, A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+3, E, A) \
+    } \
+
+#elif (Unrolling == 3)
+#define rounds24 \
+    prepareTheta \
+    for(i=0; i<24; i+=3) { \
+        thetaRhoPiChiIotaPrepareTheta(i  , A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+1, E, A) \
+        thetaRhoPiChiIotaPrepareTheta(i+2, A, E) \
+        copyStateVariables(A, E) \
+    } \
+
+#define rounds12 \
+    prepareTheta \
+    for(i=12; i<24; i+=3) { \
+        thetaRhoPiChiIotaPrepareTheta(i  , A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+1, E, A) \
+        thetaRhoPiChiIotaPrepareTheta(i+2, A, E) \
+        copyStateVariables(A, E) \
+    } \
+
+#elif (Unrolling == 2)
+#define rounds24 \
+    prepareTheta \
+    for(i=0; i<24; i+=2) { \
+        thetaRhoPiChiIotaPrepareTheta(i  , A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+1, E, A) \
+    } \
+
+#define rounds12 \
+    prepareTheta \
+    for(i=12; i<24; i+=2) { \
+        thetaRhoPiChiIotaPrepareTheta(i  , A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+1, E, A) \
+    } \
+
+#elif (Unrolling == 1)
+#define rounds24 \
+    prepareTheta \
+    for(i=0; i<24; i++) { \
+        thetaRhoPiChiIotaPrepareTheta(i  , A, E) \
+        copyStateVariables(A, E) \
+    } \
+
+#define rounds12 \
+    prepareTheta \
+    for(i=12; i<24; i++) { \
+        thetaRhoPiChiIotaPrepareTheta(i  , A, E) \
+        copyStateVariables(A, E) \
+    } \
+
+#else
+#error "Unrolling is not correctly specified!"
+#endif
+
+#define roundsN(__nrounds) \
+    prepareTheta \
+    i = 24 - (__nrounds); \
+    if ((i&1) != 0) { \
+        thetaRhoPiChiIotaPrepareTheta(i, A, E) \
+        copyStateVariables(A, E) \
+        ++i; \
+    } \
+    for( /* empty */; i<24; i+=2) { \
+        thetaRhoPiChiIotaPrepareTheta(i  , A, E) \
+        thetaRhoPiChiIotaPrepareTheta(i+1, E, A) \
+    }

--- a/src/common_avx2/sha3/keccak4x/SIMD256-config.h
+++ b/src/common_avx2/sha3/keccak4x/SIMD256-config.h
@@ -1,0 +1,3 @@
+#define KeccakP1600times4_implementation_config "AVX2, all rounds unrolled"
+#define KeccakP1600times4_fullUnrolling
+#define KeccakP1600times4_useAVX2

--- a/src/common_avx2/sha3/keccak4x/align.h
+++ b/src/common_avx2/sha3/keccak4x/align.h
@@ -1,0 +1,34 @@
+/*
+Implementation by the Keccak, Keyak and Ketje Teams, namely, Guido Bertoni,
+Joan Daemen, Michaël Peeters, Gilles Van Assche and Ronny Van Keer, hereby
+denoted as "the implementer".
+
+For more information, feedback or questions, please refer to our websites:
+http://keccak.noekeon.org/
+http://keyak.noekeon.org/
+http://ketje.noekeon.org/
+
+To the extent possible under law, the implementer has waived all copyright
+and related or neighboring rights to the source code in this file.
+http://creativecommons.org/publicdomain/zero/1.0/
+*/
+
+#ifndef _align_h_
+#define _align_h_
+
+/* on Mac OS-X and possibly others, ALIGN(x) is defined in param.h, and -Werror chokes on the redef. */
+#ifdef ALIGN
+#undef ALIGN
+#endif
+
+#if defined(__GNUC__)
+#define ALIGN(x) __attribute__((aligned(x)))
+#elif defined(_MSC_VER)
+#define ALIGN(x) __declspec(align(x))
+#elif defined(__ARMCC_VERSION)
+#define ALIGN(x) __align(x)
+#else
+#define ALIGN(x)
+#endif
+
+#endif

--- a/src/common_avx2/sha3/keccak4x/brg_endian.h
+++ b/src/common_avx2/sha3/keccak4x/brg_endian.h
@@ -1,0 +1,142 @@
+/*
+ ---------------------------------------------------------------------------
+ Copyright (c) 1998-2008, Brian Gladman, Worcester, UK. All rights reserved.
+
+ LICENSE TERMS
+
+ The redistribution and use of this software (with or without changes)
+ is allowed without the payment of fees or royalties provided that:
+
+  1. source code distributions include the above copyright notice, this
+     list of conditions and the following disclaimer;
+
+  2. binary distributions include the above copyright notice, this list
+     of conditions and the following disclaimer in their documentation;
+
+  3. the name of the copyright holder is not used to endorse products
+     built using this software without specific written permission.
+
+ DISCLAIMER
+
+ This software is provided 'as is' with no explicit or implied warranties
+ in respect of its properties, including, but not limited to, correctness
+ and/or fitness for purpose.
+ ---------------------------------------------------------------------------
+ Issue Date: 20/12/2007
+ Changes for ARM 9/9/2010
+*/
+
+#ifndef _BRG_ENDIAN_H
+#define _BRG_ENDIAN_H
+
+#define IS_BIG_ENDIAN 4321    /* byte 0 is most significant (mc68k) */
+#define IS_LITTLE_ENDIAN 1234 /* byte 0 is least significant (i386) */
+
+#if 0
+/* Include files where endian defines and byteswap functions may reside */
+#if defined(__sun)
+#include <sys/isa_defs.h>
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#include <sys/endian.h>
+#elif defined(BSD) && (BSD >= 199103) || defined(__APPLE__) || \
+    defined(__CYGWIN32__) || defined(__DJGPP__) || defined(__osf__)
+#include <machine/endian.h>
+#elif defined(__linux__) || defined(__GNUC__) || defined(__GNU_LIBRARY__)
+#if !defined(__MINGW32__) && !defined(_AIX)
+#include <endian.h>
+#if !defined(__BEOS__)
+#include <byteswap.h>
+#endif
+#endif
+#endif
+#endif
+
+/* Now attempt to set the define for platform byte order using any  */
+/* of the four forms SYMBOL, _SYMBOL, __SYMBOL & __SYMBOL__, which  */
+/* seem to encompass most endian symbol definitions                 */
+
+#if defined(BIG_ENDIAN) && defined(LITTLE_ENDIAN)
+#if defined(BYTE_ORDER) && BYTE_ORDER == BIG_ENDIAN
+#define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#elif defined(BYTE_ORDER) && BYTE_ORDER == LITTLE_ENDIAN
+#define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#endif
+#elif defined(BIG_ENDIAN)
+#define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#elif defined(LITTLE_ENDIAN)
+#define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#endif
+
+#if defined(_BIG_ENDIAN) && defined(_LITTLE_ENDIAN)
+#if defined(_BYTE_ORDER) && _BYTE_ORDER == _BIG_ENDIAN
+#define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#elif defined(_BYTE_ORDER) && _BYTE_ORDER == _LITTLE_ENDIAN
+#define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#endif
+#elif defined(_BIG_ENDIAN)
+#define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#elif defined(_LITTLE_ENDIAN)
+#define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#endif
+
+#if defined(__BIG_ENDIAN) && defined(__LITTLE_ENDIAN)
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
+#define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
+#define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#endif
+#elif defined(__BIG_ENDIAN)
+#define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#elif defined(__LITTLE_ENDIAN)
+#define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#endif
+
+#if defined(__BIG_ENDIAN__) && defined(__LITTLE_ENDIAN__)
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __BIG_ENDIAN__
+#define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#elif defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __LITTLE_ENDIAN__
+#define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#endif
+#elif defined(__BIG_ENDIAN__)
+#define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#elif defined(__LITTLE_ENDIAN__)
+#define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#endif
+
+/*  if the platform byte order could not be determined, then try to */
+/*  set this define using common machine defines                    */
+#if !defined(PLATFORM_BYTE_ORDER)
+
+#if defined(__alpha__) || defined(__alpha) || defined(i386) ||    \
+    defined(__i386__) || defined(_M_I86) || defined(_M_IX86) ||   \
+    defined(__OS2__) || defined(sun386) || defined(__TURBOC__) || \
+    defined(vax) || defined(vms) || defined(VMS) ||               \
+    defined(__VMS) || defined(_M_X64)
+#define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+
+#elif defined(AMIGA) || defined(applec) || defined(__AS400__) ||   \
+    defined(_CRAY) || defined(__hppa) || defined(__hp9000) ||      \
+    defined(ibm370) || defined(mc68000) || defined(m68k) ||        \
+    defined(__MRC__) || defined(__MVS__) || defined(__MWERKS__) || \
+    defined(sparc) || defined(__sparc) || defined(SYMANTEC_C) ||   \
+    defined(__VOS__) || defined(__TIGCC__) || defined(__TANDEM) || \
+    defined(THINK_C) || defined(__VMCMS__) || defined(_AIX)
+#define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+
+#elif defined(__arm__)
+#ifdef __BIG_ENDIAN
+#define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#else
+#define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#endif
+#elif 1 /* **** EDIT HERE IF NECESSARY **** */
+#define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
+#elif 0 /* **** EDIT HERE IF NECESSARY **** */
+#define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+#else
+#error Please edit lines 132 or 134 in brg_endian.h to set the platform byte order
+#endif
+
+#endif
+
+#endif

--- a/src/common_avx2/sha3/sha3.h
+++ b/src/common_avx2/sha3/sha3.h
@@ -1,0 +1,742 @@
+/**
+ * \file sha3.h
+ * \brief SHA3, SHAKE, and cSHAKE functions; not part of the OQS public API
+ *
+ * Contains the API and documentation for SHA3 digest and SHAKE implementations.
+ *
+ * <b>Note this is not part of the OQS public API: implementations within liboqs can use these
+ * functions, but external consumers of liboqs should not use these functions.</b>
+ *
+ * \author John Underhill, Douglas Stebila
+ */
+
+#ifndef OQS_SHA3_H
+#define OQS_SHA3_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/* SHA3 */
+
+/** The SHA-256 byte absorption rate */
+#define OQS_SHA3_SHA3_256_RATE 136
+
+/**
+ * \brief Process a message with SHA3-256 and return the hash code in the output byte array.
+ *
+ * \warning The output array must be at least 32 bytes in length.
+ *
+ * \param output The output byte array
+ * \param input The message input byte array
+ * \param inplen The number of message bytes to process
+ */
+void OQS_SHA3_sha3_256(uint8_t *output, const uint8_t *input, size_t inplen);
+
+/** Data structure for the state of the SHA3-256 incremental hashing API. */
+typedef struct {
+	/** Internal state. */
+	void *ctx;
+} OQS_SHA3_sha3_256_inc_ctx;
+
+/**
+ * \brief Initialize the state for the SHA3-256 incremental hashing API.
+ *
+ * \warning State must be allovated by the caller. Caller is responsible
+ * for releasing state by calling either OQS_SHA3_sha3_256_inc_finalize or
+ * OQS_SHA3_sha3_256_inc_ctx_release.
+ *
+ * \param state The function state to be initialized; must be allocated.
+ */
+void OQS_SHA3_sha3_256_inc_init(OQS_SHA3_sha3_256_inc_ctx *state);
+
+/**
+ * \brief The SHA3-256 absorb function.
+ * Absorb an input message array directly into the state.
+ *
+ * \warning State must be initialized by the caller.
+ *
+ * \param state The function state; must be initialized
+ * \param input The input message byte array
+ * \param inlen The number of message bytes to process
+ */
+void OQS_SHA3_sha3_256_inc_absorb(OQS_SHA3_sha3_256_inc_ctx *state, const uint8_t *input, size_t inlen);
+
+/**
+ * \brief The SHA3-256 squeeze/finalize function.
+ * Permutes and extracts the state to an output byte array.
+ * Releases state.
+ *
+ * \warning Output array must be allocated.
+ * State cannot be used after this without re-calling OQS_SHA3_sha3_256_inc_init.
+
+ * \param output The output byte array
+ * \param state The function state; must be initialized
+ */
+void OQS_SHA3_sha3_256_inc_finalize(uint8_t *output, OQS_SHA3_sha3_256_inc_ctx *state);
+
+/**
+ * \brief Release the state for the SHA3-256 incremental API.
+ *
+ * \warning State cannot be used after this without re-calling OQS_SHA3_sha3_256_inc_init.
+ *
+ * \param state The function state; must be initialized
+ */
+void OQS_SHA3_sha3_256_inc_ctx_release(OQS_SHA3_sha3_256_inc_ctx *state);
+
+/**
+ * \brief Clone the state for the SHA3-256 incremental API.
+ *
+ * \warning dest must be allocated by the caller. Caller is responsible
+ * for releasing dest by calling either OQS_SHA3_sha3_256_inc_finalize or
+ * OQS_SHA3_sha3_256_inc_ctx_release.
+ *
+ * \param dest The function state to copy into; must be initialized
+ * \param src The function state to copy; must be initialized
+ */
+void OQS_SHA3_sha3_256_inc_ctx_clone(OQS_SHA3_sha3_256_inc_ctx *dest, const OQS_SHA3_sha3_256_inc_ctx *src);
+
+/** The SHA-384 byte absorption rate */
+#define OQS_SHA3_SHA3_384_RATE 104
+
+/**
+ * \brief Process a message with SHA3-384 and return the hash code in the output byte array.
+ *
+ * \warning The output array must be at least 48 bytes in length.
+ *
+ * \param output The output byte array
+ * \param input The message input byte array
+ * \param inplen The number of message bytes to process
+ */
+void OQS_SHA3_sha3_384(uint8_t *output, const uint8_t *input, size_t inplen);
+
+/** Data structure for the state of the SHA3-384 incremental hashing API. */
+typedef struct {
+	/** Internal state. */
+	void *ctx;
+} OQS_SHA3_sha3_384_inc_ctx;
+
+/**
+ * \brief Initialize the state for the SHA3-384 incremental hashing API.
+ *
+ * \warning State must be allovated by the caller. Caller is responsible
+ * for releasing state by calling either OQS_SHA3_sha3_384_inc_finalize or
+ * OQS_SHA3_sha3_384_inc_ctx_release.
+ *
+ * \param state The function state to be initialized; must be allocated.
+ */
+void OQS_SHA3_sha3_384_inc_init(OQS_SHA3_sha3_384_inc_ctx *state);
+
+/**
+ * \brief The SHA3-384 absorb function.
+ * Absorb an input message array directly into the state.
+ *
+ * \warning State must be initialized by the caller.
+ *
+ * \param state The function state; must be initialized
+ * \param input The input message byte array
+ * \param inlen The number of message bytes to process
+ */
+void OQS_SHA3_sha3_384_inc_absorb(OQS_SHA3_sha3_384_inc_ctx *state, const uint8_t *input, size_t inlen);
+
+/**
+ * \brief The SHA3-384 squeeze/finalize function.
+ * Permutes and extracts the state to an output byte array.
+ * Releases state.
+ *
+ * \warning Output array must be allocated.
+ * State cannot be used after this without re-calling OQS_SHA3_sha3_384_inc_init.
+
+ * \param output The output byte array
+ * \param state The function state; must be initialized
+ */
+void OQS_SHA3_sha3_384_inc_finalize(uint8_t *output, OQS_SHA3_sha3_384_inc_ctx *state);
+
+/**
+ * \brief Release the state for the SHA3-384 incremental API.
+ *
+ * \warning State cannot be used after this without re-calling OQS_SHA3_sha3_384_inc_init.
+ *
+ * \param state The function state; must be initialized
+ */
+void OQS_SHA3_sha3_384_inc_ctx_release(OQS_SHA3_sha3_384_inc_ctx *state);
+
+/**
+ * \brief Clone the state for the SHA3-384 incremental API.
+ *
+ * \warning dest must be allovated by the caller. Caller is responsible
+ * for releasing dest by calling either OQS_SHA3_sha3_384_inc_finalize or
+ * OQS_SHA3_sha3_384_inc_ctx_release.
+ *
+ * \param dest The function state to copy into; must be initialized
+ * \param src The function state to copy; must be initialized
+ */
+void OQS_SHA3_sha3_384_inc_ctx_clone(OQS_SHA3_sha3_384_inc_ctx *dest, const OQS_SHA3_sha3_384_inc_ctx *src);
+
+/** The SHA-512 byte absorption rate */
+#define OQS_SHA3_SHA3_512_RATE 72
+
+/**
+ * \brief Process a message with SHA3-512 and return the hash code in the output byte array.
+ *
+ * \warning The output array must be at least 64 bytes in length.
+ *
+ * \param output The output byte array
+ * \param input The message input byte array
+ * \param inplen The number of message bytes to process
+ */
+void OQS_SHA3_sha3_512(uint8_t *output, const uint8_t *input, size_t inplen);
+
+/** Data structure for the state of the SHA3-512 incremental hashing API. */
+typedef struct {
+	/** Internal state. */
+	void *ctx;
+} OQS_SHA3_sha3_512_inc_ctx;
+
+/**
+ * \brief Initialize the state for the SHA3-512 incremental hashing API.
+ *
+ * \warning State must be allovated by the caller. Caller is responsible
+ * for releasing state by calling either OQS_SHA3_sha3_512_inc_finalize or
+ * OQS_SHA3_sha3_512_inc_ctx_release.
+ *
+ * \param state The function state to be initialized; must be allocated.
+ */
+void OQS_SHA3_sha3_512_inc_init(OQS_SHA3_sha3_512_inc_ctx *state);
+
+/**
+ * \brief The SHA3-512 absorb function.
+ * Absorb an input message array directly into the state.
+ *
+ * \warning State must be initialized by the caller.
+ *
+ * \param state The function state; must be initialized
+ * \param input The input message byte array
+ * \param inlen The number of message bytes to process
+ */
+void OQS_SHA3_sha3_512_inc_absorb(OQS_SHA3_sha3_512_inc_ctx *state, const uint8_t *input, size_t inlen);
+
+/**
+ * \brief The SHA3-512 squeeze/finalize function.
+ * Permutes and extracts the state to an output byte array.
+ * Releases state.
+ *
+ * \warning Output array must be allocated.
+ * State cannot be used after this without re-calling OQS_SHA3_sha3_512_inc_init.
+
+ * \param output The output byte array
+ * \param state The function state; must be initialized
+ */
+void OQS_SHA3_sha3_512_inc_finalize(uint8_t *output, OQS_SHA3_sha3_512_inc_ctx *state);
+
+/**
+ * \brief Release the state for the SHA3-512 incremental API.
+ *
+ * \warning State cannot be used after this without re-calling OQS_SHA3_sha3_512_inc_init.
+ *
+ * \param state The function state; must be initialized
+ */
+void OQS_SHA3_sha3_512_inc_ctx_release(OQS_SHA3_sha3_512_inc_ctx *state);
+
+/**
+ * \brief Clone the state for the SHA3-512 incremental API.
+ *
+ * \warning dest must be allovated by the caller. Caller is responsible
+ * for releasing dest by calling either OQS_SHA3_sha3_512_inc_finalize or
+ * OQS_SHA3_sha3_512_inc_ctx_release.
+ *
+ * \param dest The function state to copy into; must be initialized
+ * \param src The function state to copy; must be initialized
+ */
+void OQS_SHA3_sha3_512_inc_ctx_clone(OQS_SHA3_sha3_512_inc_ctx *dest, const OQS_SHA3_sha3_512_inc_ctx *src);
+
+/* SHAKE */
+
+/** The SHAKE-128 byte absorption rate */
+#define OQS_SHA3_SHAKE128_RATE 168
+
+/**
+ * \brief Seed a SHAKE-128 instance, and generate an array of pseudo-random bytes.
+ *
+ * \warning The output array length must not be zero.
+ *
+ * \param output The output byte array
+ * \param outlen The number of output bytes to generate
+ * \param input The input seed byte array
+ * \param inplen The number of seed bytes to process
+ */
+void OQS_SHA3_shake128(uint8_t *output, size_t outlen, const uint8_t *input, size_t inplen);
+
+/** Data structure for the state of the SHAKE128 non-incremental hashing API. */
+typedef struct {
+	/** Internal state. */
+	void *ctx;
+} OQS_SHA3_shake128_ctx;
+
+/**
+ * \brief The SHAKE-128 absorb function.
+ * Absorb and finalize an input seed byte array.
+ * Should be used in conjunction with the shake128_squeezeblocks function.
+ *
+ * \warning Finalizes the seed state, should not be used in consecutive calls.
+ * State must be allocated by the caller. State msut be freed by calling
+ * OQS_SHA3_shake128_ctx_release.
+ *
+ * \param state The function state; must be allocated
+ * \param input The input seed byte array
+ * \param inplen The number of seed bytes to process
+ */
+void OQS_SHA3_shake128_absorb(OQS_SHA3_shake128_ctx *state, const uint8_t *input, size_t inplen);
+
+/**
+ * \brief The SHAKE-128 squeeze function.
+ * Permutes and extracts the state to an output byte array.
+ * Should be used in conjunction with the shake128_absorb function.
+ *
+ * \warning Output array must be initialized to a multiple of the byte rate.
+ *
+ * \param output The output byte array
+ * \param nblocks The number of blocks to extract
+ * \param state The function state; must be allocated
+ */
+void OQS_SHA3_shake128_squeezeblocks(uint8_t *output, size_t nblocks, OQS_SHA3_shake128_ctx *state);
+
+/**
+ * \brief Frees the state for SHAKE-128.
+ *
+ * \param state The state to free
+ */
+void OQS_SHA3_shake128_ctx_release(OQS_SHA3_shake128_ctx *state);
+
+/**
+ * \brief Copies the state for SHAKE-128.
+ *
+ * \warning dest must be allocated. dest must be freed by calling
+ * OQS_SHA3_shake128_ctx_release.
+ *
+ * \param dest The state to copy into
+ * \param src The state to copy from
+ */
+void OQS_SHA3_shake128_ctx_clone(OQS_SHA3_shake128_ctx *dest, const OQS_SHA3_shake128_ctx *src);
+
+/** Data structure for the state of the SHAKE-128 incremental hashing API. */
+typedef struct {
+	/** Internal state. */
+	void *ctx;
+} OQS_SHA3_shake128_inc_ctx;
+
+/**
+ * \brief Initialize the state for the SHAKE-128 incremental hashing API.
+ *
+ * \param state The function state to be initialized; must be allocated
+ */
+void OQS_SHA3_shake128_inc_init(OQS_SHA3_shake128_inc_ctx *state);
+
+/**
+ * \brief The SHAKE-128 absorb function.
+ * Absorb an input message array directly into the state.
+ *
+ * \warning State must be initialized by the caller.
+ *
+ * \param state The function state; must be initialized
+ * \param input input buffer
+ * \param inlen length of input buffer
+ */
+void OQS_SHA3_shake128_inc_absorb(OQS_SHA3_shake128_inc_ctx *state, const uint8_t *input, size_t inlen);
+
+/**
+ * \brief The SHAKE-128 finalize function.
+ *
+ * \param state The function state; must be initialized
+ */
+void OQS_SHA3_shake128_inc_finalize(OQS_SHA3_shake128_inc_ctx *state);
+
+/**
+ * \brief The SHAKE-128 squeeze function.
+ * Extracts to an output byte array.
+ *
+ * \param output output buffer
+ * \param outlen bytes of outbut buffer
+ * \param state The function state; must be initialized
+ */
+void OQS_SHA3_shake128_inc_squeeze(uint8_t *output, size_t outlen, OQS_SHA3_shake128_inc_ctx *state);
+
+/**
+ * \brief Frees the state for the SHAKE-128 incremental hashing API.
+ *
+ * \param state The state to free
+ */
+void OQS_SHA3_shake128_inc_ctx_release(OQS_SHA3_shake128_inc_ctx *state);
+
+/**
+ * \brief Copies the state for the SHAKE-128 incremental hashing API.
+ *
+ * \warning dest must be allocated. dest must be freed by calling
+ * OQS_SHA3_shake128_inc_ctx_release.
+ *
+ * \param dest The state to copy into
+ * \param src The state to copy from
+ */
+void OQS_SHA3_shake128_inc_ctx_clone(OQS_SHA3_shake128_inc_ctx *dest, const OQS_SHA3_shake128_inc_ctx *src);
+
+/** The SHAKE-256 byte absorption rate */
+#define OQS_SHA3_SHAKE256_RATE 136
+
+/**
+ * \brief Seed a SHAKE-256 instance, and generate an array of pseudo-random bytes.
+ *
+ * \warning The output array length must not be zero.
+ *
+ * \param output The output byte array
+ * \param outlen The number of output bytes to generate
+ * \param input The input seed byte array
+ * \param inplen The number of seed bytes to process
+ */
+void OQS_SHA3_shake256(uint8_t *output, size_t outlen, const uint8_t *input, size_t inplen);
+
+/** Data structure for the state of the SHAKE256 non-incremental hashing API. */
+typedef struct {
+	/** Internal state. */
+	void *ctx;
+} OQS_SHA3_shake256_ctx;
+
+/**
+ * \brief The SHAKE-256 absorb function.
+ * Absorb and finalize an input seed byte array.
+ * Should be used in conjunction with the shake256_squeezeblocks function.
+ *
+ * \warning Finalizes the seed state, should not be used in consecutive calls.
+ * State must be allocated by the caller. State msut be freed by calling
+ * OQS_SHA3_shake256_ctx_release.
+ *
+ * \param state The function state; must be allocated
+ * \param input The input seed byte array
+ * \param inplen The number of seed bytes to process
+ */
+void OQS_SHA3_shake256_absorb(OQS_SHA3_shake256_ctx *state, const uint8_t *input, size_t inplen);
+
+/**
+ * \brief The SHAKE-256 squeeze function.
+ * Permutes and extracts the state to an output byte array.
+ * Should be used in conjunction with the shake256_absorb function.
+ *
+ * \warning Output array must be initialized to a multiple of the byte rate.
+ *
+ * \param output The output byte array
+ * \param nblocks The number of blocks to extract
+ * \param state The function state; must be allocated
+ */
+void OQS_SHA3_shake256_squeezeblocks(uint8_t *output, size_t nblocks, OQS_SHA3_shake256_ctx *state);
+
+/**
+ * \brief Frees the state for SHAKE-256.
+ *
+ * \param state The state to free
+ */
+void OQS_SHA3_shake256_ctx_release(OQS_SHA3_shake256_ctx *state);
+
+/**
+ * \brief Copies the state for SHAKE-256.
+ *
+ * \warning dest must be allocated. dest must be freed by calling
+ * OQS_SHA3_shake256_ctx_release.
+ *
+ * \param dest The state to copy into
+ * \param src The state to copy from
+ */
+void OQS_SHA3_shake256_ctx_clone(OQS_SHA3_shake256_ctx *dest, const OQS_SHA3_shake256_ctx *src);
+
+/** Data structure for the state of the SHAKE-256 incremental hashing API. */
+typedef struct {
+	/** Internal state. */
+	void *ctx;
+} OQS_SHA3_shake256_inc_ctx;
+
+/**
+ * \brief Initialize the state for the SHAKE-256 incremental hashing API.
+ *
+ * \param state The function state to be initialized; must be allocated
+ */
+void OQS_SHA3_shake256_inc_init(OQS_SHA3_shake256_inc_ctx *state);
+
+/**
+ * \brief The SHAKE-256 absorb function.
+ * Absorb an input message array directly into the state.
+ *
+ * \warning State must be initialized by the caller.
+ *
+ * \param state The function state; must be initialized
+ * \param input input buffer
+ * \param inlen length of input buffer
+ */
+void OQS_SHA3_shake256_inc_absorb(OQS_SHA3_shake256_inc_ctx *state, const uint8_t *input, size_t inlen);
+
+/**
+ * \brief The SHAKE-256 finalize function.
+ *
+ * \param state The function state; must be initialized
+ */
+void OQS_SHA3_shake256_inc_finalize(OQS_SHA3_shake256_inc_ctx *state);
+
+/**
+ * \brief The SHAKE-256 squeeze function.
+ * Extracts to an output byte array.
+ *
+ * \param output output buffer
+ * \param outlen bytes of outbut buffer
+ * \param state The function state; must be initialized
+ */
+void OQS_SHA3_shake256_inc_squeeze(uint8_t *output, size_t outlen, OQS_SHA3_shake256_inc_ctx *state);
+
+/**
+ * \brief Frees the state for the SHAKE-256 incremental hashing API.
+ *
+ * \param state The state to free
+ */
+void OQS_SHA3_shake256_inc_ctx_release(OQS_SHA3_shake256_inc_ctx *state);
+
+/**
+ * \brief Copies the state for the SHAKE-256 incremental hashing API.
+ *
+ * \warning dest must be allocated. dest must be freed by calling
+ * OQS_SHA3_shake256_inc_ctx_release.
+ *
+ * \param dest The state to copy into
+ * \param src The state to copy from
+ */
+void OQS_SHA3_shake256_inc_ctx_clone(OQS_SHA3_shake256_inc_ctx *dest, const OQS_SHA3_shake256_inc_ctx *src);
+
+/* cSHAKE */
+
+/**
+ * \brief Seed a cSHAKE-128 instance and generate pseudo-random output.
+ * Permutes and extracts the state to an output byte array.
+ *
+ * \warning This function has a counter period of 2^16.
+ *
+ * \param output The output byte array
+ * \param outlen The number of output bytes to generate
+ * \param name The function name input as a byte array
+ * \param namelen The length of the function name byte array
+ * \param cstm The customization string as a byte array
+ * \param cstmlen The length of the customization string byte array
+ * \param input The input seed byte array
+ * \param inlen The number of seed bytes to process
+ */
+void OQS_SHA3_cshake128(uint8_t *output, size_t outlen, const uint8_t *name, size_t namelen, const uint8_t *cstm, size_t cstmlen, const uint8_t *input, size_t inlen);
+
+/**
+ * \brief Initialize the state for the cSHAKE-128 incremental hashing API.
+ *
+ * \param state The function state to be initialized; must be allocated
+ * \param name The function name input as a byte array
+ * \param namelen The length of the function name byte array
+ * \param cstm The customization string as a byte array
+ * \param cstmlen The length of the customization string byte array
+ */
+void OQS_SHA3_cshake128_inc_init(OQS_SHA3_shake128_inc_ctx *state, const uint8_t *name, size_t namelen, const uint8_t *cstm, size_t cstmlen);
+
+/**
+ * \brief The cSHAKE-128 absorb function.
+ * Absorb an input message array directly into the state.
+ *
+ * \warning State must be initialized by the caller.
+ *
+ * \param state state
+ * \param input input buffer
+ * \param inlen length of input buffer
+ */
+void OQS_SHA3_cshake128_inc_absorb(OQS_SHA3_shake128_inc_ctx *state, const uint8_t *input, size_t inlen);
+
+/**
+ * \brief The cSHAKE-128 finalize function.
+ *
+ * \param state The function state; must be initialized
+ */
+void OQS_SHA3_cshake128_inc_finalize(OQS_SHA3_shake128_inc_ctx *state);
+
+/**
+ * \brief The cSHAKE-128 squeeze function.
+ * Extracts to an output byte array.
+ *
+ * \param output output buffer
+ * \param outlen bytes of outbut buffer
+ * \param state The function state; must be initialized
+ */
+void OQS_SHA3_cshake128_inc_squeeze(uint8_t *output, size_t outlen, OQS_SHA3_shake128_inc_ctx *state);
+
+/**
+ * \brief Free the cSHAKE-128 incremental context.
+ *
+ * \param state The function state; must be initialized
+ */
+void OQS_SHA3_cshake128_inc_ctx_release(OQS_SHA3_shake128_inc_ctx *state);
+
+/**
+ * \brief Copies the state for the cSHAKE-128 incremental hashing API.
+ *
+ * \warning dest must be allocated. dest must be freed by calling
+ * OQS_SHA3_cshake128_inc_ctx_release.
+ *
+ * \param dest The state to copy into
+ * \param src The state to copy from
+ */
+void OQS_SHA3_cshake128_inc_ctx_clone(OQS_SHA3_shake128_inc_ctx *dest, const OQS_SHA3_shake128_inc_ctx *src);
+
+/**
+ * \brief Seed a cSHAKE-256 instance and generate pseudo-random output.
+ * Permutes and extracts the state to an output byte array.
+ *
+ * \warning This function has a counter period of 2^16.
+ *
+ * \param output The output byte array
+ * \param outlen The number of output bytes to generate
+ * \param name The function name input as a byte array
+ * \param namelen The length of the function name byte array
+ * \param cstm The customization string as a byte array
+ * \param cstmlen The length of the customization string byte array
+ * \param input The input seed byte array
+ * \param inlen The number of seed bytes to process
+ */
+void OQS_SHA3_cshake256(uint8_t *output, size_t outlen, const uint8_t *name, size_t namelen, const uint8_t *cstm, size_t cstmlen, const uint8_t *input, size_t inlen);
+
+/**
+ * \brief Initialize the state for the cSHAKE-256 incremental hashing API.
+ *
+ * \param state The function state to be initialized; must be allocated
+ * \param name The function name input as a byte array
+ * \param namelen The length of the function name byte array
+ * \param cstm The customization string as a byte array
+ * \param cstmlen The length of the customization string byte array
+ */
+void OQS_SHA3_cshake256_inc_init(OQS_SHA3_shake256_inc_ctx *state, const uint8_t *name, size_t namelen, const uint8_t *cstm, size_t cstmlen);
+
+/**
+ * \brief The cSHAKE-256 absorb function.
+ * Absorb an input message array directly into the state.
+ *
+ * \warning State must be initialized by the caller.
+ *
+ * \param state state
+ * \param input input buffer
+ * \param inlen length of input buffer
+ */
+void OQS_SHA3_cshake256_inc_absorb(OQS_SHA3_shake256_inc_ctx *state, const uint8_t *input, size_t inlen);
+
+/**
+ * \brief The cSHAKE-256 finalize function.
+ *
+ * \param state The function state; must be initialized
+ */
+void OQS_SHA3_cshake256_inc_finalize(OQS_SHA3_shake256_inc_ctx *state);
+
+/**
+ * \brief The cSHAKE-256 squeeze function.
+ * Extracts to an output byte array.
+ *
+ * \param output output buffer
+ * \param outlen bytes of outbut buffer
+ * \param state The function state; must be initialized
+ */
+void OQS_SHA3_cshake256_inc_squeeze(uint8_t *output, size_t outlen, OQS_SHA3_shake256_inc_ctx *state);
+
+/**
+ * \brief Free the cSHAKE-256 incremental context.
+ *
+ * \param state The function state; must be initialized
+ */
+void OQS_SHA3_cshake256_inc_ctx_release(OQS_SHA3_shake256_inc_ctx *state);
+
+/**
+ * \brief Copies the state for the cSHAKE-256 incremental hashing API.
+ *
+ * \warning dest must be allocated. dest must be freed by calling
+ * OQS_SHA3_cshake256_inc_ctx_release.
+ *
+ * \param dest The state to copy into
+ * \param src The state to copy from
+ */
+void OQS_SHA3_cshake256_inc_ctx_clone(OQS_SHA3_shake256_inc_ctx *dest, const OQS_SHA3_shake256_inc_ctx *src);
+
+/**
+* \brief Seed a cSHAKE-128 instance and generate pseudo-random output, using a "simplified" customization string.
+* Permutes and extracts the state to an output byte array.
+* The "simplified" customization string procedure is ad hoc but used in several NIST candidates.
+*
+* \warning This function has a counter period of 2^16.
+*
+* \param output The output byte array
+* \param outlen The number of output bytes to generate
+* \param cstm The 16bit customization integer
+* \param input The input seed byte array
+* \param inplen The number of seed bytes to process
+*/
+void OQS_SHA3_cshake128_simple(uint8_t *output, size_t outlen, uint16_t cstm, const uint8_t *input, size_t inplen);
+
+/**
+* \brief Seed a cSHAKE-256 instance and generate pseudo-random output, using a "simplified" customization string.
+* Permutes and extracts the state to an output byte array.
+* The "simplified" customization string procedure is ad hoc but used in several NIST candidates.
+*
+* \warning This function has a counter period of 2^16.
+*
+* \param output The output byte array
+* \param outlen The number of output bytes to generate
+* \param cstm The 16bit customization integer
+* \param input The input seed byte array
+* \param inplen The number of seed bytes to process
+*/
+void OQS_SHA3_cshake256_simple(uint8_t *output, size_t outlen, uint16_t cstm, const uint8_t *input, size_t inplen);
+
+#if defined(OQS_USE_AVX2_INSTRUCTIONS) && defined(OQS_USE_AES_INSTRUCTIONS)
+/**
+ * \brief Seed 4 parallel SHAKE-128 instances, and generate 4 arrays of pseudo-random bytes.
+ *
+ * Uses a vectorized (AVX2) implementation of SHAKE-128.
+ *
+ * \warning The output array length must not be zero.
+ *
+ * \param output0 The first output byte array
+ * \param output1 The second output byte array
+ * \param output2 The third output byte array
+ * \param output3 The fourth output byte array
+ * \param outlen The number of output bytes to generate in every output array
+ * \param in0 The first input seed byte array
+ * \param in1 The second input seed byte array
+ * \param in2 The third input seed byte array
+ * \param in3 The fourth input seed byte array
+ * \param inlen The number of seed bytes to process from every input array
+ */
+void OQS_SHA3_shake128_4x(uint8_t *output0, uint8_t *output1, uint8_t *output2, uint8_t *output3, size_t outlen, const uint8_t *in0, const uint8_t *in1, const uint8_t *in2, const uint8_t *in3, size_t inlen);
+
+/**
+* \brief Seed 4 parallel cSHAKE-128 instances, and generate 4 arrays of pseudo-random output, using a "simplified" customization string.
+* Uses a vectorized (AVX2) implementation of cSHAKE-128.
+* Permutes and extracts the state to an output byte array.
+* The "simplified" customization string procedure is ad hoc but used in several NIST candidates.
+*
+* \warning This function has a counter period of 2^16.
+*
+* \param output0 The first output byte array
+* \param output1 The second output byte array
+* \param output2 The third output byte array
+* \param output3 The fourth output byte array
+* \param outlen The number of output bytes to generate in every output array
+* \param cstm0 The first 16bit customization integer
+* \param cstm1 The second 16bit customization integer
+* \param cstm2 The third 16bit customization integer
+* \param cstm3 The fourth 16bit customization integer
+* \param input The input seed byte array
+* \param inplen The number of seed bytes to process
+*/
+void OQS_SHA3_cshake128_simple4x(uint8_t *output0, uint8_t *output1, uint8_t *output2, uint8_t *output3, size_t outlen, uint16_t cstm0, uint16_t cstm1, uint16_t cstm2, uint16_t cstm3, const uint8_t *in, size_t inlen);
+#endif
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // OQS_SHA3_H

--- a/src/common_avx2/sha3/sha3_c.c
+++ b/src/common_avx2/sha3/sha3_c.c
@@ -1,0 +1,201 @@
+/**
+* \file sha3_c.c
+* \brief Implementation of the OQS SHA3 API via the files fips202.c
+* from PQClean (https://github.com/PQClean/PQClean/tree/master/common)
+*/
+
+#include <oqs/oqs.h>
+
+#include "sha3.h"
+
+#define SHA3_256_RATE OQS_SHA3_SHA3_256_RATE
+#ifndef OQS_USE_SHA3_OPENSSL
+#define sha3_256 OQS_AVX2_SHA3_sha3_256
+#else
+#define sha3_256 oqs_avx2_unused_SHA3_sha3_256
+#endif
+
+typedef struct {
+	uint64_t *ctx;
+} sha3_256incctx;
+#define sha3_256_inc_init oqs_avx2_sha3_sha3_256_inc_init
+#define sha3_256_inc_absorb oqs_avx2_sha3_sha3_256_inc_absorb
+#define sha3_256_inc_finalize oqs_avx2_sha3_sha3_256_inc_finalize
+#define sha3_256_inc_ctx_release oqs_avx2_sha3_sha3_256_inc_ctx_release
+#define sha3_256_inc_ctx_clone oqs_avx2_sha3_sha3_256_inc_ctx_clone
+
+#define SHA3_384_RATE OQS_SHA3_SHA3_384_RATE
+#ifndef OQS_USE_SHA3_OPENSSL
+#define sha3_384 OQS_AVX2_SHA3_sha3_384
+#else
+#define sha3_384 oqs_avx2_unused_SHA3_sha3_384
+#endif
+
+typedef struct {
+	uint64_t *ctx;
+} sha3_384incctx;
+#define sha3_384_inc_init oqs_avx2_sha3_sha3_384_inc_init
+#define sha3_384_inc_absorb oqs_avx2_sha3_sha3_384_inc_absorb
+#define sha3_384_inc_finalize oqs_avx2_sha3_sha3_384_inc_finalize
+#define sha3_384_inc_ctx_release oqs_avx2_sha3_sha3_384_inc_ctx_release
+#define sha3_384_inc_ctx_clone oqs_avx2_sha3_sha3_384_inc_ctx_clone
+
+#define SHA3_512_RATE OQS_SHA3_SHA3_512_RATE
+#ifndef OQS_USE_SHA3_OPENSSL
+#define sha3_512 OQS_AVX2_SHA3_sha3_512
+#else
+#define sha3_512 oqs_avx2_unused_SHA3_sha3_512
+#endif
+
+typedef struct {
+	uint64_t *ctx;
+} sha3_512incctx;
+#define sha3_512_inc_init oqs_avx2_sha3_sha3_512_inc_init
+#define sha3_512_inc_absorb oqs_avx2_sha3_sha3_512_inc_absorb
+#define sha3_512_inc_finalize oqs_avx2_sha3_sha3_512_inc_finalize
+#define sha3_512_inc_ctx_release oqs_avx2_sha3_sha3_512_inc_ctx_release
+#define sha3_512_inc_ctx_clone oqs_avx2_sha3_sha3_512_inc_ctx_clone
+
+#define SHAKE128_RATE OQS_SHA3_SHAKE128_RATE
+#ifndef OQS_USE_SHA3_OPENSSL
+#define shake128 OQS_AVX2_SHA3_shake128
+#else
+#define shake128 oqs_avx2_unused_SHA3_shake128
+#endif
+
+typedef struct {
+	uint64_t *ctx;
+} shake128ctx;
+#define shake128_absorb oqs_avx2_sha3_shake128_absorb
+#define shake128_squeezeblocks oqs_avx2_sha3_shake128_squeezeblocks
+#define shake128_ctx_release oqs_avx2_sha3_shake128_ctx_release
+#define shake128_ctx_clone oqs_avx2_sha3_shake128_ctx_clone
+
+typedef struct {
+	uint64_t *ctx;
+} shake128incctx;
+#define shake128_inc_init oqs_avx2_sha3_shake128_inc_init
+#define shake128_inc_absorb oqs_avx2_sha3_shake128_inc_absorb
+#define shake128_inc_finalize oqs_avx2_sha3_shake128_inc_finalize
+#define shake128_inc_squeeze oqs_avx2_sha3_shake128_inc_squeeze
+#define shake128_inc_ctx_release oqs_avx2_sha3_shake128_inc_ctx_release
+#define shake128_inc_ctx_clone oqs_avx2_sha3_shake128_inc_ctx_clone
+
+#define SHAKE256_RATE OQS_SHA3_SHAKE256_RATE
+#ifndef OQS_USE_SHA3_OPENSSL
+#define shake256 OQS_AVX2_SHA3_shake256
+#else
+#define shake256 oqs_avx2_unused_SHA3_shake256
+#endif
+
+typedef struct {
+	uint64_t *ctx;
+} shake256ctx;
+#define shake256_absorb oqs_avx2_sha3_shake256_absorb
+#define shake256_squeezeblocks oqs_avx2_sha3_shake256_squeezeblocks
+#define shake256_ctx_release oqs_avx2_sha3_shake256_ctx_release
+#define shake256_ctx_clone oqs_avx2_sha3_shake256_ctx_clone
+
+typedef struct {
+	uint64_t *ctx;
+} shake256incctx;
+#define shake256_inc_init oqs_avx2_sha3_shake256_inc_init
+#define shake256_inc_absorb oqs_avx2_sha3_shake256_inc_absorb
+#define shake256_inc_finalize oqs_avx2_sha3_shake256_inc_finalize
+#define shake256_inc_squeeze oqs_avx2_sha3_shake256_inc_squeeze
+#define shake256_inc_ctx_release oqs_avx2_sha3_shake256_inc_ctx_release
+#define shake256_inc_ctx_clone oqs_avx2_sha3_shake256_inc_ctx_clone
+
+#include "fips202.c"
+
+#define cshake128 OQS_SHA3_avx2_cshake128
+
+#define cshake128_inc_init oqs_avx2_sha3_cshake128_inc_init
+#define cshake128_inc_absorb oqs_avx2_sha3_cshake128_inc_absorb
+#define cshake128_inc_finalize oqs_avx2_sha3_cshake128_inc_finalize
+#define cshake128_inc_squeeze oqs_avx2_sha3_cshake128_inc_squeeze
+#define cshake128_inc_ctx_release oqs_avx2_sha3_cshake128_inc_ctx_release
+#define cshake128_inc_ctx_clone oqs_avx2_sha3_cshake128_inc_ctx_clone
+
+#define cshake256 OQS_SHA3_avx2_cshake256
+
+#define cshake256_inc_init oqs_avx2_sha3_cshake256_inc_init
+#define cshake256_inc_absorb oqs_avx2_sha3_cshake256_inc_absorb
+#define cshake256_inc_finalize oqs_avx2_sha3_cshake256_inc_finalize
+#define cshake256_inc_squeeze oqs_avx2_sha3_cshake256_inc_squeeze
+#define cshake256_inc_ctx_release oqs_avx2_sha3_cshake256_inc_ctx_release
+#define cshake256_inc_ctx_clone oqs_avx2_sha3_cshake256_inc_ctx_clone
+
+#include "sp800-185.c"
+
+void OQS_SHA3_avx2_cshake128_simple(uint8_t *output, size_t outlen, uint16_t cstm, const uint8_t *input, size_t inplen) {
+
+	shake128incctx state;
+
+	oqs_avx2_sha3_shake128_inc_init(&state);
+
+	/* Note: This function doesn't align exactly to cSHAKE (SP800-185 3.2), which should produce
+	SHAKE output if S and N = zero (sort of a customized custom-SHAKE function).
+	Padding is hard-coded as the first 32 bits, plus 16 bits of fixed S,
+	and 16 bits of counter, equivalant to S=cstm, N=0.
+	The short integer optimizes this function for a digest counter configuration */
+
+	uint8_t sep[8];
+	sep[0] = 0x01; /* bytepad */
+	sep[1] = 0xA8;
+	sep[2] = 0x01;
+	sep[3] = 0x00;
+	sep[4] = 0x01;
+	sep[5] = 0x10; /* bitlen of cstm */
+	sep[6] = cstm & 0xFF;
+	sep[7] = cstm >> 8;
+
+	state.ctx[0] = load64(sep);
+
+	/* transform the domain string */
+	KeccakF1600_StatePermute(state.ctx);
+
+	/* absorb the state */
+	oqs_avx2_sha3_cshake128_inc_absorb(&state, input, inplen);
+
+	/* generate output */
+	oqs_avx2_sha3_cshake128_inc_finalize(&state);
+	oqs_avx2_sha3_cshake128_inc_squeeze(output, outlen, &state);
+	oqs_avx2_sha3_shake128_inc_ctx_release(&state);
+}
+
+void OQS_SHA3_avx2_cshake256_simple(uint8_t *output, size_t outlen, uint16_t cstm, const uint8_t *input, size_t inplen) {
+
+	shake256incctx state;
+
+	oqs_avx2_sha3_shake256_inc_init(&state);
+
+	/* Note: This function doesn't align exactly to cSHAKE (SP800-185 3.2), which should produce
+	SHAKE output if S and N = zero (sort of a customized custom-SHAKE function).
+	Padding is hard-coded as the first 32 bits, plus 16 bits of fixed S,
+	and 16 bits of counter, equivalant to S=cstm, N=0.
+	The short integer optimizes this function for a digest counter configuration */
+
+	uint8_t sep[8];
+	sep[0] = 0x01; /* bytepad */
+	sep[1] = 0x88;
+	sep[2] = 0x01;
+	sep[3] = 0x00;
+	sep[4] = 0x01;
+	sep[5] = 0x10; /* bitlen of cstm */
+	sep[6] = cstm & 0xFF;
+	sep[7] = cstm >> 8;
+
+	state.ctx[0] = load64(sep);
+
+	/* transform the domain string */
+	KeccakF1600_StatePermute(state.ctx);
+
+	/* absorb the state */
+	oqs_avx2_sha3_cshake256_inc_absorb(&state, input, inplen);
+
+	/* generate output */
+	oqs_avx2_sha3_cshake256_inc_finalize(&state);
+	oqs_avx2_sha3_cshake256_inc_squeeze(output, outlen, &state);
+	oqs_avx2_sha3_shake256_inc_ctx_release(&state);
+}

--- a/src/common_avx2/sha3/sha3_ossl.c
+++ b/src/common_avx2/sha3/sha3_ossl.c
@@ -1,0 +1,63 @@
+/**
+ * \file sha3_ossl.c
+ * \brief Implementation of the OQS SHA3 API via calls to OpenSSL's SHA-3 functions
+ */
+
+#include <oqs/oqs.h>
+
+#ifdef OQS_USE_SHA3_OPENSSL
+
+#include "sha3.h"
+
+#include <openssl/evp.h>
+
+static void do_hash(uint8_t *output, const uint8_t *input, size_t inplen, const EVP_MD *md) {
+	EVP_MD_CTX *mdctx;
+	unsigned int outlen;
+	mdctx = EVP_MD_CTX_new();
+	EVP_DigestInit_ex(mdctx, md, NULL);
+	EVP_DigestUpdate(mdctx, input, inplen);
+	EVP_DigestFinal_ex(mdctx, output, &outlen);
+	EVP_MD_CTX_free(mdctx);
+}
+
+static void do_xof(uint8_t *output, size_t outlen, const uint8_t *input, size_t inplen, const EVP_MD *md) {
+	EVP_MD_CTX *mdctx;
+	mdctx = EVP_MD_CTX_new();
+	EVP_DigestInit_ex(mdctx, md, NULL);
+	EVP_DigestUpdate(mdctx, input, inplen);
+	EVP_DigestFinalXOF(mdctx, output, outlen);
+	EVP_MD_CTX_free(mdctx);
+}
+
+void OQS_SHA3_sha3_256(uint8_t *output, const uint8_t *input, size_t inplen) {
+	const EVP_MD *md;
+	md = EVP_sha3_256();
+	do_hash(output, input, inplen, md);
+}
+
+void OQS_SHA3_sha3_384(uint8_t *output, const uint8_t *input, size_t inplen) {
+	const EVP_MD *md;
+	md = EVP_sha3_384();
+	do_hash(output, input, inplen, md);
+}
+
+void OQS_SHA3_sha3_512(uint8_t *output, const uint8_t *input, size_t inplen) {
+	const EVP_MD *md;
+	md = EVP_sha3_512();
+	do_hash(output, input, inplen, md);
+}
+
+void OQS_SHA3_shake128(uint8_t *output, size_t outlen, const uint8_t *input, size_t inplen) {
+	const EVP_MD *md;
+	md = EVP_shake128();
+	do_xof(output, outlen, input, inplen, md);
+}
+
+void OQS_SHA3_shake256(uint8_t *output, size_t outlen, const uint8_t *input, size_t inplen) {
+	const EVP_MD *md;
+	md = EVP_shake256();
+	do_xof(output, outlen, input, inplen, md);
+}
+
+#endif

--- a/src/common_avx2/sha3/sha3x4.c
+++ b/src/common_avx2/sha3/sha3x4.c
@@ -1,0 +1,213 @@
+#include <immintrin.h>
+#include <stdint.h>
+#include <assert.h>
+
+#define SHAKE128_RATE 168
+
+#define NROUNDS 24
+#define ROL(a, offset) ((a << offset) ^ (a >> (64 - offset)))
+
+static uint64_t load64(const unsigned char *x) {
+	unsigned long long r = 0, i;
+
+	for (i = 0; i < 8; ++i) {
+		r |= (unsigned long long) x[i] << 8 * i;
+	}
+	return r;
+}
+
+static void store64(uint8_t *x, uint64_t u) {
+	unsigned int i;
+
+	for (i = 0; i < 8; ++i) {
+		x[i] = u;
+		u >>= 8;
+	}
+}
+
+/* Use implementation from the Keccak Code Package */
+#include "keccak4x/KeccakP-1600-times4-SIMD256.c"
+#define KeccakF1600_StatePermute4x KeccakP1600times4_PermuteAll_24rounds
+
+static void keccak_absorb4x(__m256i *s, unsigned int r, const unsigned char *m0, const unsigned char *m1, const unsigned char *m2, const unsigned char *m3,
+                            unsigned long long int mlen, unsigned char p) {
+	unsigned long long i;
+	unsigned char t0[200];
+	unsigned char t1[200];
+	unsigned char t2[200];
+	unsigned char t3[200];
+	unsigned long long *ss = (unsigned long long *) s;
+
+	while (mlen >= r) {
+		for (i = 0; i < r / 8; ++i) {
+			ss[4 * i + 0] ^= load64(m0 + 8 * i);
+			ss[4 * i + 1] ^= load64(m1 + 8 * i);
+			ss[4 * i + 2] ^= load64(m2 + 8 * i);
+			ss[4 * i + 3] ^= load64(m3 + 8 * i);
+		}
+
+		KeccakF1600_StatePermute4x(s);
+		mlen -= r;
+		m0 += r;
+		m1 += r;
+		m2 += r;
+		m3 += r;
+	}
+
+	for (i = 0; i < r; ++i) {
+		t0[i] = 0;
+		t1[i] = 0;
+		t2[i] = 0;
+		t3[i] = 0;
+	}
+	for (i = 0; i < mlen; ++i) {
+		t0[i] = m0[i];
+		t1[i] = m1[i];
+		t2[i] = m2[i];
+		t3[i] = m3[i];
+	}
+
+	t0[i] = p;
+	t1[i] = p;
+	t2[i] = p;
+	t3[i] = p;
+
+	t0[r - 1] |= 128;
+	t1[r - 1] |= 128;
+	t2[r - 1] |= 128;
+	t3[r - 1] |= 128;
+
+	for (i = 0; i < r / 8; ++i) {
+		ss[4 * i + 0] ^= load64(t0 + 8 * i);
+		ss[4 * i + 1] ^= load64(t1 + 8 * i);
+		ss[4 * i + 2] ^= load64(t2 + 8 * i);
+		ss[4 * i + 3] ^= load64(t3 + 8 * i);
+	}
+}
+
+static void keccak_squeezeblocks4x(unsigned char *h0, unsigned char *h1, unsigned char *h2, unsigned char *h3, unsigned long long int nblocks, __m256i *s, unsigned int r) {
+	unsigned int i;
+	unsigned long long *ss = (unsigned long long *) s;
+
+	while (nblocks > 0) {
+		KeccakF1600_StatePermute4x(s);
+		for (i = 0; i < (r >> 3); i++) {
+			store64(h0 + 8 * i, ss[4 * i + 0]);
+			store64(h1 + 8 * i, ss[4 * i + 1]);
+			store64(h2 + 8 * i, ss[4 * i + 2]);
+			store64(h3 + 8 * i, ss[4 * i + 3]);
+		}
+		h0 += r;
+		h1 += r;
+		h2 += r;
+		h3 += r;
+		nblocks--;
+	}
+}
+
+/********** SHAKE128 ***********/
+
+static void shake128_absorb4x(__m256i *s, const unsigned char *in0, const unsigned char *in1, const unsigned char *in2, const unsigned char *in3, unsigned long long inlen) {
+	unsigned int i;
+
+	for (i = 0; i < 25; i++) {
+		s[i] = _mm256_xor_si256(s[i], s[i]);    // zero state
+	}
+
+	/* Absorb input */
+	keccak_absorb4x(s, SHAKE128_RATE, in0, in1, in2, in3, inlen, 0x1F);
+}
+
+/* N is assumed to be empty; S is assumed to have at most 2 characters */
+void OQS_SHA3_shake128_4x(unsigned char *output0, unsigned char *output1, unsigned char *output2, unsigned char *output3, unsigned long long outlen,
+                          const unsigned char *in0, const unsigned char *in1, const unsigned char *in2, const unsigned char *in3, unsigned long long inlen) {
+	__m256i s[25];
+	unsigned char t0[SHAKE128_RATE];
+	unsigned char t1[SHAKE128_RATE];
+	unsigned char t2[SHAKE128_RATE];
+	unsigned char t3[SHAKE128_RATE];
+	unsigned int i;
+
+	shake128_absorb4x(s, in0, in1, in2, in3, inlen);
+
+	/* Squeeze output */
+	keccak_squeezeblocks4x(output0, output1, output2, output3, outlen / SHAKE128_RATE, s, SHAKE128_RATE);
+	output0 += (outlen / SHAKE128_RATE) * SHAKE128_RATE;
+	output1 += (outlen / SHAKE128_RATE) * SHAKE128_RATE;
+	output2 += (outlen / SHAKE128_RATE) * SHAKE128_RATE;
+	output3 += (outlen / SHAKE128_RATE) * SHAKE128_RATE;
+
+	if (outlen % SHAKE128_RATE) {
+		keccak_squeezeblocks4x(t0, t1, t2, t3, 1, s, SHAKE128_RATE);
+		for (i = 0; i < outlen % SHAKE128_RATE; i++) {
+			output0[i] = t0[i];
+			output1[i] = t1[i];
+			output2[i] = t2[i];
+			output3[i] = t3[i];
+		}
+	}
+}
+
+/********** cSHAKE128 ***********/
+
+static void cshake128_simple_absorb4x(__m256i *s, uint16_t cstm0, uint16_t cstm1, uint16_t cstm2, uint16_t cstm3, const unsigned char *in, unsigned long long inlen) {
+	unsigned char *sep = (unsigned char *) s;
+	unsigned int i;
+
+	for (i = 0; i < 25; i++) {
+		s[i] = _mm256_xor_si256(s[i], s[i]);    // zero state
+	}
+
+	/* Absorb customization (domain-separation) string */
+	for (i = 0; i < 4; i++) {
+		sep[8 * i + 0] = 0x01;
+		sep[8 * i + 1] = 0xa8;
+		sep[8 * i + 2] = 0x01;
+		sep[8 * i + 3] = 0x00;
+		sep[8 * i + 4] = 0x01;
+		sep[8 * i + 5] = 16;
+	}
+	sep[6] = cstm0 & 0xff;
+	sep[7] = cstm0 >> 8;
+	sep[14] = cstm1 & 0xff;
+	sep[15] = cstm1 >> 8;
+	sep[22] = cstm2 & 0xff;
+	sep[23] = cstm2 >> 8;
+	sep[30] = cstm3 & 0xff;
+	sep[31] = cstm3 >> 8;
+
+	KeccakF1600_StatePermute4x(s);
+
+	/* Absorb input */
+	keccak_absorb4x(s, SHAKE128_RATE, in, in, in, in, inlen, 0x04);
+}
+
+/* N is assumed to be empty; S is assumed to have at most 2 characters */
+void OQS_SHA3_cshake128_simple4x(unsigned char *output0, unsigned char *output1, unsigned char *output2, unsigned char *output3, unsigned long long outlen,
+                                 uint16_t cstm0, uint16_t cstm1, uint16_t cstm2, uint16_t cstm3, const unsigned char *in, unsigned long long inlen) {
+	__m256i s[25];
+	unsigned char t0[SHAKE128_RATE];
+	unsigned char t1[SHAKE128_RATE];
+	unsigned char t2[SHAKE128_RATE];
+	unsigned char t3[SHAKE128_RATE];
+	unsigned int i;
+
+	cshake128_simple_absorb4x(s, cstm0, cstm1, cstm2, cstm3, in, inlen);
+
+	/* Squeeze output */
+	keccak_squeezeblocks4x(output0, output1, output2, output3, outlen / SHAKE128_RATE, s, SHAKE128_RATE);
+	output0 += (outlen / SHAKE128_RATE) * SHAKE128_RATE;
+	output1 += (outlen / SHAKE128_RATE) * SHAKE128_RATE;
+	output2 += (outlen / SHAKE128_RATE) * SHAKE128_RATE;
+	output3 += (outlen / SHAKE128_RATE) * SHAKE128_RATE;
+
+	if (outlen % SHAKE128_RATE) {
+		keccak_squeezeblocks4x(t0, t1, t2, t3, 1, s, SHAKE128_RATE);
+		for (i = 0; i < outlen % SHAKE128_RATE; i++) {
+			output0[i] = t0[i];
+			output1[i] = t1[i];
+			output2[i] = t2[i];
+			output3[i] = t3[i];
+		}
+	}
+}

--- a/src/common_avx2/sha3/sp800-185.c
+++ b/src/common_avx2/sha3/sp800-185.c
@@ -1,0 +1,154 @@
+#include <stddef.h>
+#include <stdint.h>
+
+static size_t left_encode(uint8_t *encbuf, size_t value) {
+	size_t n, i, v;
+
+	for (v = value, n = 0; v && (n < sizeof(size_t)); n++, v >>= 8) {
+		; /* empty */
+	}
+	if (n == 0) {
+		n = 1;
+	}
+	for (i = 1; i <= n; i++) {
+		encbuf[i] = (uint8_t)(value >> (8 * (n - i)));
+	}
+	encbuf[0] = (uint8_t)n;
+	return n + 1;
+}
+
+void cshake128_inc_init(shake128incctx *state, const uint8_t *name, size_t namelen, const uint8_t *cstm, size_t cstmlen) {
+	uint8_t encbuf[sizeof(size_t) +1];
+
+	shake128_inc_init(state);
+
+	shake128_inc_absorb(state, encbuf, left_encode(encbuf, SHAKE128_RATE));
+
+	shake128_inc_absorb(state, encbuf, left_encode(encbuf, namelen * 8));
+	shake128_inc_absorb(state, name, namelen);
+
+	shake128_inc_absorb(state, encbuf, left_encode(encbuf, cstmlen * 8));
+	shake128_inc_absorb(state, cstm, cstmlen);
+
+	if (state->ctx[25] != 0) {
+		state->ctx[25] = SHAKE128_RATE - 1;
+		encbuf[0] = 0;
+		shake128_inc_absorb(state, encbuf, 1);
+	}
+}
+
+void cshake128_inc_absorb(shake128incctx *state, const uint8_t *input, size_t inlen) {
+	shake128_inc_absorb(state, input, inlen);
+}
+
+void cshake128_inc_finalize(shake128incctx *state) {
+	state->ctx[state->ctx[25] >> 3] ^= (uint64_t)0x04 << (8 * (state->ctx[25] & 0x07));
+	state->ctx[(SHAKE128_RATE - 1) >> 3] ^= (uint64_t)128 << (8 * ((SHAKE128_RATE - 1) & 0x07));
+	state->ctx[25] = 0;
+}
+
+void cshake128_inc_squeeze(uint8_t *output, size_t outlen, shake128incctx *state) {
+	shake128_inc_squeeze(output, outlen, state);
+}
+
+void cshake128_inc_ctx_release(shake128incctx *state) {
+	shake128_inc_ctx_release(state);
+}
+
+void cshake128_inc_ctx_clone(shake128incctx *dest, const shake128incctx *src) {
+	shake128_inc_ctx_clone(dest, src);
+}
+
+void cshake256_inc_init(shake256incctx *state, const uint8_t *name, size_t namelen, const uint8_t *cstm, size_t cstmlen) {
+	uint8_t encbuf[sizeof(size_t) +1];
+
+	shake256_inc_init(state);
+
+	shake256_inc_absorb(state, encbuf, left_encode(encbuf, SHAKE256_RATE));
+
+	shake256_inc_absorb(state, encbuf, left_encode(encbuf, namelen * 8));
+	shake256_inc_absorb(state, name, namelen);
+
+	shake256_inc_absorb(state, encbuf, left_encode(encbuf, cstmlen * 8));
+	shake256_inc_absorb(state, cstm, cstmlen);
+
+	if (state->ctx[25] != 0) {
+		state->ctx[25] = SHAKE256_RATE - 1;
+		encbuf[0] = 0;
+		shake256_inc_absorb(state, encbuf, 1);
+	}
+}
+
+void cshake256_inc_absorb(shake256incctx *state, const uint8_t *input, size_t inlen) {
+	shake256_inc_absorb(state, input, inlen);
+}
+
+void cshake256_inc_finalize(shake256incctx *state) {
+	state->ctx[state->ctx[25] >> 3] ^= (uint64_t)0x04 << (8 * (state->ctx[25] & 0x07));
+	state->ctx[(SHAKE256_RATE - 1) >> 3] ^= (uint64_t)128 << (8 * ((SHAKE256_RATE - 1) & 0x07));
+	state->ctx[25] = 0;
+}
+
+void cshake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state) {
+	shake256_inc_squeeze(output, outlen, state);
+}
+
+void cshake256_inc_ctx_release(shake256incctx *state) {
+	shake256_inc_ctx_release(state);
+}
+
+void cshake256_inc_ctx_clone(shake256incctx *dest, const shake256incctx *src) {
+	shake256_inc_ctx_clone(dest, src);
+}
+
+/*************************************************
+ * Name:        cshake128
+ *
+ * Description: cSHAKE128 XOF with non-incremental API
+ *
+ * Arguments:   - uint8_t *output: pointer to output
+ *              - size_t outlen: requested output length in bytes
+ *              - const uint8_t *name: pointer to function-name string
+ *              - size_t namelen: length of function-name string in bytes
+ *              - const uint8_t *cstm: pointer to non-empty customization string
+ *              - size_t cstmlen: length of customization string in bytes
+ *              - const uint8_t *input: pointer to input
+ *              - size_t inlen: length of input in bytes
+ **************************************************/
+void cshake128(uint8_t *output, size_t outlen,
+               const uint8_t *name, size_t namelen,
+               const uint8_t *cstm, size_t cstmlen,
+               const uint8_t *input, size_t inlen) {
+	shake128incctx state;
+	cshake128_inc_init(&state, name, namelen, cstm, cstmlen);
+	cshake128_inc_absorb(&state, input, inlen);
+	cshake128_inc_finalize(&state);
+	cshake128_inc_squeeze(output, outlen, &state);
+	cshake128_inc_ctx_release(&state);
+}
+
+/*************************************************
+ * Name:        cshake256
+ *
+ * Description: cSHAKE256 XOF with non-incremental API
+ *
+ * Arguments:   - uint8_t *output: pointer to output
+ *              - size_t outlen: requested output length in bytes
+ *              - const uint8_t *name: pointer to function-name string
+ *              - size_t namelen: length of function-name string in bytes
+ *              - const uint8_t *cstm: pointer to non-empty customization string
+ *              - size_t cstmlen: length of customization string in bytes
+ *              - const uint8_t *input: pointer to input
+ *              - size_t inlen: length of input in bytes
+ **************************************************/
+void cshake256(uint8_t *output, size_t outlen,
+               const uint8_t *name, size_t namelen,
+               const uint8_t *cstm, size_t cstmlen,
+               const uint8_t *input, size_t inlen) {
+	shake256incctx state;
+	cshake256_inc_init(&state, name, namelen, cstm, cstmlen);
+	cshake256_inc_absorb(&state, input, inlen);
+	cshake256_inc_finalize(&state);
+	cshake256_inc_squeeze(output, outlen, &state);
+	cshake256_inc_ctx_release(&state);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,13 +32,13 @@ if(NOT WIN32)
     execute_process(COMMAND ${PROJECT_SOURCE_DIR}/scripts/git_commit.sh OUTPUT_VARIABLE GIT_COMMIT)
     add_definitions(-DOQS_COMPILE_GIT_COMMIT="${GIT_COMMIT}")
 
-    add_executable(test_aes test_aes.c $<TARGET_OBJECTS:common>)
+    add_executable(test_aes test_aes.c ${COMMON_OBJS})
     target_link_libraries(test_aes PRIVATE ${INTERNAL_TEST_DEPS})
 
-    add_executable(test_hash test_hash.c $<TARGET_OBJECTS:common>)
+    add_executable(test_hash test_hash.c ${COMMON_OBJS})
     target_link_libraries(test_hash PRIVATE ${INTERNAL_TEST_DEPS})
 
-    add_executable(test_sha3 test_sha3.c $<TARGET_OBJECTS:common>)
+    add_executable(test_sha3 test_sha3.c ${COMMON_OBJS})
     target_link_libraries(test_sha3 PRIVATE ${INTERNAL_TEST_DEPS})
 
     set(UNIX_TESTS test_aes test_hash test_sha3)


### PR DESCRIPTION
In pursuit of #624 provide clean and RT-protected AVX2 optimised variant(s) of SHA3.