### PR TITLE
Fix missing sha3 symbols for some Windows configurations

### DIFF
--- a/src/common/sha3/xkcp_low/CMakeLists.txt
+++ b/src/common/sha3/xkcp_low/CMakeLists.txt
@@ -3,10 +3,10 @@
 set(_XKCP_LOW_OBJS "")
 
 # Determine which of the implementations we're building
-if(OQS_DIST_X86_64_BUILD)
+if(OQS_DIST_X86_64_BUILD AND OQS_ENABLE_SHA3_xkcp_low_avx2)
   set(BUILD_PLAIN64 ON)
   set(BUILD_AVX2 ON)
-elseif(OQS_USE_AVX2_INSTRUCTIONS)
+elseif(OQS_ENABLE_SHA3_xkcp_low_avx2)
   set(BUILD_AVX2 ON)
 else()
   set(BUILD_PLAIN64 ON)


### PR DESCRIPTION
The sha3 CMakeLists.txt file was ignoring the OQS_ENABLE_SHA3_xkcp_low_avx2 option. This option is used to disable our AVX2 implementation of sha3 on Windows. Fixing this resolves one of several problems identified in #997.