### PR TITLE
AES-NI bug fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ localCheckout: &localCheckout
     - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
     - run:
         name: Configure
-        command: scripts/git_no_checkin_in_last_day.sh || (mkdir build && cd build && source ~/.bashrc && cmake -GNinja ${CONFIGURE_ARGS} ..)
+        command: scripts/git_no_checkin_in_last_day.sh || (mkdir build && cd build && source ~/.bashrc && cmake -GNinja ${CONFIGURE_ARGS} .. && cmake -LA ..)
     - run:
         name: Build
         command: ../scripts/git_no_checkin_in_last_day.sh || ninja
@@ -52,6 +52,7 @@ localCheckout: &localCheckout
           mkdir build &&
           (cd build &&
           cmake -GNinja ${CONFIGURE_ARGS} .. &&
+          cmake -LA .. &&
           ninja &&
           ninja run_tests)
           "
@@ -78,7 +79,7 @@ localCheckout: &localCheckout
             shell: bash.exe
         - run:
             name: Configure & Build
-            command: PATH=C:\Users\circleci\project\ninja;%PATH% & call C:\PROGRA~2\MICROS~2\2019\Community\VC\Auxiliary\Build\vcvars64.bat & mkdir build & cd build & cmake -GNinja ${CONFIGURE_ARGS} .. & ninja
+            command: PATH=C:\Users\circleci\project\ninja;%PATH% & call C:\PROGRA~2\MICROS~2\2019\Community\VC\Auxiliary\Build\vcvars64.bat & mkdir build & cd build & cmake -GNinja ${CONFIGURE_ARGS} .. & cmake -LA .. & ninja
             shell: cmd.exe
         - run:
             name: Run tests
@@ -106,7 +107,7 @@ localCheckout: &localCheckout
               )
         - run:
             name: Configure
-            command: scripts/git_no_checkin_in_last_day.sh || (mkdir build && cd build && cmake -GNinja ${CONFIGURE_ARGS} ..)
+            command: scripts/git_no_checkin_in_last_day.sh || (mkdir build && cd build && cmake -GNinja ${CONFIGURE_ARGS} .. && cmake -LA ..)
         - run:
             name: Build
             command: ../scripts/git_no_checkin_in_last_day.sh || ninja

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ jobs:
     <<: *oqsjob
     environment:
       IMAGE: openquantumsafe/ci-alpine-amd64:latest
-      CONFIGURE_ARGS: -DCMAKE_BUILD_TYPE=Release -DOQS_USE_OPENSSL=ON
+      CONFIGURE_ARGS: -DCMAKE_BUILD_TYPE=Release -DOQS_USE_OPENSSL=OFF
       SKIP_TESTS: style,doxygen # not installed in alpine, no news anyway
   alpine-amd64-shared:
     <<: *oqsjob

--- a/src/common/aes/aes.c
+++ b/src/common/aes/aes.c
@@ -25,7 +25,7 @@
     stmt_c;
 #endif
 
