### PR TITLE
Test without alignment

### DIFF
--- a/tests/test_kem.c
+++ b/tests/test_kem.c
@@ -72,17 +72,17 @@ static OQS_STATUS kem_test_correctness(const char *method_name) {
 	shared_secret_e = malloc(kem->length_shared_secret + sizeof(magic_t));
 	shared_secret_d = malloc(kem->length_shared_secret + sizeof(magic_t));
 
+	if ((public_key == NULL) || (secret_key == NULL) || (ciphertext == NULL) || (shared_secret_e == NULL) || (shared_secret_d == NULL)) {
+		fprintf(stderr, "ERROR: malloc failed\n");
+		goto err;
+	}
+
 	//Set the magic numbers
 	memcpy(public_key + kem->length_public_key, magic.val, sizeof(magic_t));
 	memcpy(secret_key + kem->length_secret_key, magic.val, sizeof(magic_t));
 	memcpy(ciphertext + kem->length_ciphertext, magic.val, sizeof(magic_t));
 	memcpy(shared_secret_e + kem->length_shared_secret, magic.val, sizeof(magic_t));
 	memcpy(shared_secret_d + kem->length_shared_secret, magic.val, sizeof(magic_t));
-
-	if ((public_key == NULL) || (secret_key == NULL) || (ciphertext == NULL) || (shared_secret_e == NULL) || (shared_secret_d == NULL)) {
-		fprintf(stderr, "ERROR: malloc failed\n");
-		goto err;
-	}
 
 	rc = OQS_KEM_keypair(kem, public_key, secret_key);
 	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);

