### PR TITLE
Valgrind suppression files for AVX McEliece

### DIFF
--- a/tests/constant_time/kem/passes/mceliece-348864
+++ b/tests/constant_time/kem/passes/mceliece-348864
@@ -1,3 +1,5 @@
+# VEC implementation
+
 {
    Rejection sampling for uniform indices
    Memcheck:Cond
@@ -18,4 +20,28 @@
    src:pk_gen.c:160
    # fun:PQCLEAN_MCELIECE348864_VEC_pk_gen
    fun:PQCLEAN_MCELIECE348864_VEC_crypto_kem_keypair
+}
+
+# AVX implementation
+
+{
+   Rejection sampling for uniform indices
+   Memcheck:Cond
+   src:encrypt.c:43
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE348864_AVX_encrypt
+}
+{
+   Rejection sampling for unique indices
+   Memcheck:Cond
+   src:encrypt.c:58
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE348864_AVX_encrypt
+}
+{
+   Rejection sampling for systematic form matrix
+   Memcheck:Cond
+   src:pk_gen.c:193
+   # fun:PQCLEAN_MCELIECE348864_AVX_pk_gen
+   fun:PQCLEAN_MCELIECE348864_AVX_crypto_kem_keypair
 }

--- a/tests/constant_time/kem/passes/mceliece-348864f
+++ b/tests/constant_time/kem/passes/mceliece-348864f
@@ -1,3 +1,5 @@
+# VEC implementation
+
 {
    Rejection sampling for uniform indices
    Memcheck:Cond
@@ -25,4 +27,35 @@
    src:pk_gen.c:277
    # fun:PQCLEAN_MCELIECE348864F_VEC_pk_gen
    fun:PQCLEAN_MCELIECE348864F_VEC_crypto_kem_keypair
+}
+
+# AVX implementation
+
+{
+   Rejection sampling for uniform indices
+   Memcheck:Cond
+   src:encrypt.c:43
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE348864F_AVX_encrypt
+}
+{
+   Rejection sampling for unique indices
+   Memcheck:Cond
+   src:encrypt.c:58
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE348864F_AVX_encrypt
+}
+{
+   Rejection sampling for full rank matrix
+   Memcheck:Cond
+   src:pk_gen.c:120
+   # fun:mov_columns
+   fun:PQCLEAN_MCELIECE348864F_AVX_pk_gen
+}
+{
+   Rejection sampling for systematic form matrix
+   Memcheck:Cond
+   src:pk_gen.c:289
+   # fun:PQCLEAN_MCELIECE348864F_AVX_pk_gen
+   fun:PQCLEAN_MCELIECE348864F_AVX_crypto_kem_keypair
 }

--- a/tests/constant_time/kem/passes/mceliece-460896
+++ b/tests/constant_time/kem/passes/mceliece-460896
@@ -1,3 +1,5 @@
+# VEC implementation
+
 {
    Rejection sampling for uniform indices
    Memcheck:Cond
@@ -18,4 +20,28 @@
    src:pk_gen.c:167
    # fun:PQCLEAN_MCELIECE460896_VEC_pk_gen
    fun:PQCLEAN_MCELIECE460896_VEC_crypto_kem_keypair
+}
+
+# AVX implementation
+
+{
+   Rejection sampling for uniform indices
+   Memcheck:Cond
+   src:encrypt.c:45
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE460896_AVX_encrypt
+}
+{
+   Rejection sampling for unique indices
+   Memcheck:Cond
+   src:encrypt.c:60
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE460896_AVX_encrypt
+}
+{
+   Rejection sampling for systematic form matrix
+   Memcheck:Cond
+   src:pk_gen.c:200
+   # fun:PQCLEAN_MCELIECE460896_AVX_pk_gen
+   fun:PQCLEAN_MCELIECE460896_AVX_crypto_kem_keypair
 }

--- a/tests/constant_time/kem/passes/mceliece-460896f
+++ b/tests/constant_time/kem/passes/mceliece-460896f
@@ -1,3 +1,5 @@
+# VEC implementation
+
 {
    Rejection sampling for uniform indices
    Memcheck:Cond
@@ -25,4 +27,35 @@
    src:pk_gen.c:262
    # fun:PQCLEAN_MCELIECE460896F_VEC_pk_gen
    fun:PQCLEAN_MCELIECE460896F_VEC_crypto_kem_keypair
+}
+
+# AVX implementation
+
+{
+   Rejection sampling for uniform indices
+   Memcheck:Cond
+   src:encrypt.c:45
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE460896F_AVX_encrypt
+}
+{
+   Rejection sampling for unique indices
+   Memcheck:Cond
+   src:encrypt.c:60
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE460896F_AVX_encrypt
+}
+{
+   Rejection sampling for full rank matrix
+   Memcheck:Cond
+   src:pk_gen.c:150
+   # fun:mov_columns
+   fun:PQCLEAN_MCELIECE460896F_AVX_pk_gen
+}
+{
+   Rejection sampling for systematic form matrix
+   Memcheck:Cond
+   src:pk_gen.c:319
+   # fun:PQCLEAN_MCELIECE460896F_AVX_pk_gen
+   fun:PQCLEAN_MCELIECE460896F_AVX_crypto_kem_keypair
 }

