### PR TITLE
Don't do feature detection inside a tight loop

### DIFF
--- a/src/common/aes/aes.c
+++ b/src/common/aes/aes.c
@@ -202,13 +202,15 @@ void OQS_AES256_CTR_sch(const uint8_t *iv, size_t iv_len, const void *schedule, 
 	} else {
 		exit(EXIT_FAILURE);
 	}
+	void (*fn_ptr)(const uint8_t *plaintext, const void *_schedule, uint8_t *ciphertext);
+	C_OR_NI(
+		fn_ptr = &oqs_aes256_enc_sch_block_c,
+		fn_ptr = &oqs_aes256_enc_sch_block_ni
+	)
 	while (out_len >= 16) {
 		ctr_be = UINT32_TO_BE(ctr);
 		memcpy(&block[12], (uint8_t *) &ctr_be, 4);
-		C_OR_NI(
-		    oqs_aes256_enc_sch_block_c(block, schedule, out),
-		    oqs_aes256_enc_sch_block_ni(block, schedule, out)
-		)
+		fn_ptr(block, schedule, out);
 		out += 16;
 		out_len -= 16;
 		ctr++;
@@ -217,10 +219,7 @@ void OQS_AES256_CTR_sch(const uint8_t *iv, size_t iv_len, const void *schedule, 
 		uint8_t tmp[16];
 		ctr_be = UINT32_TO_BE(ctr);
 		memcpy(&block[12], (uint8_t *) &ctr_be, 4);
-		C_OR_NI(
-		    oqs_aes256_enc_sch_block_c(block, schedule, tmp),
-		    oqs_aes256_enc_sch_block_ni(block, schedule, tmp)
-		)
+		fn_ptr(block, schedule, tmp);
 		memcpy(out, tmp, out_len);
 	}
 }

--- a/src/common/aes/aes.c
+++ b/src/common/aes/aes.c
@@ -204,8 +204,8 @@ void OQS_AES256_CTR_sch(const uint8_t *iv, size_t iv_len, const void *schedule, 
 	}
 	void (*fn_ptr)(const uint8_t *plaintext, const void *_schedule, uint8_t *ciphertext);
 	C_OR_NI(
-		fn_ptr = &oqs_aes256_enc_sch_block_c,
-		fn_ptr = &oqs_aes256_enc_sch_block_ni
+	    fn_ptr = &oqs_aes256_enc_sch_block_c,
+	    fn_ptr = &oqs_aes256_enc_sch_block_ni
 	)
 	while (out_len >= 16) {
 		ctr_be = UINT32_TO_BE(ctr);


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
Don't do CPU feature detection every time inside a loop, just do it once. 

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [No] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [No] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
