### PR TITLE
default alg setting brought in line with documentation

### DIFF
--- a/.CMake/alg_support.cmake
+++ b/.CMake/alg_support.cmake
@@ -1,10 +1,10 @@
 include(CMakeDependentOption)
 
-if(NOT OQS_KEM_DEFAULT)
-set(OQS_KEM_DEFAULT "OQS_KEM_alg_frodokem_640_aes")
+if(NOT DEFINED OQS_KEM_DEFAULT)
+    set(OQS_KEM_DEFAULT "OQS_KEM_alg_frodokem_640_aes")
 endif()
-if(NOT OQS_SIG_DEFAULT)
-set(OQS_SIG_DEFAULT "OQS_SIG_alg_dilithium_2")
+if(NOT DEFINED OQS_SIG_DEFAULT)
+    set(OQS_SIG_DEFAULT "OQS_SIG_alg_dilithium_2")
 endif()
 
 if(NOT WIN32)

--- a/.CMake/alg_support.cmake
+++ b/.CMake/alg_support.cmake
@@ -1,7 +1,11 @@
 include(CMakeDependentOption)
 
+if(NOT OQS_KEM_DEFAULT)
 set(OQS_KEM_DEFAULT "OQS_KEM_alg_frodokem_640_aes")
+endif()
+if(NOT OQS_SIG_DEFAULT)
 set(OQS_SIG_DEFAULT "OQS_SIG_alg_dilithium_2")
+endif()
 
 if(NOT WIN32)
     option(OQS_USE_OPENSSL "" ON)


### PR DESCRIPTION
Without this, cmake-time `-D` settings for default algs have no effect