### PR TITLE
selectively exclude NOT_READY algorithms from copy_from_pyclean

### DIFF
--- a/scripts/copy_from_pqclean/copy_from_pqclean.py
+++ b/scripts/copy_from_pqclean/copy_from_pqclean.py
@@ -90,6 +90,15 @@ def upstream_check(scheme):
 def load_instructions():
     instructions = file_get_contents(os.path.join('scripts', 'copy_from_pqclean', 'copy_from_pqclean.yml'), encoding='utf-8')
     instructions = yaml.safe_load(instructions)
+    # drop instructions selectively if not ready
+    if ("NOT_READY" in os.environ):
+        not_ready=os.environ['NOT_READY'].split(" ")
+        for family in instructions['kems']:
+            if family['name'] in not_ready:
+                instructions["kems"].remove(family)
+        for family in instructions['sigs']:
+            if family['name'] in not_ready:
+                instructions["sigs"].remove(family)
     for family in instructions['kems']:
         family['type'] = 'kem'
         family['pqclean_type'] = 'kem'


### PR DESCRIPTION
Allows excluding specific algorithm families from "copy_from_pyclean" by setting the environment variable "NOT_READY" to those names, e.g., `export NOT_READY=hqc`) when running that script.

This would allow piecemeal progress until all upstream errors are resolved (e.g., on PR #835 ).

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding or removing?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)


