### PR TITLE
Allowing cmake to export project targets

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools"
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,8 @@ if(OQS_USE_OPENSSL)
     target_include_directories(oqs PUBLIC ${OPENSSL_INCLUDE_DIR})
 endif()
 
+
+
 set_target_properties(oqs
     PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
@@ -92,6 +94,10 @@ set_target_properties(oqs
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
 add_library(OQS::oqs ALIAS oqs)
+
+target_include_directories(oqs PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+)
 
 install(TARGETS oqs
         EXPORT oqsTargets

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,8 +94,21 @@ set_target_properties(oqs
 add_library(OQS::oqs ALIAS oqs)
 
 install(TARGETS oqs
+        EXPORT oqs
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
+
+install(
+    EXPORT oqs
+    NAMESPACE oqs::
+    DESTINATION lib
+)
+
+#export(
+#    TARGETS oqs
+#    NAMESPACE ${PROJECT_NAME}::
+#    FILE ...nothing  
+#)
 
 install(FILES ${PUBLIC_HEADERS}
         DESTINATION include/oqs)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,7 +99,7 @@ install(TARGETS oqs
         ARCHIVE DESTINATION lib)
 
 install(
-    EXPORT oqs
+    EXPORT oqsTargets
     NAMESPACE oqs::
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/oqs
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,7 +94,7 @@ set_target_properties(oqs
 add_library(OQS::oqs ALIAS oqs)
 
 install(TARGETS oqs
-        EXPORT oqs
+        EXPORT oqsTargets
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,11 +104,5 @@ install(
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/oqs
 )
 
-#export(
-#    TARGETS oqs
-#    NAMESPACE ${PROJECT_NAME}::
-#    FILE ...nothing  
-#)
-
 install(FILES ${PUBLIC_HEADERS}
         DESTINATION include/oqs)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,7 +101,7 @@ install(TARGETS oqs
 install(
     EXPORT oqs
     NAMESPACE oqs::
-    DESTINATION lib
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/oqs
 )
 
 #export(


### PR DESCRIPTION
Hello there,
I made a small tweak that allows inclusion of liboqs into other cmake projects using `add_subdirectory` and other funny tools.

So far, liboqs doesnt export any of its targets, and thus makes it more difficult to link against in other projects. This simple fix allows something like this to happen in a custom project:
```cmake
FetchContent_Declare(liboqs
    GIT_REPOSITORY https://github.com/onavratil-monetplus/liboqs
)
message(STATUS  "Fetching liboqs...this may take a while")
FetchContent_MakeAvailable(liboqs)
# ....

target_link_libraries(myCustomTarget PUBLIC OQS::oqs)
```
And boom! There we go, no need to install the lib system-wide prior to project build, allows to use static version of the lib etc etc etc.

Now I am nothing for a cmake professional, but this solution works nicely for me, and hopefully can help someone else as well.

On a footnote, the fix is based on a discussion regarding my desparate attempts to use cmake.
https://stackoverflow.com/questions/61504626/the-cmake-quandary