### PR TITLE
SIDH build fix

### DIFF
--- a/src/kem/kem.h
+++ b/src/kem/kem.h
@@ -356,6 +356,9 @@ OQS_API void OQS_KEM_free(OQS_KEM *kem);
 #ifdef OQS_ENABLE_KEM_SIKE
 #include <oqs/kem_sike.h>
 #endif /* OQS_ENABLE_KEM_SIKE */
+#ifdef OQS_ENABLE_KEM_SIDH
+#include <oqs/kem_sike.h>
+#endif /* OQS_ENABLE_KEM_SIDH */
 // EDIT-WHEN-ADDING-KEM
 
 #if defined(__cplusplus)


### PR DESCRIPTION
Building the library ends with an error when `OQS_ENABLE_KEM_SIKE` is disabled.
```
[archie@archlinux build]$ cmake -GNinja -DOQS_ENABLE_KEM_SIKE=OFF ..
-- The C compiler identification is GNU 9.3.0
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - yes
-- Found Threads: TRUE  
-- Found OpenSSL: /usr/lib/libcrypto.so (found suitable version "1.1.1g", minimum required is "1.1.1")  
-- Found Doxygen: /usr/bin/doxygen (found version "1.8.17") found components: doxygen dot 
-- Configuring done
-- Generating done
-- Build files have been written to: /home/archie/Documents/liboqs/build
[archie@archlinux build]$ ninja
[15/956] Building C object src/CMakeFiles/oqs.dir/kem/kem.c.o
FAILED: src/CMakeFiles/oqs.dir/kem/kem.c.o 
/usr/bin/cc  -Iinclude -fPIC -fvisibility=hidden   -Werror -Wall -Wextra -Wpedantic -Wstrict-prototypes -Wshadow -Wformat=2 -Wfloat-equal -Wwrite-strings -O3 -fomit-frame-pointer -fdata-sections -ffunction-sections -Wl,--gc-sections -std=gnu11 -MD -MT src/CMakeFiles/oqs.dir/kem/kem.c.o -MF src/CMakeFiles/oqs.dir/kem/kem.c.o.d -o src/CMakeFiles/oqs.dir/kem/kem.c.o   -c ../src/kem/kem.c
../src/kem/kem.c: In function ‘OQS_KEM_new’:
../src/kem/kem.c:738:10: error: implicit declaration of function ‘OQS_KEM_sidh_p434_new’ [-Werror=implicit-function-declaration]
  738 |   return OQS_KEM_sidh_p434_new();
      |          ^~~~~~~~~~~~~~~~~~~~~
../src/kem/kem.c:738:10: error: returning ‘int’ from a function with return type ‘OQS_KEM *’ {aka ‘struct OQS_KEM *’} makes pointer from integer without a cast [-Werror=int-conversion]
  738 |   return OQS_KEM_sidh_p434_new();
      |          ^~~~~~~~~~~~~~~~~~~~~~~
../src/kem/kem.c:744:10: error: implicit declaration of function ‘OQS_KEM_sidh_p503_new’ [-Werror=implicit-function-declaration]
  744 |   return OQS_KEM_sidh_p503_new();
      |          ^~~~~~~~~~~~~~~~~~~~~
../src/kem/kem.c:744:10: error: returning ‘int’ from a function with return type ‘OQS_KEM *’ {aka ‘struct OQS_KEM *’} makes pointer from integer without a cast [-Werror=int-conversion]
  744 |   return OQS_KEM_sidh_p503_new();
      |          ^~~~~~~~~~~~~~~~~~~~~~~
../src/kem/kem.c:750:10: error: implicit declaration of function ‘OQS_KEM_sidh_p610_new’ [-Werror=implicit-function-declaration]
  750 |   return OQS_KEM_sidh_p610_new();
      |          ^~~~~~~~~~~~~~~~~~~~~
../src/kem/kem.c:750:10: error: returning ‘int’ from a function with return type ‘OQS_KEM *’ {aka ‘struct OQS_KEM *’} makes pointer from integer without a cast [-Werror=int-conversion]
  750 |   return OQS_KEM_sidh_p610_new();
      |          ^~~~~~~~~~~~~~~~~~~~~~~
../src/kem/kem.c:756:10: error: implicit declaration of function ‘OQS_KEM_sidh_p751_new’ [-Werror=implicit-function-declaration]
  756 |   return OQS_KEM_sidh_p751_new();
      |          ^~~~~~~~~~~~~~~~~~~~~
../src/kem/kem.c:756:10: error: returning ‘int’ from a function with return type ‘OQS_KEM *’ {aka ‘struct OQS_KEM *’} makes pointer from integer without a cast [-Werror=int-conversion]
  756 |   return OQS_KEM_sidh_p751_new();
      |          ^~~~~~~~~~~~~~~~~~~~~~~
../src/kem/kem.c:786:10: error: implicit declaration of function ‘OQS_KEM_sidh_p434_compressed_new’; did you mean ‘OQS_KEM_alg_sidh_p434_compressed’? [-Werror=implicit-function-declaration]
  786 |   return OQS_KEM_sidh_p434_compressed_new();
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |          OQS_KEM_alg_sidh_p434_compressed
../src/kem/kem.c:786:10: error: returning ‘int’ from a function with return type ‘OQS_KEM *’ {aka ‘struct OQS_KEM *’} makes pointer from integer without a cast [-Werror=int-conversion]
  786 |   return OQS_KEM_sidh_p434_compressed_new();
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/kem/kem.c:792:10: error: implicit declaration of function ‘OQS_KEM_sidh_p503_compressed_new’; did you mean ‘OQS_KEM_alg_sidh_p503_compressed’? [-Werror=implicit-function-declaration]
  792 |   return OQS_KEM_sidh_p503_compressed_new();
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |          OQS_KEM_alg_sidh_p503_compressed
../src/kem/kem.c:792:10: error: returning ‘int’ from a function with return type ‘OQS_KEM *’ {aka ‘struct OQS_KEM *’} makes pointer from integer without a cast [-Werror=int-conversion]
  792 |   return OQS_KEM_sidh_p503_compressed_new();
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/kem/kem.c:798:10: error: implicit declaration of function ‘OQS_KEM_sidh_p610_compressed_new’; did you mean ‘OQS_KEM_alg_sidh_p610_compressed’? [-Werror=implicit-function-declaration]
  798 |   return OQS_KEM_sidh_p610_compressed_new();
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |          OQS_KEM_alg_sidh_p610_compressed
../src/kem/kem.c:798:10: error: returning ‘int’ from a function with return type ‘OQS_KEM *’ {aka ‘struct OQS_KEM *’} makes pointer from integer without a cast [-Werror=int-conversion]
  798 |   return OQS_KEM_sidh_p610_compressed_new();
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/kem/kem.c:804:10: error: implicit declaration of function ‘OQS_KEM_sidh_p751_compressed_new’; did you mean ‘OQS_KEM_alg_sidh_p751_compressed’? [-Werror=implicit-function-declaration]
  804 |   return OQS_KEM_sidh_p751_compressed_new();
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |          OQS_KEM_alg_sidh_p751_compressed
../src/kem/kem.c:804:10: error: returning ‘int’ from a function with return type ‘OQS_KEM *’ {aka ‘struct OQS_KEM *’} makes pointer from integer without a cast [-Werror=int-conversion]
  804 |   return OQS_KEM_sidh_p751_compressed_new();
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
[24/956] Building C object src/kem/frodoke...les/frodokem.dir/external/frodo1344aes.c.o
ninja: build stopped: subcommand failed.
```
This PR fixes the bug