### PR TITLE
Kyber768 ref dependencies (#899)

### DIFF
--- a/docs/algorithms/kem/kyber.md
+++ b/docs/algorithms/kem/kyber.md
@@ -11,7 +11,7 @@ Implementation
 --------------
 
 - **Source of implementation**: https://github.com/pq-crystals/kyber
-- **Implementation version**: https://github.com/pq-crystals/kyber/commit/28413dfbf523fdde181246451c2bd77199c0f7ff
+- **Implementation version**: https://github.com/pq-crystals/kyber/commit/8e9308bd0f25fa698e4f37aba216249261f8b352
 - **License**: Public domain
 - **Constant-time**: Yes
 - **Optimizations**: Portable C with AES, AVX2, POPCNT, SSE2 and SSSE3 instructions (if available at run-time)

--- a/scripts/copy_from_upstream/copy_from_upstream.yml
+++ b/scripts/copy_from_upstream/copy_from_upstream.yml
@@ -12,7 +12,7 @@ upstreams:
     name: pqcrystals-kyber
     git_url: https://github.com/pq-crystals/kyber.git
     git_branch: master
-    git_commit: 28413dfbf523fdde181246451c2bd77199c0f7ff
+    git_commit: 8e9308bd0f25fa698e4f37aba216249261f8b352
     kem_meta_path: '{pretty_name_full}_META.yml'
     common_meta_path: 'Common_META.yml'
     kem_scheme_path: '.'

--- a/src/kem/kyber/CMakeLists.txt
+++ b/src/kem/kyber/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 set(_KYBER_OBJS "")
 
-if(OQS_ENABLE_KEM_kyber_512 OR OQS_ENABLE_KEM_kyber_1024 OR OQS_ENABLE_KEM_kyber_512_90s OR OQS_ENABLE_KEM_kyber_768_90s OR OQS_ENABLE_KEM_kyber_1024_90s)
+if(OQS_ENABLE_KEM_kyber_512 OR OQS_ENABLE_KEM_kyber_768 OR OQS_ENABLE_KEM_kyber_1024 OR OQS_ENABLE_KEM_kyber_512_90s OR OQS_ENABLE_KEM_kyber_768_90s OR OQS_ENABLE_KEM_kyber_1024_90s)
     add_library(kyber_common_ref OBJECT pqcrystals-kyber_common_ref/aes256ctr.c pqcrystals-kyber_common_ref/fips202.c)
     target_include_directories(kyber_common_ref PRIVATE ${CMAKE_CURRENT_LIST_DIR}/pqcrystals-kyber_common_ref)
     set(_KYBER_OBJS ${_KYBER_OBJS} $<TARGET_OBJECTS:kyber_common_ref>)

--- a/src/kem/kyber/kem_kyber_1024.c
+++ b/src/kem/kyber/kem_kyber_1024.c
@@ -13,7 +13,7 @@ OQS_KEM *OQS_KEM_kyber_1024_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_kyber_1024;
-	kem->alg_version = "https://github.com/pq-crystals/kyber/commit/74cad307858b61e434490c75f812cb9b9ef7279b";
+	kem->alg_version = "https://github.com/pq-crystals/kyber/commit/28413dfbf523fdde181246451c2bd77199c0f7ff";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = true;

--- a/src/kem/kyber/kem_kyber_1024_90s.c
+++ b/src/kem/kyber/kem_kyber_1024_90s.c
@@ -13,7 +13,7 @@ OQS_KEM *OQS_KEM_kyber_1024_90s_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_kyber_1024_90s;
-	kem->alg_version = "https://github.com/pq-crystals/kyber/commit/74cad307858b61e434490c75f812cb9b9ef7279b";
+	kem->alg_version = "https://github.com/pq-crystals/kyber/commit/28413dfbf523fdde181246451c2bd77199c0f7ff";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = true;

--- a/src/kem/kyber/kem_kyber_512_90s.c
+++ b/src/kem/kyber/kem_kyber_512_90s.c
@@ -13,7 +13,7 @@ OQS_KEM *OQS_KEM_kyber_512_90s_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_kyber_512_90s;
-	kem->alg_version = "https://github.com/pq-crystals/kyber/commit/74cad307858b61e434490c75f812cb9b9ef7279b";
+	kem->alg_version = "https://github.com/pq-crystals/kyber/commit/28413dfbf523fdde181246451c2bd77199c0f7ff";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;

--- a/src/kem/kyber/kem_kyber_768.c
+++ b/src/kem/kyber/kem_kyber_768.c
@@ -13,7 +13,7 @@ OQS_KEM *OQS_KEM_kyber_768_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_kyber_768;
-	kem->alg_version = "https://github.com/pq-crystals/kyber/commit/74cad307858b61e434490c75f812cb9b9ef7279b";
+	kem->alg_version = "https://github.com/pq-crystals/kyber/commit/28413dfbf523fdde181246451c2bd77199c0f7ff";
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = true;


### PR DESCRIPTION
Fixes #899, unblocks #903

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding or removing?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)