### PR TITLE
enable Valgrind memory use testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
           working_directory: build
       - run:
           name: Run tests
-          command: python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --junitxml=build/test-results/pytest/test-results.xml << parameters.PYTEST_ARGS >>
+          command: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --junitxml=build/test-results/pytest/test-results.xml << parameters.PYTEST_ARGS >>
       - store_test_results: # Note that this command will fail when running CircleCI locally, that is expected behaviour
           path: build/test-results
       - store_artifacts:
@@ -95,7 +95,7 @@ jobs:
             (cd build &&
             cmake -GNinja << parameters.CMAKE_ARGS >> .. && cmake -LA .. &&
             ninja) &&
-            python3 -m pytest --verbose --numprocesses=auto --ignore=tests/test_code_conventions.py --junitxml=build/test-results/pytest/test-results.xml
+            mkdir -p tmp && python3 -m pytest --verbose --numprocesses=auto --ignore=tests/test_code_conventions.py --junitxml=build/test-results/pytest/test-results.xml
             "
       - store_test_results:
           path: build/test-results
@@ -131,7 +131,7 @@ jobs:
           working_directory: build
       - run:
           name: Run tests
-          command: python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --junitxml=build/test-results/pytest/test-results.xml << parameters.PYTEST_ARGS >>
+          command: mkdir tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --junitxml=build/test-results/pytest/test-results.xml << parameters.PYTEST_ARGS >>
       - store_test_results: # Note that this command will fail when running CircleCI locally, that is expected behaviour
           path: build/test-results
       - store_artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ before_test:
 test_script:
   - cmd: |-
          cd %APPVEYOR_BUILD_FOLDER%
-         set PATH=%cd%\build\bin;%PATH% && python -m pytest --numprocesses=auto --verbose --ignore=tests/test_code_conventions.py --junitxml=build\test-results\pytest\test-results.xml
+         set PATH=%cd%\build\bin;%PATH% && if not exist tmp (mkdir tmp) && python -m pytest --numprocesses=auto --verbose --ignore=tests/test_code_conventions.py --junitxml=build\test-results\pytest\test-results.xml
 
 after_test:
   - ps: |-

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,6 +86,9 @@ else ()
     target_link_libraries(test_sig PRIVATE ${API_TEST_DEPS})
 endif()
 
+add_executable(test_sig_mem test_sig_mem.c)
+target_link_libraries(test_sig_mem PRIVATE ${API_TEST_DEPS})
+
 add_executable(speed_sig speed_sig.c)
 target_link_libraries(speed_sig PRIVATE ${API_TEST_DEPS})
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,7 +101,7 @@ add_definitions(-DOQS_COMPILE_OPTIONS="[${OQS_COMPILE_OPTIONS}]")
 # for DLL builds.
 add_custom_target(
     run_tests
-    COMMAND ${PYTHON3_EXEC} -m pytest --verbose --numprocesses=auto
+    COMMAND mkdir -p tmp && ${PYTHON3_EXEC} -m pytest --verbose --numprocesses=auto
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    DEPENDS oqs example_kem kat_kem test_kem example_sig kat_sig test_sig ${UNIX_TESTS}
+    DEPENDS oqs example_kem kat_kem test_kem example_sig kat_sig test_sig test_sig_mem test_kem_mem ${UNIX_TESTS}
     USES_TERMINAL)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,9 @@ else ()
     target_link_libraries(test_kem PRIVATE ${API_TEST_DEPS})
 endif()
 
+add_executable(test_kem_mem test_kem_mem.c)
+target_link_libraries(test_kem_mem PRIVATE ${API_TEST_DEPS})
+
 add_executable(speed_kem speed_kem.c)
 target_link_libraries(speed_kem PRIVATE ${API_TEST_DEPS})
 

