### PR TITLE
change MSVC compile options

### DIFF
--- a/.CMake/compiler_opts.cmake
+++ b/.CMake/compiler_opts.cmake
@@ -139,6 +139,8 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     add_compile_options(/wd4146)
     # Need a larger stack for Classic McEliece
     add_link_options(/STACK:8192000)
+    # bring compile options in line with openssl options; link otherwise fails
+    add_compile_options(/MT)
 endif()
 
 if(MINGW OR MSYS OR CYGWIN)


### PR DESCRIPTION
Changing MS Visual Studio/Windows-only compile options.

This enables correct downstream linking using MSVC (https://github.com/open-quantum-safe/openssl/issues/236).

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)
