### PR TITLE
Add canaries around malloc'd regions in test_sig

### DIFF
--- a/tests/test_kem.c
+++ b/tests/test_kem.c
@@ -127,6 +127,7 @@ static OQS_STATUS kem_test_correctness(const char *method_name) {
 		printf("shared secrets are equal\n");
 	}
 
+#ifndef OQS_ENABLE_TEST_CONSTANT_TIME
 	rv = memcmp(public_key + kem->length_public_key, magic.val, sizeof(magic_t));
 	rv |= memcmp(secret_key + kem->length_secret_key, magic.val, sizeof(magic_t));
 	rv |= memcmp(ciphertext + kem->length_ciphertext, magic.val, sizeof(magic_t));
@@ -141,6 +142,7 @@ static OQS_STATUS kem_test_correctness(const char *method_name) {
 		fprintf(stderr, "ERROR: Magic numbers do not match\n");
 		goto err;
 	}
+#endif
 
 	// test invalid encapsulation (call should either fail or result in invalid shared secret)
 	OQS_randombytes(ciphertext, kem->length_ciphertext);

--- a/tests/test_kem.c
+++ b/tests/test_kem.c
@@ -127,6 +127,17 @@ static OQS_STATUS kem_test_correctness(const char *method_name) {
 		printf("shared secrets are equal\n");
 	}
 
+	// test invalid encapsulation (call should either fail or result in invalid shared secret)
+	OQS_randombytes(ciphertext, kem->length_ciphertext);
+	OQS_TEST_CT_DECLASSIFY(ciphertext, kem->length_ciphertext);
+	rc = OQS_KEM_decaps(kem, shared_secret_d, ciphertext, secret_key);
+	OQS_TEST_CT_DECLASSIFY(shared_secret_d, kem->length_shared_secret);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	if (rc == OQS_SUCCESS && memcmp(shared_secret_e, shared_secret_d, kem->length_shared_secret) == 0) {
+		fprintf(stderr, "ERROR: OQS_KEM_decaps succeeded on wrong input\n");
+		goto err;
+	}
+
 #ifndef OQS_ENABLE_TEST_CONSTANT_TIME
 	rv = memcmp(public_key + kem->length_public_key, magic.val, sizeof(magic_t));
 	rv |= memcmp(secret_key + kem->length_secret_key, magic.val, sizeof(magic_t));
@@ -143,17 +154,6 @@ static OQS_STATUS kem_test_correctness(const char *method_name) {
 		goto err;
 	}
 #endif
-
-	// test invalid encapsulation (call should either fail or result in invalid shared secret)
-	OQS_randombytes(ciphertext, kem->length_ciphertext);
-	OQS_TEST_CT_DECLASSIFY(ciphertext, kem->length_ciphertext);
-	rc = OQS_KEM_decaps(kem, shared_secret_d, ciphertext, secret_key);
-	OQS_TEST_CT_DECLASSIFY(shared_secret_d, kem->length_shared_secret);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
-	if (rc == OQS_SUCCESS && memcmp(shared_secret_e, shared_secret_d, kem->length_shared_secret) == 0) {
-		fprintf(stderr, "ERROR: OQS_KEM_decaps succeeded on wrong input\n");
-		goto err;
-	}
 
 	ret = OQS_SUCCESS;
 	goto cleanup;

--- a/tests/test_sig.c
+++ b/tests/test_sig.c
@@ -25,6 +25,10 @@
 
 #include "system_info.c"
 
