### PR TITLE
Make OQS_USE_CPU_EXTENSIONS imply OQS_PORTABLE_BUILD=OFF; alternative…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ else()
     message(FATAL_ERROR "Unknown or unsupported processor: " ${CMAKE_SYSTEM_PROCESSOR})
 endif()
 
+if(NOT OQS_USE_CPU_EXTENSIONS AND OQS_PORTABLE_BUILD)
+    message(WARNING "OQS_PORTABLE_BUILD requires OQS_USE_CPU_EXTENSIONS")
+    set(OQS_PORTABLE_BUILD OFF)
+endif()
+
 if(OQS_PORTABLE_BUILD AND ARCH_X86_64)
     set(OQS_PORTABLE_X86_64_BUILD ON)
 endif()


### PR DESCRIPTION
#941 fixes the broken `OQS_PORTABLE_BUILD=ON` + `OQS_USE_CPU_EXTENSIONS=OFF` combination (#939) as part of a larger effort to fix OQS_PORTABLE_BUILD. Unfortunately that's now waiting on new sha3 to merge.

@baentsch, in #939, writes:
> What I've been looking for in this case was a portable image without the need for/cost of CPU feature checks. And that --I thought-- `OQS_USE_CPU_EXTENSIONS=OFF` should yield.

Here it sounds like you actually do want  `OQS_PORTABLE_BUILD=OFF` + `OQS_USE_CPU_EXTENSIONS=OFF`.

That doesn't change the fact that we should have a short-term mitigation for the broken configuration. I'm fine with forcing OQS_PORTABLE_BUILD=OFF when OQS_USE_CPU_EXTENSIONS=OFF. This PR does that.