### PR TITLE
adding alpine, shared OSX CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,39 @@ localCheckout: &localCheckout
         - store_artifacts:
             path: build/test-results
 
+.macjob: &macjob
+    macos:
+        xcode: "11.3.0"
+    steps:
+        - checkout
+        - run:
+            name: Install dependencies
+            command: |
+              scripts/git_no_checkin_in_last_day.sh || (
+              brew update &&
+              brew unlink python@2 &&
+              brew install cmake ninja doxygen astyle &&
+              pip3 install pytest pytest-xdist
+              )
+        - run:
+            name: Configure
+            command: scripts/git_no_checkin_in_last_day.sh || (mkdir build && cd build && cmake -GNinja ${CONFIGURE_ARGS} ..)
+        - run:
+            name: Build
+            command: ../scripts/git_no_checkin_in_last_day.sh || ninja
+            working_directory: build
+        - run:
+            name: System information
+            command: scripts/git_no_checkin_in_last_day.sh || (sysctl -a | grep machdep.cpu)
+        - run:
+            name: Run tests
+            command: ../scripts/git_no_checkin_in_last_day.sh || ninja run_tests
+            working_directory: build
+        - store_test_results: # Note that this command will fail when running CircleCI locally, that is expected behaviour
+            path: build/test-results
+        - store_artifacts:
+            path: build/test-results
+
 jobs:
   centos-7-amd64:
     <<: *oqsjob
@@ -123,6 +156,18 @@ jobs:
     environment:
       CONFIGURE_ARGS: -DCMAKE_BUILD_TYPE=Release -DOQS_ENABLE_SIG_SPHINCS=OFF # sig-sphincs exhausts memory on CircleCI servers
       ARCH: armel
+  alpine-amd64-static:
+    <<: *oqsjob
+    environment:
+      IMAGE: openquantumsafe/ci-alpine-amd64:latest
+      CONFIGURE_ARGS: -DCMAKE_BUILD_TYPE=Release -DOQS_USE_OPENSSL=OFF
+      SKIP_TESTS: style,doxygen # not installed in alpine, no news anyway
+  alpine-amd64-shared:
+    <<: *oqsjob
+    environment:
+      IMAGE: openquantumsafe/ci-alpine-amd64:latest
+      CONFIGURE_ARGS: -DCMAKE_BUILD_TYPE=Release -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON
+      SKIP_TESTS: style,doxygen # not installed in alpine, no news anyway
   ubuntu-bionic-x86_64-gcc8:
     <<: *oqsjob
     environment:
@@ -160,41 +205,16 @@ jobs:
       IMAGE: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
       CC: clang-9
       CONFIGURE_ARGS: -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Undefined
-  macOS:
-    macos:
-        xcode: "11.3.0"
+  macOS-static-noopenssl:
+    <<: *macjob
     environment:
         CONFIGURE_ARGS: -DOQS_USE_OPENSSL=OFF
         SKIP_TESTS: style
-    steps:
-        - checkout
-        - run:
-            name: Install dependencies
-            command: |
-              scripts/git_no_checkin_in_last_day.sh || (
-              brew update &&
-              brew unlink python@2 &&
-              brew install cmake ninja doxygen astyle &&
-              pip3 install pytest pytest-xdist
-              )
-        - run:
-            name: Configure
-            command: scripts/git_no_checkin_in_last_day.sh || (mkdir build && cd build && cmake -GNinja ${CONFIGURE_ARGS} ..)
-        - run:
-            name: Build
-            command: ../scripts/git_no_checkin_in_last_day.sh || ninja
-            working_directory: build
-        - run:
-            name: System information
-            command: scripts/git_no_checkin_in_last_day.sh || (sysctl -a | grep machdep.cpu)
-        - run:
-            name: Run tests
-            command: ../scripts/git_no_checkin_in_last_day.sh || ninja run_tests
-            working_directory: build
-        - store_test_results: # Note that this command will fail when running CircleCI locally, that is expected behaviour
-            path: build/test-results
-        - store_artifacts:
-            path: build/test-results
+  macOS-shared-openssl:
+    <<: *macjob
+    environment:
+        CONFIGURE_ARGS: -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON
+        SKIP_TESTS: style
   win-static:
     <<: *winjob
     environment:
@@ -223,7 +243,10 @@ workflows:
       - centos-7-amd64
       - centos-8-amd64
       - debian-buster-amd64
-      - macOS
+      - alpine-amd64-static
+      - macOS-static-noopenssl
+      - alpine-amd64-shared
+      - macOS-shared-openssl
       - ubuntu-bionic-x86_64-gcc8
       - ubuntu-bionic-x86_64-clang9
       - ubuntu-bionic-x86_64-gcc7-shared
@@ -242,7 +265,6 @@ workflows:
       - debian-buster-arm64
       - debian-buster-armhf
       - debian-buster-armel
-      - macOS
       - ubuntu-bionic-x86_64-gcc7-noopenssl
       - ubuntu-bionic-x86_64-gcc7-shared
       - ubuntu-bionic-x86_64-gcc8


### PR DESCRIPTION
As once discussed with @xvzcf and to draw on the "catch" by the Centos8 CI test on PR #780 this is to add more CI platforms.

The tests are running (results [here](https://app.circleci.com/pipelines/github/baentsch/liboqs/291/workflows/11fba35f-c766-453c-9a56-6875ede52af2)) so this PR seems OK. 

The results warrant investigation, though:

Quickly looking into the newly emerged failures show 
- a wrong file-extension check for OSX [here](https://github.com/open-quantum-safe/liboqs/blob/7f7bbaf59e9bc1847c7ffc9efe298409a0b71ea2/tests/test_namespace.py#L15) and 
- failures when testing several (15) algorithms (e.g., BIKE1-L3-FO, SIKE-p751-compressed, FrodoKEM-976-AES). When running them manually, it's always a SIGSEGV (core dump): Quick gdb runs show the error in functions like `OQS_KEM_bike1_l3_fo_decode`,  `EphemeralKeyGeneration_A_extended`, `oqs_kem_frodokem_976_aes_mul_add_sa_plus_e`). Unfortunately I couldn't dig deeper as `liboqs` build for release type `Debug` had these core dumps disappear :-(

As the latter point hits so many different algorithms I wonder whether the CI-Alpine image is somehow not in line with our prerequisites... so asking for feedback from @xvzcf whether you see something glaring wrong with [this Dockerfile](https://github.com/open-quantum-safe/ci-containers/blob/master/alpine/Dockerfile) and the below:
```
~/project/build # gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-alpine-linux-musl/9.2.0/lto-wrapper
Target: x86_64-alpine-linux-musl
Configured with: /home/buildozer/aports/main/gcc/src/gcc-9.2.0/configure --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --build=x86_64-alpine-linux-musl --host=x86_64-alpine-linux-musl --target=x86_64-alpine-linux-musl --with-pkgversion='Alpine 9.2.0' --enable-checking=release --disable-fixed-point --disable-libstdcxx-pch --disable-multilib --disable-nls --disable-werror --disable-symvers --enable-__cxa_atexit --enable-default-pie --enable-default-ssp --enable-cloog-backend --enable-languages=c,c++,objc,fortran,ada --disable-libssp --disable-libmpx --disable-libmudflap --disable-libsanitizer --enable-shared --enable-threads --enable-tls --with-system-zlib --with-linker-hash-style=gnu
Thread model: posix
gcc version 9.2.0 (Alpine 9.2.0)
```

Hence only Draft PR for the time being. All and any feedback very welcome!