--- a/tests/test_kem.c
+++ b/tests/test_kem.c
@@ -32,7 +32,7 @@ static void OQS_print_hex_string(const char *label, const uint8_t *str, size_t l
 }
 
 typedef struct magic_s {
-	uint8_t val[32];
+	uint8_t val[31];
 } magic_t;
 
 static OQS_STATUS kem_test_correctness(const char *method_name) {
@@ -46,15 +46,10 @@ static OQS_STATUS kem_test_correctness(const char *method_name) {
 	OQS_STATUS rc, ret = OQS_ERROR;
 	int rv;
 
-	//The magic numbers are 32 random values.
-	//The length of the magic number was chosen arbitrarilly to 32.
-	magic_t magic = {{
-			0xfa, 0xfa, 0xfa, 0xfa, 0xbc, 0xbc, 0xbc, 0xbc,
-			0x15, 0x61, 0x15, 0x61, 0x15, 0x61, 0x15, 0x61,
-			0xad, 0xad, 0x43, 0x43, 0xad, 0xad, 0x34, 0x34,
-			0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78
-		}
-	};
+	//The magic numbers are random values.
+	//The length of the magic number was chosen to be 31 to break alignment
+	magic_t magic;
+	OQS_randombytes(magic.val, sizeof(magic_t));
 
 	kem = OQS_KEM_new(method_name);
 	if (kem == NULL) {
@@ -66,18 +61,31 @@ static OQS_STATUS kem_test_correctness(const char *method_name) {
 	printf("Sample computation for KEM %s\n", kem->method_name);
 	printf("================================================================================\n");
 
-	public_key = malloc(kem->length_public_key + sizeof(magic_t));
-	secret_key = malloc(kem->length_secret_key + sizeof(magic_t));
-	ciphertext = malloc(kem->length_ciphertext + sizeof(magic_t));
-	shared_secret_e = malloc(kem->length_shared_secret + sizeof(magic_t));
-	shared_secret_d = malloc(kem->length_shared_secret + sizeof(magic_t));
+	public_key = malloc(kem->length_public_key + 2*sizeof(magic_t));
+	secret_key = malloc(kem->length_secret_key + 2*sizeof(magic_t));
+	ciphertext = malloc(kem->length_ciphertext + 2*sizeof(magic_t));
+	shared_secret_e = malloc(kem->length_shared_secret + 2*sizeof(magic_t));
+	shared_secret_d = malloc(kem->length_shared_secret + 2*sizeof(magic_t));
 
 	if ((public_key == NULL) || (secret_key == NULL) || (ciphertext == NULL) || (shared_secret_e == NULL) || (shared_secret_d == NULL)) {
 		fprintf(stderr, "ERROR: malloc failed\n");
 		goto err;
 	}
 
-	//Set the magic numbers
+	//Set the magic numbers before
+	memcpy(public_key, magic.val, sizeof(magic_t));
+	memcpy(secret_key, magic.val, sizeof(magic_t));
+	memcpy(ciphertext, magic.val, sizeof(magic_t));
+	memcpy(shared_secret_e, magic.val, sizeof(magic_t));
+	memcpy(shared_secret_d, magic.val, sizeof(magic_t));
+
+	public_key += sizeof(magic_t);
+	secret_key += sizeof(magic_t);
+	ciphertext += sizeof(magic_t);
+	shared_secret_e += sizeof(magic_t);
+	shared_secret_d += sizeof(magic_t);
+
+	// and after
 	memcpy(public_key + kem->length_public_key, magic.val, sizeof(magic_t));
 	memcpy(secret_key + kem->length_secret_key, magic.val, sizeof(magic_t));
 	memcpy(ciphertext + kem->length_ciphertext, magic.val, sizeof(magic_t));
@@ -124,6 +132,11 @@ static OQS_STATUS kem_test_correctness(const char *method_name) {
 	rv |= memcmp(ciphertext + kem->length_ciphertext, magic.val, sizeof(magic_t));
 	rv |= memcmp(shared_secret_e + kem->length_shared_secret, magic.val, sizeof(magic_t));
 	rv |= memcmp(shared_secret_d + kem->length_shared_secret, magic.val, sizeof(magic_t));
+	rv |= memcmp(public_key - sizeof(magic_t), magic.val, sizeof(magic_t));
+	rv |= memcmp(secret_key - sizeof(magic_t), magic.val, sizeof(magic_t));
+	rv |= memcmp(ciphertext - sizeof(magic_t), magic.val, sizeof(magic_t));
+	rv |= memcmp(shared_secret_e - sizeof(magic_t), magic.val, sizeof(magic_t));
+	rv |= memcmp(shared_secret_d - sizeof(magic_t), magic.val, sizeof(magic_t));
 	if (rv != 0) {
 		fprintf(stderr, "ERROR: Magic numbers do not match\n");
 		goto err;
@@ -148,12 +161,12 @@ err:
 
 cleanup:
 	if (kem != NULL) {
-		OQS_MEM_secure_free(secret_key, kem->length_secret_key);
-		OQS_MEM_secure_free(shared_secret_e, kem->length_shared_secret);
-		OQS_MEM_secure_free(shared_secret_d, kem->length_shared_secret);
+		OQS_MEM_secure_free(secret_key - sizeof(magic_t), kem->length_secret_key + 2*sizeof(magic_t));
+		OQS_MEM_secure_free(shared_secret_e - sizeof(magic_t), kem->length_shared_secret + 2*sizeof(magic_t));
+		OQS_MEM_secure_free(shared_secret_d - sizeof(magic_t), kem->length_shared_secret + 2*sizeof(magic_t));
 	}
-	OQS_MEM_insecure_free(public_key);
-	OQS_MEM_insecure_free(ciphertext);
+	OQS_MEM_insecure_free(public_key - sizeof(magic_t));
+	OQS_MEM_insecure_free(ciphertext - sizeof(magic_t));
 	OQS_KEM_free(kem);
 
 	return ret;

--- a/tests/test_kem.c
+++ b/tests/test_kem.c
@@ -61,11 +61,11 @@ static OQS_STATUS kem_test_correctness(const char *method_name) {
 	printf("Sample computation for KEM %s\n", kem->method_name);
 	printf("================================================================================\n");
 
-	public_key = malloc(kem->length_public_key + 2*sizeof(magic_t));
-	secret_key = malloc(kem->length_secret_key + 2*sizeof(magic_t));
-	ciphertext = malloc(kem->length_ciphertext + 2*sizeof(magic_t));
-	shared_secret_e = malloc(kem->length_shared_secret + 2*sizeof(magic_t));
-	shared_secret_d = malloc(kem->length_shared_secret + 2*sizeof(magic_t));
+	public_key = malloc(kem->length_public_key + 2 * sizeof(magic_t));
+	secret_key = malloc(kem->length_secret_key + 2 * sizeof(magic_t));
+	ciphertext = malloc(kem->length_ciphertext + 2 * sizeof(magic_t));
+	shared_secret_e = malloc(kem->length_shared_secret + 2 * sizeof(magic_t));
+	shared_secret_d = malloc(kem->length_shared_secret + 2 * sizeof(magic_t));
 
 	if ((public_key == NULL) || (secret_key == NULL) || (ciphertext == NULL) || (shared_secret_e == NULL) || (shared_secret_d == NULL)) {
 		fprintf(stderr, "ERROR: malloc failed\n");
@@ -161,9 +161,9 @@ err:
 
 cleanup:
 	if (kem != NULL) {
-		OQS_MEM_secure_free(secret_key - sizeof(magic_t), kem->length_secret_key + 2*sizeof(magic_t));
-		OQS_MEM_secure_free(shared_secret_e - sizeof(magic_t), kem->length_shared_secret + 2*sizeof(magic_t));
-		OQS_MEM_secure_free(shared_secret_d - sizeof(magic_t), kem->length_shared_secret + 2*sizeof(magic_t));
+		OQS_MEM_secure_free(secret_key - sizeof(magic_t), kem->length_secret_key + 2 * sizeof(magic_t));
+		OQS_MEM_secure_free(shared_secret_e - sizeof(magic_t), kem->length_shared_secret + 2 * sizeof(magic_t));
+		OQS_MEM_secure_free(shared_secret_d - sizeof(magic_t), kem->length_shared_secret + 2 * sizeof(magic_t));
 	}
 	OQS_MEM_insecure_free(public_key - sizeof(magic_t));
 	OQS_MEM_insecure_free(ciphertext - sizeof(magic_t));


### PR DESCRIPTION
This changes the test_kem.c functions like those in PQClean:
  * also prefix magic bytes for checking for out-of-bounds access
  * use odd numbers for breaking alignment

Includes #985