### PR TITLE
Added invalid ciphertext test in test_kem

### DIFF
--- a/tests/test_kem.c
+++ b/tests/test_kem.c
@@ -113,6 +113,14 @@ static OQS_STATUS kem_test_correctness(const char *method_name) {
 		goto err;
 	}
 
+	// test invalid encapsulation (call should either fail or result in invalid shared secret)
+	OQS_randombytes(ciphertext, kem->length_ciphertext);
+	rc = OQS_KEM_decaps(kem, shared_secret_d, ciphertext, secret_key);
+	if (rc == OQS_SUCCESS && memcmp(shared_secret_e, shared_secret_d, kem->length_shared_secret) == 0) {
+		fprintf(stderr, "ERROR: OQS_KEM_decaps succeeded on wrong input\n");
+		goto err;
+	}
+
 	ret = OQS_SUCCESS;
 	goto cleanup;
 

--- a/tests/test_sig.c
+++ b/tests/test_sig.c
@@ -68,7 +68,7 @@ static OQS_STATUS sig_test_correctness(const char *method_name) {
 	}
 
 	/* modify the signature to invalidate it */
-	signature[0]++;
+	OQS_randombytes(signature, signature_len);
 	rc = OQS_SIG_verify(sig, message, message_len, signature, signature_len, public_key);
 	if (rc != OQS_ERROR) {
 		fprintf(stderr, "ERROR: OQS_SIG_verify should have failed!\n");


### PR DESCRIPTION
Test now generates a random ciphertext and expect an invalid decapsulation or non-matching shared secret. Also replaced invalid signature with random array vs one with only the first byte modified (to potentially catch more errors).

- [ ] Fix SIKE compressed decapsulation error on bad data before merging this (issue #788)