### PR TITLE
Enable liboqs build in UEFI/EDKII.

### DIFF
--- a/src/common/common.h
+++ b/src/common/common.h
@@ -75,7 +75,7 @@ extern "C" {
 #define OQS_API __attribute__((visibility("default")))
 #endif
 
-#if defined(__UEFI__)
+#if defined(OQS_SYS_UEFI)
 #undef OQS_API
 #define OQS_API
 #endif
@@ -205,7 +205,7 @@ void OQS_MEM_aligned_free(void *ptr);
 #define UNUSED
 #endif
 
-#if defined(__UEFI__)
+#if defined(OQS_SYS_UEFI)
 #undef UNUSED
 #define UNUSED
 #endif

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -75,6 +75,11 @@ extern "C" {
 #define OQS_API __attribute__((visibility("default")))
 #endif
 
+#if defined(__UEFI__)
+#undef OQS_API
+#define OQS_API
+#endif
+
 /**
  * Represents return values from functions.
  *
@@ -197,6 +202,11 @@ void OQS_MEM_aligned_free(void *ptr);
 #define UNUSED __attribute__((unused))
 #else
 // __attribute__ not supported in VS
+#define UNUSED
+#endif
+
+#if defined(__UEFI__)
+#undef UNUSED
 #define UNUSED
 #endif
 


### PR DESCRIPTION
UEFI/EDKII used openssl as crypto lib with OPENSSL_SYS_UEFI.

This patch adds __UEFI__ macro in liboqs to indicate special build in UEFI/EDKII.
With this patch, we can start building liboqs in UEFI/EDKII.

For algorithm specific patches, we will submit one by one later.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>
