### PR TITLE
Fix address sanitizer error on SPHINCS+

### DIFF
--- a/src/sig/sphincs/pqclean_sphincs-haraka-256f-robust_aesni/haraka.c
+++ b/src/sig/sphincs/pqclean_sphincs-haraka-256f-robust_aesni/haraka.c
@@ -14,7 +14,7 @@ Plain C implementation of the Haraka256 and Haraka512 permutations.
 #define u64 uint64_t
 #define u128 __m128i
 
-#define LOAD(src) _mm_load_si128((u128 *)(src))
+#define LOAD(src) _mm_loadu_si128((u128 *)(src))
 #define STORE(dest,src) _mm_storeu_si128((u128 *)(dest),src)
 
 #define XOR128(a, b) _mm_xor_si128(a, b)

--- a/src/sig/sphincs/pqclean_sphincs-haraka-256f-simple_aesni/haraka.c
+++ b/src/sig/sphincs/pqclean_sphincs-haraka-256f-simple_aesni/haraka.c
@@ -14,7 +14,7 @@ Plain C implementation of the Haraka256 and Haraka512 permutations.
 #define u64 uint64_t
 #define u128 __m128i
 
-#define LOAD(src) _mm_load_si128((u128 *)(src))
+#define LOAD(src) _mm_loadu_si128((u128 *)(src))
 #define STORE(dest,src) _mm_storeu_si128((u128 *)(dest),src)
 
 #define XOR128(a, b) _mm_xor_si128(a, b)

--- a/src/sig/sphincs/pqclean_sphincs-haraka-256s-robust_aesni/haraka.c
+++ b/src/sig/sphincs/pqclean_sphincs-haraka-256s-robust_aesni/haraka.c
@@ -14,7 +14,7 @@ Plain C implementation of the Haraka256 and Haraka512 permutations.
 #define u64 uint64_t
 #define u128 __m128i
 
-#define LOAD(src) _mm_load_si128((u128 *)(src))
+#define LOAD(src) _mm_loadu_si128((u128 *)(src))
 #define STORE(dest,src) _mm_storeu_si128((u128 *)(dest),src)
 
 #define XOR128(a, b) _mm_xor_si128(a, b)

--- a/src/sig/sphincs/pqclean_sphincs-haraka-256s-simple_aesni/haraka.c
+++ b/src/sig/sphincs/pqclean_sphincs-haraka-256s-simple_aesni/haraka.c
@@ -14,7 +14,7 @@ Plain C implementation of the Haraka256 and Haraka512 permutations.
 #define u64 uint64_t
 #define u128 __m128i
 
-#define LOAD(src) _mm_load_si128((u128 *)(src))
+#define LOAD(src) _mm_loadu_si128((u128 *)(src))
 #define STORE(dest,src) _mm_storeu_si128((u128 *)(dest),src)
 
 #define XOR128(a, b) _mm_xor_si128(a, b)


### PR DESCRIPTION
Fix address sanitizer error on SPHINCS+, as reported in https://github.com/open-quantum-safe/liboqs/issues/808

Fixes #808 

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding or removing?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
