### PR TITLE
Add OQS_MINIMAL_BUILD option and redefine CI workflow

### DIFF
--- a/.CMake/compiler_opts.cmake
+++ b/.CMake/compiler_opts.cmake
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: MIT
 
-option(OQS_PORTABLE_BUILD "Ensure the resulting library is portable. This implies having run-time checks for CPU extensions." ON)
-option(OQS_BUILD_ONLY_LIB "Build only liboqs and do not expose build targets for tests, documentation, and pretty-printing available." OFF)
-
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Werror)
     add_compile_options(-Wall)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,6 +298,10 @@ workflows:
           <<: *require_buildcheck
           name: address-sanitizer
           context: openquantumsafe
+          filters:
+            branches:
+              only:
+                - /^audit.*/
           CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
           CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address
           PYTEST_ARGS: --ignore=tests/test_portability.py --numprocesses=auto

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,17 @@ require_stylecheck: &require_stylecheck
   requires:
     - stylecheck
 
+require_buildcheck: &require_buildcheck
+  requires:
+    - stylecheck
+    - buildcheck
+
+require_testapproval: &require_testapproval
+  requires:
+    - stylecheck
+    - buildcheck
+    - testapproval
+
 # CircleCI doesn't handle large file sets properly for local builds
 # https://github.com/CircleCI-Public/circleci-cli/issues/281#issuecomment-472808051
 localCheckout: &localCheckout
@@ -234,55 +245,57 @@ workflows:
       - stylecheck
       - buildcheck:
           <<: *require_stylecheck
-          name: ubuntu-focal-buildcheck
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
           KEM_NAME: kyber_768
           SIG_NAME: dilithium_3
+      - testapproval:
+          <<: *require_buildcheck
+          type: approval
       - linux_x64:
-          <<: *require_stylecheck
+          <<: *require_buildcheck
           name: alpine-noopenssl
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-alpine-amd64:latest
           CMAKE_ARGS: -DCMAKE_BUILD_TYPE=Release -DOQS_USE_OPENSSL=OFF
       - linux_x64:
-          <<: *require_stylecheck
+          <<: *require_buildcheck
           name: alpine
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-alpine-amd64:latest
           CMAKE_ARGS: -DCMAKE_BUILD_TYPE=Release -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON
       - linux_x64:
-          <<: *require_stylecheck
+          <<: *require_buildcheck
           name: centos-8
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-centos-8-amd64:latest
           CMAKE_ARGS: -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Release -DOQS_PORTABLE_BUILD=OFF
       - linux_x64:
-          <<: *require_stylecheck
+          <<: *require_buildcheck
           name: debian-buster
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-debian-buster-amd64:latest
       - linux_x64:
-          <<: *require_stylecheck
+          <<: *require_buildcheck
           name: ubuntu-focal-noopenssl
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
           CMAKE_ARGS: -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_BUILD_TYPE=Release -DOQS_USE_OPENSSL=OFF
       - linux_x64:
-          <<: *require_stylecheck
+          <<: *require_buildcheck
           name: ubuntu-focal-shared-noopenssl
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
           CMAKE_ARGS: -DCMAKE_C_COMPILER=gcc-7 -DCMAKE_BUILD_TYPE=Release -DOQS_USE_OPENSSL=OFF -DBUILD_SHARED_LIBS=ON
           PYTEST_ARGS: --ignore=tests/test_namespace.py --numprocesses=auto
       - linux_x64:
-          <<: *require_stylecheck
+          <<: *require_buildcheck
           name: ubuntu-focal-clang9
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
           CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9
       - linux_x64:
-          <<: *require_stylecheck
+          <<: *require_buildcheck
           name: address-sanitizer
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
@@ -301,27 +314,27 @@ workflows:
       # SPHINCS exhausts memory on CircleCI servers
       # for these configurations.
       - arm_emulated:
-          <<: *require_stylecheck
+          <<: *require_testapproval
           name: arm64
           ARCH: arm64
           CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF
       - arm_emulated:
-          <<: *require_stylecheck
+          <<: *require_testapproval
           name: armhf
           ARCH: armhf
           CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF
       - arm_emulated:
-          <<: *require_stylecheck
+          <<: *require_testapproval
           name: armel
           ARCH: armel
           CMAKE_ARGS: -DCMAKE_BUILD_TYPE=Release  -DOQS_ENABLE_SIG_SPHINCS=OFF
 
       - macOS:
-          <<: *require_stylecheck
+          <<: *require_buildcheck
           name: macOS-noopenssl
           CMAKE_ARGS: -DOQS_USE_OPENSSL=OFF
       - macOS:
-          <<: *require_stylecheck
+          <<: *require_buildcheck
           name: macOS-shared
           CMAKE_ARGS: -DBUILD_SHARED_LIBS=ON
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,34 @@ jobs:
           name: Check that doxygen can parse the documentation
           command: mkdir -p build/docs && doxygen docs/.Doxyfile
 
