### PR TITLE
Add missing OQS_ENABLE_SHA3_xkcp_low_avx2 line to oqsconfig.h

### DIFF
--- a/src/oqsconfig.h.cmake
+++ b/src/oqsconfig.h.cmake
@@ -41,6 +41,8 @@
 
 #cmakedefine OQS_ENABLE_TEST_CONSTANT_TIME 1
 
+#cmakedefine OQS_ENABLE_SHA3_xkcp_low_avx2 1
+
 #cmakedefine OQS_ENABLE_KEM_BIKE 1
 #cmakedefine OQS_ENABLE_KEM_bike1_l1_cpa 1
 #cmakedefine OQS_ENABLE_KEM_bike1_l3_cpa 1


### PR DESCRIPTION
Fixes a missing #define, which is causing the loss of performance for Frodo and Kyber on https://github.com/open-quantum-safe/profiling/issues/47.