### PR TITLE
Compile Picnic's Keccak with NO_MISALIGNED_ACCESSES

### DIFF
--- a/src/sig/picnic/CMakeLists.txt
+++ b/src/sig/picnic/CMakeLists.txt
@@ -71,6 +71,7 @@ else()
     target_include_directories(picnic PRIVATE external/sha3/opt64)
 endif()
 target_compile_definitions(picnic PRIVATE PICNIC_STATIC
+                                          NO_MISALIGNED_ACCESSES
                                           WITH_ZKBPP
                                           WITH_UNRUH
                                           WITH_KKW


### PR DESCRIPTION
Temporary fix for #921 until #922 lands