### PR TITLE
Change return value of `USING_TIME_RATHER_THAN_CYCLES` to unsigned int.

### DIFF
--- a/tests/ds_benchmark.h
+++ b/tests/ds_benchmark.h
@@ -139,7 +139,7 @@ static uint64_t _bench_rdtsc(void) {
 #define USING_TIME_RATHER_THAN_CYCLES
 	struct timespec time;
 	clock_gettime(CLOCK_REALTIME, &time);
-	return (int64_t)(time.tv_sec * 1e9 + time.tv_nsec);
+	return (uint64_t)(time.tv_sec * 1e9 + time.tv_nsec);
 #endif
 }
 


### PR DESCRIPTION
Resolves issue #776 when attempting to build for arm64-v8a in clang.

Would also like advice on whether `_bench_init_perfcounters` parameters and local variables should be unsigned, as it would make sense to fix them here.