-void OQS_AES128_ECB_load_schedule(const uint8_t *key, void **_schedule, UNUSED int for_encryption) {
+void OQS_AES128_ECB_load_schedule(const uint8_t *key, void **_schedule, int for_encryption) {
 	C_OR_NI(
 	    oqs_aes128_load_schedule_c(key, _schedule, for_encryption),
 	    oqs_aes128_load_schedule_ni(key, _schedule, for_encryption)

--- a/src/common/aes/aes.c
+++ b/src/common/aes/aes.c
@@ -28,7 +28,7 @@
 void OQS_AES128_ECB_load_schedule(const uint8_t *key, void **_schedule, UNUSED int for_encryption) {
 	C_OR_NI(
 	    oqs_aes128_load_schedule_c(key, _schedule, for_encryption),
-	    oqs_aes128_load_schedule_ni(key, _schedule)
+	    oqs_aes128_load_schedule_ni(key, _schedule, for_encryption)
 	)
 }
 

--- a/src/common/aes/aes.h
+++ b/src/common/aes/aes.h
@@ -40,7 +40,6 @@ void OQS_AES128_free_schedule(void *schedule);
  * @param key           Key to be used for encryption.
  * @param ciphertext    Pointer to a block of memory which >= in size to the plaintext block. The result will be written here.
  * @warning plaintext_len must be a multiple of 16.
- * @warning ciphertext must be aligned to a 16-byte boundary when use AES-NI instructions.
  */
 void OQS_AES128_ECB_enc(const uint8_t *plaintext, const size_t plaintext_len, const uint8_t *key, uint8_t *ciphertext);
 
@@ -53,7 +52,6 @@ void OQS_AES128_ECB_enc(const uint8_t *plaintext, const size_t plaintext_len, co
  * @param key            Key to be used for encryption.
  * @param plaintext      Pointer to a block of memory which >= in size to the ciphertext block. The result will be written here.
  * @warning ciphertext_len must be a multiple of 16.
- * @warning plaintext must be aligned to a 16-byte boundary when use AES-NI instructions.
  */
 void OQS_AES128_ECB_dec(const uint8_t *ciphertext, const size_t ciphertext_len, const uint8_t *key, uint8_t *plaintext);
 
@@ -107,7 +105,6 @@ void OQS_AES256_free_schedule(void *schedule);
  * @param key           Key to be used for encryption.
  * @param ciphertext    Pointer to a block of memory which >= in size to the plaintext block. The result will be written here.
  * @warning plaintext_len must be a multiple of 16.
- * @warning ciphertext must be aligned to a 16-byte boundary when use AES-NI instructions.
  */
 void OQS_AES256_ECB_enc(const uint8_t *plaintext, const size_t plaintext_len, const uint8_t *key, uint8_t *ciphertext);
 
@@ -120,7 +117,6 @@ void OQS_AES256_ECB_enc(const uint8_t *plaintext, const size_t plaintext_len, co
  * @param key            Key to be used for encryption.
  * @param plaintext      Pointer to a block of memory which >= in size to the ciphertext block. The result will be written here.
  * @warning ciphertext_len must be a multiple of 16.
- * @warning plaintext must be aligned to a 16-byte boundary when use AES-NI instructions.
  */
 void OQS_AES256_ECB_dec(const uint8_t *ciphertext, const size_t ciphertext_len, const uint8_t *key, uint8_t *plaintext);
 

--- a/src/common/aes/aes.h
+++ b/src/common/aes/aes.h
@@ -39,6 +39,8 @@ void OQS_AES128_free_schedule(void *schedule);
  * @param plaintext_len Length on the plaintext in bytes. Must be a multiple of 16.
  * @param key           Key to be used for encryption.
  * @param ciphertext    Pointer to a block of memory which >= in size to the plaintext block. The result will be written here.
+ * @warning plaintext_len must be a multiple of 16.
+ * @warning ciphertext must be aligned to a 16-byte boundary when use AES-NI instructions.
  */
 void OQS_AES128_ECB_enc(const uint8_t *plaintext, const size_t plaintext_len, const uint8_t *key, uint8_t *ciphertext);
 
@@ -50,6 +52,8 @@ void OQS_AES128_ECB_enc(const uint8_t *plaintext, const size_t plaintext_len, co
  * @param ciphertext_len Length on the ciphertext in bytes. Must be a multiple of 16.
  * @param key            Key to be used for encryption.
  * @param plaintext      Pointer to a block of memory which >= in size to the ciphertext block. The result will be written here.
+ * @warning ciphertext_len must be a multiple of 16.
+ * @warning plaintext must be aligned to a 16-byte boundary when use AES-NI instructions.
  */
 void OQS_AES128_ECB_dec(const uint8_t *ciphertext, const size_t ciphertext_len, const uint8_t *key, uint8_t *plaintext);
 
@@ -102,6 +106,8 @@ void OQS_AES256_free_schedule(void *schedule);
  * @param plaintext_len Length on the plaintext in bytes. Must be a multiple of 16.
  * @param key           Key to be used for encryption.
  * @param ciphertext    Pointer to a block of memory which >= in size to the plaintext block. The result will be written here.
+ * @warning plaintext_len must be a multiple of 16.
+ * @warning ciphertext must be aligned to a 16-byte boundary when use AES-NI instructions.
  */
 void OQS_AES256_ECB_enc(const uint8_t *plaintext, const size_t plaintext_len, const uint8_t *key, uint8_t *ciphertext);
 
@@ -113,6 +119,8 @@ void OQS_AES256_ECB_enc(const uint8_t *plaintext, const size_t plaintext_len, co
  * @param ciphertext_len Length on the ciphertext in bytes. Must be a multiple of 16.
  * @param key            Key to be used for encryption.
  * @param plaintext      Pointer to a block of memory which >= in size to the ciphertext block. The result will be written here.
+ * @warning ciphertext_len must be a multiple of 16.
+ * @warning plaintext must be aligned to a 16-byte boundary when use AES-NI instructions.
  */
 void OQS_AES256_ECB_dec(const uint8_t *ciphertext, const size_t ciphertext_len, const uint8_t *key, uint8_t *plaintext);
 

--- a/src/common/aes/aes128_ni.c
+++ b/src/common/aes/aes128_ni.c
@@ -11,7 +11,7 @@
 
 // From crypto_core/aes128ncrypt/dolbeau/aesenc-int
 static inline void aes128ni_setkey_encrypt(const unsigned char *key, __m128i rkeys[11]) {
-	__m128i key0 = _mm_loadu_si128((const __m128i_u *)(key + 0));
+	__m128i key0 = _mm_loadu_si128((const __m128i *)(key + 0));
 	__m128i temp0, temp1, temp4;
 	int idx = 0;
 

--- a/src/common/aes/aes128_ni.c
+++ b/src/common/aes/aes128_ni.c
@@ -77,7 +77,7 @@ void oqs_aes128_free_schedule_ni(void *schedule) {
 
 // From crypto_core/aes128encrypt/dolbeau/aesenc-int
 static inline void aes128ni_encrypt(const __m128i rkeys[11], const unsigned char *n, unsigned char *out) {
-	__m128i nv = _mm_load_si128((const __m128i *)n);
+	__m128i nv = _mm_loadu_si128((const __m128i *)n);
 	__m128i temp = _mm_xor_si128(nv, rkeys[0]);
 	temp = _mm_aesenc_si128(temp, rkeys[1]);
 	temp = _mm_aesenc_si128(temp, rkeys[2]);
@@ -89,7 +89,7 @@ static inline void aes128ni_encrypt(const __m128i rkeys[11], const unsigned char
 	temp = _mm_aesenc_si128(temp, rkeys[8]);
 	temp = _mm_aesenc_si128(temp, rkeys[9]);
 	temp = _mm_aesenclast_si128(temp, rkeys[10]);
-	_mm_store_si128((__m128i *)(out), temp);
+	_mm_storeu_si128((__m128i *)(out), temp);
 }
 
 void oqs_aes128_enc_sch_block_ni(const uint8_t *plaintext, const void *_schedule, uint8_t *ciphertext) {
@@ -99,7 +99,7 @@ void oqs_aes128_enc_sch_block_ni(const uint8_t *plaintext, const void *_schedule
 
 // From crypto_core/aes128decrypt/dolbeau/aesenc-int
 static inline void aes128ni_decrypt(const __m128i rkeys[11], const unsigned char *n, unsigned char *out) {
-	__m128i nv = _mm_load_si128((const __m128i *)n);
+	__m128i nv = _mm_loadu_si128((const __m128i *)n);
 	__m128i temp = _mm_xor_si128(nv, rkeys[0]);
 	temp = _mm_aesdec_si128(temp, rkeys[1]);
 	temp = _mm_aesdec_si128(temp, rkeys[2]);
@@ -111,7 +111,7 @@ static inline void aes128ni_decrypt(const __m128i rkeys[11], const unsigned char
 	temp = _mm_aesdec_si128(temp, rkeys[8]);
 	temp = _mm_aesdec_si128(temp, rkeys[9]);
 	temp = _mm_aesdeclast_si128(temp, rkeys[10]);
-	_mm_store_si128((__m128i *)(out), temp);
+	_mm_storeu_si128((__m128i *)(out), temp);
 }
 
 void oqs_aes128_dec_sch_block_ni(const uint8_t *ciphertext, const void *_schedule, uint8_t *plaintext) {

--- a/src/common/aes/aes256_ni.c
+++ b/src/common/aes/aes256_ni.c
@@ -12,8 +12,8 @@
 
 // From crypto_core/aes256encrypt/dolbeau/aesenc-int
 static inline void aes256ni_setkey_encrypt(const unsigned char *key, __m128i rkeys[15]) {
-	__m128i key0 = _mm_loadu_si128((const __m128i_u *)(key + 0));
-	__m128i key1 = _mm_loadu_si128((const __m128i_u *)(key + 16));
+	__m128i key0 = _mm_loadu_si128((const __m128i *)(key + 0));
+	__m128i key1 = _mm_loadu_si128((const __m128i *)(key + 16));
 	__m128i temp0, temp1, temp2, temp4;
 	int idx = 0;
 

--- a/src/common/aes/aes256_ni.c
+++ b/src/common/aes/aes256_ni.c
@@ -104,7 +104,7 @@ void oqs_aes256_free_schedule_ni(void *schedule) {
 
 // From crypto_core/aes256encrypt/dolbeau/aesenc-int
 static inline void aes256ni_encrypt(const __m128i rkeys[15], const unsigned char *n, unsigned char *out) {
-	__m128i nv = _mm_load_si128((const __m128i *)n);
+	__m128i nv = _mm_loadu_si128((const __m128i *)n);
 	__m128i temp = _mm_xor_si128(nv, rkeys[0]);
 	temp = _mm_aesenc_si128(temp, rkeys[1]);
 	temp = _mm_aesenc_si128(temp, rkeys[2]);
@@ -120,7 +120,7 @@ static inline void aes256ni_encrypt(const __m128i rkeys[15], const unsigned char
 	temp = _mm_aesenc_si128(temp, rkeys[12]);
 	temp = _mm_aesenc_si128(temp, rkeys[13]);
 	temp = _mm_aesenclast_si128(temp, rkeys[14]);
-	_mm_store_si128((__m128i *)(out), temp);
+	_mm_storeu_si128((__m128i *)(out), temp);
 }
 
 void oqs_aes256_enc_sch_block_ni(const uint8_t *plaintext, const void *_schedule, uint8_t *ciphertext) {
@@ -130,7 +130,7 @@ void oqs_aes256_enc_sch_block_ni(const uint8_t *plaintext, const void *_schedule
 
 // From crypto_core/aes256decrypt/dolbeau/aesenc-int
 static inline void aes256ni_decrypt(const __m128i rkeys[15], const unsigned char *n, unsigned char *out) {
-	__m128i nv = _mm_load_si128((const __m128i *)n);
+	__m128i nv = _mm_loadu_si128((const __m128i *)n);
 	__m128i temp = _mm_xor_si128(nv, rkeys[0]);
 	temp = _mm_aesdec_si128(temp, rkeys[1]);
 	temp = _mm_aesdec_si128(temp, rkeys[2]);
@@ -146,7 +146,7 @@ static inline void aes256ni_decrypt(const __m128i rkeys[15], const unsigned char
 	temp = _mm_aesdec_si128(temp, rkeys[12]);
 	temp = _mm_aesdec_si128(temp, rkeys[13]);
 	temp = _mm_aesdeclast_si128(temp, rkeys[14]);
-	_mm_store_si128((__m128i *)(out), temp);
+	_mm_storeu_si128((__m128i *)(out), temp);
 }
 
 void oqs_aes256_dec_sch_block_ni(const uint8_t *ciphertext, const void *_schedule, uint8_t *plaintext) {

--- a/src/common/aes/aes_local.h
+++ b/src/common/aes/aes_local.h
@@ -2,14 +2,14 @@
 
 #include <stdint.h>
 
-void oqs_aes128_load_schedule_ni(const uint8_t *key, void **_schedule);
+void oqs_aes128_load_schedule_ni(const uint8_t *key, void **_schedule, int for_encryption);
 void oqs_aes128_free_schedule_ni(void *schedule);
 void oqs_aes128_enc_sch_block_ni(const uint8_t *plaintext, const void *_schedule, uint8_t *ciphertext);
 void oqs_aes128_dec_sch_block_ni(const uint8_t *ciphertext, const void *_schedule, uint8_t *plaintext);
 void oqs_aes128_ecb_enc_sch_ni(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext);
 void oqs_aes128_ecb_dec_sch_ni(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext);
 
-void oqs_aes128_load_schedule_c(const uint8_t *key, void **_schedule, UNUSED int for_encryption);
+void oqs_aes128_load_schedule_c(const uint8_t *key, void **_schedule, int for_encryption);
 void oqs_aes128_free_schedule_c(void *schedule);
 void oqs_aes128_enc_sch_block_c(const uint8_t *plaintext, const void *_schedule, uint8_t *ciphertext);
 void oqs_aes128_dec_sch_block_c(const uint8_t *ciphertext, const void *_schedule, uint8_t *plaintext);
@@ -23,7 +23,7 @@ void oqs_aes256_dec_sch_block_ni(const uint8_t *ciphertext, const void *_schedul
 void oqs_aes256_ecb_enc_sch_ni(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext);
 void oqs_aes256_ecb_dec_sch_ni(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext);
 
-void oqs_aes256_load_schedule_c(const uint8_t *key, void **_schedule, UNUSED int for_encryption);
+void oqs_aes256_load_schedule_c(const uint8_t *key, void **_schedule, int for_encryption);
 void oqs_aes256_free_schedule_c(void *schedule);
 void oqs_aes256_enc_sch_block_c(const uint8_t *plaintext, const void *_schedule, uint8_t *ciphertext);
 void oqs_aes256_dec_sch_block_c(const uint8_t *ciphertext, const void *_schedule, uint8_t *plaintext);

--- a/src/kem/bike/additional/aes_wrap.h
+++ b/src/kem/bike/additional/aes_wrap.h
@@ -38,7 +38,9 @@ aes256_key_expansion(OUT aes256_ks_t *ks, IN const aes256_key_t *key) {
 
 _INLINE_ ret_t
 aes256_enc(OUT uint8_t *ct, IN const uint8_t *pt, IN const aes256_ks_t ks) {
-	OQS_AES256_ECB_enc_sch(pt, AES256_BLOCK_SIZE, ks, ct);
+	ALIGN(16) uint8_t out[AES256_BLOCK_SIZE];
+	OQS_AES256_ECB_enc_sch(pt, AES256_BLOCK_SIZE, ks, out);
+	memcpy(ct, out, AES256_BLOCK_SIZE);
 	return SUCCESS;
 }
 

--- a/src/kem/bike/additional/aes_wrap.h
+++ b/src/kem/bike/additional/aes_wrap.h
@@ -38,9 +38,7 @@ aes256_key_expansion(OUT aes256_ks_t *ks, IN const aes256_key_t *key) {
 
 _INLINE_ ret_t
 aes256_enc(OUT uint8_t *ct, IN const uint8_t *pt, IN const aes256_ks_t ks) {
-	ALIGN(16) uint8_t out[AES256_BLOCK_SIZE];
-	OQS_AES256_ECB_enc_sch(pt, AES256_BLOCK_SIZE, ks, out);
-	memcpy(ct, out, AES256_BLOCK_SIZE);
+	OQS_AES256_ECB_enc_sch(pt, AES256_BLOCK_SIZE, ks, ct);
 	return SUCCESS;
 }
 


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
Fixes a few bugs related to the introduction of AES-NI code.  In particular:

- Makes sure the key schedule is actually being set for decryption.
- Uses the type `__m128i` rather than `__m128i_u` since some compilers choke on the latter.
- Notes in the API documentation that output arrays for AES must now be aligned to a 16-byte boundary, and applies this to BIKE.
  - This was the cause of the BIKE crash in #799.
  - Most AES calls in BIKE seemed to have been aligned, but the `sk_t` `sigma0->raw` and `sigma1->raw` members were not, which was causing the crash.  
  - The solution I took for BIKE was to wrap the AES call in a wrapper that ensures it's always aligned [[aes_wrap.h, line 41]](https://github.com/open-quantum-safe/liboqs/pull/800/files#diff-c3f72798cb0514e552cfcdd92d68a116R41). I tried to keep the scope of the change relatively small, but this does come at a small performance penalty on all BIKE AES calls.  
  - Just putting `ALIGN(16)` around the `r_t` type didn't work, as there are some subsequent routines that call sizeof on that struct, and adding ALIGN(16) apparently changes its size.  
  - @drucker-nir, is my approach okay?  If you have a better solution, please go ahead, I'm not too experienced with alignment issues.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
Fixes #799.

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [No] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [No] Does this PR change the the list of algorithms available -- either adding or removing?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
