### PR TITLE
Fixing test behavior

### DIFF
--- a/tests/kat_kem.c
+++ b/tests/kat_kem.c
@@ -120,6 +120,7 @@ static OQS_STATUS kem_kat(const char *method_name) {
 
 err:
 	ret = OQS_ERROR;
+	goto cleanup;
 
 algo_not_enabled:
 	ret = OQS_SUCCESS;

--- a/tests/kat_sig.c
+++ b/tests/kat_sig.c
@@ -718,6 +718,7 @@ OQS_STATUS sig_kat(const char *method_name) {
 
 err:
 	ret = OQS_ERROR;
+	goto cleanup;
 
 algo_not_enabled:
 	ret = OQS_SUCCESS;


### PR DESCRIPTION
`kem_kat` and `sig_kat` never end with an error because the `ret` variable is overwritten with `OQS_SUCCESS`