### PR TITLE
correct compile time feature display

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -21,16 +21,56 @@ static unsigned int available_cpu_extensions_set = 0;
 #include "x86_64_helpers.h"
 
 const char *const X64_EXTENSIONS_NAMES[] = {
+#ifdef OQS_USE_AES_INSTRUCTIONS
 	"AES",
+#else
+        "",
+#endif
+#ifdef OQS_USE_AVX_INSTRUCTIONS
 	"AVX",
+#else
+        "",
+#endif
+#ifdef OQS_USE_AVX2_INSTRUCTIONS
 	"AVX2",
+#else
+        "",
+#endif
+#ifdef OQS_USE_AVX512_INSTRUCTIONS
 	"AVX512",
+#else
+        "",
+#endif
+#ifdef OQS_USE_BMI_INSTRUCTIONS
 	"BMI",
+#else
+        "",
+#endif
+#ifdef OQS_USE_BMI2_INSTRUCTIONS
 	"BMI2",
+#else
+        "",
+#endif
+#ifdef OQS_USE_POPCNT_INSTRUCTIONS
 	"POPCNT",
+#else
+        "",
+#endif
+#ifdef OQS_USE_SSE_INSTRUCTIONS
 	"SSE",
+#else
+        "",
+#endif
+#ifdef OQS_USE_SSE2_INSTRUCTIONS
 	"SSE2",
+#else
+        "",
+#endif
+#ifdef OQS_USE_SSE3_INSTRUCTIONS
 	"SSE3"
+#else
+        "",
+#endif
 };
 
 OQS_API const char *OQS_get_cpu_extension_name(unsigned int i) {

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -24,52 +24,52 @@ const char *const X64_EXTENSIONS_NAMES[] = {
 #ifdef OQS_USE_AES_INSTRUCTIONS
 	"AES",
 #else
-        "",
+	"",
 #endif
 #ifdef OQS_USE_AVX_INSTRUCTIONS
 	"AVX",
 #else
-        "",
+	"",
 #endif
 #ifdef OQS_USE_AVX2_INSTRUCTIONS
 	"AVX2",
 #else
-        "",
+	"",
 #endif
 #ifdef OQS_USE_AVX512_INSTRUCTIONS
 	"AVX512",
 #else
-        "",
+	"",
 #endif
 #ifdef OQS_USE_BMI_INSTRUCTIONS
 	"BMI",
 #else
-        "",
+	"",
 #endif
 #ifdef OQS_USE_BMI2_INSTRUCTIONS
 	"BMI2",
 #else
-        "",
+	"",
 #endif
 #ifdef OQS_USE_POPCNT_INSTRUCTIONS
 	"POPCNT",
 #else
-        "",
+	"",
 #endif
 #ifdef OQS_USE_SSE_INSTRUCTIONS
 	"SSE",
 #else
-        "",
+	"",
 #endif
 #ifdef OQS_USE_SSE2_INSTRUCTIONS
 	"SSE2",
 #else
-        "",
+	"",
 #endif
 #ifdef OQS_USE_SSE3_INSTRUCTIONS
 	"SSE3"
 #else
-        "",
+	"",
 #endif
 };
 

--- a/tests/system_info.c
+++ b/tests/system_info.c
@@ -3,6 +3,7 @@
 #include <oqs/oqs.h>
 
 #include <stdio.h>
+#include <string.h>
 
 // based on macros in https://sourceforge.net/p/predef/wiki/Compilers/
 static void print_compiler_info(void) {
@@ -72,9 +73,12 @@ static void print_cpu_extensions(void) {
 	unsigned int it = sizeof(ext_u.ext_a) / sizeof(ext_u.ext_a[0]);
 	for (unsigned int i = 0; i < it; i++) {
 		if (ext_u.ext_a[i]) {
-			printf("%s", OQS_get_cpu_extension_name(i));
-			if (i != it - 1) {
-				printf("-");
+			const char *aname = OQS_get_cpu_extension_name(i);
+			if ((strlen(aname)>0) && (i != it - 1)) {
+				printf("%s-", aname);
+			}
+                        else {
+				printf("%s", aname);
 			}
 		}
 	}

--- a/tests/system_info.c
+++ b/tests/system_info.c
@@ -74,10 +74,9 @@ static void print_cpu_extensions(void) {
 	for (unsigned int i = 0; i < it; i++) {
 		if (ext_u.ext_a[i]) {
 			const char *aname = OQS_get_cpu_extension_name(i);
-			if ((strlen(aname)>0) && (i != it - 1)) {
+			if ((strlen(aname) > 0) && (i != it - 1)) {
 				printf("%s-", aname);
-			}
-                        else {
+			} else {
 				printf("%s", aname);
 			}
 		}


### PR DESCRIPTION
This ensures that only the combination of build- _and_ runtime-CPU-featuresets are reported, not just runtime feature sets. The latter led to wrong result interpretation in performance testing.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding or removing?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)