--- a/tests/test_kem_mem.c
+++ b/tests/test_kem_mem.c
@@ -42,6 +42,7 @@ static OQS_STATUS kem_test_correctness(const char *method_name, KEM_OPS op) {
 	uint8_t *shared_secret_d = NULL;
 	OQS_STATUS rc, ret = OQS_ERROR;
 	int rv;
+	size_t retlen;
 
 	kem = OQS_KEM_new(method_name);
 	if (kem == NULL) {
@@ -92,10 +93,10 @@ static OQS_STATUS kem_test_correctness(const char *method_name, KEM_OPS op) {
 			goto err;
 		}
 
-		if (oqs_fload("pk", public_key, kem->length_public_key) != OQS_SUCCESS) {
+		if (oqs_fload("pk", public_key, kem->length_public_key, &retlen) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fload("sk", secret_key, kem->length_secret_key) != OQS_SUCCESS) {
+		if (oqs_fload("sk", secret_key, kem->length_secret_key, &retlen) != OQS_SUCCESS) {
 			goto err;
 		}
 		rc = OQS_KEM_encaps(kem, ciphertext, shared_secret_e, public_key);
@@ -127,16 +128,16 @@ static OQS_STATUS kem_test_correctness(const char *method_name, KEM_OPS op) {
 			fprintf(stderr, "ERROR: malloc failed\n");
 			goto err;
 		}
-		if (oqs_fload("pk", public_key, kem->length_public_key) != OQS_SUCCESS) {
+		if (oqs_fload("pk", public_key, kem->length_public_key, &retlen) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fload("sk", secret_key, kem->length_secret_key) != OQS_SUCCESS) {
+		if (oqs_fload("sk", secret_key, kem->length_secret_key, &retlen) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fload("ct", ciphertext, kem->length_ciphertext) != OQS_SUCCESS) {
+		if (oqs_fload("ct", ciphertext, kem->length_ciphertext, &retlen) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fload("se", shared_secret_e, kem->length_shared_secret) != OQS_SUCCESS) {
+		if (oqs_fload("se", shared_secret_e, kem->length_shared_secret, &retlen) != OQS_SUCCESS) {
 			goto err;
 		}
 

--- a/tests/test_kem_mem.c
+++ b/tests/test_kem_mem.c
@@ -212,7 +212,7 @@ int main(int argc, char **argv) {
 
 	OQS_STATUS rc;
 
-	rc = kem_test_correctness(alg_name, atoi(argv[2]));
+	rc = kem_test_correctness(alg_name, (unsigned int)atoi(argv[2]));
 
 	if (rc != OQS_SUCCESS) {
 		return EXIT_FAILURE;

--- a/tests/test_kem_mem.c
+++ b/tests/test_kem_mem.c
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <oqs/oqs.h>
+
+#include "system_info.c"
+
+/* Displays hexadecimal strings */
+static void OQS_print_hex_string(const char *label, const uint8_t *str, size_t len) {
+	printf("%-20s (%4zu bytes):  ", label, len);
+	for (size_t i = 0; i < (len); i++) {
+		printf("%02X", str[i]);
+	}
+	printf("\n");
+}
+
+typedef struct magic_s {
+	uint8_t val[32];
+} magic_t;
+
+typedef enum kem_ops {
+	KEM_KEYGEN    = 0,
+        KEM_ENCAPS    = 1,
+        KEM_DECAPS    = 2
+} KEM_OPS;
+
+#define STORE_PREFIX "/tmp/oqs-temp-file-"
+#define MAXPATHLEN 64
+
+static OQS_STATUS oqs_fstore(const char* fname, uint8_t *data, int len) {
+	char fpath[MAXPATHLEN];
+	strcpy(fpath,STORE_PREFIX);
+	FILE* fp = fopen(strcat(fpath,fname), "wb");
+	if (!fp) {
+		fprintf(stderr, "Couldn't open %s for writing.\n", fpath);
+		return OQS_ERROR;
+	}
+	fwrite(data,len,1,fp);
+	fclose(fp);
+	return OQS_SUCCESS;
+}
+
+static OQS_STATUS oqs_fload(const char* fname, uint8_t *data, int len) {
+	char fpath[MAXPATHLEN];
+	strcpy(fpath,STORE_PREFIX);
+	FILE* fp = fopen(strcat(fpath,fname), "r");
+	if (!fp) {
+		fprintf(stderr, "Couldn't open %s for reading.\n", fpath);
+		return OQS_ERROR;
+	}
+	if (fread(data,len,1,fp) != 1) {
+		fprintf(stderr, "Couldn't read all %d bytes correctly. Exiting.\n", len);
+		return OQS_ERROR;
+	}
+	fclose(fp);
+	return OQS_SUCCESS;
+}
+
+static OQS_STATUS kem_test_correctness(const char *method_name, KEM_OPS op) {
+
+	OQS_KEM *kem = NULL;
+	uint8_t *public_key = NULL;
+	uint8_t *secret_key = NULL;
+	uint8_t *ciphertext = NULL;
+	uint8_t *shared_secret_e = NULL;
+	uint8_t *shared_secret_d = NULL;
+	OQS_STATUS rc, ret = OQS_ERROR;
+	int rv;
+
+	kem = OQS_KEM_new(method_name);
+	if (kem == NULL) {
+		fprintf(stderr, "ERROR: OQS_KEM_new failed\n");
+		goto err;
+	}
+
+	printf("================================================================================\n");
+	printf("Sample computation for KEM %s\n", kem->method_name);
+	printf("================================================================================\n");
+
+	public_key = malloc(kem->length_public_key);
+	secret_key = malloc(kem->length_secret_key);
+	ciphertext = malloc(kem->length_ciphertext);
+	shared_secret_e = malloc(kem->length_shared_secret);
+	shared_secret_d = malloc(kem->length_shared_secret);
+
+	if ((public_key == NULL) || (secret_key == NULL) || (ciphertext == NULL) || (shared_secret_e == NULL) || (shared_secret_d == NULL)) {
+		fprintf(stderr, "ERROR: malloc failed\n");
+		goto err;
+	}
+
+	if (op == KEM_KEYGEN) {
+		rc = OQS_KEM_keypair(kem, public_key, secret_key);
+		if (rc != OQS_SUCCESS) {
+			fprintf(stderr, "ERROR: OQS_KEM_keypair failed\n");
+			goto err;
+		}
+		if (oqs_fstore("pk", public_key, kem->length_public_key) != OQS_SUCCESS) goto err;
+		if (oqs_fstore("sk", secret_key, kem->length_secret_key) != OQS_SUCCESS) goto err;
+		ret = OQS_SUCCESS;
+		goto cleanup;
+	}
+	else { // get it from file
+		if (oqs_fload("pk", public_key, kem->length_public_key) != OQS_SUCCESS) goto err;
+                if (oqs_fload("sk", secret_key, kem->length_secret_key) != OQS_SUCCESS) goto err;	
+	}
+
+	if (op == KEM_ENCAPS) {
+		rc = OQS_KEM_encaps(kem, ciphertext, shared_secret_e, public_key);
+		if (rc != OQS_SUCCESS) {
+			fprintf(stderr, "ERROR: OQS_KEM_encaps failed\n");
+			goto err;
+		}
+		if (oqs_fstore("ct", ciphertext, kem->length_ciphertext) != OQS_SUCCESS) goto err;
+		if (oqs_fstore("se", shared_secret_e, kem->length_shared_secret) != OQS_SUCCESS) goto err;
+		ret = OQS_SUCCESS;
+		goto cleanup;
+	}
+	else { // get it from file
+		if (oqs_fload("ct", ciphertext, kem->length_ciphertext) != OQS_SUCCESS) goto err;
+                if (oqs_fload("se", shared_secret_e, kem->length_shared_secret) != OQS_SUCCESS) goto err;	
+	}
+
+	if (op == KEM_DECAPS) {
+		rc = OQS_KEM_decaps(kem, shared_secret_d, ciphertext, secret_key);
+		if (rc != OQS_SUCCESS) {
+			fprintf(stderr, "ERROR: OQS_KEM_decaps failed\n");
+			goto err;
+		}
+
+	 	rv = memcmp(shared_secret_e, shared_secret_d, kem->length_shared_secret);
+		if (rv != 0) {
+			fprintf(stderr, "ERROR: shared secrets are not equal\n");
+			OQS_print_hex_string("shared_secret_e", shared_secret_e, kem->length_shared_secret);
+			OQS_print_hex_string("shared_secret_d", shared_secret_d, kem->length_shared_secret);
+			goto err;
+		} else {
+			printf("shared secrets are equal\n");
+		}
+	}
+
+	ret = OQS_SUCCESS;
+	goto cleanup;
+
+err:
+	ret = OQS_ERROR;
+
+cleanup:
+	if (kem != NULL) {
+		OQS_MEM_secure_free(secret_key, kem->length_secret_key);
+		OQS_MEM_secure_free(shared_secret_e, kem->length_shared_secret);
+		OQS_MEM_secure_free(shared_secret_d, kem->length_shared_secret);
+	}
+	OQS_MEM_insecure_free(public_key);
+	OQS_MEM_insecure_free(ciphertext);
+	OQS_KEM_free(kem);
+
+	return ret;
+}
+
+int main(int argc, char **argv) {
+
+	if (argc != 3) {
+		fprintf(stderr, "Usage: test_kem_mem algname operation (0,1,2)\n");
+		fprintf(stderr, "  algname: ");
+		for (size_t i = 0; i < OQS_KEM_algs_length; i++) {
+			if (i > 0) {
+				fprintf(stderr, ", ");
+			}
+			fprintf(stderr, "%s", OQS_KEM_alg_identifier(i));
+		}
+		fprintf(stderr, "\n");
+		return EXIT_FAILURE;
+	}
+
+	print_system_info();
+
+	char *alg_name = argv[1];
+	if (!OQS_KEM_alg_is_enabled(alg_name)) {
+		printf("KEM algorithm %s not enabled!\n", alg_name);
+		return EXIT_FAILURE;
+	}
+
+	// Use system RNG in this program
+	OQS_randombytes_switch_algorithm(OQS_RAND_alg_system);
+
+	OQS_STATUS rc;
+
+	rc = kem_test_correctness(alg_name, atoi(argv[2]));
+
+	if (rc != OQS_SUCCESS) {
+		return EXIT_FAILURE;
+	}
+	return EXIT_SUCCESS;
+}

--- a/tests/test_kem_mem.c
+++ b/tests/test_kem_mem.c
@@ -29,9 +29,6 @@ typedef enum kem_ops {
 	KEM_DECAPS    = 2
 } KEM_OPS;
 
-#define STORE_PREFIX "/tmp/oqs-temp-file-"
-#define MAXPATHLEN 64
-
 static OQS_STATUS kem_test_correctness(const char *method_name, KEM_OPS op) {
 
 	OQS_KEM *kem = NULL;
@@ -69,10 +66,10 @@ static OQS_STATUS kem_test_correctness(const char *method_name, KEM_OPS op) {
 			fprintf(stderr, "ERROR: OQS_KEM_keypair failed\n");
 			goto err;
 		}
-		if (oqs_fstore("pk", public_key, kem->length_public_key) != OQS_SUCCESS) {
+		if (oqs_fstore("pk", method_name, public_key, kem->length_public_key) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fstore("sk", secret_key, kem->length_secret_key) != OQS_SUCCESS) {
+		if (oqs_fstore("sk", method_name, secret_key, kem->length_secret_key) != OQS_SUCCESS) {
 			goto err;
 		}
 		ret = OQS_SUCCESS;
@@ -93,10 +90,10 @@ static OQS_STATUS kem_test_correctness(const char *method_name, KEM_OPS op) {
 			goto err;
 		}
 
-		if (oqs_fload("pk", public_key, kem->length_public_key, &retlen) != OQS_SUCCESS) {
+		if (oqs_fload("pk", method_name, public_key, kem->length_public_key, &retlen) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fload("sk", secret_key, kem->length_secret_key, &retlen) != OQS_SUCCESS) {
+		if (oqs_fload("sk", method_name, secret_key, kem->length_secret_key, &retlen) != OQS_SUCCESS) {
 			goto err;
 		}
 		rc = OQS_KEM_encaps(kem, ciphertext, shared_secret_e, public_key);
@@ -104,10 +101,10 @@ static OQS_STATUS kem_test_correctness(const char *method_name, KEM_OPS op) {
 			fprintf(stderr, "ERROR: OQS_KEM_encaps failed\n");
 			goto err;
 		}
-		if (oqs_fstore("ct", ciphertext, kem->length_ciphertext) != OQS_SUCCESS) {
+		if (oqs_fstore("ct", method_name, ciphertext, kem->length_ciphertext) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fstore("se", shared_secret_e, kem->length_shared_secret) != OQS_SUCCESS) {
+		if (oqs_fstore("se", method_name, shared_secret_e, kem->length_shared_secret) != OQS_SUCCESS) {
 			goto err;
 		}
 		ret = OQS_SUCCESS;
@@ -128,16 +125,16 @@ static OQS_STATUS kem_test_correctness(const char *method_name, KEM_OPS op) {
 			fprintf(stderr, "ERROR: malloc failed\n");
 			goto err;
 		}
-		if (oqs_fload("pk", public_key, kem->length_public_key, &retlen) != OQS_SUCCESS) {
+		if (oqs_fload("pk", method_name, public_key, kem->length_public_key, &retlen) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fload("sk", secret_key, kem->length_secret_key, &retlen) != OQS_SUCCESS) {
+		if (oqs_fload("sk", method_name, secret_key, kem->length_secret_key, &retlen) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fload("ct", ciphertext, kem->length_ciphertext, &retlen) != OQS_SUCCESS) {
+		if (oqs_fload("ct", method_name, ciphertext, kem->length_ciphertext, &retlen) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fload("se", shared_secret_e, kem->length_shared_secret, &retlen) != OQS_SUCCESS) {
+		if (oqs_fload("se", method_name, shared_secret_e, kem->length_shared_secret, &retlen) != OQS_SUCCESS) {
 			goto err;
 		}
 

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+
+import helpers
+import os
+import os.path
+import pytest
+import platform
+from hashlib import sha256
+
+@helpers.filtered_test
+@pytest.mark.parametrize('kem_name', helpers.available_kems_by_name())
+def test_kem(kem_name):
+    kats = helpers.get_kats("kem")
+    if not(helpers.is_kem_enabled_by_name(kem_name)): pytest.skip('Not enabled')
+    for i in range(3):
+       helpers.run_subprocess([helpers.path_to_executable('test_kem_mem'), kem_name, str(i)])
+
+@helpers.filtered_test
+@pytest.mark.parametrize('sig_name', helpers.available_sigs_by_name())
+def test_sig(sig_name):
+    if not(helpers.is_sig_enabled_by_name(sig_name)): pytest.skip('Not enabled')
+    for i in range(3):
+       helpers.run_subprocess([helpers.path_to_executable('test_sig_mem'), sig_name, str(i)])
+
+if __name__ == "__main__":
+    import sys
+    pytest.main(sys.argv)
+

--- a/tests/test_sig_mem.c
+++ b/tests/test_sig_mem.c
@@ -13,7 +13,7 @@
 #include "system_info.c"
 #include "tmp_store.c"
 
-typedef enum kem_ops {
+typedef enum sig_ops {
 	SIG_KEYGEN = 0,
 	SIG_SIGN   = 1,
 	SIG_VERIFY = 2
@@ -194,7 +194,7 @@ int main(int argc, char **argv) {
 	// Use system RNG in this program
 	OQS_randombytes_switch_algorithm(OQS_RAND_alg_system);
 
-	OQS_STATUS rc = sig_test_correctness(alg_name, atoi(argv[2]));
+	OQS_STATUS rc = sig_test_correctness(alg_name, (unsigned int)atoi(argv[2]));
 
 	if (rc != OQS_SUCCESS) {
 		return EXIT_FAILURE;

--- a/tests/test_sig_mem.c
+++ b/tests/test_sig_mem.c
@@ -19,9 +19,6 @@ typedef enum sig_ops {
 	SIG_VERIFY = 2
 } SIG_OPS;
 
-#define STORE_PREFIX "/tmp/oqs-temp-file-"
-#define MAXPATHLEN 64
-
 static OQS_STATUS sig_test_correctness(const char *method_name, SIG_OPS op) {
 
 	OQS_SIG *sig = NULL;
@@ -56,10 +53,10 @@ static OQS_STATUS sig_test_correctness(const char *method_name, SIG_OPS op) {
 			fprintf(stderr, "ERROR: OQS_SIG_keypair failed\n");
 			goto err;
 		}
-		if (oqs_fstore("pk", public_key, sig->length_public_key) != OQS_SUCCESS) {
+		if (oqs_fstore("pk", method_name, public_key, sig->length_public_key) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fstore("sk", secret_key, sig->length_secret_key) != OQS_SUCCESS) {
+		if (oqs_fstore("sk", method_name, secret_key, sig->length_secret_key) != OQS_SUCCESS) {
 			goto err;
 		}
 		ret = OQS_SUCCESS;
@@ -79,10 +76,10 @@ static OQS_STATUS sig_test_correctness(const char *method_name, SIG_OPS op) {
 			fprintf(stderr, "ERROR: malloc failed\n");
 			goto err;
 		}
-		if (oqs_fload("pk", public_key, sig->length_public_key, &signature_len) != OQS_SUCCESS) {
+		if (oqs_fload("pk", method_name, public_key, sig->length_public_key, &signature_len) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fload("sk", secret_key, sig->length_secret_key, &signature_len) != OQS_SUCCESS) {
+		if (oqs_fload("sk", method_name, secret_key, sig->length_secret_key, &signature_len) != OQS_SUCCESS) {
 			goto err;
 		}
 
@@ -93,10 +90,10 @@ static OQS_STATUS sig_test_correctness(const char *method_name, SIG_OPS op) {
 			fprintf(stderr, "ERROR: OQS_SIG_sign failed\n");
 			goto err;
 		}
-		if (oqs_fstore("ct", message, message_len) != OQS_SUCCESS) {
+		if (oqs_fstore("ct", method_name, message, message_len) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fstore("se", signature, signature_len) != OQS_SUCCESS) {
+		if (oqs_fstore("se", method_name, signature, signature_len) != OQS_SUCCESS) {
 			goto err;
 		}
 		ret = OQS_SUCCESS;
@@ -116,16 +113,16 @@ static OQS_STATUS sig_test_correctness(const char *method_name, SIG_OPS op) {
 			fprintf(stderr, "ERROR: malloc failed\n");
 			goto err;
 		}
-		if (oqs_fload("pk", public_key, sig->length_public_key, &signature_len) != OQS_SUCCESS) {
+		if (oqs_fload("pk", method_name, public_key, sig->length_public_key, &signature_len) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fload("sk", secret_key, sig->length_secret_key, &signature_len) != OQS_SUCCESS) {
+		if (oqs_fload("sk", method_name, secret_key, sig->length_secret_key, &signature_len) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fload("ct", message, message_len, &signature_len) != OQS_SUCCESS) {
+		if (oqs_fload("ct", method_name, message, message_len, &signature_len) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fload("se", signature, sig->length_signature, &signature_len) != OQS_SUCCESS) {
+		if (oqs_fload("se", method_name, signature, sig->length_signature, &signature_len) != OQS_SUCCESS) {
 			goto err;
 		}
 

--- a/tests/test_sig_mem.c
+++ b/tests/test_sig_mem.c
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: MIT
+
+#if defined(_WIN32)
+#pragma warning(disable : 4244 4293)
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <oqs/oqs.h>
+
+#include "system_info.c"
+#include "tmp_store.c"
+
+typedef enum kem_ops {
+	SIG_KEYGEN = 0,
+	SIG_SIGN   = 1,
+	SIG_VERIFY = 2
+} SIG_OPS;
+
+#define STORE_PREFIX "/tmp/oqs-temp-file-"
+#define MAXPATHLEN 64
+
+static OQS_STATUS sig_test_correctness(const char *method_name, SIG_OPS op) {
+
+	OQS_SIG *sig = NULL;
+	uint8_t *public_key = NULL;
+	uint8_t *secret_key = NULL;
+	uint8_t *message = NULL;
+	size_t message_len = 100;
+	uint8_t *signature = NULL;
+	size_t signature_len;
+	OQS_STATUS rc, ret = OQS_ERROR;
+
+	sig = OQS_SIG_new(method_name);
+	if (sig == NULL) {
+		fprintf(stderr, "ERROR: OQS_SIG_new failed\n");
+		goto err;
+	}
+
+	switch (op) {
+	case SIG_KEYGEN:
+		printf("================================================================================\n");
+		printf("Executing keygen for SIGALG %s\n", sig->method_name);
+		printf("================================================================================\n");
+
+		public_key = malloc(sig->length_public_key);
+		secret_key = malloc(sig->length_secret_key);
+		if ((public_key == NULL) || (secret_key == NULL)) {
+			fprintf(stderr, "ERROR: malloc failed\n");
+			goto err;
+		}
+		rc = OQS_SIG_keypair(sig, public_key, secret_key);
+		if (rc != OQS_SUCCESS) {
+			fprintf(stderr, "ERROR: OQS_SIG_keypair failed\n");
+			goto err;
+		}
+		if (oqs_fstore("pk", public_key, sig->length_public_key) != OQS_SUCCESS) {
+			goto err;
+		}
+		if (oqs_fstore("sk", secret_key, sig->length_secret_key) != OQS_SUCCESS) {
+			goto err;
+		}
+		ret = OQS_SUCCESS;
+		goto cleanup;
+
+	case SIG_SIGN:
+		printf("================================================================================\n");
+		printf("Executing sign for SIGALG %s\n", sig->method_name);
+		printf("================================================================================\n");
+
+		public_key = malloc(sig->length_public_key);
+		secret_key = malloc(sig->length_secret_key);
+		message = malloc(message_len);
+		signature = malloc(sig->length_signature);
+
+		if ((public_key == NULL) || (secret_key == NULL) || (message == NULL) || (signature == NULL)) {
+			fprintf(stderr, "ERROR: malloc failed\n");
+			goto err;
+		}
+		if (oqs_fload("pk", public_key, sig->length_public_key) != OQS_SUCCESS) {
+			goto err;
+		}
+		if (oqs_fload("sk", secret_key, sig->length_secret_key) != OQS_SUCCESS) {
+			goto err;
+		}
+
+		OQS_randombytes(message, message_len);
+
+		rc = OQS_SIG_sign(sig, signature, &signature_len, message, message_len, secret_key);
+		if (rc != OQS_SUCCESS) {
+			fprintf(stderr, "ERROR: OQS_SIG_sign failed\n");
+			goto err;
+		}
+		if (sig->length_signature != signature_len) {
+			fprintf(stderr, "WARNING: Unexpected signature length: %ld vs %ld\n", signature_len, sig->length_signature);
+		}
+		if (oqs_fstore("ct", message, message_len) != OQS_SUCCESS) {
+			goto err;
+		}
+		if (oqs_fstore("se", signature, sig->length_signature) != OQS_SUCCESS) {
+			goto err;
+		}
+		ret = OQS_SUCCESS;
+		goto cleanup;
+
+	case SIG_VERIFY:
+		printf("================================================================================\n");
+		printf("Executing verify for SIGALG %s\n", sig->method_name);
+		printf("================================================================================\n");
+
+		public_key = malloc(sig->length_public_key);
+		secret_key = malloc(sig->length_secret_key);
+		message = malloc(message_len);
+		signature = malloc(sig->length_signature);
+
+		if ((public_key == NULL) || (secret_key == NULL) || (message == NULL) || (signature == NULL)) {
+			fprintf(stderr, "ERROR: malloc failed\n");
+			goto err;
+		}
+		if (oqs_fload("pk", public_key, sig->length_public_key) != OQS_SUCCESS) {
+			goto err;
+		}
+		if (oqs_fload("sk", secret_key, sig->length_secret_key) != OQS_SUCCESS) {
+			goto err;
+		}
+		if (oqs_fload("ct", message, message_len) != OQS_SUCCESS) {
+			goto err;
+		}
+		if (oqs_fload("se", signature, sig->length_signature) != OQS_SUCCESS) {
+			goto err;
+		}
+
+		rc = OQS_SIG_verify(sig, message, message_len, signature, sig->length_signature, public_key);
+		if (rc != OQS_SUCCESS) {
+			fprintf(stderr, "ERROR: OQS_SIG_verify failed\n");
+			goto err;
+		}
+
+		printf("verification passes as expected\n");
+		ret = OQS_SUCCESS;
+		goto cleanup;
+
+	default:
+		fprintf(stderr, "Incorrect operation requested. Aborting.\n");
+		goto err;
+	}
+
+err:
+	ret = OQS_ERROR;
+
+cleanup:
+	if (public_key) {
+		OQS_MEM_insecure_free(public_key);
+	}
+	if (message) {
+		OQS_MEM_insecure_free(message);
+	}
+	if (signature) {
+		OQS_MEM_insecure_free(signature);
+	}
+	if (sig != NULL) {
+		OQS_MEM_secure_free(secret_key, sig->length_secret_key);
+		OQS_SIG_free(sig);
+	}
+
+	return ret;
+}
+
+int main(int argc, char **argv) {
+
+	if (argc != 3) {
+		fprintf(stderr, "Usage: test_sig algname operation (0,1,2)\n");
+		fprintf(stderr, "  algname: ");
+		for (size_t i = 0; i < OQS_SIG_algs_length; i++) {
+			if (i > 0) {
+				fprintf(stderr, ", ");
+			}
+			fprintf(stderr, "%s", OQS_SIG_alg_identifier(i));
+		}
+		fprintf(stderr, "\n");
+		return EXIT_FAILURE;
+	}
+
+	print_system_info();
+
+	char *alg_name = argv[1];
+	if (!OQS_SIG_alg_is_enabled(alg_name)) {
+		printf("Signature algorithm %s not enabled!\n", alg_name);
+		return EXIT_FAILURE;
+	}
+
+	// Use system RNG in this program
+	OQS_randombytes_switch_algorithm(OQS_RAND_alg_system);
+
+	OQS_STATUS rc = sig_test_correctness(alg_name, atoi(argv[2]));
+
+	if (rc != OQS_SUCCESS) {
+		return EXIT_FAILURE;
+	}
+	return EXIT_SUCCESS;
+}

--- a/tests/test_sig_mem.c
+++ b/tests/test_sig_mem.c
@@ -79,10 +79,10 @@ static OQS_STATUS sig_test_correctness(const char *method_name, SIG_OPS op) {
 			fprintf(stderr, "ERROR: malloc failed\n");
 			goto err;
 		}
-		if (oqs_fload("pk", public_key, sig->length_public_key) != OQS_SUCCESS) {
+		if (oqs_fload("pk", public_key, sig->length_public_key, &signature_len) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fload("sk", secret_key, sig->length_secret_key) != OQS_SUCCESS) {
+		if (oqs_fload("sk", secret_key, sig->length_secret_key, &signature_len) != OQS_SUCCESS) {
 			goto err;
 		}
 
@@ -93,13 +93,10 @@ static OQS_STATUS sig_test_correctness(const char *method_name, SIG_OPS op) {
 			fprintf(stderr, "ERROR: OQS_SIG_sign failed\n");
 			goto err;
 		}
-		if (sig->length_signature != signature_len) {
-			fprintf(stderr, "WARNING: Unexpected signature length: %zu vs %zu\n", signature_len, sig->length_signature);
-		}
 		if (oqs_fstore("ct", message, message_len) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fstore("se", signature, sig->length_signature) != OQS_SUCCESS) {
+		if (oqs_fstore("se", signature, signature_len) != OQS_SUCCESS) {
 			goto err;
 		}
 		ret = OQS_SUCCESS;
@@ -119,20 +116,20 @@ static OQS_STATUS sig_test_correctness(const char *method_name, SIG_OPS op) {
 			fprintf(stderr, "ERROR: malloc failed\n");
 			goto err;
 		}
-		if (oqs_fload("pk", public_key, sig->length_public_key) != OQS_SUCCESS) {
+		if (oqs_fload("pk", public_key, sig->length_public_key, &signature_len) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fload("sk", secret_key, sig->length_secret_key) != OQS_SUCCESS) {
+		if (oqs_fload("sk", secret_key, sig->length_secret_key, &signature_len) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fload("ct", message, message_len) != OQS_SUCCESS) {
+		if (oqs_fload("ct", message, message_len, &signature_len) != OQS_SUCCESS) {
 			goto err;
 		}
-		if (oqs_fload("se", signature, sig->length_signature) != OQS_SUCCESS) {
+		if (oqs_fload("se", signature, sig->length_signature, &signature_len) != OQS_SUCCESS) {
 			goto err;
 		}
 
-		rc = OQS_SIG_verify(sig, message, message_len, signature, sig->length_signature, public_key);
+		rc = OQS_SIG_verify(sig, message, message_len, signature, signature_len, public_key);
 		if (rc != OQS_SUCCESS) {
 			fprintf(stderr, "ERROR: OQS_SIG_verify failed\n");
 			goto err;

--- a/tests/test_sig_mem.c
+++ b/tests/test_sig_mem.c
@@ -94,7 +94,7 @@ static OQS_STATUS sig_test_correctness(const char *method_name, SIG_OPS op) {
 			goto err;
 		}
 		if (sig->length_signature != signature_len) {
-			fprintf(stderr, "WARNING: Unexpected signature length: %ld vs %ld\n", signature_len, sig->length_signature);
+			fprintf(stderr, "WARNING: Unexpected signature length: %zu vs %zu\n", signature_len, sig->length_signature);
 		}
 		if (oqs_fstore("ct", message, message_len) != OQS_SUCCESS) {
 			goto err;

--- a/tests/tmp_store.c
+++ b/tests/tmp_store.c
@@ -4,10 +4,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define STORE_PREFIX "/tmp/oqs-temp-file-"
+#define STORE_PREFIX "tmp/oqs-temp-file-"
 #define MAXPATHLEN 128
 
-static OQS_STATUS oqs_fstore(const char *fname, const char* mname, uint8_t *data, size_t len) {
+static OQS_STATUS oqs_fstore(const char *fname, const char *mname, uint8_t *data, size_t len) {
 	char fpath[MAXPATHLEN];
 	strcpy(fpath, STORE_PREFIX);
 	strcat(fpath, mname);
@@ -21,7 +21,7 @@ static OQS_STATUS oqs_fstore(const char *fname, const char* mname, uint8_t *data
 	return OQS_SUCCESS;
 }
 
-static OQS_STATUS oqs_fload(const char *fname, const char* mname, uint8_t *data, size_t len, size_t *rcvd) {
+static OQS_STATUS oqs_fload(const char *fname, const char *mname, uint8_t *data, size_t len, size_t *rcvd) {
 	char fpath[MAXPATHLEN];
 	strcpy(fpath, STORE_PREFIX);
 	strcat(fpath, mname);

--- a/tests/tmp_store.c
+++ b/tests/tmp_store.c
@@ -7,7 +7,7 @@
 #define STORE_PREFIX "/tmp/oqs-temp-file-"
 #define MAXPATHLEN 64
 
-static OQS_STATUS oqs_fstore(const char *fname, uint8_t *data, int len) {
+static OQS_STATUS oqs_fstore(const char *fname, uint8_t *data, size_t len) {
 	char fpath[MAXPATHLEN];
 	strcpy(fpath, STORE_PREFIX);
 	FILE *fp = fopen(strcat(fpath, fname), "wb");
@@ -20,7 +20,7 @@ static OQS_STATUS oqs_fstore(const char *fname, uint8_t *data, int len) {
 	return OQS_SUCCESS;
 }
 
-static OQS_STATUS oqs_fload(const char *fname, uint8_t *data, int len) {
+static OQS_STATUS oqs_fload(const char *fname, uint8_t *data, size_t len) {
 	char fpath[MAXPATHLEN];
 	strcpy(fpath, STORE_PREFIX);
 	FILE *fp = fopen(strcat(fpath, fname), "r");
@@ -29,7 +29,7 @@ static OQS_STATUS oqs_fload(const char *fname, uint8_t *data, int len) {
 		return OQS_ERROR;
 	}
 	if (fread(data, len, 1, fp) != 1) {
-		fprintf(stderr, "Couldn't read all %d bytes correctly (operations called in proper sequence?). Exiting.\n", len);
+		fprintf(stderr, "Couldn't read all %ld bytes correctly (operations called in proper sequence?). Exiting.\n", len);
 		return OQS_ERROR;
 	}
 	fclose(fp);

--- a/tests/tmp_store.c
+++ b/tests/tmp_store.c
@@ -29,7 +29,7 @@ static OQS_STATUS oqs_fload(const char *fname, uint8_t *data, size_t len) {
 		return OQS_ERROR;
 	}
 	if (fread(data, len, 1, fp) != 1) {
-		fprintf(stderr, "Couldn't read all %d bytes correctly (operations called in proper sequence?). Exiting.\n", (int)len);
+		fprintf(stderr, "Couldn't read all %zu bytes correctly (operations called in proper sequence?). Exiting.\n", len);
 		return OQS_ERROR;
 	}
 	fclose(fp);

--- a/tests/tmp_store.c
+++ b/tests/tmp_store.c
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define STORE_PREFIX "/tmp/oqs-temp-file-"
+#define MAXPATHLEN 64
+
+static OQS_STATUS oqs_fstore(const char *fname, uint8_t *data, int len) {
+	char fpath[MAXPATHLEN];
+	strcpy(fpath, STORE_PREFIX);
+	FILE *fp = fopen(strcat(fpath, fname), "wb");
+	if (!fp) {
+		fprintf(stderr, "Couldn't open %s for writing.\n", fpath);
+		return OQS_ERROR;
+	}
+	fwrite(data, len, 1, fp);
+	fclose(fp);
+	return OQS_SUCCESS;
+}
+
+static OQS_STATUS oqs_fload(const char *fname, uint8_t *data, int len) {
+	char fpath[MAXPATHLEN];
+	strcpy(fpath, STORE_PREFIX);
+	FILE *fp = fopen(strcat(fpath, fname), "r");
+	if (!fp) {
+		fprintf(stderr, "Couldn't open %s for reading.\n", fpath);
+		return OQS_ERROR;
+	}
+	if (fread(data, len, 1, fp) != 1) {
+		fprintf(stderr, "Couldn't read all %d bytes correctly (operations called in proper sequence?). Exiting.\n", len);
+		return OQS_ERROR;
+	}
+	fclose(fp);
+	return OQS_SUCCESS;
+}
+

--- a/tests/tmp_store.c
+++ b/tests/tmp_store.c
@@ -22,16 +22,23 @@ static OQS_STATUS oqs_fstore(const char *fname, const char *mname, uint8_t *data
 }
 
 static OQS_STATUS oqs_fload(const char *fname, const char *mname, uint8_t *data, size_t len, size_t *rcvd) {
+	size_t len_read = 0, r = 0;
+	uint8_t *dr = NULL;
 	char fpath[MAXPATHLEN];
 	strcpy(fpath, STORE_PREFIX);
 	strcat(fpath, mname);
-	FILE *fp = fopen(strcat(fpath, fname), "r");
+	FILE *fp = fopen(strcat(fpath, fname), "rb");
 	if (!fp) {
 		fprintf(stderr, "Couldn't open %s for reading.\n", fpath);
 		return OQS_ERROR;
 	}
-	*rcvd = fread(data, 1, len, fp);
-	if (*rcvd < 1) {
+	do { // assume some OSs don't deliver all data in one go...
+		dr = (uint8_t *)(data + len_read);
+		r = fread(dr, 1, len - len_read, fp);
+		len_read += r;
+	} while (r > 0);
+	*rcvd = len_read;
+	if (len_read <= 0) {
 		fprintf(stderr, "Error reading data (operations called in proper sequence?). Expecting %zu. Exiting.\n", len);
 		return OQS_ERROR;
 	}

--- a/tests/tmp_store.c
+++ b/tests/tmp_store.c
@@ -5,11 +5,12 @@
 #include <string.h>
 
 #define STORE_PREFIX "/tmp/oqs-temp-file-"
-#define MAXPATHLEN 64
+#define MAXPATHLEN 128
 
-static OQS_STATUS oqs_fstore(const char *fname, uint8_t *data, size_t len) {
+static OQS_STATUS oqs_fstore(const char *fname, const char* mname, uint8_t *data, size_t len) {
 	char fpath[MAXPATHLEN];
 	strcpy(fpath, STORE_PREFIX);
+	strcat(fpath, mname);
 	FILE *fp = fopen(strcat(fpath, fname), "wb");
 	if (!fp) {
 		fprintf(stderr, "Couldn't open %s for writing.\n", fpath);
@@ -20,9 +21,10 @@ static OQS_STATUS oqs_fstore(const char *fname, uint8_t *data, size_t len) {
 	return OQS_SUCCESS;
 }
 
-static OQS_STATUS oqs_fload(const char *fname, uint8_t *data, size_t len, size_t *rcvd) {
+static OQS_STATUS oqs_fload(const char *fname, const char* mname, uint8_t *data, size_t len, size_t *rcvd) {
 	char fpath[MAXPATHLEN];
 	strcpy(fpath, STORE_PREFIX);
+	strcat(fpath, mname);
 	FILE *fp = fopen(strcat(fpath, fname), "r");
 	if (!fp) {
 		fprintf(stderr, "Couldn't open %s for reading.\n", fpath);

--- a/tests/tmp_store.c
+++ b/tests/tmp_store.c
@@ -20,7 +20,7 @@ static OQS_STATUS oqs_fstore(const char *fname, uint8_t *data, size_t len) {
 	return OQS_SUCCESS;
 }
 
-static OQS_STATUS oqs_fload(const char *fname, uint8_t *data, size_t len) {
+static OQS_STATUS oqs_fload(const char *fname, uint8_t *data, size_t len, size_t *rcvd) {
 	char fpath[MAXPATHLEN];
 	strcpy(fpath, STORE_PREFIX);
 	FILE *fp = fopen(strcat(fpath, fname), "r");
@@ -28,8 +28,9 @@ static OQS_STATUS oqs_fload(const char *fname, uint8_t *data, size_t len) {
 		fprintf(stderr, "Couldn't open %s for reading.\n", fpath);
 		return OQS_ERROR;
 	}
-	if (fread(data, len, 1, fp) != 1) {
-		fprintf(stderr, "Couldn't read all %zu bytes correctly (operations called in proper sequence?). Exiting.\n", len);
+	*rcvd = fread(data, 1, len, fp);
+	if (*rcvd < 1) {
+		fprintf(stderr, "Error reading data (operations called in proper sequence?). Expecting %zu. Exiting.\n", len);
 		return OQS_ERROR;
 	}
 	fclose(fp);

--- a/tests/tmp_store.c
+++ b/tests/tmp_store.c
@@ -29,7 +29,7 @@ static OQS_STATUS oqs_fload(const char *fname, uint8_t *data, size_t len) {
 		return OQS_ERROR;
 	}
 	if (fread(data, len, 1, fp) != 1) {
-		fprintf(stderr, "Couldn't read all %ld bytes correctly (operations called in proper sequence?). Exiting.\n", len);
+		fprintf(stderr, "Couldn't read all %d bytes correctly (operations called in proper sequence?). Exiting.\n", (int)len);
 		return OQS_ERROR;
 	}
 	fclose(fp);


### PR DESCRIPTION
Fixes #439, replaces #853 

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding or removing?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)
