### PR TITLE
Improve random sources when not using OpenSSL

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -49,6 +49,13 @@ if(OQS_USE_OPENSSL)
     target_include_directories(common PRIVATE ${OPENSSL_INCLUDE_DIR})
 endif()
 
+if(NOT OQS_USE_OPENSSL)
+    check_symbol_exists(getentropy "unistd.h;sys/random.h" CMAKE_HAVE_GETENTROPY)
+    if(${CMAKE_HAVE_GETENTROPY})
+        target_compile_definitions(common PRIVATE OQS_HAVE_GETENTROPY)
+    endif()
+endif()
+
 if(NOT OQS_USE_SHA3_OPENSSL) # using XKCP
     set(_COMMON_OBJS ${_COMMON_OBJS} ${XKCP_LOW_OBJS})
 endif()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MIT
 
+include(CheckSymbolExists)
+
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR
    CMAKE_C_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wbad-function-cast)

--- a/src/common/rand/rand.c
+++ b/src/common/rand/rand.c
@@ -60,13 +60,18 @@ OQS_API void OQS_randombytes(uint8_t *random_array, size_t bytes_to_read) {
 }
 
 #if !defined(_WIN32)
-#if defined(HAVE_GETENTROPY)
+#if defined(OQS_HAVE_GETENTROPY)
 void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
-
-	int rc;
-	do {
-		rc = getentropy(random_array, bytes_to_read);
-	} while (rc != 0);
+	while(bytes_to_read > 256) {
+		if(getentropy(random_array, 256)) {
+			exit(EXIT_FAILURE);
+		}
+		random_array += 256;
+		bytes_to_read -= 256;
+	}
+	if(getentropy(random_array, bytes_to_read)) {
+		exit(EXIT_FAILURE);
+	}
 }
 #else
 static __inline void delay(unsigned int count) {

--- a/src/common/rand/rand.c
+++ b/src/common/rand/rand.c
@@ -77,6 +77,7 @@ void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
 void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
 
 	FILE *handle;
+	size_t bytes_read;
 
 	handle = fopen("/dev/urandom", "rb");
 	if (!handle) {
@@ -84,8 +85,8 @@ void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
 		exit(EXIT_FAILURE);
 	}
 
-	fread(random_array, 1, bytes_to_read, handle);
-	if (ferror(handle)) {
+	bytes_read = fread(random_array, 1, bytes_to_read, handle);
+	if (bytes_read < bytes_to_read || ferror(handle)) {
 		perror("OQS_randombytes");
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
Our `common/rand/rand.c` has two Linux/macOS implementations of OQS_randombytes_system. One uses the getrandom syscall through the getentropy interface. The other reads from /dev/urandom.

The getentropy-based implementation fails to respect the 256 byte length limit on getentropy calls and hangs in an infinite loop when longer requests are made. It is also guarded by `#if defined(HAVE_GETENTROPY)`, and we aren't setting HAVE_GETENTROPY anywhere.

The other implementation uses C standard buffered I/O (fopen, fread) to /dev/urandom. There are problems with how it handles fopen and fread errors.
 * On fopen failure it calls "delay" and then attempts to open the file again. The "delay" function is optimized out at -O2, and in general `fopen` errors are not recoverable.
 * On fread failure (specifically a short return) it would call delay and then attempt to read again. A short return from fread is an unrecoverable error and not a signal to try again.

The first commit in this PR fixes the getentropy-based implementation.

The second commit adds CMake logic to set an `OQS_HAVE_GETENTROPY` define. This makes getentropy the default on recent systems when we are not using OpenSSL.

The third commit improves the use of fopen/fread. There probably are recoverable errors for fopen (maybe EINTR?), so I'm open to suggestions there.