### PR TITLE
Install dll in output bin directory on windows cross-compile

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,7 +95,8 @@ add_library(OQS::oqs ALIAS oqs)
 
 install(TARGETS oqs
         LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
+        ARCHIVE DESTINATION lib
+	RUNTIME DESTINATION bin)
 
 install(FILES ${PUBLIC_HEADERS}
         DESTINATION include/oqs)


### PR DESCRIPTION
Now installs `liboqs.dll` in the output bin directory when cross-compiling the shared libs for Windows. Fixes issue #773.
