### PR TITLE
Update cross-compiling instructions for Windows in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Or to compile for Windows AMD64 from Ubuntu Bionic:
 
 	apt install gcc-mingw-w64
 	mkdir build && cd build
-	cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_windows-amd64.cmake ..
+	cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_windows-amd64.cmake -DOQS_USE_CPU_EXTENSIONS=OFF ..
 	ninja
 
 ## Documentation


### PR DESCRIPTION
OQS_USE_CPU_EXTENSIONS has to be OFF in the cross-compiling scenario, or CMake will fail.