### PR TITLE
Picnic Dec 2020 update.

### DIFF
--- a/docs/algorithms/sig/picnic.md
+++ b/docs/algorithms/sig/picnic.md
@@ -12,7 +12,7 @@ Implementation
 --------------
 
 - **Source of implementation**: https://github.com/IAIK/Picnic
-- **Implementation version**: https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00
+- **Implementation version**: https://github.com/IAIK/Picnic/tree/v3.0.4
 - **License**: MIT License
 - **Constant-time**: Yes
 - **Optimizations**: Portable C with optional use of AVX2 and SSE2 instructions (selected at compile-time, enabled by default if available)

--- a/docs/algorithms/sig/picnic.md
+++ b/docs/algorithms/sig/picnic.md
@@ -12,7 +12,7 @@ Implementation
 --------------
 
 - **Source of implementation**: https://github.com/IAIK/Picnic
-- **Implementation version**: https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e
+- **Implementation version**: https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00
 - **License**: MIT License
 - **Constant-time**: Yes
 - **Optimizations**: Portable C with optional use of AVX2 and SSE2 instructions (selected at compile-time, enabled by default if available)

--- a/docs/algorithms/sig/picnic.md
+++ b/docs/algorithms/sig/picnic.md
@@ -12,7 +12,7 @@ Implementation
 --------------
 
 - **Source of implementation**: https://github.com/IAIK/Picnic
-- **Implementation version**: https://github.com/IAIK/Picnic/tree/v3.0.3
+- **Implementation version**: https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e
 - **License**: MIT License
 - **Constant-time**: Yes
 - **Optimizations**: Portable C with optional use of AVX2 and SSE2 instructions (selected at compile-time, enabled by default if available)

--- a/src/sig/picnic/external/CHANGELOG.md
+++ b/src/sig/picnic/external/CHANGELOG.md
@@ -1,3 +1,10 @@
+Version 3.0.4 -- 2020-12-17
+---------------------------
+
+* Slightly improve memory consumption
+* Initial work to support PQClean integration in the future
+* Add cmake options to control availability of specific LowMC instances
+
 Version 3.0.3 -- 2020-10-12
 ---------------------------
 

--- a/src/sig/picnic/external/LICENSE
+++ b/src/sig/picnic/external/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 AIT Austrian Institute of Technology
+Copyright (c) 2019-2020 Sebastian Ramacher, AIT Austrian Institute of Technology
 Copyright (c) 2016-2018 Graz University of Technology
 Copyright (c) 2017 Angela Promitzer
 

--- a/src/sig/picnic/external/README.md
+++ b/src/sig/picnic/external/README.md
@@ -28,6 +28,7 @@ make
 
 The cmake based build system supports the following flags:
 * ``WITH_ZKBPP``: Enable ZKB++-based Picnic instances.
+* ``WITH_UNRUH``: Enables ZKB++-based Picnic instances using the Unruh transform (requires ``WITH_ZKBPP`` to be enabled).
 * ``WITH_KKW``: Enable KKW-based Picnic instances.
 * ``WITH_SIMD_OPT``: Enable SIMD optimizations.
 * ``WITH_AVX2``: Use AVX2 if available.
@@ -36,6 +37,14 @@ The cmake based build system supports the following flags:
 * ``WITH_MARCH_NATIVE``: Build with -march=native -mtune=native (if supported).
 * ``WITH_LTO``: Enable link-time optimization (if supported).
 * ``WITH_SHA3_IMPL={opt64,avx2,armv8a-neon,s390-cpacf}``: Select SHA3 implementation opt64 (the default, from Keccak code package), avx2 (for AVX2 capable x86-64 systems, from Keccak code package), armv8a-neon (for NEON capable ARM systems, from Keccak code package), s390-cpacf (for IBM z14 and newer systems supporting SHAKE)
+
+Furthermore, the availability of specific LowMC instances can be controlled with ``WITH_LOWMC_$n_$k_$r``. Note though, that at least one instance needs to be enabled, and if ``WITH_KKW`` is enabled, at least one of full Sbox layer instances needs to be enabled as well:
+* ``WITH_LOWMC_128_128_20``: Enable partial Sbox layer instance for L1.
+* ``WITH_LOWMC_192_192_30``: Enable partial Sbox layer instance for L3.
+* ``WITH_LOWMC_256_256_38``: Enable partial Sbox layer instance for L5.
+* ``WITH_LOWMC_129_129_4``: Enable full Sbox layer instance for L1.
+* ``WITH_LOWMC_192_192_4``: Enable full Sbox layer instance for L3.
+* ``WITH_LOWMC_255_255_4``: Enable full Sbox layer instance for L5.
 
 Building on Windows
 -------------------

