### PR TITLE
Fix small error in comments of kem.h and sig.h

### DIFF
--- a/src/kem/kem.h
+++ b/src/kem/kem.h
@@ -2,7 +2,7 @@
  * \file kem.h
  * \brief Key encapsulation mechanisms
  *
- * The file `src/kem/example_kem.c` contains two examples on using the OQS_KEM API.
+ * The file `tests/example_kem.c` contains two examples on using the OQS_KEM API.
  *
  * The first example uses the individual scheme's algorithms directly and uses
  * no dynamic memory allocation -- all buffers are allocated on the stack, with

--- a/src/sig/sig.h
+++ b/src/sig/sig.h
@@ -2,7 +2,7 @@
  * \file sig.h
  * \brief Signature schemes
  *
- * The file `src/sig/example_sig.c` contains two examples on using the OQS_SIG API.
+ * The file `tests/example_sig.c` contains two examples on using the OQS_SIG API.
  *
  * The first example uses the individual scheme's algorithms directly and uses
  * no dynamic memory allocation -- all buffers are allocated on the stack, with


### PR DESCRIPTION
They made a reference to example files that had been moved at some point.
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