--- a/tests/constant_time/kem/passes/mceliece-6688128
+++ b/tests/constant_time/kem/passes/mceliece-6688128
@@ -1,3 +1,5 @@
+# VEC implementation
+
 {
    Rejection sampling for uniform indices
    Memcheck:Cond
@@ -18,4 +20,28 @@
    src:pk_gen.c:159
    # fun:PQCLEAN_MCELIECE6688128_VEC_pk_gen
    fun:PQCLEAN_MCELIECE6688128_VEC_crypto_kem_keypair
+}
+
+# AVX implementation
+
+{
+   Rejection sampling for uniform indices
+   Memcheck:Cond
+   src:encrypt.c:45
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE6688128_AVX_encrypt
+}
+{
+   Rejection sampling for unique indices
+   Memcheck:Cond
+   src:encrypt.c:60
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE6688128_AVX_encrypt
+}
+{
+   Rejection sampling for systematic form matrix
+   Memcheck:Cond
+   src:pk_gen.c:199
+   # fun:PQCLEAN_MCELIECE6688128_AVX_pk_gen
+   fun:PQCLEAN_MCELIECE6688128_AVX_crypto_kem_keypair
 }

--- a/tests/constant_time/kem/passes/mceliece-6688128f
+++ b/tests/constant_time/kem/passes/mceliece-6688128f
@@ -1,3 +1,5 @@
+# VEC implementation
+
 {
    Rejection sampling for uniform indices
    Memcheck:Cond
@@ -25,4 +27,35 @@
    src:pk_gen.c:102
    # fun:mov_columns
    fun:PQCLEAN_MCELIECE6688128F_VEC_pk_gen
+}
+
+# AVX implementation
+
+{
+   Rejection sampling for uniform indices
+   Memcheck:Cond
+   src:encrypt.c:45
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE6688128F_AVX_encrypt
+}
+{
+   Rejection sampling for unique indices
+   Memcheck:Cond
+   src:encrypt.c:60
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE6688128F_AVX_encrypt
+}
+{
+   Rejection sampling for systematic form matrix
+   Memcheck:Cond
+   src:pk_gen.c:320
+   # fun:PQCLEAN_MCELIECE6688128F_AVX_pk_gen
+   fun:PQCLEAN_MCELIECE6688128F_AVX_crypto_kem_keypair
+}
+{
+   Rejection sampling for full rank matrix
+   Memcheck:Cond
+   src:pk_gen.c:151
+   # fun:mov_columns
+   fun:PQCLEAN_MCELIECE6688128F_AVX_pk_gen
 }

--- a/tests/constant_time/kem/passes/mceliece-6960119
+++ b/tests/constant_time/kem/passes/mceliece-6960119
@@ -1,3 +1,5 @@
+# VEC implementation
+
 {
    Rejection sampling for uniform indices
    Memcheck:Cond
@@ -18,4 +20,28 @@
    src:pk_gen.c:166
    # fun:PQCLEAN_MCELIECE6960119_VEC_pk_gen
    fun:PQCLEAN_MCELIECE6960119_VEC_crypto_kem_keypair
+}
+
+# AVX implementation
+
+{
+   Rejection sampling for uniform indices
+   Memcheck:Cond
+   src:encrypt.c:45
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE6960119_AVX_encrypt
+}
+{
+   Rejection sampling for unique indices
+   Memcheck:Cond
+   src:encrypt.c:60
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE6960119_AVX_encrypt
+}
+{
+   Rejection sampling for systematic form matrix
+   Memcheck:Cond
+   src:pk_gen.c:200
+   # fun:PQCLEAN_MCELIECE6960119_AVX_pk_gen
+   fun:PQCLEAN_MCELIECE6960119_AVX_crypto_kem_keypair
 }

