### PR TITLE
Use C rounding code in Dilithium instead of AVX2

### DIFF
--- a/src/sig/dilithium/pqclean_dilithium3_avx2/rounding.c
+++ b/src/sig/dilithium/pqclean_dilithium3_avx2/rounding.c
@@ -4,6 +4,32 @@
 #include "rounding.h"
 #include "consts.h"
 
+// copied from pqclean_dilithium3_clean/rounding.c
+/*************************************************
+* Name:        power2round
+*
+* Description: For finite field element a, compute a0, a1 such that
+*              a mod Q = a1*2^D + a0 with -2^{D-1} < a0 <= 2^{D-1}.
+*              Assumes a to be standard representative.
+*
+* Arguments:   - uint32_t a: input element
+*              - uint32_t *a0: pointer to output element Q + a0
+*
+* Returns a1.
+**************************************************/
+static inline uint32_t power2round(uint32_t a, uint32_t *a0)  {
+  int32_t t;
+
+  /* Centralized remainder mod 2^D */
+  t = a & ((1U << D) - 1);
+  t -= (1U << (D-1)) + 1;
+  t += (t >> 31) & (1U << D);
+  t -= (1U << (D-1)) - 1;
+  *a0 = Q + t;
+  a = (a - t) >> D;
+  return a;
+}
+
 /*************************************************
 * Name:        power2round
 *
@@ -18,6 +44,13 @@
 **************************************************/
 void power2round_avx(uint32_t * restrict a1, uint32_t * restrict a0, const uint32_t * restrict a)
 {
+  // temporarily use plain C version of power2round
+  // https://github.com/open-quantum-safe/liboqs/issues/793
+  // https://github.com/pq-crystals/dilithium/issues/31
+  for (size_t i = 0; i < N; i++) {
+    a1[i] = power2round(a[i], &a0[i]);
+  }
+#if 0
   unsigned int i;
   __m256i f,f0,f1;
   const __m256i q = _mm256_load_si256((__m256i *)&qdata[_8XQ]);
@@ -34,6 +67,7 @@ void power2round_avx(uint32_t * restrict a1, uint32_t * restrict a0, const uint3
     _mm256_store_si256((__m256i *)&a1[8*i], f1);
     _mm256_store_si256((__m256i *)&a0[8*i], f0);
   }
+#endif
 }
 
 /*************************************************

--- a/src/sig/dilithium/pqclean_dilithium4_avx2/rounding.c
+++ b/src/sig/dilithium/pqclean_dilithium4_avx2/rounding.c
@@ -4,6 +4,32 @@
 #include "rounding.h"
 #include "consts.h"
 
+// copied from pqclean_dilithium4_clean/rounding.c
+/*************************************************
+* Name:        power2round
+*
+* Description: For finite field element a, compute a0, a1 such that
+*              a mod Q = a1*2^D + a0 with -2^{D-1} < a0 <= 2^{D-1}.
+*              Assumes a to be standard representative.
+*
+* Arguments:   - uint32_t a: input element
+*              - uint32_t *a0: pointer to output element Q + a0
+*
+* Returns a1.
+**************************************************/
+static inline uint32_t power2round(uint32_t a, uint32_t *a0)  {
+  int32_t t;
+
+  /* Centralized remainder mod 2^D */
+  t = a & ((1U << D) - 1);
+  t -= (1U << (D-1)) + 1;
+  t += (t >> 31) & (1U << D);
+  t -= (1U << (D-1)) - 1;
+  *a0 = Q + t;
+  a = (a - t) >> D;
+  return a;
+}
+
 /*************************************************
 * Name:        power2round
 *
@@ -18,6 +44,13 @@
 **************************************************/
 void power2round_avx(uint32_t * restrict a1, uint32_t * restrict a0, const uint32_t * restrict a)
 {
+  // temporarily use plain C version of power2round
+  // https://github.com/open-quantum-safe/liboqs/issues/793
+  // https://github.com/pq-crystals/dilithium/issues/31
+  for (size_t i = 0; i < N; i++) {
+    a1[i] = power2round(a[i], &a0[i]);
+  }
+#if 0
   unsigned int i;
   __m256i f,f0,f1;
   const __m256i q = _mm256_load_si256((__m256i *)&qdata[_8XQ]);
@@ -34,6 +67,7 @@ void power2round_avx(uint32_t * restrict a1, uint32_t * restrict a0, const uint3
     _mm256_store_si256((__m256i *)&a1[8*i], f1);
     _mm256_store_si256((__m256i *)&a0[8*i], f0);
   }
+#endif
 }
 
 /*************************************************


### PR DESCRIPTION
Temporary workaround for #793 until proper fix developed in https://github.com/pq-crystals/dilithium/issues/31

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [No] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [No] Does this PR change the the list of algorithms available -- either adding or removing?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
