### PR TITLE
disable pthreads testing for mem test

### DIFF
--- a/tests/test_kem.c
+++ b/tests/test_kem.c
@@ -155,8 +155,8 @@ void *test_wrapper(void *arg) {
 
 int main(int argc, char **argv) {
 
-	if (argc != 2) {
-		fprintf(stderr, "Usage: test_kem algname\n");
+	if ((argc != 2) && !( (argc == 3) && !strncmp(argv[2], "-mem", 4) )) {
+		fprintf(stderr, "Usage: test_kem algname [-mem]\n");
 		fprintf(stderr, "  algname: ");
 		for (size_t i = 0; i < OQS_KEM_algs_length; i++) {
 			if (i > 0) {
@@ -191,7 +191,7 @@ int main(int argc, char **argv) {
 			break;
 		}
 	}
-	if (test_in_thread) {
+	if (test_in_thread && argc != 3) { // no pthread testing if -mem option has been set
 		pthread_t thread;
 		struct thread_data td;
 		td.alg_name = alg_name;

--- a/tests/test_sig.c
+++ b/tests/test_sig.c
@@ -108,8 +108,8 @@ void *test_wrapper(void *arg) {
 
 int main(int argc, char **argv) {
 
-	if (argc != 2) {
-		fprintf(stderr, "Usage: test_sig algname\n");
+	if ((argc != 2) && !( (argc == 3) && !strncmp(argv[2], "-mem", 4) ))  {
+		fprintf(stderr, "Usage: test_sig algname [-mem]\n");
 		fprintf(stderr, "  algname: ");
 		for (size_t i = 0; i < OQS_SIG_algs_length; i++) {
 			if (i > 0) {
@@ -144,7 +144,7 @@ int main(int argc, char **argv) {
 			break;
 		}
 	}
-	if (test_in_thread) {
+	if (test_in_thread && argc != 3) { // no pthread testing if -mem option has been set
 		pthread_t thread;
 		struct thread_data td;
 		td.alg_name = alg_name;


### PR DESCRIPTION
Implementation (preparation) for #439 (see discussion there) reusing existing test code.

@xvzcf , @dstebila : Please (re)confirm that `test_kem`/`test_sig` do not do more testing than desirable when setting the new `-mem` option.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding or removing?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

