### PR TITLE
Fix shake context leak in Dilithium

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,7 @@ workflows:
                 - /^audit.*/
           CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
           CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address
-          PYTEST_ARGS: --ignore=tests/test_portability.py --numprocesses=auto
+          PYTEST_ARGS: --ignore=tests/test_portability.py --numprocesses=auto --maxprocesses=10
       # Disabling test_constant_time for now
       #- linux_x64:
       #    <<: *require_buildcheck

--- a/scripts/copy_from_upstream/patches/pqcrystals-dilithium-avx2-shake.patch
+++ b/scripts/copy_from_upstream/patches/pqcrystals-dilithium-avx2-shake.patch
@@ -1,9 +1,17 @@
-d11f165e597a2dc20c8dc1f7dda8640905af7ed9
+3a2763b7448b2d9e2fd3ba7b5b96636806c3c96c
 diff --git a/avx2/poly.c b/avx2/poly.c
-index 0e9e988..26254d9 100644
+index 0e9e988..bb268fd 100644
 --- a/avx2/poly.c
 +++ b/avx2/poly.c
-@@ -418,7 +418,7 @@ void poly_uniform_4x(poly *a0,
+@@ -403,6 +403,7 @@ void poly_uniform(poly *a, const uint8_t seed[SEEDBYTES], uint16_t nonce)
+   stream128_state state;
+   stream128_init(&state, seed, nonce);
+   poly_uniform_preinit(a, &state);
++  stream128_release(&state);
+ }
+ 
+ #ifndef DILITHIUM_USE_AES
+@@ -418,7 +419,7 @@ void poly_uniform_4x(poly *a0,
  {
    unsigned int ctr0, ctr1, ctr2, ctr3;
    ALIGNED_UINT8(REJ_UNIFORM_BUFLEN+8) buf[4];
@@ -12,7 +20,7 @@ index 0e9e988..26254d9 100644
    __m256i f;
  
    f = _mm256_loadu_si256((__m256i *)seed);
-@@ -436,6 +436,7 @@ void poly_uniform_4x(poly *a0,
+@@ -436,6 +437,7 @@ void poly_uniform_4x(poly *a0,
    buf[3].coeffs[SEEDBYTES+0] = nonce3;
    buf[3].coeffs[SEEDBYTES+1] = nonce3 >> 8;
  
@@ -20,7 +28,7 @@ index 0e9e988..26254d9 100644
    shake128x4_absorb_once(&state, buf[0].coeffs, buf[1].coeffs, buf[2].coeffs, buf[3].coeffs, SEEDBYTES + 2);
    shake128x4_squeezeblocks(buf[0].coeffs, buf[1].coeffs, buf[2].coeffs, buf[3].coeffs, REJ_UNIFORM_NBLOCKS, &state);
  
-@@ -452,6 +453,7 @@ void poly_uniform_4x(poly *a0,
+@@ -452,6 +454,7 @@ void poly_uniform_4x(poly *a0,
      ctr2 += rej_uniform(a2->coeffs + ctr2, N - ctr2, buf[2].coeffs, SHAKE128_RATE);
      ctr3 += rej_uniform(a3->coeffs + ctr3, N - ctr3, buf[3].coeffs, SHAKE128_RATE);
    }
@@ -28,7 +36,15 @@ index 0e9e988..26254d9 100644
  }
  #endif
  
-@@ -552,7 +554,7 @@ void poly_uniform_eta_4x(poly *a0,
+@@ -535,6 +538,7 @@ void poly_uniform_eta(poly *a, const uint8_t seed[CRHBYTES], uint16_t nonce)
+   stream256_state state;
+   stream256_init(&state, seed, nonce);
+   poly_uniform_eta_preinit(a, &state);
++  stream256_release(&state);
+ }
+ 
+ #ifndef DILITHIUM_USE_AES
+@@ -552,7 +556,7 @@ void poly_uniform_eta_4x(poly *a0,
    ALIGNED_UINT8(REJ_UNIFORM_ETA_BUFLEN) buf[4];
  
    __m256i f;
@@ -37,7 +53,7 @@ index 0e9e988..26254d9 100644
  
    f = _mm256_loadu_si256((__m256i *)&seed[0]);
    _mm256_store_si256(&buf[0].vec[0],f);
-@@ -574,6 +576,7 @@ void poly_uniform_eta_4x(poly *a0,
+@@ -574,6 +578,7 @@ void poly_uniform_eta_4x(poly *a0,
    buf[3].coeffs[64] = nonce3;
    buf[3].coeffs[65] = nonce3 >> 8;
  
@@ -45,7 +61,7 @@ index 0e9e988..26254d9 100644
    shake256x4_absorb_once(&state, buf[0].coeffs, buf[1].coeffs, buf[2].coeffs, buf[3].coeffs, 66);
    shake256x4_squeezeblocks(buf[0].coeffs, buf[1].coeffs, buf[2].coeffs, buf[3].coeffs, REJ_UNIFORM_ETA_NBLOCKS, &state);
  
-@@ -590,6 +593,7 @@ void poly_uniform_eta_4x(poly *a0,
+@@ -590,6 +595,7 @@ void poly_uniform_eta_4x(poly *a0,
      ctr2 += rej_eta(a2->coeffs + ctr2, N - ctr2, buf[2].coeffs, SHAKE256_RATE);
      ctr3 += rej_eta(a3->coeffs + ctr3, N - ctr3, buf[3].coeffs, SHAKE256_RATE);
    }
@@ -53,7 +69,15 @@ index 0e9e988..26254d9 100644
  }
  #endif
  
-@@ -632,7 +636,7 @@ void poly_uniform_gamma1_4x(poly *a0,
+@@ -618,6 +624,7 @@ void poly_uniform_gamma1(poly *a, const uint8_t seed[CRHBYTES], uint16_t nonce)
+   stream256_state state;
+   stream256_init(&state, seed, nonce);
+   poly_uniform_gamma1_preinit(a, &state);
++  stream256_release(&state);
+ }
+ 
+ #ifndef DILITHIUM_USE_AES
+@@ -632,7 +639,7 @@ void poly_uniform_gamma1_4x(poly *a0,
                              uint16_t nonce3)
  {
    ALIGNED_UINT8(POLY_UNIFORM_GAMMA1_NBLOCKS*STREAM256_BLOCKBYTES+14) buf[4];
@@ -62,7 +86,7 @@ index 0e9e988..26254d9 100644
    __m256i f;
  
    f = _mm256_loadu_si256((__m256i *)&seed[0]);
-@@ -655,8 +659,10 @@ void poly_uniform_gamma1_4x(poly *a0,
+@@ -655,8 +662,10 @@ void poly_uniform_gamma1_4x(poly *a0,
    buf[3].coeffs[64] = nonce3;
    buf[3].coeffs[65] = nonce3 >> 8;
  
@@ -73,7 +97,7 @@ index 0e9e988..26254d9 100644
  
    polyz_unpack(a0, buf[0].coeffs);
    polyz_unpack(a1, buf[1].coeffs);
-@@ -679,12 +685,12 @@ void poly_challenge(poly * restrict c, const uint8_t seed[SEEDBYTES]) {
+@@ -679,12 +688,12 @@ void poly_challenge(poly * restrict c, const uint8_t seed[SEEDBYTES]) {
    unsigned int i, b, pos;
    uint64_t signs;
    ALIGNED_UINT8(SHAKE256_RATE) buf;
@@ -91,7 +115,7 @@ index 0e9e988..26254d9 100644
  
    memcpy(&signs, buf.coeffs, 8);
    pos = 8;
-@@ -704,6 +710,7 @@ void poly_challenge(poly * restrict c, const uint8_t seed[SEEDBYTES]) {
+@@ -704,6 +713,7 @@ void poly_challenge(poly * restrict c, const uint8_t seed[SEEDBYTES]) {
      c->coeffs[b] = 1 - 2*(signs & 1);
      signs >>= 1;
    }
@@ -199,10 +223,19 @@ index 3dee7a6..408f0ba 100644
      if(buf.coeffs[i] != sig[i])
        return -1;
 diff --git a/avx2/symmetric.h b/avx2/symmetric.h
-index 7eb6f98..3c6a8de 100644
+index 7eb6f98..ed476d1 100644
 --- a/avx2/symmetric.h
 +++ b/avx2/symmetric.h
-@@ -24,14 +24,14 @@ typedef aes256ctr_ctx stream256_state;
+@@ -17,29 +17,33 @@ typedef aes256ctr_ctx stream256_state;
+ 
+ #define stream128_init(STATE, SEED, NONCE) aes256ctr_init(STATE, SEED, NONCE)
+ #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
++#define stream128_release(STATE)
+ #define stream256_init(STATE, SEED, NONCE) aes256ctr_init(STATE, SEED, NONCE)
+ #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
++#define stream256_release(STATE)
+ 
+ #else
  
  #include "fips202.h"
  
@@ -221,3 +254,13 @@ index 7eb6f98..3c6a8de 100644
  
  #define STREAM128_BLOCKBYTES SHAKE128_RATE
  #define STREAM256_BLOCKBYTES SHAKE256_RATE
+ 
+ #define stream128_init(STATE, SEED, NONCE) dilithium_shake128_stream_init(STATE, SEED, NONCE)
+ #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
++#define stream128_release(STATE) shake128_inc_ctx_release(STATE)
+ #define stream256_init(STATE, SEED, NONCE) dilithium_shake256_stream_init(STATE, SEED, NONCE)
+ #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) shake256_squeezeblocks(OUT, OUTBLOCKS, STATE)
++#define stream256_release(STATE) shake256_inc_ctx_release(STATE)
+ 
+ #endif
+ 

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2-aes_avx2/poly.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2-aes_avx2/poly.c
@@ -403,6 +403,7 @@ void poly_uniform(poly *a, const uint8_t seed[SEEDBYTES], uint16_t nonce)
   stream128_state state;
   stream128_init(&state, seed, nonce);
   poly_uniform_preinit(a, &state);
+  stream128_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES
@@ -537,6 +538,7 @@ void poly_uniform_eta(poly *a, const uint8_t seed[CRHBYTES], uint16_t nonce)
   stream256_state state;
   stream256_init(&state, seed, nonce);
   poly_uniform_eta_preinit(a, &state);
+  stream256_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES
@@ -622,6 +624,7 @@ void poly_uniform_gamma1(poly *a, const uint8_t seed[CRHBYTES], uint16_t nonce)
   stream256_state state;
   stream256_init(&state, seed, nonce);
   poly_uniform_gamma1_preinit(a, &state);
+  stream256_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2-aes_avx2/symmetric.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2-aes_avx2/symmetric.h
@@ -17,8 +17,10 @@ typedef aes256ctr_ctx stream256_state;
 
 #define stream128_init(STATE, SEED, NONCE) aes256ctr_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) aes256ctr_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_release(STATE)
 
 #else
 
@@ -38,8 +40,10 @@ void dilithium_shake256_stream_init(shake256incctx *state, const uint8_t seed[CR
 
 #define stream128_init(STATE, SEED, NONCE) dilithium_shake128_stream_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_release(STATE) shake128_inc_ctx_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) dilithium_shake256_stream_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) shake256_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_release(STATE) shake256_inc_ctx_release(STATE)
 
 #endif
 

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/poly.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/poly.c
@@ -403,6 +403,7 @@ void poly_uniform(poly *a, const uint8_t seed[SEEDBYTES], uint16_t nonce)
   stream128_state state;
   stream128_init(&state, seed, nonce);
   poly_uniform_preinit(a, &state);
+  stream128_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES
@@ -537,6 +538,7 @@ void poly_uniform_eta(poly *a, const uint8_t seed[CRHBYTES], uint16_t nonce)
   stream256_state state;
   stream256_init(&state, seed, nonce);
   poly_uniform_eta_preinit(a, &state);
+  stream256_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES
@@ -622,6 +624,7 @@ void poly_uniform_gamma1(poly *a, const uint8_t seed[CRHBYTES], uint16_t nonce)
   stream256_state state;
   stream256_init(&state, seed, nonce);
   poly_uniform_gamma1_preinit(a, &state);
+  stream256_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/symmetric.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/symmetric.h
@@ -17,8 +17,10 @@ typedef aes256ctr_ctx stream256_state;
 
 #define stream128_init(STATE, SEED, NONCE) aes256ctr_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) aes256ctr_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_release(STATE)
 
 #else
 
@@ -38,8 +40,10 @@ void dilithium_shake256_stream_init(shake256incctx *state, const uint8_t seed[CR
 
 #define stream128_init(STATE, SEED, NONCE) dilithium_shake128_stream_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_release(STATE) shake128_inc_ctx_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) dilithium_shake256_stream_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) shake256_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_release(STATE) shake256_inc_ctx_release(STATE)
 
 #endif
 

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3-aes_avx2/poly.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3-aes_avx2/poly.c
@@ -403,6 +403,7 @@ void poly_uniform(poly *a, const uint8_t seed[SEEDBYTES], uint16_t nonce)
   stream128_state state;
   stream128_init(&state, seed, nonce);
   poly_uniform_preinit(a, &state);
+  stream128_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES
@@ -537,6 +538,7 @@ void poly_uniform_eta(poly *a, const uint8_t seed[CRHBYTES], uint16_t nonce)
   stream256_state state;
   stream256_init(&state, seed, nonce);
   poly_uniform_eta_preinit(a, &state);
+  stream256_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES
@@ -622,6 +624,7 @@ void poly_uniform_gamma1(poly *a, const uint8_t seed[CRHBYTES], uint16_t nonce)
   stream256_state state;
   stream256_init(&state, seed, nonce);
   poly_uniform_gamma1_preinit(a, &state);
+  stream256_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3-aes_avx2/symmetric.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3-aes_avx2/symmetric.h
@@ -17,8 +17,10 @@ typedef aes256ctr_ctx stream256_state;
 
 #define stream128_init(STATE, SEED, NONCE) aes256ctr_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) aes256ctr_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_release(STATE)
 
 #else
 
@@ -38,8 +40,10 @@ void dilithium_shake256_stream_init(shake256incctx *state, const uint8_t seed[CR
 
 #define stream128_init(STATE, SEED, NONCE) dilithium_shake128_stream_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_release(STATE) shake128_inc_ctx_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) dilithium_shake256_stream_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) shake256_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_release(STATE) shake256_inc_ctx_release(STATE)
 
 #endif
 

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/poly.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/poly.c
@@ -403,6 +403,7 @@ void poly_uniform(poly *a, const uint8_t seed[SEEDBYTES], uint16_t nonce)
   stream128_state state;
   stream128_init(&state, seed, nonce);
   poly_uniform_preinit(a, &state);
+  stream128_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES
@@ -537,6 +538,7 @@ void poly_uniform_eta(poly *a, const uint8_t seed[CRHBYTES], uint16_t nonce)
   stream256_state state;
   stream256_init(&state, seed, nonce);
   poly_uniform_eta_preinit(a, &state);
+  stream256_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES
@@ -622,6 +624,7 @@ void poly_uniform_gamma1(poly *a, const uint8_t seed[CRHBYTES], uint16_t nonce)
   stream256_state state;
   stream256_init(&state, seed, nonce);
   poly_uniform_gamma1_preinit(a, &state);
+  stream256_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/symmetric.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/symmetric.h
@@ -17,8 +17,10 @@ typedef aes256ctr_ctx stream256_state;
 
 #define stream128_init(STATE, SEED, NONCE) aes256ctr_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) aes256ctr_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_release(STATE)
 
 #else
 
@@ -38,8 +40,10 @@ void dilithium_shake256_stream_init(shake256incctx *state, const uint8_t seed[CR
 
 #define stream128_init(STATE, SEED, NONCE) dilithium_shake128_stream_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_release(STATE) shake128_inc_ctx_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) dilithium_shake256_stream_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) shake256_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_release(STATE) shake256_inc_ctx_release(STATE)
 
 #endif
 

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium_5-aes_avx2/poly.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium_5-aes_avx2/poly.c
@@ -403,6 +403,7 @@ void poly_uniform(poly *a, const uint8_t seed[SEEDBYTES], uint16_t nonce)
   stream128_state state;
   stream128_init(&state, seed, nonce);
   poly_uniform_preinit(a, &state);
+  stream128_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES
@@ -537,6 +538,7 @@ void poly_uniform_eta(poly *a, const uint8_t seed[CRHBYTES], uint16_t nonce)
   stream256_state state;
   stream256_init(&state, seed, nonce);
   poly_uniform_eta_preinit(a, &state);
+  stream256_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES
@@ -622,6 +624,7 @@ void poly_uniform_gamma1(poly *a, const uint8_t seed[CRHBYTES], uint16_t nonce)
   stream256_state state;
   stream256_init(&state, seed, nonce);
   poly_uniform_gamma1_preinit(a, &state);
+  stream256_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium_5-aes_avx2/symmetric.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium_5-aes_avx2/symmetric.h
@@ -17,8 +17,10 @@ typedef aes256ctr_ctx stream256_state;
 
 #define stream128_init(STATE, SEED, NONCE) aes256ctr_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) aes256ctr_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_release(STATE)
 
 #else
 
@@ -38,8 +40,10 @@ void dilithium_shake256_stream_init(shake256incctx *state, const uint8_t seed[CR
 
 #define stream128_init(STATE, SEED, NONCE) dilithium_shake128_stream_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_release(STATE) shake128_inc_ctx_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) dilithium_shake256_stream_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) shake256_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_release(STATE) shake256_inc_ctx_release(STATE)
 
 #endif
 

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium_5_avx2/poly.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium_5_avx2/poly.c
@@ -403,6 +403,7 @@ void poly_uniform(poly *a, const uint8_t seed[SEEDBYTES], uint16_t nonce)
   stream128_state state;
   stream128_init(&state, seed, nonce);
   poly_uniform_preinit(a, &state);
+  stream128_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES
@@ -537,6 +538,7 @@ void poly_uniform_eta(poly *a, const uint8_t seed[CRHBYTES], uint16_t nonce)
   stream256_state state;
   stream256_init(&state, seed, nonce);
   poly_uniform_eta_preinit(a, &state);
+  stream256_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES
@@ -622,6 +624,7 @@ void poly_uniform_gamma1(poly *a, const uint8_t seed[CRHBYTES], uint16_t nonce)
   stream256_state state;
   stream256_init(&state, seed, nonce);
   poly_uniform_gamma1_preinit(a, &state);
+  stream256_release(&state);
 }
 
 #ifndef DILITHIUM_USE_AES

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium_5_avx2/symmetric.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium_5_avx2/symmetric.h
@@ -17,8 +17,10 @@ typedef aes256ctr_ctx stream256_state;
 
 #define stream128_init(STATE, SEED, NONCE) aes256ctr_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) aes256ctr_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) aes256ctr_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_release(STATE)
 
 #else
 
@@ -38,8 +40,10 @@ void dilithium_shake256_stream_init(shake256incctx *state, const uint8_t seed[CR
 
 #define stream128_init(STATE, SEED, NONCE) dilithium_shake128_stream_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) shake128_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream128_release(STATE) shake128_inc_ctx_release(STATE)
 #define stream256_init(STATE, SEED, NONCE) dilithium_shake256_stream_init(STATE, SEED, NONCE)
 #define stream256_squeezeblocks(OUT, OUTBLOCKS, STATE) shake256_squeezeblocks(OUT, OUTBLOCKS, STATE)
+#define stream256_release(STATE) shake256_inc_ctx_release(STATE)
 
 #endif
 


### PR DESCRIPTION
A recent address-sanitizer [run](https://app.circleci.com/pipelines/github/open-quantum-safe/liboqs/1377/workflows/3ec747c5-0774-42a5-b071-da0506d1dfbd/jobs/13636) noticed that a shake context was not getting freed in Dilithium 3.