### PR TITLE
astyle is needed to be installed on MacOS for run_tests to succeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ We realize some parties may want to deploy quantum-safe cryptography prior to th
 
 	On macOS, using a package manager of your choice (we've picked Homebrew):
 
-		brew install cmake ninja openssl@1.1 wget doxygen graphviz
+		brew install cmake ninja openssl@1.1 wget doxygen graphviz astyle
 		pip3 install pytest pytest-xdist
-	
+
 	Note that, if you want liboqs to use OpenSSL for various symmetric crypto algorithms (AES, SHA-2, etc.) then you must have OpenSSL version 1.1.1 or higher.
 
 2. Get the source:


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

astyle is needed to be installed so the running of the tests succeeds. This just adds the needed dependency to be installed.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

Does not resolved any issue.

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)

* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