--- a/src/sig/picnic/external/endian_compat.h
+++ b/src/sig/picnic/external/endian_compat.h
@@ -133,6 +133,16 @@ static inline uint64_t ATTR_CONST bswap64(uint64_t x) {
 #endif
 
 #if !defined(PICNIC_IS_LITTLE_ENDIAN) && !defined(PICNIC_IS_BIG_ENDIAN)
+#if defined(__ORDER_BIG_ENDIAN__) && defined(__ORDER_LITTLE_ENDIAN__)
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define PICNIC_IS_BIG_ENDIAN
+#elif defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define PICNIC_IS_LITTLE_ENDIAN
+#endif
+#endif
+#endif
+
+#if !defined(PICNIC_IS_LITTLE_ENDIAN) && !defined(PICNIC_IS_BIG_ENDIAN)
 #error "Unknown platform!"
 #endif
 

--- a/src/sig/picnic/external/kdf_shake.h
+++ b/src/sig/picnic/external/kdf_shake.h
@@ -18,6 +18,214 @@
 #if defined(WITH_SHAKE_S390_CPACF)
 /* use the KIMD/KLMD instructions from CPACF for SHAKE support on S390 */
 #include "sha3/s390_cpacf.h"
+#elif defined(OQS) || defined(PQCLEAN)
+#if defined(OQS)
+/* use OQS's SHAKE implementation */
+#include <oqs/sha3.h>
+#elif defined(PQCLEAN)
+/* PQClean's SHAKE implementation */
+#include <fips202.h>
+
+#define OQS_SHA3_shake128_inc_ctx shake128incctx
+#define OQS_SHA3_shake128_inc_init shake128_inc_init
+#define OQS_SHA3_shake128_inc_absorb shake128_inc_absorb
+#define OQS_SHA3_shake128_inc_finalize shake128_inc_finalize
+#define OQS_SHA3_shake128_inc_squeeze shake128_inc_squeeze
+#define OQS_SHA3_shake128_inc_ctx_release shake128_inc_ctx_release
+#define OQS_SHA3_shake256_inc_ctx shake256incctx
+#define OQS_SHA3_shake256_inc_init shake256_inc_init
+#define OQS_SHA3_shake256_inc_absorb shake256_inc_absorb
+#define OQS_SHA3_shake256_inc_finalize shake256_inc_finalize
+#define OQS_SHA3_shake256_inc_squeeze shake256_inc_squeeze
+#define OQS_SHA3_shake256_inc_ctx_release shake256_inc_ctx_release
+#endif
+
+typedef struct hash_context_oqs_s {
+  union {
+    OQS_SHA3_shake128_inc_ctx shake128_ctx;
+    OQS_SHA3_shake256_inc_ctx shake256_ctx;
+  };
+  unsigned char shake256;
+} hash_context;
+
+/**
+ * Initialize hash context based on the digest size used by Picnic. If the size is 32 bytes,
+ * SHAKE128 is used, otherwise SHAKE256 is used.
+ */
+static inline void hash_init(hash_context* ctx, size_t digest_size) {
+  if (digest_size == 32) {
+    OQS_SHA3_shake128_inc_init(&ctx->shake128_ctx);
+    ctx->shake256 = 0;
+  } else {
+    OQS_SHA3_shake256_inc_init(&ctx->shake256_ctx);
+    ctx->shake256 = 1;
+  }
+}
+
+static inline void hash_update(hash_context* ctx, const uint8_t* data, size_t size) {
+  if (ctx->shake256) {
+    OQS_SHA3_shake256_inc_absorb(&ctx->shake256_ctx, data, size);
+  } else {
+    OQS_SHA3_shake128_inc_absorb(&ctx->shake128_ctx, data, size);
+  }
+}
+
+static inline void hash_final(hash_context* ctx) {
+  if (ctx->shake256) {
+    OQS_SHA3_shake256_inc_finalize(&ctx->shake256_ctx);
+  } else {
+    OQS_SHA3_shake128_inc_finalize(&ctx->shake128_ctx);
+  }
+}
+
+static inline void hash_squeeze(hash_context* ctx, uint8_t* buffer, size_t buflen) {
+  if (ctx->shake256) {
+    OQS_SHA3_shake256_inc_squeeze(buffer, buflen, &ctx->shake256_ctx);
+  } else {
+    OQS_SHA3_shake128_inc_squeeze(buffer, buflen, &ctx->shake128_ctx);
+  }
+}
+
+static inline void hash_clear(hash_context* ctx) {
+  if (ctx->shake256) {
+    OQS_SHA3_shake256_inc_ctx_release(&ctx->shake256_ctx);
+  } else {
+    OQS_SHA3_shake128_inc_ctx_release(&ctx->shake128_ctx);
+  }
+}
+
+/* Instances that work with 4 states in parallel using the base implementation. */
+typedef struct hash_context_x4_oqs_s {
+  union {
+    OQS_SHA3_shake128_inc_ctx shake128_ctx[4];
+    OQS_SHA3_shake256_inc_ctx shake256_ctx[4];
+  };
+  unsigned int shake256;
+} hash_context_x4;
+
+
+static inline void hash_init_x4(hash_context_x4* ctx, size_t digest_size) {
+  if (digest_size == 32) {
+    for (unsigned int i = 0; i < 4; ++i) {
+      OQS_SHA3_shake128_inc_init(&ctx->shake128_ctx[i]);
+    }
+    ctx->shake256 = 0;
+  } else {
+    for (unsigned int i = 0; i < 4; ++i) {
+      OQS_SHA3_shake256_inc_init(&ctx->shake256_ctx[i]);
+    }
+    ctx->shake256 = 1;
+  }
+}
+
+static inline void hash_update_x4(hash_context_x4* ctx, const uint8_t** data,
+                                  size_t size) {
+  if (ctx->shake256) {
+    for (unsigned int i = 0; i < 4; ++i) {
+      OQS_SHA3_shake256_inc_absorb(&ctx->shake256_ctx[i], data[i], size);
+    }
+  } else {
+    for (unsigned int i = 0; i < 4; ++i) {
+      OQS_SHA3_shake128_inc_absorb(&ctx->shake128_ctx[i], data[i], size);
+    }
+  }
+}
+
+static inline void hash_update_x4_4(hash_context_x4* ctx, const uint8_t* data0,
+                                    const uint8_t* data1, const uint8_t* data2,
+                                    const uint8_t* data3, size_t size) {
+  if (ctx->shake256) {
+    OQS_SHA3_shake256_inc_absorb(&ctx->shake256_ctx[0], data0, size);
+    OQS_SHA3_shake256_inc_absorb(&ctx->shake256_ctx[1], data1, size);
+    OQS_SHA3_shake256_inc_absorb(&ctx->shake256_ctx[2], data2, size);
+    OQS_SHA3_shake256_inc_absorb(&ctx->shake256_ctx[3], data3, size);
+  } else {
+    OQS_SHA3_shake128_inc_absorb(&ctx->shake128_ctx[0], data0, size);
+    OQS_SHA3_shake128_inc_absorb(&ctx->shake128_ctx[1], data1, size);
+    OQS_SHA3_shake128_inc_absorb(&ctx->shake128_ctx[2], data2, size);
+    OQS_SHA3_shake128_inc_absorb(&ctx->shake128_ctx[3], data3, size);
+  }
+}
+
+static inline void hash_update_x4_1(hash_context_x4* ctx, const uint8_t* data, size_t size) {
+  if (ctx->shake256) {
+    for (unsigned int i = 0; i < 4; ++i) {
+      OQS_SHA3_shake256_inc_absorb(&ctx->shake256_ctx[i], data, size);
+    }
+  } else {
+    for (unsigned int i = 0; i < 4; ++i) {
+      OQS_SHA3_shake128_inc_absorb(&ctx->shake128_ctx[i], data, size);
+    }
+  }
+}
+
+static inline void hash_init_prefix_x4(hash_context_x4* ctx, size_t digest_size,
+                                       const uint8_t prefix) {
+  if (digest_size == 32) {
+    for (unsigned int i = 0; i < 4; ++i) {
+      OQS_SHA3_shake128_inc_init(&ctx->shake128_ctx[i]);
+      OQS_SHA3_shake128_inc_absorb(&ctx->shake128_ctx[i], &prefix, sizeof(prefix));
+    }
+    ctx->shake256 = 0;
+  } else {
+    for (unsigned int i = 0; i < 4; ++i) {
+      OQS_SHA3_shake256_inc_init(&ctx->shake256_ctx[i]);
+      OQS_SHA3_shake256_inc_absorb(&ctx->shake256_ctx[i], &prefix, sizeof(prefix));
+    }
+    ctx->shake256 = 1;
+  }
+}
+
+static inline void hash_final_x4(hash_context_x4* ctx) {
+  if (ctx->shake256) {
+    for (unsigned int i = 0; i < 4; ++i) {
+      OQS_SHA3_shake256_inc_finalize(&ctx->shake256_ctx[i]);
+    }
+  } else {
+    for (unsigned int i = 0; i < 4; ++i) {
+      OQS_SHA3_shake128_inc_finalize(&ctx->shake128_ctx[i]);
+    }
+  }
+}
+
+static inline void hash_squeeze_x4(hash_context_x4* ctx, uint8_t** buffer, size_t buflen) {
+  if (ctx->shake256) {
+    for (unsigned int i = 0; i < 4; ++i) {
+      OQS_SHA3_shake256_inc_squeeze(buffer[i], buflen, &ctx->shake256_ctx[i]);
+    }
+  } else {
+    for (unsigned int i = 0; i < 4; ++i) {
+      OQS_SHA3_shake128_inc_squeeze(buffer[i], buflen, &ctx->shake128_ctx[i]);
+    }
+  }
+}
+
+static inline void hash_squeeze_x4_4(hash_context_x4* ctx, uint8_t* buffer0, uint8_t* buffer1,
+                                     uint8_t* buffer2, uint8_t* buffer3, size_t buflen) {
+  if (ctx->shake256) {
+    OQS_SHA3_shake256_inc_squeeze(buffer0, buflen, &ctx->shake256_ctx[0]);
+    OQS_SHA3_shake256_inc_squeeze(buffer1, buflen, &ctx->shake256_ctx[1]);
+    OQS_SHA3_shake256_inc_squeeze(buffer2, buflen, &ctx->shake256_ctx[2]);
+    OQS_SHA3_shake256_inc_squeeze(buffer3, buflen, &ctx->shake256_ctx[3]);
+  } else {
+    OQS_SHA3_shake128_inc_squeeze(buffer0, buflen, &ctx->shake128_ctx[0]);
+    OQS_SHA3_shake128_inc_squeeze(buffer1, buflen, &ctx->shake128_ctx[1]);
+    OQS_SHA3_shake128_inc_squeeze(buffer2, buflen, &ctx->shake128_ctx[2]);
+    OQS_SHA3_shake128_inc_squeeze(buffer3, buflen, &ctx->shake128_ctx[3]);
+  }
+}
+
+static inline void hash_clear_x4(hash_context_x4* ctx) {
+  if (ctx->shake256) {
+    for (unsigned int i = 0; i < 4; ++i) {
+      OQS_SHA3_shake256_inc_ctx_release(&ctx->shake256_ctx[i]);
+    }
+  } else {
+    for (unsigned int i = 0; i < 4; ++i) {
+      OQS_SHA3_shake128_inc_ctx_release(&ctx->shake128_ctx[i]);
+    }
+  }
+}
 #else
 #if !defined(SUPERCOP)
 /* use SHAKE implementation in sha3/ */
@@ -57,6 +265,8 @@ static inline void hash_final(hash_context* ctx) {
 static inline void hash_squeeze(hash_context* ctx, uint8_t* buffer, size_t buflen) {
   Keccak_HashSqueeze(ctx, buffer, buflen << 3);
 }
+
+#define hash_clear(ctx)
 #endif
 
 static inline void hash_update_uint16_le(hash_context* ctx, uint16_t data) {
@@ -78,9 +288,58 @@ typedef hash_context kdf_shake_t;
 #define kdf_shake_update_key_uint16_le(ctx, key) hash_update_uint16_le((ctx), (key))
 #define kdf_shake_finalize_key(ctx) hash_final((ctx))
 #define kdf_shake_get_randomness(ctx, dst, count) hash_squeeze((ctx), (dst), (count))
-#define kdf_shake_clear(ctx)
+#define kdf_shake_clear(ctx) hash_clear((ctx))
 
-#if !defined(WITH_KECCAK_X4)
+#if defined(WITH_KECCAK_X4)
+/* Instances that work with 4 states in parallel. */
+typedef Keccak_HashInstancetimes4 hash_context_x4 ATTR_ALIGNED(32);
+
+static inline void hash_init_x4(hash_context_x4* ctx, size_t digest_size) {
+  if (digest_size == 32) {
+    Keccak_HashInitializetimes4_SHAKE128(ctx);
+  } else {
+    Keccak_HashInitializetimes4_SHAKE256(ctx);
+  }
+}
+
+static inline void hash_update_x4(hash_context_x4* ctx, const uint8_t** data, size_t size) {
+  Keccak_HashUpdatetimes4(ctx, data, size << 3);
+}
+
+static inline void hash_update_x4_4(hash_context_x4* ctx, const uint8_t* data0,
+                                    const uint8_t* data1, const uint8_t* data2,
+                                    const uint8_t* data3, size_t size) {
+  const uint8_t* data[4] = { data0, data1, data2, data3 };
+  hash_update_x4(ctx, data, size);
+}
+
+static inline void hash_update_x4_1(hash_context_x4* ctx, const uint8_t* data, size_t size) {
+  const uint8_t* tmp[4] = { data, data, data, data };
+  hash_update_x4(ctx, tmp, size);
+}
+
+static inline void hash_init_prefix_x4(hash_context_x4* ctx, size_t digest_size,
+                                       const uint8_t prefix) {
+  hash_init_x4(ctx, digest_size);
+  hash_update_x4_1(ctx, &prefix, sizeof(prefix));
+}
+
+static inline void hash_final_x4(hash_context_x4* ctx) {
+  Keccak_HashFinaltimes4(ctx, NULL);
+}
+
+static inline void hash_squeeze_x4(hash_context_x4* ctx, uint8_t** buffer, size_t buflen) {
+  Keccak_HashSqueezetimes4(ctx, buffer, buflen << 3);
+}
+
+static inline void hash_squeeze_x4_4(hash_context_x4* ctx, uint8_t* buffer0, uint8_t* buffer1,
+                                     uint8_t* buffer2, uint8_t* buffer3, size_t buflen) {
+  uint8_t* buffer[4] = { buffer0, buffer1, buffer2, buffer3 };
+  hash_squeeze_x4(ctx, buffer, buflen);
+}
+
+#define hash_clear_x4(ctx)
+#elif !defined(OQS)
 /* Instances that work with 4 states in parallel using the base Keccak implementation. */
 typedef struct hash_context_x4_s {
   hash_context instances[4];
@@ -99,8 +358,8 @@ static inline void hash_update_x4(hash_context_x4* ctx, const uint8_t** data, si
 }
 
 static inline void hash_update_x4_4(hash_context_x4* ctx, const uint8_t* data0,
-				    const uint8_t* data1, const uint8_t* data2,
-				    const uint8_t* data3, size_t size) {
+                                    const uint8_t* data1, const uint8_t* data2,
+                                    const uint8_t* data3, size_t size) {
   hash_update(&ctx->instances[0], data0, size);
   hash_update(&ctx->instances[1], data1, size);
   hash_update(&ctx->instances[2], data2, size);
@@ -133,59 +392,14 @@ static inline void hash_squeeze_x4(hash_context_x4* ctx, uint8_t** buffer, size_
 }
 
 static inline void hash_squeeze_x4_4(hash_context_x4* ctx, uint8_t* buffer0, uint8_t* buffer1,
-				     uint8_t* buffer2, uint8_t* buffer3, size_t buflen) {
+                                     uint8_t* buffer2, uint8_t* buffer3, size_t buflen) {
   hash_squeeze(&ctx->instances[0], buffer0, buflen);
   hash_squeeze(&ctx->instances[1], buffer1, buflen);
   hash_squeeze(&ctx->instances[2], buffer2, buflen);
   hash_squeeze(&ctx->instances[3], buffer3, buflen);
 }
-#else
-/* Instances that work with 4 states in parallel. */
-typedef Keccak_HashInstancetimes4 hash_context_x4 ATTR_ALIGNED(32);
 
-static inline void hash_init_x4(hash_context_x4* ctx, size_t digest_size) {
-  if (digest_size == 32) {
-    Keccak_HashInitializetimes4_SHAKE128(ctx);
-  } else {
-    Keccak_HashInitializetimes4_SHAKE256(ctx);
-  }
-}
-
-static inline void hash_update_x4(hash_context_x4* ctx, const uint8_t** data, size_t size) {
-  Keccak_HashUpdatetimes4(ctx, data, size << 3);
-}
-
-static inline void hash_update_x4_4(hash_context_x4* ctx, const uint8_t* data0,
-				    const uint8_t* data1, const uint8_t* data2,
-				    const uint8_t* data3, size_t size) {
-  const uint8_t* data[4] = { data0, data1, data2, data3 };
-  hash_update_x4(ctx, data, size);
-}
-
-static inline void hash_update_x4_1(hash_context_x4* ctx, const uint8_t* data, size_t size) {
-  const uint8_t* tmp[4] = { data, data, data, data };
-  hash_update_x4(ctx, tmp, size);
-}
-
-static inline void hash_init_prefix_x4(hash_context_x4* ctx, size_t digest_size,
-                                       const uint8_t prefix) {
-  hash_init_x4(ctx, digest_size);
-  hash_update_x4_1(ctx, &prefix, sizeof(prefix));
-}
-
-static inline void hash_final_x4(hash_context_x4* ctx) {
-  Keccak_HashFinaltimes4(ctx, NULL);
-}
-
-static inline void hash_squeeze_x4(hash_context_x4* ctx, uint8_t** buffer, size_t buflen) {
-  Keccak_HashSqueezetimes4(ctx, buffer, buflen << 3);
-}
-
-static inline void hash_squeeze_x4_4(hash_context_x4* ctx, uint8_t* buffer0, uint8_t* buffer1,
-				     uint8_t* buffer2, uint8_t* buffer3, size_t buflen) {
-  uint8_t* buffer[4] = { buffer0, buffer1, buffer2, buffer3 };
-  hash_squeeze_x4(ctx, buffer, buflen);
-}
+#define hash_clear_x4(ctx)
 #endif
 
 static inline void hash_update_x4_uint16_le(hash_context_x4* ctx, uint16_t data) {
@@ -217,6 +431,6 @@ typedef hash_context_x4 kdf_shake_x4_t;
 #define kdf_shake_x4_get_randomness(ctx, dst, count) hash_squeeze_x4((ctx), (dst), (count))
 #define kdf_shake_x4_get_randomness_4(ctx, dst0, dst1, dst2, dst3, count)                          \
   hash_squeeze_x4_4((ctx), (dst0), (dst1), (dst2), (dst3), (count))
-#define kdf_shake_x4_clear(ctx)
+#define kdf_shake_x4_clear(ctx) hash_clear_x4((ctx))
 
 #endif

--- a/src/sig/picnic/external/kdf_shake.h
+++ b/src/sig/picnic/external/kdf_shake.h
@@ -18,9 +18,14 @@
 #if defined(WITH_SHAKE_S390_CPACF)
 /* use the KIMD/KLMD instructions from CPACF for SHAKE support on S390 */
 #include "sha3/s390_cpacf.h"
-#elif defined(OQS) || defined(PQCLEAN)
-#if defined(OQS)
-/* use OQS's SHAKE implementation */
+#elif (0 && defined(OQS)) || defined(PQCLEAN)
+#if (0 && defined(OQS))
+/*use OQS's SHAKE implementation (disabled)
+ *
+ * OQS currently does not expose the AVX2-optimized version of Keccak or the Keccakx4
+ * implementation. Consequently we currently still use our copy of Keccak by default. Once these
+ * issues are fixed in OQS, this code path will be enabled by default.
+ */
 #include <oqs/sha3.h>
 #elif defined(PQCLEAN)
 /* PQClean's SHAKE implementation */

--- a/src/sig/picnic/external/macros.h
+++ b/src/sig/picnic/external/macros.h
@@ -129,14 +129,17 @@
 /* unreachable builtin */
 #if GNUC_CHECK(4, 5) || __has_builtin(__builtin_unreachable)
 #define UNREACHABLE __builtin_unreachable()
+#define HAVE_USEFUL_UNREACHABLE
 /* #elif defined(_MSC_VER)
 #define UNREACHABLE __assume(0) */
+#else
+#define UNREACHABLE
 #endif
 
 /* assume aligned builtin */
 #if GNUC_CHECK(4, 9) || __has_builtin(__builtin_assume_aligned)
 #define ASSUME_ALIGNED(p, a) __builtin_assume_aligned((p), (a))
-#elif defined(UNREACHABLE) && defined(HAVE_USEFUL_ATTR_ALIGNED)
+#elif defined(HAVE_USEFUL_UNREACHABLE) && defined(HAVE_USEFUL_ATTR_ALIGNED)
 #define ASSUME_ALIGNED(p, a) (((((uintptr_t)(p)) % (a)) == 0) ? (p) : (UNREACHABLE, (p)))
 #else
 #define ASSUME_ALIGNED(p, a) (p)

--- a/src/sig/picnic/external/mpc_lowmc_impl.c.i
+++ b/src/sig/picnic/external/mpc_lowmc_impl.c.i
@@ -29,7 +29,7 @@ static void N_SIGN(mzd_local_t const* p, view_t* views, in_out_shares_t* in_out_
   mzd_local_t x[SC_PROOF][((LOWMC_N) + 255) / 256];
   mzd_local_t y[SC_PROOF][((LOWMC_N) + 255) / 256];
 
-  MPC_LOOP_CONST(MUL, x, in_out_shares[0].s, LOWMC_INSTANCE.k0_matrix, reduced_shares);
+  MPC_LOOP_CONST(MUL, x, in_out_shares->s, LOWMC_INSTANCE.k0_matrix, reduced_shares);
   MPC_LOOP_CONST_C(XOR, x, x, p, reduced_shares, ch);
 
 #if defined(LOWMC_PARTIAL)
@@ -38,7 +38,7 @@ static void N_SIGN(mzd_local_t const* p, view_t* views, in_out_shares_t* in_out_
   #include "mpc_lowmc_loop.c.i"
 #endif
 
-  MPC_LOOP_SHARED_1(COPY, in_out_shares[1].s, x, SC_PROOF);
+  MPC_LOOP_SHARED_1(COPY, in_out_shares->s, x, SC_PROOF);
 
 #undef reduced_shares
 #undef RECOVER_FROM_STATE
@@ -67,7 +67,7 @@ static void N_VERIFY(mzd_local_t const* p, view_t* views, in_out_shares_t* in_ou
   mzd_local_t x[SC_VERIFY][((LOWMC_N) + 255) / 256];
   mzd_local_t y[SC_VERIFY][((LOWMC_N) + 255) / 256];
 
-  MPC_LOOP_CONST(MUL, x, in_out_shares[0].s, LOWMC_INSTANCE.k0_matrix, SC_VERIFY);
+  MPC_LOOP_CONST(MUL, x, in_out_shares->s, LOWMC_INSTANCE.k0_matrix, SC_VERIFY);
   MPC_LOOP_CONST_C(XOR, x, x, p, SC_VERIFY, ch);
 
 #if defined(LOWMC_PARTIAL)
@@ -76,7 +76,7 @@ static void N_VERIFY(mzd_local_t const* p, view_t* views, in_out_shares_t* in_ou
   #include "mpc_lowmc_loop.c.i"
 #endif
 
-  MPC_LOOP_SHARED_1(COPY, in_out_shares[1].s, x, SC_VERIFY);
+  MPC_LOOP_SHARED_1(COPY, in_out_shares->s, x, SC_VERIFY);
 
 #undef sbox
 #undef reduced_shares

--- a/src/sig/picnic/external/mpc_lowmc_loop.c.i
+++ b/src/sig/picnic/external/mpc_lowmc_loop.c.i
@@ -15,7 +15,7 @@ for (unsigned i = 0; i < (LOWMC_R); ++i, ++views, ++round, ++rvec) {
   SBOX(sbox, y, x, views, rvec, LOWMC_N, shares, reduced_shares);
   MPC_LOOP_CONST(MUL, x, y, round->l_matrix, reduced_shares);
   MPC_LOOP_CONST_C(XOR, x, x, round->constant, reduced_shares, ch);
-  MPC_LOOP_CONST(ADDMUL, x, in_out_shares[0].s, round->k_matrix, reduced_shares);
+  MPC_LOOP_CONST(ADDMUL, x, in_out_shares->s, round->k_matrix, reduced_shares);
 }
 #if defined(RECOVER_FROM_STATE)
 RECOVER_FROM_STATE(x, LOWMC_R);

--- a/src/sig/picnic/external/mpc_lowmc_loop_partial.c.i
+++ b/src/sig/picnic/external/mpc_lowmc_loop_partial.c.i
@@ -10,7 +10,7 @@
 lowmc_partial_round_t const* round = LOWMC_INSTANCE.rounds;
   mzd_local_t nl_part[reduced_shares][(LOWMC_R * 32 + 255) / 256];
   MPC_LOOP_CONST_C(XOR, x, x, LOWMC_INSTANCE.precomputed_constant_linear, reduced_shares, ch);
-  MPC_LOOP_CONST(MUL_MC, nl_part, in_out_shares[0].s,
+  MPC_LOOP_CONST(MUL_MC, nl_part, in_out_shares->s,
                  LOWMC_INSTANCE.precomputed_non_linear_part_matrix, reduced_shares);
   MPC_LOOP_CONST_C(XOR_MC, nl_part, nl_part, LOWMC_INSTANCE.precomputed_constant_non_linear, reduced_shares, ch);
   for (unsigned i = 0; i < (LOWMC_R-1); ++i, ++views, ++round, ++rvec) {

--- a/src/sig/picnic/external/mzd_additional.c
+++ b/src/sig/picnic/external/mzd_additional.c
@@ -813,8 +813,8 @@ mm256_compute_mask(const word idx, const size_t bit) {
 
 ATTR_TARGET_AVX2 ATTR_ARTIFICIAL ATTR_CONST static inline word256
 mm256_compute_mask_2(const word idx, const size_t bit) {
-  const uint64_t m1 = -((idx >> bit) & 1);
-  const uint64_t m2 = -((idx >> (bit + 1)) & 1);
+  const word m1 = -((idx >> bit) & 1);
+  const word m2 = -((idx >> (bit + 1)) & 1);
   return _mm256_set_epi64x(m2, m2, m1, m1);
 }
 
@@ -1090,8 +1090,8 @@ void mzd_addmul_v_uint64_128(mzd_local_t* c, mzd_local_t const* v, mzd_local_t c
   for (unsigned int w = 2; w; --w, ++vptr) {
     word idx = *vptr;
     for (unsigned int i = sizeof(word) * 8; i; i -= 2, idx >>= 2, Ablock += 1) {
-      const uint64_t mask1 = -(idx & 1);
-      const uint64_t mask2 = -((idx >> 1) & 1);
+      const word mask1 = -(idx & 1);
+      const word mask2 = -((idx >> 1) & 1);
       cblock->w64[0] ^= (Ablock->w64[0] & mask1) ^ (Ablock->w64[2] & mask2);
       cblock->w64[1] ^= (Ablock->w64[1] & mask1) ^ (Ablock->w64[3] & mask2);
     }
@@ -1110,8 +1110,8 @@ void mzd_addmul_v_uint64_129(mzd_local_t* c, mzd_local_t const* v, mzd_local_t c
 
   Ablock += 63;
   {
-    word idx            = (*vptr) >> 63;
-    const uint64_t mask = -(idx & 1);
+    word idx        = (*vptr) >> 63;
+    const word mask = -(idx & 1);
     mzd_xor_mask_uint64_block(cblock, Ablock, mask, 3);
     Ablock++;
     vptr++;
@@ -1120,7 +1120,7 @@ void mzd_addmul_v_uint64_129(mzd_local_t* c, mzd_local_t const* v, mzd_local_t c
   for (unsigned int w = 2; w; --w, ++vptr) {
     word idx = *vptr;
     for (unsigned int i = sizeof(word) * 8; i; --i, idx >>= 1, ++Ablock) {
-      const uint64_t mask = -(idx & 1);
+      const word mask = -(idx & 1);
       mzd_xor_mask_uint64_block(cblock, Ablock, mask, 3);
     }
   }
@@ -1139,7 +1139,7 @@ void mzd_addmul_v_uint64_192(mzd_local_t* c, mzd_local_t const* v, mzd_local_t c
   for (unsigned int w = 3; w; --w, ++vptr) {
     word idx = *vptr;
     for (unsigned int i = sizeof(word) * 8; i; --i, idx >>= 1, ++Ablock) {
-      const uint64_t mask = -(idx & 1);
+      const word mask = -(idx & 1);
       mzd_xor_mask_uint64_block(cblock, Ablock, mask, 3);
     }
   }
@@ -1159,7 +1159,7 @@ void mzd_addmul_v_uint64_256(mzd_local_t* c, mzd_local_t const* v, mzd_local_t c
     word idx = *vptr;
 
     for (unsigned int i = sizeof(word) * 8; i; --i, idx >>= 1, ++Ablock) {
-      const uint64_t mask = -(idx & 1);
+      const word mask = -(idx & 1);
       mzd_xor_mask_uint64_block(cblock, Ablock, mask, 4);
     }
   }
@@ -1181,7 +1181,7 @@ void mzd_mul_v_uint64_128_640(mzd_local_t* c, mzd_local_t const* v, mzd_local_t 
   for (unsigned int w = 2; w; --w, ++vptr) {
     word idx = *vptr;
     for (unsigned int i = sizeof(word) * 8; i; --i, idx >>= 1, ++Ablock) {
-      const uint64_t mask = -(idx & 1);
+      const word mask = -(idx & 1);
       for (unsigned int j = 0; j < 2; ++j, ++Ablock) {
         mzd_xor_mask_uint64_block(BLOCK(c, j), Ablock, mask, 4);
       }
@@ -1202,7 +1202,7 @@ void mzd_mul_v_uint64_192_960(mzd_local_t* c, mzd_local_t const* v, mzd_local_t 
   for (unsigned int w = 3; w; --w, ++vptr) {
     word idx = *vptr;
     for (unsigned int i = sizeof(word) * 8; i; --i, idx >>= 1, ++Ablock) {
-      const uint64_t mask = -(idx & 1);
+      const word mask = -(idx & 1);
       for (unsigned int j = 0; j < 3; ++j, ++Ablock) {
         mzd_xor_mask_uint64_block(BLOCK(c, j), Ablock, mask, 4);
       }
@@ -1223,7 +1223,7 @@ void mzd_mul_v_uint64_256_1216(mzd_local_t* c, mzd_local_t const* v, mzd_local_t
   for (unsigned int w = 4; w; --w, ++vptr) {
     word idx = *vptr;
     for (unsigned int i = sizeof(word) * 8; i; --i, idx >>= 1, ++Ablock) {
-      const uint64_t mask = -(idx & 1);
+      const word mask = -(idx & 1);
       for (unsigned int j = 0; j < 4; ++j, ++Ablock) {
         mzd_xor_mask_uint64_block(BLOCK(c, j), Ablock, mask, 4);
       }
@@ -1277,8 +1277,8 @@ void mzd_addmul_v_uint64_30_128(mzd_local_t* c, mzd_local_t const* v, mzd_local_
 
   word idx = CONST_BLOCK(v, 0)->w64[1] >> 34;
   for (unsigned int i = 15; i; --i, idx >>= 2, ++Ablock) {
-    const uint64_t mask1 = -(idx & 1);
-    const uint64_t mask2 = -((idx >> 1) & 1);
+    const word mask1 = -(idx & 1);
+    const word mask2 = -((idx >> 1) & 1);
     for (unsigned int j = 0; j < 2; ++j) {
       cblock->w64[j] ^= (Ablock->w64[j] & mask1) ^ (Ablock->w64[j + 2] & mask2);
     }
@@ -1293,7 +1293,7 @@ void mzd_addmul_v_uint64_30_192(mzd_local_t* c, mzd_local_t const* v, mzd_local_
 
   word idx = CONST_BLOCK(v, 0)->w64[2] >> 34;
   for (unsigned int i = 30; i; --i, idx >>= 1, ++Ablock) {
-    const uint64_t mask = -(idx & 1);
+    const word mask = -(idx & 1);
     mzd_xor_mask_uint64_block(cblock, Ablock, mask, 3);
   }
 }
@@ -1306,7 +1306,7 @@ void mzd_addmul_v_uint64_30_256(mzd_local_t* c, mzd_local_t const* v, mzd_local_
 
   word idx = CONST_BLOCK(v, 0)->w64[3] >> 34;
   for (unsigned int i = 30; i; --i, idx >>= 1, ++Ablock) {
-    const uint64_t mask = -(idx & 1);
+    const word mask = -(idx & 1);
     mzd_xor_mask_uint64_block(cblock, Ablock, mask, 4);
   }
 }

--- a/src/sig/picnic/external/picnic3_tree.c
+++ b/src/sig/picnic/external/picnic3_tree.c
@@ -17,6 +17,7 @@
 #include <assert.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "endian_compat.h"
 #include "kdf_shake.h"
@@ -127,6 +128,7 @@ static void hashSeed(uint8_t* digest, const uint8_t* inputSeed, uint8_t* salt, u
   hash_update_uint16_le(&ctx, nodeIndex);
   hash_final(&ctx);
   hash_squeeze(&ctx, digest, 2 * params->seed_size);
+  hash_clear(&ctx);
 }
 
 static void hashSeed_x4(uint8_t** digest, const uint8_t** inputSeed, uint8_t* salt,
@@ -146,6 +148,7 @@ static void hashSeed_x4(uint8_t** digest, const uint8_t** inputSeed, uint8_t* sa
 
   hash_final_x4(&ctx);
   hash_squeeze_x4(&ctx, digest, 2 * params->seed_size);
+  hash_clear_x4(&ctx);
 }
 
 static void expandSeeds(tree_t* tree, uint8_t* salt, size_t repIndex,
@@ -432,6 +435,7 @@ static void computeParentHash(tree_t* tree, size_t child, uint8_t* salt,
   hash_update_uint16_le(&ctx, parent);
   hash_final(&ctx);
   hash_squeeze(&ctx, tree->nodes[parent], params->digest_size);
+  hash_clear(&ctx);
   tree->haveNode[parent] = 1;
 }
 

--- a/src/sig/picnic/external/picnic_instances.h
+++ b/src/sig/picnic/external/picnic_instances.h
@@ -22,7 +22,18 @@
 #include "picnic.h"
 
 #define SALT_SIZE 32
+
+/* max digest and seed size */
+#if defined(WITH_LOWMC_255_255_4) || defined(WITH_LOWMC_256_256_38)
 #define MAX_DIGEST_SIZE 64
+#define MAX_SEED_SIZE 32
+#elif defined(WITH_LOWMC_192_192_4) || defined(WITH_LOWMC_192_192_30)
+#define MAX_DIGEST_SIZE 48
+#define MAX_SEED_SIZE 24
+#elif defined(WITH_LOWMC_129_129_4) || defined(WITH_LOWMC_128_128_20)
+#define MAX_DIGEST_SIZE 32
+#define MAX_SEED_SIZE 16
+#endif
 
 typedef struct picnic_instance_t {
   lowmc_parameters_t lowmc;

--- a/src/sig/picnic/external/sha3/s390_cpacf.h
+++ b/src/sig/picnic/external/sha3/s390_cpacf.h
@@ -156,4 +156,6 @@ static inline void hash_squeeze(hash_context* ctx, uint8_t* buffer, size_t bufle
   }
 }
 
+#define hash_clear(ctx)
+
 #endif

--- a/src/sig/picnic/sig_picnic.c
+++ b/src/sig/picnic/sig_picnic.c
@@ -125,7 +125,7 @@ OQS_SIG *OQS_SIG_picnic_L1_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.4";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -164,7 +164,7 @@ OQS_SIG *OQS_SIG_picnic_L1_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.4";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -203,7 +203,7 @@ OQS_SIG *OQS_SIG_picnic_L1_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.4";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -242,7 +242,7 @@ OQS_SIG *OQS_SIG_picnic_L3_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.4";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -281,7 +281,7 @@ OQS_SIG *OQS_SIG_picnic_L3_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.4";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -320,7 +320,7 @@ OQS_SIG *OQS_SIG_picnic_L3_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.4";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -359,7 +359,7 @@ OQS_SIG *OQS_SIG_picnic_L5_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.4";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -399,7 +399,7 @@ OQS_SIG *OQS_SIG_picnic_L5_UR_new() {
 	}
 
 	sig->method_name = OQS_SIG_alg_picnic_L5_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.4";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -438,7 +438,7 @@ OQS_SIG *OQS_SIG_picnic_L5_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.4";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -475,7 +475,7 @@ OQS_SIG *OQS_SIG_picnic3_L1_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L1;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.4";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -513,7 +513,7 @@ OQS_SIG *OQS_SIG_picnic3_L3_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L3;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.4";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -551,7 +551,7 @@ OQS_SIG *OQS_SIG_picnic3_L5_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L5;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.4";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;

--- a/src/sig/picnic/sig_picnic.c
+++ b/src/sig/picnic/sig_picnic.c
@@ -125,7 +125,7 @@ OQS_SIG *OQS_SIG_picnic_L1_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.3";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -164,7 +164,7 @@ OQS_SIG *OQS_SIG_picnic_L1_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.3";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -203,7 +203,7 @@ OQS_SIG *OQS_SIG_picnic_L1_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.3";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -242,7 +242,7 @@ OQS_SIG *OQS_SIG_picnic_L3_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.3";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -281,7 +281,7 @@ OQS_SIG *OQS_SIG_picnic_L3_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.3";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -320,7 +320,7 @@ OQS_SIG *OQS_SIG_picnic_L3_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.3";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -359,7 +359,7 @@ OQS_SIG *OQS_SIG_picnic_L5_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.3";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -399,7 +399,7 @@ OQS_SIG *OQS_SIG_picnic_L5_UR_new() {
 	}
 
 	sig->method_name = OQS_SIG_alg_picnic_L5_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.3";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -438,7 +438,7 @@ OQS_SIG *OQS_SIG_picnic_L5_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.3";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -475,7 +475,7 @@ OQS_SIG *OQS_SIG_picnic3_L1_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L1;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.3";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -513,7 +513,7 @@ OQS_SIG *OQS_SIG_picnic3_L3_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L3;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.3";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -551,7 +551,7 @@ OQS_SIG *OQS_SIG_picnic3_L5_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L5;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.3";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;

--- a/src/sig/picnic/sig_picnic.c
+++ b/src/sig/picnic/sig_picnic.c
@@ -125,7 +125,7 @@ OQS_SIG *OQS_SIG_picnic_L1_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -164,7 +164,7 @@ OQS_SIG *OQS_SIG_picnic_L1_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -203,7 +203,7 @@ OQS_SIG *OQS_SIG_picnic_L1_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -242,7 +242,7 @@ OQS_SIG *OQS_SIG_picnic_L3_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -281,7 +281,7 @@ OQS_SIG *OQS_SIG_picnic_L3_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -320,7 +320,7 @@ OQS_SIG *OQS_SIG_picnic_L3_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -359,7 +359,7 @@ OQS_SIG *OQS_SIG_picnic_L5_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -399,7 +399,7 @@ OQS_SIG *OQS_SIG_picnic_L5_UR_new() {
 	}
 
 	sig->method_name = OQS_SIG_alg_picnic_L5_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -438,7 +438,7 @@ OQS_SIG *OQS_SIG_picnic_L5_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -475,7 +475,7 @@ OQS_SIG *OQS_SIG_picnic3_L1_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L1;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -513,7 +513,7 @@ OQS_SIG *OQS_SIG_picnic3_L3_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L3;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -551,7 +551,7 @@ OQS_SIG *OQS_SIG_picnic3_L5_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L5;
-	sig->alg_version = "https://github.com/IAIK/Picnic/commit/fcddc7732ac464dda31fe9b165c59e01b844127e";
+	sig->alg_version = "https://github.com/IAIK/Picnic/commit/ca45b2e00c0297f5608cbd59132e8e178a465d00";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;


### PR DESCRIPTION
Updated picnic from tag v3.0.3 to v3.0.4 ([github compare](https://github.com/IAIK/Picnic/compare/1797ab...v3.0.4)), which include clean-ups.
