### PR TITLE
Make BIKE compile for older CMake versions when AVX512 is used

### DIFF
--- a/src/kem/bike/CMakeLists.txt
+++ b/src/kem/bike/CMakeLists.txt
@@ -53,20 +53,20 @@ if(OQS_ENABLE_KEM_bike_l1 OR OQS_ENABLE_KEM_bike_l3)
         FILE(GLOB_RECURSE AVX2_SRCS additional_r3/*_avx2.c)
         FILE(GLOB_RECURSE AVX512_SRCS additional_r3/*_avx512.c)
 
-        set(AVX512_FLAGS "-mavx512f;-mavx512bw;-mavx512dq")
+        set(AVX512_FLAGS "-mavx512f -mavx512bw -mavx512dq")
 
         # Set appropriate flags for avx files
-        set_source_files_properties(${AVX2_SRCS} PROPERTIES COMPILE_OPTIONS "-mavx2")
-        set_source_files_properties(${AVX512_SRCS} PROPERTIES COMPILE_OPTIONS "${AVX512_FLAGS}")
+        set_source_files_properties(${AVX2_SRCS} PROPERTIES COMPILE_FLAGS "-mavx2")
+        set_source_files_properties(${AVX512_SRCS} PROPERTIES COMPILE_FLAGS "${AVX512_FLAGS}")
 
-        set_source_files_properties(additional_r3/gf2x_mul_base_pclmul.c PROPERTIES COMPILE_OPTIONS "-mpclmul;-msse2")
+        set_source_files_properties(additional_r3/gf2x_mul_base_pclmul.c PROPERTIES COMPILE_FLAGS "-mpclmul -msse2")
 
         # Some older compilers don't support the "mvpclmulqdq" flag so we have to check.
         try_compile(VPCLMUL_SUPPORTED ${CMAKE_BINARY_DIR}
                     ${CMAKE_CURRENT_LIST_DIR}/additional_r3/noop_main.c
                     COMPILE_DEFINITIONS -mvpclmulqdq)
         if (VPCLMUL_SUPPORTED) 
-            set_source_files_properties(additional_r3/gf2x_mul_base_vpclmul.c PROPERTIES COMPILE_OPTIONS "-mvpclmulqdq;${AVX512_FLAGS}")
+            set_source_files_properties(additional_r3/gf2x_mul_base_vpclmul.c PROPERTIES COMPILE_FLAGS "-mvpclmulqdq ${AVX512_FLAGS}")
         else()
             set(CPP_DEFS_R3 ${CPP_DEFS_R3} DISABLE_VPCLMUL)
         endif()


### PR DESCRIPTION
BIKE compilation fails when AVX512 and older CMake versions (like 3.10.*) are to be used.

Fixes #1032, resolves https://github.com/open-quantum-safe/boringssl/issues/64.

