### PR TITLE
Mb randloop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
   stylecheck:
     description: Validate formatting of code and documentation
     docker:
-      - image: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
+      - image: openquantumsafe/ci-ubuntu-focal-x86_64:latest
 # Re-enable iff docker enforces rate limitations without auth:
 #        auth:
 #          username: $DOCKER_LOGIN
@@ -229,35 +229,35 @@ workflows:
           CONTAINER: openquantumsafe/ci-debian-buster-amd64:latest
       - linux_x64:
           <<: *require_stylecheck
-          name: ubuntu-bionic-noopenssl
+          name: ubuntu-focal-noopenssl
           context: openquantumsafe
-          CONTAINER: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
+          CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
           CMAKE_ARGS: -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_BUILD_TYPE=Release -DOQS_USE_OPENSSL=OFF
       - linux_x64:
           <<: *require_stylecheck
-          name: ubuntu-bionic-shared-noopenssl
+          name: ubuntu-focal-shared-noopenssl
           context: openquantumsafe
-          CONTAINER: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
+          CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
           CMAKE_ARGS: -DCMAKE_C_COMPILER=gcc-7 -DCMAKE_BUILD_TYPE=Release -DOQS_USE_OPENSSL=OFF -DBUILD_SHARED_LIBS=ON
           PYTEST_ARGS: --ignore=tests/test_namespace.py --numprocesses=auto
       - linux_x64:
           <<: *require_stylecheck
-          name: ubuntu-bionic-clang9
+          name: ubuntu-focal-clang9
           context: openquantumsafe
-          CONTAINER: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
+          CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
           CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9
       - linux_x64:
           <<: *require_stylecheck
           name: address-sanitizer
           context: openquantumsafe
-          CONTAINER: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
+          CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
           CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address
           PYTEST_ARGS: --ignore=tests/test_portability.py --numprocesses=auto
       # Disabling for now due to https://github.com/open-quantum-safe/liboqs/issues/791
       #- linux_x64:
       #    name: undefined-sanitizer
       #    context: openquantumsafe
-      #    CONTAINER: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
+      #    CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
       #    CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Undefined
            # Normally the linux tests are run with 35 processes, but that
            # exhausts memory for this test

--- a/src/common/rand/rand.c
+++ b/src/common/rand/rand.c
@@ -112,11 +112,18 @@ void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
 #endif
 
 #ifdef OQS_USE_OPENSSL
+#define OQS_GETRAND_REPEAT 3 // in case failure to get randomness is a temporary problem, allow some repeats
 void OQS_randombytes_openssl(uint8_t *random_array, size_t bytes_to_read) {
-	int rc;
+	int rc, rep = OQS_GETRAND_REPEAT;
 	SIZE_T_TO_INT_OR_EXIT(bytes_to_read, bytes_to_read_int)
 	do {
 		rc = RAND_bytes(random_array, bytes_to_read_int);
-	} while (rc != 1);
+	} while ((rc != 1) && (rep-- >= 0));
+	if (rc != 1) {
+		fprintf(stderr, "No OpenSSL randonmess retrieved. DRBG available?\n");
+		// because of void signature we have no other way to signal the problem
+		// we cannot possibly return without randomness
+		exit(EXIT_FAILURE);
+	}
 }
 #endif

--- a/src/common/rand/rand.c
+++ b/src/common/rand/rand.c
@@ -112,15 +112,18 @@ void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
 #endif
 
 #ifdef OQS_USE_OPENSSL
-#define OQS_GETRAND_REPEAT 3 // in case failure to get randomness is a temporary problem, allow some repeats
+#define OQS_RAND_POLL_RETRY 3 // in case failure to get randomness is a temporary problem, allow some repeats
 void OQS_randombytes_openssl(uint8_t *random_array, size_t bytes_to_read) {
-	int rc, rep = OQS_GETRAND_REPEAT;
+	int rep = OQS_RAND_POLL_RETRY;
 	SIZE_T_TO_INT_OR_EXIT(bytes_to_read, bytes_to_read_int)
 	do {
-		rc = RAND_bytes(random_array, bytes_to_read_int);
-	} while ((rc != 1) && (rep-- >= 0));
-	if (rc != 1) {
-		fprintf(stderr, "No OpenSSL randonmess retrieved. DRBG available?\n");
+		if (RAND_status() == 1) {
+			break;
+		}
+		RAND_poll();
+	} while (rep-- >= 0);
+	if (RAND_bytes(random_array, bytes_to_read_int) != 1) {
+		fprintf(stderr, "No OpenSSL randomness retrieved. DRBG available?\n");
 		// because of void signature we have no other way to signal the problem
 		// we cannot possibly return without randomness
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
- Fixes #895
- Upgrades CCI to ubuntu 20

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding or removing?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)


