### PR TITLE
Switch AES C implementation to PQClean's

### DIFF
--- a/src/common/aes/aes.c
+++ b/src/common/aes/aes.c
@@ -63,16 +63,7 @@ void OQS_AES128_ECB_enc(const uint8_t *plaintext, const size_t plaintext_len, co
 	OQS_AES128_free_schedule(schedule);
 }
 
-#if defined(OQS_DIST_X86_64_BUILD) || defined(OQS_USE_AES_INSTRUCTIONS)
-void oqs_aes128_ecb_enc_sch_ni(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext) {
-	assert(plaintext_len % 16 == 0);
-	for (size_t block = 0; block < plaintext_len / 16; block++) {
-		oqs_aes128_enc_sch_block_ni(plaintext + (16 * block), schedule, ciphertext + (16 * block));
-	}
-}
-#endif
-
-void OQS_AES128_ECB_enc_sch(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, UNUSED uint8_t *ciphertext) {
+void OQS_AES128_ECB_enc_sch(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext) {
 	C_OR_NI(
 	    oqs_aes128_ecb_enc_sch_c(plaintext, plaintext_len, schedule, ciphertext),
 	    oqs_aes128_ecb_enc_sch_ni(plaintext, plaintext_len, schedule, ciphertext)
@@ -85,15 +76,6 @@ void OQS_AES256_ECB_enc(const uint8_t *plaintext, const size_t plaintext_len, co
 	OQS_AES256_ECB_enc_sch(plaintext, plaintext_len, schedule, ciphertext);
 	OQS_AES256_free_schedule(schedule);
 }
-
-#if defined(OQS_DIST_X86_64_BUILD) || defined(OQS_USE_AES_INSTRUCTIONS)
-void oqs_aes256_ecb_enc_sch_ni(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext) {
-	assert(plaintext_len % 16 == 0);
-	for (size_t block = 0; block < plaintext_len / 16; block++) {
-		oqs_aes256_enc_sch_block_ni(plaintext + (16 * block), schedule, ciphertext + (16 * block));
-	}
-}
-#endif
 
 void OQS_AES256_ECB_enc_sch(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext) {
 	C_OR_NI(

--- a/src/common/aes/aes128_ni.c
+++ b/src/common/aes/aes128_ni.c
@@ -76,24 +76,9 @@ void oqs_aes128_enc_sch_block_ni(const uint8_t *plaintext, const void *_schedule
 	aes128ni_encrypt(schedule, plaintext, ciphertext);
 }
 
-// From crypto_core/aes128decrypt/dolbeau/aesenc-int
-static inline void aes128ni_decrypt(const __m128i rkeys[11], const unsigned char *n, unsigned char *out) {
-	__m128i nv = _mm_loadu_si128((const __m128i *)n);
-	__m128i temp = _mm_xor_si128(nv, rkeys[0]);
-	temp = _mm_aesdec_si128(temp, rkeys[1]);
-	temp = _mm_aesdec_si128(temp, rkeys[2]);
-	temp = _mm_aesdec_si128(temp, rkeys[3]);
-	temp = _mm_aesdec_si128(temp, rkeys[4]);
-	temp = _mm_aesdec_si128(temp, rkeys[5]);
-	temp = _mm_aesdec_si128(temp, rkeys[6]);
-	temp = _mm_aesdec_si128(temp, rkeys[7]);
-	temp = _mm_aesdec_si128(temp, rkeys[8]);
-	temp = _mm_aesdec_si128(temp, rkeys[9]);
-	temp = _mm_aesdeclast_si128(temp, rkeys[10]);
-	_mm_storeu_si128((__m128i *)(out), temp);
-}
-
-void oqs_aes128_dec_sch_block_ni(const uint8_t *ciphertext, const void *_schedule, uint8_t *plaintext) {
-	const __m128i *schedule = (const __m128i *) _schedule;
-	aes128ni_decrypt(schedule, ciphertext, plaintext);
+void oqs_aes128_ecb_enc_sch_ni(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext) {
+	assert(plaintext_len % 16 == 0);
+	for (size_t block = 0; block < plaintext_len / 16; block++) {
+		oqs_aes128_enc_sch_block_ni(plaintext + (16 * block), schedule, ciphertext + (16 * block));
+	}
 }

--- a/src/common/aes/aes256_ni.c
+++ b/src/common/aes/aes256_ni.c
@@ -103,28 +103,9 @@ void oqs_aes256_enc_sch_block_ni(const uint8_t *plaintext, const void *_schedule
 	aes256ni_encrypt(schedule, plaintext, ciphertext);
 }
 
-// From crypto_core/aes256decrypt/dolbeau/aesenc-int
-static inline void aes256ni_decrypt(const __m128i rkeys[15], const unsigned char *n, unsigned char *out) {
-	__m128i nv = _mm_loadu_si128((const __m128i *)n);
-	__m128i temp = _mm_xor_si128(nv, rkeys[0]);
-	temp = _mm_aesdec_si128(temp, rkeys[1]);
-	temp = _mm_aesdec_si128(temp, rkeys[2]);
-	temp = _mm_aesdec_si128(temp, rkeys[3]);
-	temp = _mm_aesdec_si128(temp, rkeys[4]);
-	temp = _mm_aesdec_si128(temp, rkeys[5]);
-	temp = _mm_aesdec_si128(temp, rkeys[6]);
-	temp = _mm_aesdec_si128(temp, rkeys[7]);
-	temp = _mm_aesdec_si128(temp, rkeys[8]);
-	temp = _mm_aesdec_si128(temp, rkeys[9]);
-	temp = _mm_aesdec_si128(temp, rkeys[10]);
-	temp = _mm_aesdec_si128(temp, rkeys[11]);
-	temp = _mm_aesdec_si128(temp, rkeys[12]);
-	temp = _mm_aesdec_si128(temp, rkeys[13]);
-	temp = _mm_aesdeclast_si128(temp, rkeys[14]);
-	_mm_storeu_si128((__m128i *)(out), temp);
-}
-
-void oqs_aes256_dec_sch_block_ni(const uint8_t *ciphertext, const void *_schedule, uint8_t *plaintext) {
-	const __m128i *schedule = (const __m128i *) _schedule;
-	aes256ni_decrypt(schedule, ciphertext, plaintext);
+void oqs_aes256_ecb_enc_sch_ni(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext) {
+	assert(plaintext_len % 16 == 0);
+	for (size_t block = 0; block < plaintext_len / 16; block++) {
+		oqs_aes256_enc_sch_block_ni(plaintext + (16 * block), schedule, ciphertext + (16 * block));
+	}
 }

--- a/src/common/aes/aes_c.c
+++ b/src/common/aes/aes_c.c
@@ -574,7 +574,7 @@ static void aes_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, 
 	} else if (iv_len == 16) {
 		br_range_dec32le(ivw, 4, iv);
 	} else {
-		assert(1 == 0);
+		exit(EXIT_FAILURE);
 	}
 	memcpy(ivw +  4, ivw, 3 * sizeof(uint32_t));
 	memcpy(ivw +  8, ivw, 3 * sizeof(uint32_t));

--- a/src/common/aes/aes_c.c
+++ b/src/common/aes/aes_c.c
@@ -1,273 +1,647 @@
-// Simple, thoroughly commented implementation of 128-bit AES / Rijndael using C
-// Chris Hulbert - chris.hulbert@gmail.com - http://splinter.com.au/blog
-// References:
-// http://en.wikipedia.org/wiki/Advanced_Encryption_Standard
-// http://en.wikipedia.org/wiki/Rijndael_key_schedule
-// http://en.wikipedia.org/wiki/Rijndael_mix_columns
-// http://en.wikipedia.org/wiki/Rijndael_S-box
-// This code is public domain, or any OSI-approved license, your choice. No warranty.
 // SPDX-License-Identifier: MIT
+/* Adapted for OQS from PQClean. */
+/*
+ * AES implementation based on code from BearSSL (https://bearssl.org/)
+ * by Thomas Pornin.
+ *
+ *
+ * Copyright (c) 2016 Thomas Pornin <pornin@bolet.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 
 #include <assert.h>
-#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "aes.h"
 #include <oqs/common.h>
 
-typedef unsigned char byte;
+#define AES128_KEYBYTES 16
+#define AES256_KEYBYTES 32
+#define AESCTR_NONCEBYTES 12
+#define AES_BLOCKBYTES 16
 
-// Here are all the lookup tables for the row shifts, rcon, s-boxes, and galois field multiplications
-static const byte shift_rows_table[] = {0, 5, 10, 15, 4, 9, 14, 3, 8, 13, 2, 7, 12, 1, 6, 11};
-static const byte lookup_rcon[] = {
-	0x8d, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36, 0x6c, 0xd8, 0xab, 0x4d, 0x9a
-};
-static const byte lookup_sbox[] = {
-	0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5, 0x30, 0x01, 0x67, 0x2b, 0xfe, 0xd7, 0xab, 0x76,
-	0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0, 0xad, 0xd4, 0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0,
-	0xb7, 0xfd, 0x93, 0x26, 0x36, 0x3f, 0xf7, 0xcc, 0x34, 0xa5, 0xe5, 0xf1, 0x71, 0xd8, 0x31, 0x15,
-	0x04, 0xc7, 0x23, 0xc3, 0x18, 0x96, 0x05, 0x9a, 0x07, 0x12, 0x80, 0xe2, 0xeb, 0x27, 0xb2, 0x75,
-	0x09, 0x83, 0x2c, 0x1a, 0x1b, 0x6e, 0x5a, 0xa0, 0x52, 0x3b, 0xd6, 0xb3, 0x29, 0xe3, 0x2f, 0x84,
-	0x53, 0xd1, 0x00, 0xed, 0x20, 0xfc, 0xb1, 0x5b, 0x6a, 0xcb, 0xbe, 0x39, 0x4a, 0x4c, 0x58, 0xcf,
-	0xd0, 0xef, 0xaa, 0xfb, 0x43, 0x4d, 0x33, 0x85, 0x45, 0xf9, 0x02, 0x7f, 0x50, 0x3c, 0x9f, 0xa8,
-	0x51, 0xa3, 0x40, 0x8f, 0x92, 0x9d, 0x38, 0xf5, 0xbc, 0xb6, 0xda, 0x21, 0x10, 0xff, 0xf3, 0xd2,
-	0xcd, 0x0c, 0x13, 0xec, 0x5f, 0x97, 0x44, 0x17, 0xc4, 0xa7, 0x7e, 0x3d, 0x64, 0x5d, 0x19, 0x73,
-	0x60, 0x81, 0x4f, 0xdc, 0x22, 0x2a, 0x90, 0x88, 0x46, 0xee, 0xb8, 0x14, 0xde, 0x5e, 0x0b, 0xdb,
-	0xe0, 0x32, 0x3a, 0x0a, 0x49, 0x06, 0x24, 0x5c, 0xc2, 0xd3, 0xac, 0x62, 0x91, 0x95, 0xe4, 0x79,
-	0xe7, 0xc8, 0x37, 0x6d, 0x8d, 0xd5, 0x4e, 0xa9, 0x6c, 0x56, 0xf4, 0xea, 0x65, 0x7a, 0xae, 0x08,
-	0xba, 0x78, 0x25, 0x2e, 0x1c, 0xa6, 0xb4, 0xc6, 0xe8, 0xdd, 0x74, 0x1f, 0x4b, 0xbd, 0x8b, 0x8a,
-	0x70, 0x3e, 0xb5, 0x66, 0x48, 0x03, 0xf6, 0x0e, 0x61, 0x35, 0x57, 0xb9, 0x86, 0xc1, 0x1d, 0x9e,
-	0xe1, 0xf8, 0x98, 0x11, 0x69, 0xd9, 0x8e, 0x94, 0x9b, 0x1e, 0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf,
-	0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42, 0x68, 0x41, 0x99, 0x2d, 0x0f, 0xb0, 0x54, 0xbb, 0x16
-};
-static const byte lookup_g2[] = {
-	0x00, 0x02, 0x04, 0x06, 0x08, 0x0a, 0x0c, 0x0e, 0x10, 0x12, 0x14, 0x16, 0x18, 0x1a, 0x1c, 0x1e,
-	0x20, 0x22, 0x24, 0x26, 0x28, 0x2a, 0x2c, 0x2e, 0x30, 0x32, 0x34, 0x36, 0x38, 0x3a, 0x3c, 0x3e,
-	0x40, 0x42, 0x44, 0x46, 0x48, 0x4a, 0x4c, 0x4e, 0x50, 0x52, 0x54, 0x56, 0x58, 0x5a, 0x5c, 0x5e,
-	0x60, 0x62, 0x64, 0x66, 0x68, 0x6a, 0x6c, 0x6e, 0x70, 0x72, 0x74, 0x76, 0x78, 0x7a, 0x7c, 0x7e,
-	0x80, 0x82, 0x84, 0x86, 0x88, 0x8a, 0x8c, 0x8e, 0x90, 0x92, 0x94, 0x96, 0x98, 0x9a, 0x9c, 0x9e,
-	0xa0, 0xa2, 0xa4, 0xa6, 0xa8, 0xaa, 0xac, 0xae, 0xb0, 0xb2, 0xb4, 0xb6, 0xb8, 0xba, 0xbc, 0xbe,
-	0xc0, 0xc2, 0xc4, 0xc6, 0xc8, 0xca, 0xcc, 0xce, 0xd0, 0xd2, 0xd4, 0xd6, 0xd8, 0xda, 0xdc, 0xde,
-	0xe0, 0xe2, 0xe4, 0xe6, 0xe8, 0xea, 0xec, 0xee, 0xf0, 0xf2, 0xf4, 0xf6, 0xf8, 0xfa, 0xfc, 0xfe,
-	0x1b, 0x19, 0x1f, 0x1d, 0x13, 0x11, 0x17, 0x15, 0x0b, 0x09, 0x0f, 0x0d, 0x03, 0x01, 0x07, 0x05,
-	0x3b, 0x39, 0x3f, 0x3d, 0x33, 0x31, 0x37, 0x35, 0x2b, 0x29, 0x2f, 0x2d, 0x23, 0x21, 0x27, 0x25,
-	0x5b, 0x59, 0x5f, 0x5d, 0x53, 0x51, 0x57, 0x55, 0x4b, 0x49, 0x4f, 0x4d, 0x43, 0x41, 0x47, 0x45,
-	0x7b, 0x79, 0x7f, 0x7d, 0x73, 0x71, 0x77, 0x75, 0x6b, 0x69, 0x6f, 0x6d, 0x63, 0x61, 0x67, 0x65,
-	0x9b, 0x99, 0x9f, 0x9d, 0x93, 0x91, 0x97, 0x95, 0x8b, 0x89, 0x8f, 0x8d, 0x83, 0x81, 0x87, 0x85,
-	0xbb, 0xb9, 0xbf, 0xbd, 0xb3, 0xb1, 0xb7, 0xb5, 0xab, 0xa9, 0xaf, 0xad, 0xa3, 0xa1, 0xa7, 0xa5,
-	0xdb, 0xd9, 0xdf, 0xdd, 0xd3, 0xd1, 0xd7, 0xd5, 0xcb, 0xc9, 0xcf, 0xcd, 0xc3, 0xc1, 0xc7, 0xc5,
-	0xfb, 0xf9, 0xff, 0xfd, 0xf3, 0xf1, 0xf7, 0xf5, 0xeb, 0xe9, 0xef, 0xed, 0xe3, 0xe1, 0xe7, 0xe5
-};
-static const byte lookup_g3[] = {
-	0x00, 0x03, 0x06, 0x05, 0x0c, 0x0f, 0x0a, 0x09, 0x18, 0x1b, 0x1e, 0x1d, 0x14, 0x17, 0x12, 0x11,
-	0x30, 0x33, 0x36, 0x35, 0x3c, 0x3f, 0x3a, 0x39, 0x28, 0x2b, 0x2e, 0x2d, 0x24, 0x27, 0x22, 0x21,
-	0x60, 0x63, 0x66, 0x65, 0x6c, 0x6f, 0x6a, 0x69, 0x78, 0x7b, 0x7e, 0x7d, 0x74, 0x77, 0x72, 0x71,
-	0x50, 0x53, 0x56, 0x55, 0x5c, 0x5f, 0x5a, 0x59, 0x48, 0x4b, 0x4e, 0x4d, 0x44, 0x47, 0x42, 0x41,
-	0xc0, 0xc3, 0xc6, 0xc5, 0xcc, 0xcf, 0xca, 0xc9, 0xd8, 0xdb, 0xde, 0xdd, 0xd4, 0xd7, 0xd2, 0xd1,
-	0xf0, 0xf3, 0xf6, 0xf5, 0xfc, 0xff, 0xfa, 0xf9, 0xe8, 0xeb, 0xee, 0xed, 0xe4, 0xe7, 0xe2, 0xe1,
-	0xa0, 0xa3, 0xa6, 0xa5, 0xac, 0xaf, 0xaa, 0xa9, 0xb8, 0xbb, 0xbe, 0xbd, 0xb4, 0xb7, 0xb2, 0xb1,
-	0x90, 0x93, 0x96, 0x95, 0x9c, 0x9f, 0x9a, 0x99, 0x88, 0x8b, 0x8e, 0x8d, 0x84, 0x87, 0x82, 0x81,
-	0x9b, 0x98, 0x9d, 0x9e, 0x97, 0x94, 0x91, 0x92, 0x83, 0x80, 0x85, 0x86, 0x8f, 0x8c, 0x89, 0x8a,
-	0xab, 0xa8, 0xad, 0xae, 0xa7, 0xa4, 0xa1, 0xa2, 0xb3, 0xb0, 0xb5, 0xb6, 0xbf, 0xbc, 0xb9, 0xba,
-	0xfb, 0xf8, 0xfd, 0xfe, 0xf7, 0xf4, 0xf1, 0xf2, 0xe3, 0xe0, 0xe5, 0xe6, 0xef, 0xec, 0xe9, 0xea,
-	0xcb, 0xc8, 0xcd, 0xce, 0xc7, 0xc4, 0xc1, 0xc2, 0xd3, 0xd0, 0xd5, 0xd6, 0xdf, 0xdc, 0xd9, 0xda,
-	0x5b, 0x58, 0x5d, 0x5e, 0x57, 0x54, 0x51, 0x52, 0x43, 0x40, 0x45, 0x46, 0x4f, 0x4c, 0x49, 0x4a,
-	0x6b, 0x68, 0x6d, 0x6e, 0x67, 0x64, 0x61, 0x62, 0x73, 0x70, 0x75, 0x76, 0x7f, 0x7c, 0x79, 0x7a,
-	0x3b, 0x38, 0x3d, 0x3e, 0x37, 0x34, 0x31, 0x32, 0x23, 0x20, 0x25, 0x26, 0x2f, 0x2c, 0x29, 0x2a,
-	0x0b, 0x08, 0x0d, 0x0e, 0x07, 0x04, 0x01, 0x02, 0x13, 0x10, 0x15, 0x16, 0x1f, 0x1c, 0x19, 0x1a
-};
-// Xor's all elements in a n byte array a by b
-static void xor (byte *a, const byte *b, int n) {
-	int i;
-	for (i = 0; i < n; i++) {
-		a[i] ^= b[i];
+#define PQC_AES128_STATESIZE 88
+typedef struct {
+	uint64_t sk_exp[PQC_AES128_STATESIZE];
+} aes128ctx;
+
+#define PQC_AES256_STATESIZE 120
+typedef struct {
+	uint64_t sk_exp[PQC_AES256_STATESIZE];
+} aes256ctx;
+
+
+static inline uint32_t br_dec32le(const unsigned char *src) {
+	return (uint32_t)src[0]
+	       | ((uint32_t)src[1] << 8)
+	       | ((uint32_t)src[2] << 16)
+	       | ((uint32_t)src[3] << 24);
+}
+
+
+static void br_range_dec32le(uint32_t *v, size_t num, const unsigned char *src) {
+	while (num-- > 0) {
+		*v ++ = br_dec32le(src);
+		src += 4;
 	}
 }
 
-// Xor the current cipher state by a specific round key
-static void xor_round_key(byte *state, const byte *keys, int round) {
-	xor(state, keys + round * 16, 16);
+
+static inline uint32_t br_swap32(uint32_t x) {
+	x = ((x & (uint32_t)0x00FF00FF) << 8)
+	    | ((x >> 8) & (uint32_t)0x00FF00FF);
+	return (x << 16) | (x >> 16);
 }
 
-// Apply the rijndael s-box to all elements in an array
-// http://en.wikipedia.org/wiki/Rijndael_S-box
-static void sub_bytes(byte *a, int n) {
-	int i;
-	for (i = 0; i < n; i++) {
-		a[i] = lookup_sbox[a[i]];
+
+static inline void br_enc32le(unsigned char *dst, uint32_t x) {
+	dst[0] = (unsigned char)x;
+	dst[1] = (unsigned char)(x >> 8);
+	dst[2] = (unsigned char)(x >> 16);
+	dst[3] = (unsigned char)(x >> 24);
+}
+
+
+static void br_range_enc32le(unsigned char *dst, const uint32_t *v, size_t num) {
+	while (num-- > 0) {
+		br_enc32le(dst, *v ++);
+		dst += 4;
 	}
 }
 
-// Rotate the first four bytes of the input eight bits to the left
-static inline void rot_word(byte *a) {
-	byte temp = a[0];
-	a[0] = a[1];
-	a[1] = a[2];
-	a[2] = a[3];
-	a[3] = temp;
+
+static void br_aes_ct64_bitslice_Sbox(uint64_t *q) {
+	/*
+	 * This S-box implementation is a straightforward translation of
+	 * the circuit described by Boyar and Peralta in "A new
+	 * combinational logic minimization technique with applications
+	 * to cryptology" (https://eprint.iacr.org/2009/191.pdf).
+	 *
+	 * Note that variables x* (input) and s* (output) are numbered
+	 * in "reverse" order (x0 is the high bit, x7 is the low bit).
+	 */
+
+	uint64_t x0, x1, x2, x3, x4, x5, x6, x7;
+	uint64_t y1, y2, y3, y4, y5, y6, y7, y8, y9;
+	uint64_t y10, y11, y12, y13, y14, y15, y16, y17, y18, y19;
+	uint64_t y20, y21;
+	uint64_t z0, z1, z2, z3, z4, z5, z6, z7, z8, z9;
+	uint64_t z10, z11, z12, z13, z14, z15, z16, z17;
+	uint64_t t0, t1, t2, t3, t4, t5, t6, t7, t8, t9;
+	uint64_t t10, t11, t12, t13, t14, t15, t16, t17, t18, t19;
+	uint64_t t20, t21, t22, t23, t24, t25, t26, t27, t28, t29;
+	uint64_t t30, t31, t32, t33, t34, t35, t36, t37, t38, t39;
+	uint64_t t40, t41, t42, t43, t44, t45, t46, t47, t48, t49;
+	uint64_t t50, t51, t52, t53, t54, t55, t56, t57, t58, t59;
+	uint64_t t60, t61, t62, t63, t64, t65, t66, t67;
+	uint64_t s0, s1, s2, s3, s4, s5, s6, s7;
+
+	x0 = q[7];
+	x1 = q[6];
+	x2 = q[5];
+	x3 = q[4];
+	x4 = q[3];
+	x5 = q[2];
+	x6 = q[1];
+	x7 = q[0];
+
+	/*
+	 * Top linear transformation.
+	 */
+	y14 = x3 ^ x5;
+	y13 = x0 ^ x6;
+	y9 = x0 ^ x3;
+	y8 = x0 ^ x5;
+	t0 = x1 ^ x2;
+	y1 = t0 ^ x7;
+	y4 = y1 ^ x3;
+	y12 = y13 ^ y14;
+	y2 = y1 ^ x0;
+	y5 = y1 ^ x6;
+	y3 = y5 ^ y8;
+	t1 = x4 ^ y12;
+	y15 = t1 ^ x5;
+	y20 = t1 ^ x1;
+	y6 = y15 ^ x7;
+	y10 = y15 ^ t0;
+	y11 = y20 ^ y9;
+	y7 = x7 ^ y11;
+	y17 = y10 ^ y11;
+	y19 = y10 ^ y8;
+	y16 = t0 ^ y11;
+	y21 = y13 ^ y16;
+	y18 = x0 ^ y16;
+
+	/*
+	 * Non-linear section.
+	 */
+	t2 = y12 & y15;
+	t3 = y3 & y6;
+	t4 = t3 ^ t2;
+	t5 = y4 & x7;
+	t6 = t5 ^ t2;
+	t7 = y13 & y16;
+	t8 = y5 & y1;
+	t9 = t8 ^ t7;
+	t10 = y2 & y7;
+	t11 = t10 ^ t7;
+	t12 = y9 & y11;
+	t13 = y14 & y17;
+	t14 = t13 ^ t12;
+	t15 = y8 & y10;
+	t16 = t15 ^ t12;
+	t17 = t4 ^ t14;
+	t18 = t6 ^ t16;
+	t19 = t9 ^ t14;
+	t20 = t11 ^ t16;
+	t21 = t17 ^ y20;
+	t22 = t18 ^ y19;
+	t23 = t19 ^ y21;
+	t24 = t20 ^ y18;
+
+	t25 = t21 ^ t22;
+	t26 = t21 & t23;
+	t27 = t24 ^ t26;
+	t28 = t25 & t27;
+	t29 = t28 ^ t22;
+	t30 = t23 ^ t24;
+	t31 = t22 ^ t26;
+	t32 = t31 & t30;
+	t33 = t32 ^ t24;
+	t34 = t23 ^ t33;
+	t35 = t27 ^ t33;
+	t36 = t24 & t35;
+	t37 = t36 ^ t34;
+	t38 = t27 ^ t36;
+	t39 = t29 & t38;
+	t40 = t25 ^ t39;
+
+	t41 = t40 ^ t37;
+	t42 = t29 ^ t33;
+	t43 = t29 ^ t40;
+	t44 = t33 ^ t37;
+	t45 = t42 ^ t41;
+	z0 = t44 & y15;
+	z1 = t37 & y6;
+	z2 = t33 & x7;
+	z3 = t43 & y16;
+	z4 = t40 & y1;
+	z5 = t29 & y7;
+	z6 = t42 & y11;
+	z7 = t45 & y17;
+	z8 = t41 & y10;
+	z9 = t44 & y12;
+	z10 = t37 & y3;
+	z11 = t33 & y4;
+	z12 = t43 & y13;
+	z13 = t40 & y5;
+	z14 = t29 & y2;
+	z15 = t42 & y9;
+	z16 = t45 & y14;
+	z17 = t41 & y8;
+
+	/*
+	 * Bottom linear transformation.
+	 */
+	t46 = z15 ^ z16;
+	t47 = z10 ^ z11;
+	t48 = z5 ^ z13;
+	t49 = z9 ^ z10;
+	t50 = z2 ^ z12;
+	t51 = z2 ^ z5;
+	t52 = z7 ^ z8;
+	t53 = z0 ^ z3;
+	t54 = z6 ^ z7;
+	t55 = z16 ^ z17;
+	t56 = z12 ^ t48;
+	t57 = t50 ^ t53;
+	t58 = z4 ^ t46;
+	t59 = z3 ^ t54;
+	t60 = t46 ^ t57;
+	t61 = z14 ^ t57;
+	t62 = t52 ^ t58;
+	t63 = t49 ^ t58;
+	t64 = z4 ^ t59;
+	t65 = t61 ^ t62;
+	t66 = z1 ^ t63;
+	s0 = t59 ^ t63;
+	s6 = t56 ^ ~t62;
+	s7 = t48 ^ ~t60;
+	t67 = t64 ^ t65;
+	s3 = t53 ^ t66;
+	s4 = t51 ^ t66;
+	s5 = t47 ^ t65;
+	s1 = t64 ^ ~s3;
+	s2 = t55 ^ ~t67;
+
+	q[7] = s0;
+	q[6] = s1;
+	q[5] = s2;
+	q[4] = s3;
+	q[3] = s4;
+	q[2] = s5;
+	q[1] = s6;
+	q[0] = s7;
 }
 
-// Perform the core key schedule transform on 4 bytes, as part of the key expansion process
-// http://en.wikipedia.org/wiki/Rijndael_key_schedule#Key_schedule_core
-static void key_schedule_core(byte *a, int i) {
-	byte temp = a[0]; // Rotate the output eight bits to the left
-	a[0] = a[1];
-	a[1] = a[2];
-	a[2] = a[3];
-	a[3] = temp;
-	sub_bytes(a, 4);        // Apply Rijndael's S-box on all four individual bytes in the output word
-	a[0] ^= lookup_rcon[i]; // On just the first (leftmost) byte of the output word, perform the rcon operation with i
-	// as the input, and exclusive or the rcon output with the first byte of the output word
+static void br_aes_ct64_ortho(uint64_t *q) {
+#define SWAPN(cl, ch, s, x, y)   do { \
+        uint64_t a, b; \
+        a = (x); \
+        b = (y); \
+        (x) = (a & (uint64_t)(cl)) | ((b & (uint64_t)(cl)) << (s)); \
+        (y) = ((a & (uint64_t)(ch)) >> (s)) | (b & (uint64_t)(ch)); \
+    } while (0)
+
+#define SWAP2(x, y)    SWAPN(0x5555555555555555, 0xAAAAAAAAAAAAAAAA,  1, x, y)
+#define SWAP4(x, y)    SWAPN(0x3333333333333333, 0xCCCCCCCCCCCCCCCC,  2, x, y)
+#define SWAP8(x, y)    SWAPN(0x0F0F0F0F0F0F0F0F, 0xF0F0F0F0F0F0F0F0,  4, x, y)
+
+	SWAP2(q[0], q[1]);
+	SWAP2(q[2], q[3]);
+	SWAP2(q[4], q[5]);
+	SWAP2(q[6], q[7]);
+
+	SWAP4(q[0], q[2]);
+	SWAP4(q[1], q[3]);
+	SWAP4(q[4], q[6]);
+	SWAP4(q[5], q[7]);
+
+	SWAP8(q[0], q[4]);
+	SWAP8(q[1], q[5]);
+	SWAP8(q[2], q[6]);
+	SWAP8(q[3], q[7]);
 }
 
-// Expand the 16-byte key to 11 round keys (176 bytes)
-// http://en.wikipedia.org/wiki/Rijndael_key_schedule#The_key_schedule
-void oqs_aes128_load_schedule_c(const uint8_t *key, void **_schedule) {
-	*_schedule = malloc(16 * 11);
-	OQS_EXIT_IF_NULLPTR(*_schedule);
-	uint8_t *schedule = (uint8_t *) *_schedule;
-	int bytes = 16;            // The count of how many bytes we've created so far
-	int i = 1;                 // The rcon iteration value i is set to 1
-	int j;                     // For repeating the second stage 3 times
-	byte t[4];                 // Temporary working area known as 't' in the Wiki article
-	memcpy(schedule, key, 16); // The first 16 bytes of the expanded key are simply the encryption key
 
-	while (bytes < 176) {                   // Until we have 176 bytes of expanded key, we do the following:
-		memcpy(t, schedule + bytes - 4, 4); // We assign the value of the previous four bytes in the expanded key to t
-		key_schedule_core(t, i);            // We perform the key schedule core on t, with i as the rcon iteration value
-		i++;                                // We increment i by 1
-		xor(t, schedule + bytes - 16, 4);   // We exclusive-or t with the four-byte block 16 bytes before the new expanded key.
-		memcpy(schedule + bytes, t, 4);     // This becomes the next 4 bytes in the expanded key
-		bytes += 4;                         // Keep track of how many expanded key bytes we've added
+static void br_aes_ct64_interleave_in(uint64_t *q0, uint64_t *q1, const uint32_t *w) {
+	uint64_t x0, x1, x2, x3;
 
-		// We then do the following three times to create the next twelve bytes
-		for (j = 0; j < 3; j++) {
-			memcpy(t, schedule + bytes - 4, 4); // We assign the value of the previous 4 bytes in the expanded key to t
-			xor(t, schedule + bytes - 16, 4);   // We exclusive-or t with the four-byte block n bytes before
-			memcpy(schedule + bytes, t, 4);     // This becomes the next 4 bytes in the expanded key
-			bytes += 4;                         // Keep track of how many expanded key bytes we've added
+	x0 = w[0];
+	x1 = w[1];
+	x2 = w[2];
+	x3 = w[3];
+	x0 |= (x0 << 16);
+	x1 |= (x1 << 16);
+	x2 |= (x2 << 16);
+	x3 |= (x3 << 16);
+	x0 &= (uint64_t)0x0000FFFF0000FFFF;
+	x1 &= (uint64_t)0x0000FFFF0000FFFF;
+	x2 &= (uint64_t)0x0000FFFF0000FFFF;
+	x3 &= (uint64_t)0x0000FFFF0000FFFF;
+	x0 |= (x0 << 8);
+	x1 |= (x1 << 8);
+	x2 |= (x2 << 8);
+	x3 |= (x3 << 8);
+	x0 &= (uint64_t)0x00FF00FF00FF00FF;
+	x1 &= (uint64_t)0x00FF00FF00FF00FF;
+	x2 &= (uint64_t)0x00FF00FF00FF00FF;
+	x3 &= (uint64_t)0x00FF00FF00FF00FF;
+	*q0 = x0 | (x2 << 8);
+	*q1 = x1 | (x3 << 8);
+}
+
+
+static void br_aes_ct64_interleave_out(uint32_t *w, uint64_t q0, uint64_t q1) {
+	uint64_t x0, x1, x2, x3;
+
+	x0 = q0 & (uint64_t)0x00FF00FF00FF00FF;
+	x1 = q1 & (uint64_t)0x00FF00FF00FF00FF;
+	x2 = (q0 >> 8) & (uint64_t)0x00FF00FF00FF00FF;
+	x3 = (q1 >> 8) & (uint64_t)0x00FF00FF00FF00FF;
+	x0 |= (x0 >> 8);
+	x1 |= (x1 >> 8);
+	x2 |= (x2 >> 8);
+	x3 |= (x3 >> 8);
+	x0 &= (uint64_t)0x0000FFFF0000FFFF;
+	x1 &= (uint64_t)0x0000FFFF0000FFFF;
+	x2 &= (uint64_t)0x0000FFFF0000FFFF;
+	x3 &= (uint64_t)0x0000FFFF0000FFFF;
+	w[0] = (uint32_t)x0 | (uint32_t)(x0 >> 16);
+	w[1] = (uint32_t)x1 | (uint32_t)(x1 >> 16);
+	w[2] = (uint32_t)x2 | (uint32_t)(x2 >> 16);
+	w[3] = (uint32_t)x3 | (uint32_t)(x3 >> 16);
+}
+
+static const unsigned char Rcon[] = {
+	0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1B, 0x36
+};
+
+static uint32_t sub_word(uint32_t x) {
+	uint64_t q[8];
+
+	memset(q, 0, sizeof q);
+	q[0] = x;
+	br_aes_ct64_ortho(q);
+	br_aes_ct64_bitslice_Sbox(q);
+	br_aes_ct64_ortho(q);
+	return (uint32_t)q[0];
+}
+
+static void br_aes_ct64_keysched(uint64_t *comp_skey, const unsigned char *key, unsigned int key_len) {
+	unsigned int i, j, k, nk, nkf;
+	uint32_t tmp;
+	uint32_t skey[60];
+	unsigned nrounds = 10 + ((key_len - 16) >> 2);
+
+	nk = (key_len >> 2);
+	nkf = ((nrounds + 1) << 2);
+	br_range_dec32le(skey, (key_len >> 2), key);
+	tmp = skey[(key_len >> 2) - 1];
+	for (i = nk, j = 0, k = 0; i < nkf; i ++) {
+		if (j == 0) {
+			tmp = (tmp << 24) | (tmp >> 8);
+			tmp = sub_word(tmp) ^ Rcon[k];
+		} else if (nk > 6 && j == 4) {
+			tmp = sub_word(tmp);
+		}
+		tmp ^= skey[i - nk];
+		skey[i] = tmp;
+		if (++ j == nk) {
+			j = 0;
+			k ++;
 		}
 	}
+
+	for (i = 0, j = 0; i < nkf; i += 4, j += 2) {
+		uint64_t q[8];
+
+		br_aes_ct64_interleave_in(&q[0], &q[4], skey + i);
+		q[1] = q[0];
+		q[2] = q[0];
+		q[3] = q[0];
+		q[5] = q[4];
+		q[6] = q[4];
+		q[7] = q[4];
+		br_aes_ct64_ortho(q);
+		comp_skey[j + 0] =
+		    (q[0] & (uint64_t)0x1111111111111111)
+		    | (q[1] & (uint64_t)0x2222222222222222)
+		    | (q[2] & (uint64_t)0x4444444444444444)
+		    | (q[3] & (uint64_t)0x8888888888888888);
+		comp_skey[j + 1] =
+		    (q[4] & (uint64_t)0x1111111111111111)
+		    | (q[5] & (uint64_t)0x2222222222222222)
+		    | (q[6] & (uint64_t)0x4444444444444444)
+		    | (q[7] & (uint64_t)0x8888888888888888);
+	}
+}
+
+static void br_aes_ct64_skey_expand(uint64_t *skey, const uint64_t *comp_skey, unsigned int nrounds) {
+	unsigned u, v, n;
+
+	n = (nrounds + 1) << 1;
+	for (u = 0, v = 0; u < n; u ++, v += 4) {
+		uint64_t x0, x1, x2, x3;
+
+		x0 = x1 = x2 = x3 = comp_skey[u];
+		x0 &= (uint64_t)0x1111111111111111;
+		x1 &= (uint64_t)0x2222222222222222;
+		x2 &= (uint64_t)0x4444444444444444;
+		x3 &= (uint64_t)0x8888888888888888;
+		x1 >>= 1;
+		x2 >>= 2;
+		x3 >>= 3;
+		skey[v + 0] = (x0 << 4) - x0;
+		skey[v + 1] = (x1 << 4) - x1;
+		skey[v + 2] = (x2 << 4) - x2;
+		skey[v + 3] = (x3 << 4) - x3;
+	}
+}
+
+
+static inline void add_round_key(uint64_t *q, const uint64_t *sk) {
+	q[0] ^= sk[0];
+	q[1] ^= sk[1];
+	q[2] ^= sk[2];
+	q[3] ^= sk[3];
+	q[4] ^= sk[4];
+	q[5] ^= sk[5];
+	q[6] ^= sk[6];
+	q[7] ^= sk[7];
+}
+
+static inline void shift_rows(uint64_t *q) {
+	int i;
+
+	for (i = 0; i < 8; i ++) {
+		uint64_t x;
+
+		x = q[i];
+		q[i] = (x & (uint64_t)0x000000000000FFFF)
+		       | ((x & (uint64_t)0x00000000FFF00000) >> 4)
+		       | ((x & (uint64_t)0x00000000000F0000) << 12)
+		       | ((x & (uint64_t)0x0000FF0000000000) >> 8)
+		       | ((x & (uint64_t)0x000000FF00000000) << 8)
+		       | ((x & (uint64_t)0xF000000000000000) >> 12)
+		       | ((x & (uint64_t)0x0FFF000000000000) << 4);
+	}
+}
+
+static inline uint64_t rotr32(uint64_t x) {
+	return (x << 32) | (x >> 32);
+}
+
+static inline void mix_columns(uint64_t *q) {
+	uint64_t q0, q1, q2, q3, q4, q5, q6, q7;
+	uint64_t r0, r1, r2, r3, r4, r5, r6, r7;
+
+	q0 = q[0];
+	q1 = q[1];
+	q2 = q[2];
+	q3 = q[3];
+	q4 = q[4];
+	q5 = q[5];
+	q6 = q[6];
+	q7 = q[7];
+	r0 = (q0 >> 16) | (q0 << 48);
+	r1 = (q1 >> 16) | (q1 << 48);
+	r2 = (q2 >> 16) | (q2 << 48);
+	r3 = (q3 >> 16) | (q3 << 48);
+	r4 = (q4 >> 16) | (q4 << 48);
+	r5 = (q5 >> 16) | (q5 << 48);
+	r6 = (q6 >> 16) | (q6 << 48);
+	r7 = (q7 >> 16) | (q7 << 48);
+
+	q[0] = q7 ^ r7 ^ r0 ^ rotr32(q0 ^ r0);
+	q[1] = q0 ^ r0 ^ q7 ^ r7 ^ r1 ^ rotr32(q1 ^ r1);
+	q[2] = q1 ^ r1 ^ r2 ^ rotr32(q2 ^ r2);
+	q[3] = q2 ^ r2 ^ q7 ^ r7 ^ r3 ^ rotr32(q3 ^ r3);
+	q[4] = q3 ^ r3 ^ q7 ^ r7 ^ r4 ^ rotr32(q4 ^ r4);
+	q[5] = q4 ^ r4 ^ r5 ^ rotr32(q5 ^ r5);
+	q[6] = q5 ^ r5 ^ r6 ^ rotr32(q6 ^ r6);
+	q[7] = q6 ^ r6 ^ r7 ^ rotr32(q7 ^ r7);
+}
+
+
+static void inc4_be(uint32_t *x) {
+	uint32_t t = br_swap32(*x) + 4;
+	*x = br_swap32(t);
+}
+
+
+static void aes_ecb4x(unsigned char out[64], const uint32_t ivw[16], const uint64_t *sk_exp, unsigned int nrounds) {
+	uint32_t w[16];
+	uint64_t q[8];
+	unsigned int i;
+
+	memcpy(w, ivw, sizeof(w));
+	for (i = 0; i < 4; i++) {
+		br_aes_ct64_interleave_in(&q[i], &q[i + 4], w + (i << 2));
+	}
+	br_aes_ct64_ortho(q);
+
+
+	add_round_key(q, sk_exp);
+	for (i = 1; i < nrounds; i++) {
+		br_aes_ct64_bitslice_Sbox(q);
+		shift_rows(q);
+		mix_columns(q);
+		add_round_key(q, sk_exp + (i << 3));
+	}
+	br_aes_ct64_bitslice_Sbox(q);
+	shift_rows(q);
+	add_round_key(q, sk_exp + 8 * nrounds);
+
+	br_aes_ct64_ortho(q);
+	for (i = 0; i < 4; i ++) {
+		br_aes_ct64_interleave_out(w + (i << 2), q[i], q[i + 4]);
+	}
+	br_range_enc32le(out, w, 16);
+}
+
+
+static void aes_ctr4x(unsigned char out[64], uint32_t ivw[16], const uint64_t *sk_exp, unsigned int nrounds) {
+	aes_ecb4x(out, ivw, sk_exp, nrounds);
+
+	/* Increase counter for next 4 blocks */
+	inc4_be(ivw + 3);
+	inc4_be(ivw + 7);
+	inc4_be(ivw + 11);
+	inc4_be(ivw + 15);
+}
+
+
+static void aes_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const uint64_t *rkeys, unsigned int nrounds) {
+	uint32_t blocks[16];
+	unsigned char t[64];
+
+	while (nblocks >= 4) {
+		br_range_dec32le(blocks, 16, in);
+		aes_ecb4x(out, blocks, rkeys, nrounds);
+		nblocks -= 4;
+		in += 64;
+		out += 64;
+	}
+
+	if (nblocks) {
+		br_range_dec32le(blocks, nblocks * 4, in);
+		aes_ecb4x(t, blocks, rkeys, nrounds);
+		memcpy(out, t, nblocks * 16);
+	}
+}
+
+
+static void aes_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const size_t iv_len, const uint64_t *rkeys, unsigned int nrounds) {
+	uint32_t ivw[16];
+	size_t i;
+	uint32_t cc;
+
+	if (iv_len == 12) {
+		br_range_dec32le(ivw, 3, iv);
+		ivw[3] = 0;
+	} else if (iv_len == 16) {
+		br_range_dec32le(ivw, 4, iv);
+	} else {
+		assert(1 == 0);
+	}
+	memcpy(ivw +  4, ivw, 3 * sizeof(uint32_t));
+	memcpy(ivw +  8, ivw, 3 * sizeof(uint32_t));
+	memcpy(ivw + 12, ivw, 3 * sizeof(uint32_t));
+	cc = br_swap32(ivw[3]);
+	ivw[ 7] = br_swap32(cc + 1);
+	ivw[11] = br_swap32(cc + 2);
+	ivw[15] = br_swap32(cc + 3);
+
+	while (outlen > 64) {
+		aes_ctr4x(out, ivw, rkeys, nrounds);
+		out += 64;
+		outlen -= 64;
+	}
+	if (outlen > 0) {
+		unsigned char tmp[64];
+		aes_ctr4x(tmp, ivw, rkeys, nrounds);
+		for (i = 0; i < outlen; i++) {
+			out[i] = tmp[i];
+		}
+	}
+}
+
+void oqs_aes128_load_schedule_c(const uint8_t *key, void **_schedule) {
+	*_schedule = malloc(sizeof(aes128ctx));
+	OQS_EXIT_IF_NULLPTR(*_schedule);
+	aes128ctx *ctx = (aes128ctx *) *_schedule;
+	uint64_t skey[22];
+	br_aes_ct64_keysched(skey, key, 16);
+	br_aes_ct64_skey_expand(ctx->sk_exp, skey, 10);
+}
+
+void oqs_aes256_load_schedule_c(const uint8_t *key, void **_schedule) {
+	*_schedule = malloc(sizeof(aes256ctx));
+	OQS_EXIT_IF_NULLPTR(*_schedule);
+	aes256ctx *ctx = (aes256ctx *) *_schedule;
+	uint64_t skey[30];
+	br_aes_ct64_keysched(skey, key, 32);
+	br_aes_ct64_skey_expand(ctx->sk_exp, skey, 14);
+}
+
+void oqs_aes128_ecb_enc_sch_c(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext) {
+	assert(plaintext_len % 16 == 0);
+	const aes128ctx *ctx = (const aes128ctx *) schedule;
+	aes_ecb(ciphertext, plaintext, plaintext_len / 16, ctx->sk_exp, 10);
+}
+
+void oqs_aes256_ecb_enc_sch_c(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext) {
+	assert(plaintext_len % 16 == 0);
+	const aes256ctx *ctx = (const aes256ctx *) schedule;
+	aes_ecb(ciphertext, plaintext, plaintext_len / 16, ctx->sk_exp, 14);
+}
+
+void oqs_aes256_ctr_enc_sch_c(const uint8_t *iv, const size_t iv_len, const void *schedule, uint8_t *out, size_t out_len) {
+	const aes256ctx *ctx = (const aes256ctx *) schedule;
+	aes_ctr(out, out_len, iv, iv_len, ctx->sk_exp, 14);
 }
 
 void oqs_aes128_free_schedule_c(void *schedule) {
 	if (schedule != NULL) {
-		OQS_MEM_secure_free(schedule, 176);
+		aes128ctx *ctx = (aes128ctx *) schedule;
+		OQS_MEM_secure_free(ctx, sizeof(aes128ctx));
 	}
 }
-
-// Expand the 16-byte key to 15 round keys (240 bytes)
-// http://en.wikipedia.org/wiki/Rijndael_key_schedule#The_key_schedule
-void oqs_aes256_load_schedule_c(const uint8_t *key, void **_schedule) {
-	*_schedule = malloc(16 * 15);
-	OQS_EXIT_IF_NULLPTR(*_schedule);
-	uint8_t *schedule = (uint8_t *) *_schedule;
-	int i = 0;    // The count of how many iterations we've done
-	uint8_t t[4]; // Temporary working area
-
-	// The first 32 bytes of the expanded key are simply the encryption key
-	memcpy(schedule, key, 8 * 4);
-
-	// The remaining 240-32 bytes of the expanded key are computed in one of three ways:
-	for (i = 8; i < 4 * 15; i++) {
-		if (i % 8 == 0) {
-			memcpy(t, schedule + 4 * (i - 1), 4); // We assign the value of the previous 4 bytes in the expanded key to t
-			sub_bytes(t, 4);                      // We apply byte-wise substitution to t
-			rot_word(t);                          // We rotate t one byte left
-			t[0] ^= lookup_rcon[i / 8];           // We xor in the round constant
-			xor(t, schedule + 4 * (i - 8), 4);    // We xor in the four-byte block n bytes before
-			memcpy(schedule + 4 * i, t, 4);       // This becomes the next 4 bytes in the expanded key
-		} else if (i % 8 == 4) {
-			memcpy(t, schedule + 4 * (i - 1), 4); // We assign the value of the previous 4 bytes in the expanded key to t
-			sub_bytes(t, 4);                      // We apply byte-wise substitution to t
-			xor(t, schedule + 4 * (i - 8), 4);    // We xor in the four-byte block n bytes before
-			memcpy(schedule + 4 * i, t, 4);       // This becomes the next 4 bytes in the expanded key
-		} else {
-			memcpy(t, schedule + 4 * (i - 1), 4); // We assign the value of the previous 4 bytes in the expanded key to t
-			xor(t, schedule + 4 * (i - 8), 4);    // We xor in the four-byte block n bytes before
-			memcpy(schedule + 4 * i, t, 4);       // This becomes the next 4 bytes in the expanded key
-		}
-	}
-}
-
 void oqs_aes256_free_schedule_c(void *schedule) {
 	if (schedule != NULL) {
-		OQS_MEM_secure_free(schedule, 16 * 15);
+		aes256ctx *ctx = (aes256ctx *) schedule;
+		OQS_MEM_secure_free(ctx, sizeof(aes256ctx));
 	}
-}
-
-// Apply the shift rows step on the 16 byte cipher state
-// http://en.wikipedia.org/wiki/Advanced_Encryption_Standard#The_ShiftRows_step
-static void shift_rows(byte *state) {
-	int i;
-	byte temp[16];
-	memcpy(temp, state, 16);
-	for (i = 0; i < 16; i++) {
-		state[i] = temp[shift_rows_table[i]];
-	}
-}
-
-// Perform the mix columns matrix on one column of 4 bytes
-// http://en.wikipedia.org/wiki/Rijndael_mix_columns
-static void mix_col(byte *state) {
-	byte a0 = state[0];
-	byte a1 = state[1];
-	byte a2 = state[2];
-	byte a3 = state[3];
-	state[0] = lookup_g2[a0] ^ lookup_g3[a1] ^ a2 ^ a3;
-	state[1] = lookup_g2[a1] ^ lookup_g3[a2] ^ a3 ^ a0;
-	state[2] = lookup_g2[a2] ^ lookup_g3[a3] ^ a0 ^ a1;
-	state[3] = lookup_g2[a3] ^ lookup_g3[a0] ^ a1 ^ a2;
-}
-
-// Perform the mix columns matrix on each column of the 16 bytes
-static void mix_cols(byte *state) {
-	mix_col(state);
-	mix_col(state + 4);
-	mix_col(state + 8);
-	mix_col(state + 12);
-}
-
-void oqs_aes128_enc_sch_block_c(const uint8_t *plaintext, const void *_schedule, uint8_t *ciphertext) {
-	const uint8_t *schedule = (const uint8_t *) _schedule;
-	int i; // To count the rounds
-
-	// First Round
-	memcpy(ciphertext, plaintext, 16);
-	xor_round_key(ciphertext, schedule, 0);
-
-	// Middle rounds
-	for (i = 0; i < 9; i++) {
-		sub_bytes(ciphertext, 16);
-		shift_rows(ciphertext);
-		mix_cols(ciphertext);
-		xor_round_key(ciphertext, schedule, i + 1);
-	}
-
-	// Final Round
-	sub_bytes(ciphertext, 16);
-	shift_rows(ciphertext);
-	xor_round_key(ciphertext, schedule, 10);
-}
-
-void oqs_aes256_enc_sch_block_c(const uint8_t *plaintext, const void *_schedule, uint8_t *ciphertext) {
-	const uint8_t *schedule = (const uint8_t *) _schedule;
-	int i; // To count the rounds
-
-	// First Round
-	memcpy(ciphertext, plaintext, 16);
-	xor_round_key(ciphertext, schedule, 0);
-
-	// Middle rounds
-	for (i = 0; i < 13; i++) {
-		sub_bytes(ciphertext, 16);
-		shift_rows(ciphertext);
-		mix_cols(ciphertext);
-		xor_round_key(ciphertext, schedule, i + 1);
-	}
-
-	// Final Round
-	sub_bytes(ciphertext, 16);
-	shift_rows(ciphertext);
-	xor_round_key(ciphertext, schedule, 14);
 }

--- a/src/common/aes/aes_local.h
+++ b/src/common/aes/aes_local.h
@@ -9,15 +9,15 @@ void oqs_aes128_ecb_enc_sch_ni(const uint8_t *plaintext, const size_t plaintext_
 
 void oqs_aes128_load_schedule_c(const uint8_t *key, void **_schedule);
 void oqs_aes128_free_schedule_c(void *schedule);
-void oqs_aes128_enc_sch_block_c(const uint8_t *plaintext, const void *_schedule, uint8_t *ciphertext);
 void oqs_aes128_ecb_enc_sch_c(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext);
 
 void oqs_aes256_load_schedule_ni(const uint8_t *key, void **_schedule);
 void oqs_aes256_free_schedule_ni(void *schedule);
 void oqs_aes256_enc_sch_block_ni(const uint8_t *plaintext, const void *_schedule, uint8_t *ciphertext);
 void oqs_aes256_ecb_enc_sch_ni(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext);
+void oqs_aes256_ctr_enc_sch_ni(const uint8_t *iv, const size_t iv_len, const void *schedule, uint8_t *out, size_t out_len);
 
 void oqs_aes256_load_schedule_c(const uint8_t *key, void **_schedule);
 void oqs_aes256_free_schedule_c(void *schedule);
-void oqs_aes256_enc_sch_block_c(const uint8_t *plaintext, const void *_schedule, uint8_t *ciphertext);
 void oqs_aes256_ecb_enc_sch_c(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext);
+void oqs_aes256_ctr_enc_sch_c(const uint8_t *iv, const size_t iv_len, const void *schedule, uint8_t *out, size_t out_len);


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
Fixes #949. 

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [No] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [No] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
