### PR TITLE
Modifying naive random selection to Fisher-Yates shuffle in HQC 

### DIFF
--- a/src/kem/hqc/pqclean_hqc-128-1-cca2_leaktime/vector.c
+++ b/src/kem/hqc/pqclean_hqc-128-1-cca2_leaktime/vector.c
@@ -90,6 +90,60 @@ void PQCLEAN_HQC1281CCA2_LEAKTIME_vect_set_random_fixed_weight(AES_XOF_struct *c
     size_t random_bytes_size = 3 * weight;
     uint8_t rand_bytes[3 * PARAM_OMEGA_R] = {0}; // weight is expected to be <= PARAM_OMEGA_R
     uint32_t random_data = 0;
+    // uint32_t tmp[PARAM_OMEGA_R] = {0};
+    uint32_t tmp[PARAM_N] = {0};
+    // uint8_t exist = 0;
+    size_t j = 0;
+
+    seedexpander(ctx, rand_bytes, random_bytes_size);
+
+    for (uint32_t i = 0; i < weight; ++i) {
+        // exist = 0;
+        tmp[i] = i;
+        do {
+            if (j == random_bytes_size) {
+                seedexpander(ctx, rand_bytes, random_bytes_size);
+                j = 0;
+            }
+
+            random_data  = ((uint32_t) rand_bytes[j++]) << 16;
+            random_data |= ((uint32_t) rand_bytes[j++]) << 8;
+            random_data |= rand_bytes[j++];
+
+        } while (random_data >= UTILS_REJECTION_THRESHOLD);
+
+        random_data = random_data % PARAM_N;
+
+        // for (uint32_t k = 0; k < i; k++) {
+        //     if (tmp[k] == random_data) {
+        //         exist = 1;
+        //     }
+        // }
+
+        // if (exist == 1) {
+        //     i--;
+        // } else {
+        //     tmp[i] = random_data;
+        // }
+
+        //Fisher-Yates Shuffling
+        int temp = tmp[i];
+        tmp[i] = tmp[random_data];
+        tmp[random_data] = temp;
+    }
+
+    for (uint16_t i = 0; i < weight; ++i) {
+        int32_t index = tmp[i] / 8;
+        int32_t pos = tmp[i] % 8;
+        v[index] |= 1 << pos;
+    }
+}
+
+void PQCLEAN_HQC1281CCA2_LEAKTIME_vect_set_random_fixed_weight(AES_XOF_struct *ctx, uint8_t *v, uint16_t weight) {
+
+    size_t random_bytes_size = 3 * weight;
+    uint8_t rand_bytes[3 * PARAM_OMEGA_R] = {0}; // weight is expected to be <= PARAM_OMEGA_R
+    uint32_t random_data = 0;
     uint32_t tmp[PARAM_OMEGA_R] = {0};
     uint8_t exist = 0;
     size_t j = 0;
@@ -131,7 +185,6 @@ void PQCLEAN_HQC1281CCA2_LEAKTIME_vect_set_random_fixed_weight(AES_XOF_struct *c
         v[index] |= 1 << pos;
     }
 }
-
 
 
 /**


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
HQC uses a naive random selection algorithm for creating a random vector of fixed weight which could be improved upon by Fisher-Yates shuffle algorithm. Navie random selection algorithm has a best-case time complexity of &Omega;(n<sup>2</sup>) whereas the Fisher–Yates shuffle has the worst-case complexity of O(n)(since random element is selected in O(1)). The downside is that while naive random selection uses  O(&omega;<sub>r</sub>) &thickapprox; O(&Sqrt;n) memory, Fisher-Yates shuffle uses O(n) memory. 
<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding or removing?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