--- a/tests/constant_time/kem/passes/mceliece-6960119f
+++ b/tests/constant_time/kem/passes/mceliece-6960119f
@@ -1,3 +1,5 @@
+# VEC implementation
+
 {
    Rejection sampling for uniform indices
    Memcheck:Cond
@@ -25,4 +27,35 @@
    src:pk_gen.c:103
    # fun:mov_columns
    fun:PQCLEAN_MCELIECE6960119F_VEC_pk_gen
+}
+
+# AVX implementation
+
+{
+   Rejection sampling for uniform indices
+   Memcheck:Cond
+   src:encrypt.c:45
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE6960119F_AVX_encrypt
+}
+{
+   Rejection sampling for unique indices
+   Memcheck:Cond
+   src:encrypt.c:60
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE6960119F_AVX_encrypt
+}
+{
+   Rejection sampling for systematic form matrix
+   Memcheck:Cond
+   src:pk_gen.c:324
+   # fun:PQCLEAN_MCELIECE6960119F_AVX_pk_gen
+   fun:PQCLEAN_MCELIECE6960119F_AVX_crypto_kem_keypair
+}
+{
+   Rejection sampling for full rank matrix
+   Memcheck:Cond
+   src:pk_gen.c:152
+   # fun:mov_columns
+   fun:PQCLEAN_MCELIECE6960119F_AVX_pk_gen
 }

--- a/tests/constant_time/kem/passes/mceliece-8192128
+++ b/tests/constant_time/kem/passes/mceliece-8192128
@@ -1,3 +1,5 @@
+# VEC implementation
+
 {
    Rejection sampling for unique indices
    Memcheck:Cond
@@ -11,4 +13,21 @@
    src:pk_gen.c:162
    # fun:PQCLEAN_MCELIECE8192128_VEC_pk_gen
    fun:PQCLEAN_MCELIECE8192128_VEC_crypto_kem_keypair
+}
+
+# AVX implementation
+
+{
+   Rejection sampling for unique indices
+   Memcheck:Cond
+   src:encrypt.c:42
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE8192128_AVX_encrypt
+}
+{
+   Rejection sampling for systematic form matrix
+   Memcheck:Cond
+   src:pk_gen.c:196
+   # fun:PQCLEAN_MCELIECE8192128_AVX_pk_gen
+   fun:PQCLEAN_MCELIECE8192128_AVX_crypto_kem_keypair
 }

--- a/tests/constant_time/kem/passes/mceliece-8192128f
+++ b/tests/constant_time/kem/passes/mceliece-8192128f
@@ -1,3 +1,5 @@
+# VEC implementation
+
 {
    Rejection sampling for unique indices
    Memcheck:Cond
@@ -18,4 +20,28 @@
    src:pk_gen.c:103
    # fun:mov_columns
    fun:PQCLEAN_MCELIECE8192128F_VEC_pk_gen
+}
+
+# AVX implementation
+
+{
+   Rejection sampling for unique indices
+   Memcheck:Cond
+   src:encrypt.c:42
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE8192128F_AVX_encrypt
+}
+{
+   Rejection sampling for systematic form matrix
+   Memcheck:Cond
+   src:pk_gen.c:319
+   # fun:PQCLEAN_MCELIECE8192128F_AVX_pk_gen
+   fun:PQCLEAN_MCELIECE8192128F_AVX_crypto_kem_keypair
+}
+{
+   Rejection sampling for full rank matrix
+   Memcheck:Cond
+   src:pk_gen.c:151
+   # fun:mov_columns
+   fun:PQCLEAN_MCELIECE8192128F_AVX_pk_gen
 }

--- a/tests/constant_time/kem/passes/mceliece-sk_gen
+++ b/tests/constant_time/kem/passes/mceliece-sk_gen
@@ -1,3 +1,5 @@
+# VEC implementation
+
 {
    Rejection sampling for systematic form matrix
    Memcheck:Cond
@@ -11,4 +13,21 @@
    src:sk_gen.c:91
    # fun:PQCLEAN_MCELIECE*_VEC_perm_check
    fun:PQCLEAN_MCELIECE*_VEC_crypto_kem_keypair
+}
+
+# AVX implementation
+
+{
+   Rejection sampling for systematic form matrix
+   Memcheck:Cond
+   src:sk_gen.c:49
+   # fun:PQCLEAN_MCELIECE*_AVX_genpoly_gen
+   fun:PQCLEAN_MCELIECE*_AVX_crypto_kem_keypair
+}
+{
+   Rejection sampling for permutation
+   Memcheck:Cond
+   src:sk_gen.c:91
+   # fun:PQCLEAN_MCELIECE*_AVX_perm_check
+   fun:PQCLEAN_MCELIECE*_AVX_crypto_kem_keypair
 }


### PR DESCRIPTION
Valgrind reports no new instances of suspected non-constant time behaviour in the AVX McEliece code. The warnings that are issued are identical (modulo line number) to the warnings that are issued for the "vec" implementation. All of these are false positives.