+  buildcheck:
+    description: Test that we can build a single KEM/Signature pair as part of a minimal build.
+    parameters:
+      CONTAINER:
+        description: "The docker container to use."
+        type: string
+      CMAKE_ARGS:
+        description: "Arguments to pass to CMake."
+        type: string
+        default: ''
+      KEM_NAME:
+        description: "The KEM to build."
+        type: string
+      SIG_NAME:
+        description: "The signature scheme to build."
+        type: string
+    docker:
+      - image: << parameters.CONTAINER >>
+    steps:
+      - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
+      - run:
+          name: Configure
+          command: mkdir build && cd build && source ~/.bashrc && cmake -GNinja << parameters.CMAKE_ARGS >> -DOQS_MINIMAL_BUILD=ON -DOQS_KEM_DEFAULT=OQS_KEM_alg_<< parameters.KEM_NAME >> -DOQS_SIG_DEFAULT=OQS_SIG_alg_<< parameters.SIG_NAME >> .. && cmake -LA ..
+      - run:
+          name: Build
+          command: ninja
+          working_directory: build
+
   linux_x64:
     description: A template for running liboqs tests on x64 Linux Docker VMs
     parameters:
@@ -204,6 +232,13 @@ workflows:
         equal: [ main, << pipeline.git.branch >> ]
     jobs:
       - stylecheck
+      - buildcheck:
+          <<: *require_stylecheck
+          name: ubuntu-focal-buildcheck
+          context: openquantumsafe
+          CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+          KEM_NAME: kyber_768
+          SIG_NAME: dilithium_3
       - linux_x64:
           <<: *require_stylecheck
           name: alpine-noopenssl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,17 +264,19 @@ workflows:
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-alpine-amd64:latest
           CMAKE_ARGS: -DCMAKE_BUILD_TYPE=Release -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON
-      - linux_x64:
-          <<: *require_buildcheck
-          name: centos-8
-          context: openquantumsafe
-          CONTAINER: openquantumsafe/ci-centos-8-amd64:latest
-          CMAKE_ARGS: -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Release -DOQS_PORTABLE_BUILD=OFF
-      - linux_x64:
-          <<: *require_buildcheck
-          name: debian-buster
-          context: openquantumsafe
-          CONTAINER: openquantumsafe/ci-debian-buster-amd64:latest
+      # Disabling centos-8 and debian-buster.
+      # Re-enable if specific configurations (package versions etc) that need to be tested are identified.
+      #- linux_x64:
+      #    <<: *require_buildcheck
+      #    name: centos-8
+      #    context: openquantumsafe
+      #    CONTAINER: openquantumsafe/ci-centos-8-amd64:latest
+      #    CMAKE_ARGS: -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Release -DOQS_PORTABLE_BUILD=OFF
+      #- linux_x64:
+      #    <<: *require_buildcheck
+      #    name: debian-buster
+      #    context: openquantumsafe
+      #    CONTAINER: openquantumsafe/ci-debian-buster-amd64:latest
       - linux_x64:
           <<: *require_buildcheck
           name: ubuntu-focal-noopenssl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,14 @@ endif()
 if(WIN32)
     set(CMAKE_GENERATOR_CC cl)
 endif()
-include(.CMake/compiler_opts.cmake)
 
+option(OQS_PORTABLE_BUILD "Ensure the resulting library is portable. This implies having run-time checks for CPU extensions." ON)
+option(OQS_BUILD_ONLY_LIB "Build only liboqs and do not expose build targets for tests, documentation, and pretty-printing available." OFF)
+option(OQS_MINIMAL_BUILD  "Only build the default KEM and Signature schemes." OFF)
+
+include(.CMake/compiler_opts.cmake)
 include(.CMake/alg_support.cmake)
+
 if(OQS_USE_OPENSSL)
     if(NOT DEFINED OPENSSL_ROOT_DIR)
         if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin")


### PR DESCRIPTION
This adds an option to build only the default KEM and Signature scheme. For example, with this patch, if you want to build liboqs with only the Kyber512 and Dilithium2 algorithms you can use:
```
cmake -GNinja -DOQS_MINIMAL_BUILD=ON -DOQS_KEM_DEFAULT=OQS_KEM_alg_kyber_512 -DOQS_SIG_DEFAULT=OQS_SIG_alg_dilithium_2 ..
```

This will build the exact match for the default kem and sig and also any "_aesni" or "_avx2" implementations that are supported by the platform.

Opening this PR, at @baentsch's recommendation, for discussion about whether this is a useful feature / what else we would like it to do.


**Edit:** Tacking on proposed CI workflow from https://github.com/open-quantum-safe/liboqs/issues/907#issuecomment-777771017