### PR TITLE
Improve sha3x4 performance with musl libc

### DIFF
--- a/scripts/copy_from_xkcp/patches/lib_low_KeccakP-1600-times4_AVX2_KeccakP-1600-times4-SIMD256.c
+++ b/scripts/copy_from_xkcp/patches/lib_low_KeccakP-1600-times4_AVX2_KeccakP-1600-times4-SIMD256.c
@@ -41,7 +41,7 @@
 +
 +static void store64(unsigned char *out, uint64_t in)
 +{
-+    memmove(out, &in, sizeof(uint64_t));
++    memcpy(out, &in, sizeof(uint64_t));
 +}
 +
  void KeccakP1600times4_InitializeAll(void *states)

--- a/src/common/sha3/xkcp_low/KeccakP-1600times4/avx2/KeccakP-1600-times4-SIMD256.c
+++ b/src/common/sha3/xkcp_low/KeccakP-1600times4/avx2/KeccakP-1600-times4-SIMD256.c
@@ -102,7 +102,7 @@ static inline uint64_t load64(const unsigned char *x) {
 }
 
 static void store64(unsigned char *out, uint64_t in) {
-	memmove(out, &in, sizeof(uint64_t));
+	memcpy(out, &in, sizeof(uint64_t));
 }
 
 void KeccakP1600times4_InitializeAll(void *states) {


### PR DESCRIPTION
Schemes using sha3x4 showed some modest [loss of performance](https://github.com/open-quantum-safe/profiling/issues/47) on Alpine linux with our new sha3 implementations.

It turns out that musl libc has a slow implementation of memmove, and a single memmove that I added while removing undefined behaviour from the avx2 sha3x4 implementation was the culprit. Switching this particular memmove to a memcpy does not re-introduce any undefined behaviour.

This PR restores the lost performance in my local tests with our profiling container.

IMO we should still switch to a different libc for benchmarking.