### PR TITLE
Potential work-around for ongoing SIGKILL issues

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -17,14 +17,14 @@ def run_subprocess(command, working_dir='.', env=None, expected_returncode=0, in
     Helper function to run a shell command and report success/failure
     depending on the exit status of the shell command.
     """
+    env_ = os.environ.copy()
     if env is not None:
-        env_ = os.environ.copy()
         env_.update(env)
-        env = env_
+    env = env_
 
     # Detect if we're running in CircleCI.
     # https://circleci.com/docs/2.0/env-vars/
-    circleci = env is not None and 'CIRCLECI' in env
+    circleci = 'CIRCLECI' in env
 
     # CircleCI has its own timeout mechanism. Disable ours.
     timeout = None if circleci else 10*60


### PR DESCRIPTION
Some recent CI jobs have failed with
```
AssertionError: Got unexpected return code -9
```
and a backtrace pointing to:
```python
    try:
        out, _ = proc.communicate(input=input, timeout=480)
    except subprocess.TimeoutExpired:
        proc.kill()
        out, _ = proc.communicate()

    if not(ignore_returncode) and (proc.returncode != expected_returncode):
        print(out.decode('utf-8'))
        assert False, "Got unexpected return code {}".format(proc.returncode)
```

I see two possibilites:
1. CircleCI actually sent SIGKILL to our subprocess.
2. We hit our self-imposed timeout. The -9 return code came from our own call to proc.kill().

This PR adds logic to retry a subprocess if we're running in CircleCI and our subprocess receives a SIGKILL. It's harmless to retry, since CircleCI will kill our python process if it really wants us to shut down.

This PR also disambiguates the above possibilities by raising a more informative assertion error in the timeout case. 

```python
    try:
        out, _ = proc.communicate(input=input, timeout=480)
    except subprocess.TimeoutExpired as T:
        proc.kill()
        assert False, str(T)
```
Note: The python documentation suggests that the proc.kill() is unnecessary. I've left it in case it's there from experience with a race condition or something.