### PR TITLE
output CPU feature CT/RT distinction

### DIFF
--- a/tests/system_info.c
+++ b/tests/system_info.c
@@ -110,7 +110,7 @@ static void print_cpu_extensions(void) {
 		printf(" NEON");
 	}
 #else
-	printf("CPU exts active: ");
+	printf("CPU exts compile-time: ");
 #ifdef OQS_USE_ADX_INSTRUCTIONS
 	printf(" ADX");
 #endif


### PR DESCRIPTION
When running any test, the system information output should distinguish whether it displays CPU features present at compile-time **or** at run-time. Without this distinction, one can chase for hours problems caused in reality by missing CPU runtime features, e.g., in a cloud infrastructure sometimes offering those features and sometimes not offering them (one of the reasons for https://github.com/open-quantum-safe/profiling/issues/57 and manifested by [this output](https://github.com/open-quantum-safe/profiling/issues/57#issuecomment-831018780)).
```
```
)

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

