### PR TITLE
tests/constant_time: update passes file for AVX2 impl of HQC [skip ci]

### DIFF
--- a/tests/constant_time/kem/passes/hqc
+++ b/tests/constant_time/kem/passes/hqc
@@ -10,3 +10,17 @@
     src:vector.c:56
     # fun:PQCLEAN_HQCRMRS*_CLEAN_vect_set_random_fixed_weight_by_coordinates
 }
+
+# AVX2 implementation
+{
+    Rejection sampling for uniform indices
+    Memcheck:Cond
+    src:vector.c:60
+    # fun:PQCLEAN_HQCRMRS*_AVX2_vect_set_random_fixed_weight
+}
+{
+    Rejection sampling for unique indices
+    Memcheck:Cond
+    src:vector.c:66
+    # fun:PQCLEAN_HQCRMRS*_AVX2_vect_set_random_fixed_weight
+}


### PR DESCRIPTION
This PR documents two false positives in test_constant_time for the AVX2 implementations of HQC.