### PR TITLE
Increasing message counter during sign-benchmark

### DIFF
--- a/tests/speed_sig.c
+++ b/tests/speed_sig.c
@@ -21,6 +21,7 @@ static OQS_STATUS sig_speed_wrapper(const char *method_name, uint64_t duration, 
 	uint8_t *secret_key = NULL;
 	uint8_t *message = NULL;
 	uint8_t *signature = NULL;
+	size_t *message_ctr = NULL;
 	size_t message_len = 50;
 	size_t signature_len = 0;
 	OQS_STATUS ret = OQS_ERROR;
@@ -40,11 +41,13 @@ static OQS_STATUS sig_speed_wrapper(const char *method_name, uint64_t duration, 
 		goto err;
 	}
 
+	message_ctr = (size_t *)message;
+
 	OQS_randombytes(message, message_len);
 
 	printf("%-30s | %10s | %14s | %15s | %10s | %25s | %10s\n", sig->method_name, "", "", "", "", "", "");
 	TIME_OPERATION_SECONDS(OQS_SIG_keypair(sig, public_key, secret_key), "keypair", duration)
-	TIME_OPERATION_SECONDS(OQS_SIG_sign(sig, signature, &signature_len, message, message_len, secret_key), "sign", duration)
+	TIME_OPERATION_SECONDS(OQS_SIG_sign(sig, signature, &signature_len, message, message_len, secret_key); (*message_ctr)++, "sign", duration)
 	TIME_OPERATION_SECONDS(OQS_SIG_verify(sig, message, message_len, signature, signature_len, public_key), "verify", duration)
 
 	if (printInfo) {


### PR DESCRIPTION
The purpose of this PR is to better capture message-dependencies in the sign-benchmarks. Currently, the message is selected at random once and is then fixed during the benchmark run. If the runtime is message-dependent, such as in deterministic Dilithium or Rainbow, the runtimes vary across benchmark runs.

To address this issue, this code change varies the message in the benchmark-loop. This results in stable total runtimes, but captures the variance in the "std. dev." column of the benchmark. To avoid the overhead of generating a new random message after each sign-iteration, a message counter is increased inside the message. This is sufficient for signatures that follow a hash-then-sign paradigm.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)