### PR TITLE
Suppression file update after ppc64le constant-time check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+before_script:
+  - sudo apt -y install astyle cmake gcc ninja-build libssl-dev python3-pytest python3-pytest-xdist unzip xsltproc doxygen graphviz valgrind
+jobs:
+  include:
+    - arch: ppc64le         # The IBM Power LXD container based build for OSS only
+      os: linux             # required for arch different than amd64
+      dist: focal           # or bionic | xenial with xenial as default
+      compiler: gcc
+      script:
+        - mkdir build && cd build && cmake -GNinja .. && cmake -LA .. && ninja
+        - cd build & ninja run_tests

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[AppVeyor](https://ci.appveyor.com/project/dstebila/liboqs): ![Build status image](https://ci.appveyor.com/api/projects/status/9d2ts78x88r8wnii/branch/main?svg=true), [CircleCI](https://circleci.com/gh/open-quantum-safe/liboqs/tree/main): ![Build status image](https://circleci.com/gh/open-quantum-safe/liboqs/tree/main.svg?style=svg)
+[AppVeyor](https://ci.appveyor.com/project/dstebila/liboqs): ![Build status image](https://ci.appveyor.com/api/projects/status/9d2ts78x88r8wnii/branch/main?svg=true), [CircleCI](https://circleci.com/gh/open-quantum-safe/liboqs/tree/main): ![Build status image](https://circleci.com/gh/open-quantum-safe/liboqs/tree/main.svg?style=svg), [TravisCI](https://travis-ci.com/github/bhess/liboqs): [![Build Status](https://travis-ci.com/bhess/liboqs.svg?branch=travis-ppc)](https://travis-ci.com/bhess/liboqs)
 
 liboqs
 ======================

--- a/tests/constant_time/kem/issues.json
+++ b/tests/constant_time/kem/issues.json
@@ -1,4 +1,6 @@
 {
+  "BIKE-L1": ["bike_has_no_timing_protections"],
+  "BIKE-L3": ["bike_has_no_timing_protections"],
   "BIKE1-L1-CPA": ["bike_has_no_timing_protections"],
   "BIKE1-L1-FO": ["bike_has_no_timing_protections"],
   "BIKE1-L3-CPA": ["bike_has_no_timing_protections"],

--- a/tests/constant_time/kem/issues.json
+++ b/tests/constant_time/kem/issues.json
@@ -1,6 +1,4 @@
 {
-  "BIKE-L1": ["bike_has_no_timing_protections"],
-  "BIKE-L3": ["bike_has_no_timing_protections"],
   "BIKE1-L1-CPA": ["bike_has_no_timing_protections"],
   "BIKE1-L1-FO": ["bike_has_no_timing_protections"],
   "BIKE1-L3-CPA": ["bike_has_no_timing_protections"],

--- a/tests/constant_time/sig/passes/dilithium
+++ b/tests/constant_time/sig/passes/dilithium
@@ -1,7 +1,7 @@
 {
    Rejection sampling for uniformly distributed public A matrix
    Memcheck:Cond
-   src:poly.c:343 # fun:rej_uniform
+   fun:rej_uniform
    fun:pqcrystals_dilithium*_ref_poly_uniform
    fun:pqcrystals_dilithium*_ref_polyvec_matrix_expand
 }

--- a/tests/constant_time/sig/passes/dilithium-aes-avx2
+++ b/tests/constant_time/sig/passes/dilithium-aes-avx2
@@ -23,7 +23,7 @@
 {
    Requested number of random bytes is not secret
    Memcheck:Cond
-   src:poly.c:413
+   src:poly.c:394
    # fun:pqcrystals_dilithium2aes_avx2_poly_uniform_preinit
 }
 
@@ -46,6 +46,6 @@
 {
    Requested number of random bytes is not secret
    Memcheck:Cond
-   src:poly.c:546
+   src:poly.c:530
    # fun:pqcrystals_dilithium*aes_avx2_poly_uniform_eta_preinit
 }


### PR DESCRIPTION
Minor suppression file updates after a constant-time check on ppc64le (see https://github.com/open-quantum-safe/liboqs/pull/1037):

- Dilithium: (i) two line numbers changed, (ii) using explicit function name (fun:rej_uniform) for generic Dilithium
- ~~Adds the new BIKE variants (adding to issues.json like the previous variants, expert review might be needed here)~~

The CI log with BIKE and Dilithium reports is available here: [ppc64le.txt](https://github.com/open-quantum-safe/liboqs/files/6733709/ppc64le.txt)
The SPHINCS+ reports are documented separately in #1038.

The reported issues (except #1038) should also be reproducible using the `constant-time-x64-extensions` / `constant-time-x64` circleci jobs. After this fix, all constant-time checks pass on x86_64 / ppc64le. BIKE will have to be added separately after this PR.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [No] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [No] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