+typedef struct magic_s {
+	uint8_t val[31];
+} magic_t;
+
 static OQS_STATUS sig_test_correctness(const char *method_name) {
 
 	OQS_SIG *sig = NULL;
@@ -35,6 +39,12 @@ static OQS_STATUS sig_test_correctness(const char *method_name) {
 	uint8_t *signature = NULL;
 	size_t signature_len;
 	OQS_STATUS rc, ret = OQS_ERROR;
+	int rv = 0;
+
+	//The magic numbers are random values.
+	//The length of the magic number was chosen to be 31 to break alignment
+	magic_t magic;
+	OQS_randombytes(magic.val, sizeof(magic_t));
 
 	sig = OQS_SIG_new(method_name);
 	if (sig == NULL) {
@@ -46,15 +56,32 @@ static OQS_STATUS sig_test_correctness(const char *method_name) {
 	printf("Sample computation for signature %s\n", sig->method_name);
 	printf("================================================================================\n");
 
-	public_key = malloc(sig->length_public_key);
-	secret_key = malloc(sig->length_secret_key);
-	message = malloc(message_len);
-	signature = malloc(sig->length_signature);
+	public_key = malloc(sig->length_public_key + 2 * sizeof(magic_t));
+	secret_key = malloc(sig->length_secret_key + 2 * sizeof(magic_t));
+	message = malloc(message_len + 2 * sizeof(magic_t));
+	signature = malloc(sig->length_signature + 2 * sizeof(magic_t));
 
 	if ((public_key == NULL) || (secret_key == NULL) || (message == NULL) || (signature == NULL)) {
 		fprintf(stderr, "ERROR: malloc failed\n");
 		goto err;
 	}
+
+	//Set the magic numbers before
+	memcpy(public_key, magic.val, sizeof(magic_t));
+	memcpy(secret_key, magic.val, sizeof(magic_t));
+	memcpy(message, magic.val, sizeof(magic_t));
+	memcpy(signature, magic.val, sizeof(magic_t));
+
+	public_key += sizeof(magic_t);
+	secret_key += sizeof(magic_t);
+	message += sizeof(magic_t);
+	signature += sizeof(magic_t);
+
+	// and after
+	memcpy(public_key + sig->length_public_key, magic.val, sizeof(magic_t));
+	memcpy(secret_key + sig->length_secret_key, magic.val, sizeof(magic_t));
+	memcpy(message + message_len, magic.val, sizeof(magic_t));
+	memcpy(signature + sig->length_signature, magic.val, sizeof(magic_t));
 
 	OQS_randombytes(message, message_len);
 	OQS_TEST_CT_DECLASSIFY(message, message_len);
@@ -91,6 +118,21 @@ static OQS_STATUS sig_test_correctness(const char *method_name) {
 		fprintf(stderr, "ERROR: OQS_SIG_verify should have failed!\n");
 		goto err;
 	}
+
+	/* check magic values */
+	rv = memcmp(public_key + sig->length_public_key, magic.val, sizeof(magic_t));
+	rv |= memcmp(secret_key + sig->length_secret_key, magic.val, sizeof(magic_t));
+	rv |= memcmp(message + message_len, magic.val, sizeof(magic_t));
+	rv |= memcmp(signature + sig->length_signature, magic.val, sizeof(magic_t));
+	rv |= memcmp(public_key - sizeof(magic_t), magic.val, sizeof(magic_t));
+	rv |= memcmp(secret_key - sizeof(magic_t), magic.val, sizeof(magic_t));
+	rv |= memcmp(message - sizeof(magic_t), magic.val, sizeof(magic_t));
+	rv |= memcmp(signature - sizeof(magic_t), magic.val, sizeof(magic_t));
+	if (rv) {
+		fprintf(stderr, "ERROR: Magic numbers do not mtach\n");
+		goto err;
+	}
+
 	printf("verification passes as expected\n");
 	ret = OQS_SUCCESS;
 	goto cleanup;
@@ -100,11 +142,11 @@ err:
 
 cleanup:
 	if (sig != NULL) {
-		OQS_MEM_secure_free(secret_key, sig->length_secret_key);
+		OQS_MEM_secure_free(secret_key - sizeof(magic_t), sig->length_secret_key + 2 * sizeof(magic_t));
 	}
-	OQS_MEM_insecure_free(public_key);
-	OQS_MEM_insecure_free(message);
-	OQS_MEM_insecure_free(signature);
+	OQS_MEM_insecure_free(public_key - sizeof(magic_t));
+	OQS_MEM_insecure_free(message - sizeof(magic_t));
+	OQS_MEM_insecure_free(signature - sizeof(magic_t));
 	OQS_SIG_free(sig);
 
 	return ret;

--- a/tests/test_sig.c
+++ b/tests/test_sig.c
@@ -39,7 +39,6 @@ static OQS_STATUS sig_test_correctness(const char *method_name) {
 	uint8_t *signature = NULL;
 	size_t signature_len;
 	OQS_STATUS rc, ret = OQS_ERROR;
-	int rv = 0;
 
 	//The magic numbers are random values.
 	//The length of the magic number was chosen to be 31 to break alignment
@@ -119,8 +118,9 @@ static OQS_STATUS sig_test_correctness(const char *method_name) {
 		goto err;
 	}
 
+#ifndef OQS_ENABLE_TEST_CONSTANT_TIME
 	/* check magic values */
-	rv = memcmp(public_key + sig->length_public_key, magic.val, sizeof(magic_t));
+	int rv = memcmp(public_key + sig->length_public_key, magic.val, sizeof(magic_t));
 	rv |= memcmp(secret_key + sig->length_secret_key, magic.val, sizeof(magic_t));
 	rv |= memcmp(message + message_len, magic.val, sizeof(magic_t));
 	rv |= memcmp(signature + sig->length_signature, magic.val, sizeof(magic_t));
@@ -132,6 +132,7 @@ static OQS_STATUS sig_test_correctness(const char *method_name) {
 		fprintf(stderr, "ERROR: Magic numbers do not mtach\n");
 		goto err;
 	}
+#endif
 
 	printf("verification passes as expected\n");
 	ret = OQS_SUCCESS;


### PR DESCRIPTION
#986 inadvertently broke test_constant_time by using memcmp on some canaries in test_kem. This PR disables the canary checks when OQS_ENABLE_TEST_CONSTANT_TIME=ON.

More importantly, this PR adds canaries to test_sig. I followed #986 in using an odd length for the canaries in the hope of catching alignment bugs.