### PR TITLE
guard Frodo AVX2 code if CPU_EXTENSIONS not requested

### DIFF
--- a/src/kem/frodokem/external/frodo_macrify_optimized.c
+++ b/src/kem/frodokem/external/frodo_macrify_optimized.c
@@ -27,7 +27,7 @@ int frodo_mul_add_as_plus_e(uint16_t *out, const uint16_t *s, const uint16_t *e,
 { // Generate-and-multiply: generate matrix A (N x N) row-wise, multiply by s on the right.
   // Inputs: s, e (N x N_BAR)
   // Output: out = A*s + e (N x N_BAR)
-#if defined(OQS_PORTABLE_X86_64_BUILD)
+#if defined(OQS_USE_AVX2_INSTRUCTIONS) && defined(OQS_PORTABLE_X86_64_BUILD)
     OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
     if (available_cpu_extensions.AVX2_ENABLED) {
       return frodo_mul_add_as_plus_e_avx2(out, s, e, seed_A);
@@ -46,7 +46,7 @@ int frodo_mul_add_sa_plus_e(uint16_t *out, const uint16_t *s, const uint16_t *e,
   // Inputs: s', e' (N_BAR x N)
   // Output: out = s'*A + e' (N_BAR x N)
 #if defined(USE_AES128_FOR_A)
-  #if defined(OQS_PORTABLE_X86_64_BUILD)
+  #if defined(OQS_USE_AVX2_INSTRUCTIONS) && defined(OQS_PORTABLE_X86_64_BUILD)
     OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
     if (available_cpu_extensions.AVX2_ENABLED) {
         return frodo_mul_add_sa_plus_e_aes_avx2(out, s, e, seed_A);
@@ -59,7 +59,7 @@ int frodo_mul_add_sa_plus_e(uint16_t *out, const uint16_t *s, const uint16_t *e,
     return frodo_mul_add_sa_plus_e_aes_portable(out, s, e, seed_A);
   #endif
 #elif defined(USE_SHAKE128_FOR_A)
-  #if defined(OQS_PORTABLE_X86_64_BUILD)
+  #if defined(OQS_USE_AVX2_INSTRUCTIONS) && defined(OQS_PORTABLE_X86_64_BUILD)
     OQS_CPU_EXTENSIONS available_cpu_extensions = OQS_get_available_CPU_extensions();
     if (available_cpu_extensions.AVX2_ENABLED) {
         return frodo_mul_add_sa_plus_e_shake_avx2(out, s, e, seed_A);


### PR DESCRIPTION
#927 breaks builds when [OQS_USE_CPU_EXTENSIONS=OFF](https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs#oqs_use_cpu_extensions): See e.g. [here](https://app.circleci.com/pipelines/github/open-quantum-safe/oqs-demos/338/workflows/84da16f9-8f90-446e-b371-25d7e6d88258/jobs/413). This PR is one way to fix it. Another alternative is to not set `OQS_PORTABLE_X86_64_BUILD` if `OQS_USE_CPU_EXTENSIONS=OFF`: Any preference, @jschanck ?

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

