### PR TITLE
remove docker auth for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,10 @@ jobs:
     description: Validate formatting of code and documentation
     docker:
       - image: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
-        auth:
-          username: $DOCKER_LOGIN
-          password: $DOCKER_PASSWORD
+# Re-enable iff docker enforces rate limitations without auth:
+#        auth:
+#          username: $DOCKER_LOGIN
+#          password: $DOCKER_PASSWORD
     steps:
       - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
       - run:
@@ -49,9 +50,10 @@ jobs:
         default: --numprocesses=auto
     docker:
       - image: << parameters.CONTAINER >>
-        auth:
-          username: $DOCKER_LOGIN
-          password: $DOCKER_PASSWORD
+# Re-enable iff docker enforces rate limitations without auth:
+#        auth:
+#          username: $DOCKER_LOGIN
+#          password: $DOCKER_PASSWORD
     steps:
       - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
       - run:
@@ -140,9 +142,10 @@ jobs:
   trigger-downstream-ci:
     docker:
       - image: cimg/base:2020.01
-        auth:
-          username: $DOCKER_LOGIN
-          password: $DOCKER_PASSWORD
+# Re-enable iff docker enforces rate limitations without auth:
+#        auth:
+#          username: $DOCKER_LOGIN
+#          password: $DOCKER_PASSWORD
     steps:
       - run:
           name: Trigger OQS-OpenSSL CI


### PR DESCRIPTION
Disables docker auth in CI.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding or removing?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

