### PR TITLE
Removing default algs

### DIFF
--- a/.CMake/alg_support.cmake
+++ b/.CMake/alg_support.cmake
@@ -2,11 +2,11 @@
 
 include(CMakeDependentOption)
 
-if(NOT DEFINED OQS_KEM_DEFAULT)
-    set(OQS_KEM_DEFAULT "OQS_KEM_alg_frodokem_640_aes")
+if(DEFINED OQS_KEM_DEFAULT)
+    message(WARNING "OQS_KEM_DEFAULT not longer supported")
 endif()
-if(NOT DEFINED OQS_SIG_DEFAULT)
-    set(OQS_SIG_DEFAULT "OQS_SIG_alg_dilithium_2")
+if(DEFINED OQS_SIG_DEFAULT)
+    message(WARNING "OQS_SIG_DEFAULT not longer supported")
 endif()
 
 # Only enable OpenSSL by default on not-Windows

--- a/.CMake/alg_support.cmake
+++ b/.CMake/alg_support.cmake
@@ -569,7 +569,7 @@ if((OQS_MINIMAL_BUILD STREQUAL "ON"))
    message(FATAL_ERROR "OQS_MINIMAL_BUILD option ${OQS_MINIMAL_BUILD} no longer supported")
 endif()
 
-if(NOT (OQS_MINIMAL_BUILD STREQUAL "OFF"))
+if(NOT ((OQS_MINIMAL_BUILD STREQUAL "") OR (OQS_MINIMAL_BUILD STREQUAL "OFF")))
   # Set every OQS_ENABLE_* variable =OFF unless it one of the following.
   #  1. the switch for one of the requested minimal build algorithm's family, e.g OQS_ENABLE_KEM_KYBER
   #  2. the switch for one of the requested algorithms, e.g. OQS_ENABLE_KEM_kyber_768.

--- a/.CMake/alg_support.cmake
+++ b/.CMake/alg_support.cmake
@@ -565,42 +565,45 @@ endif()
 
 ##### OQS_COPY_FROM_UPSTREAM_FRAGMENT_ADD_ENABLE_BY_ALG_END
 
-if(${OQS_MINIMAL_BUILD})
-  # Set every OQS_ENABLE_* variable =OFF unless it one of the following.
-  #  1. the switch for the default algorithm's family, e.g OQS_ENABLE_KEM_KYBER
-  #  2. the switch for the default algorithm, e.g. OQS_ENABLE_KEM_kyber_768.
-  #  3. the switch for platform-specific ("_aesni" or "_avx2") implementation of
-  #     the default algorithm, e.g. OQS_ENABLE_KEM_kyber_768_avx2.
+if((OQS_MINIMAL_BUILD STREQUAL "ON"))
+   message(FATAL_ERROR "OQS_MINIMAL_BUILD option ${OQS_MINIMAL_BUILD} no longer supported")
+endif()
 
-  string(REPLACE "OQS_KEM_alg_" "OQS_ENABLE_KEM_" default_kem_switch ${OQS_KEM_DEFAULT})
-  string(REPLACE "OQS_SIG_alg_" "OQS_ENABLE_SIG_" default_sig_switch ${OQS_SIG_DEFAULT})
-  string(TOUPPER ${default_kem_switch} default_kem_switch_upper) # The default kem's family is a prefix of this string.
-  string(TOUPPER ${default_sig_switch} default_sig_switch_upper)
+if(NOT (OQS_MINIMAL_BUILD STREQUAL "OFF"))
+  # Set every OQS_ENABLE_* variable =OFF unless it one of the following.
+  #  1. the switch for one of the requested minimal build algorithm's family, e.g OQS_ENABLE_KEM_KYBER
+  #  2. the switch for one of the requested algorithms, e.g. OQS_ENABLE_KEM_kyber_768.
+  #  3. the switch for platform-specific ("_aesni" or "_avx2") implementation of
+  #     one of the requested algorithms, e.g. OQS_ENABLE_KEM_kyber_768_avx2.
 
   get_cmake_property(_vars VARIABLES)
   foreach (_var ${_vars})
       if(_var MATCHES "^OQS_ENABLE_..._" AND NOT _var MATCHES "_AVAILABLE$")
           set(${_var} OFF)
           # Case 1, family name
-          if(${default_kem_switch_upper} MATCHES "^${_var}"
-          OR ${default_sig_switch_upper} MATCHES "^${_var}")
-              set(${_var} ON)
-          endif()
+          foreach (_alg ${OQS_MINIMAL_BUILD})
+             string(TOUPPER ${_alg} upalg)
+             if(${upalg} MATCHES "^${_var}")
+                 set(${_var} ON)
+             endif()
+          endforeach()
           # Case 2, exact match
-          if(${_var}X STREQUAL ${default_kem_switch}X
-          OR ${_var}X STREQUAL ${default_sig_switch}X)
-              set(${_var} ON)
-          endif()
+          foreach (_alg ${OQS_MINIMAL_BUILD})
+             if(${_var}X STREQUAL ${_alg}X)
+                 set(${_var} ON)
+             endif()
+          endforeach()
           # Case 3, platform specific
           string(REPLACE "_aesni" "" _var_base ${_var})
           string(REPLACE "_avx2" "" _var_base ${_var_base})
           string(REPLACE "_avx" "" _var_base ${_var_base})
-          if(${_var}_AVAILABLE)
-              if(${_var_base}X STREQUAL ${default_kem_switch}X
-              OR ${_var_base}X STREQUAL ${default_sig_switch}X)
+          foreach (_alg ${OQS_MINIMAL_BUILD})
+            if(${_var}_AVAILABLE)
+              if(${_var_base}X STREQUAL ${_alg}X)
                   set(${_var} ON)
               endif()
-          endif()
+            endif()
+          endforeach()
       endif()
   endforeach()
 endif()

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
             mkdir build && cd build && source ~/.bashrc && \
             cmake .. --warn-uninitialized \
                      -GNinja << parameters.CMAKE_ARGS >> \
-                     -DOQS_MINIMAL_BUILD="OQS_KEM_alg_<< parameters.KEM_NAME >>;OQS_SIG_alg_<< parameters.SIG_NAME >>" \
+                     -DOQS_MINIMAL_BUILD="OQS_ENABLE_KEM_<< parameters.KEM_NAME >>;OQS_ENABLE_SIG_<< parameters.SIG_NAME >>" \
                      > config.log 2>&1 && \
             cat config.log && \
             cmake -LA .. && ! (grep "uninitialized variable" config.log)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,8 @@ jobs:
             mkdir build && cd build && source ~/.bashrc && \
             cmake .. --warn-uninitialized \
                      -GNinja << parameters.CMAKE_ARGS >> \
-                     -DOQS_MINIMAL_BUILD=ON \
-                     -DOQS_KEM_DEFAULT=OQS_KEM_alg_<< parameters.KEM_NAME >> \
-                     -DOQS_SIG_DEFAULT=OQS_SIG_alg_<< parameters.SIG_NAME >> > config.log 2>&1 && \
+                     -DOQS_MINIMAL_BUILD="OQS_KEM_alg_<< parameters.KEM_NAME >>;OQS_SIG_alg_<< parameters.SIG_NAME >>" \
+                     > config.log 2>&1 && \
             cat config.log && \
             cmake -LA .. && ! (grep "uninitialized variable" config.log)
       - run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ project(liboqs C ASM)
 
 option(OQS_DIST_BUILD "Build distributable library with optimized code for several CPU microarchitectures. Enables run-time CPU feature detection." OFF)
 option(OQS_BUILD_ONLY_LIB "Build only liboqs and do not expose build targets for tests, documentation, and pretty-printing available." OFF)
-set(OQS_MINIMAL_BUILD auto CACHE STRING "Only build specifically listed algorithms.")
+set(OQS_MINIMAL_BUILD "" CACHE STRING "Only build specifically listed algorithms.")
 option(OQS_PERMIT_UNSUPPORTED_ARCHITECTURE "Permit compilation on an an unsupported architecture." OFF)
 
 set(OQS_OPT_TARGET auto CACHE STRING "The target microarchitecture for optimization.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ project(liboqs C ASM)
 
 option(OQS_DIST_BUILD "Build distributable library with optimized code for several CPU microarchitectures. Enables run-time CPU feature detection." OFF)
 option(OQS_BUILD_ONLY_LIB "Build only liboqs and do not expose build targets for tests, documentation, and pretty-printing available." OFF)
-option(OQS_MINIMAL_BUILD  "Only build the default KEM and Signature schemes." OFF)
+option(OQS_MINIMAL_BUILD  "Only build specifically listed algorithms." OFF)
 option(OQS_PERMIT_UNSUPPORTED_ARCHITECTURE "Permit compilation on an an unsupported architecture." OFF)
 
 set(OQS_OPT_TARGET auto CACHE STRING "The target microarchitecture for optimization.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ project(liboqs C ASM)
 
 option(OQS_DIST_BUILD "Build distributable library with optimized code for several CPU microarchitectures. Enables run-time CPU feature detection." OFF)
 option(OQS_BUILD_ONLY_LIB "Build only liboqs and do not expose build targets for tests, documentation, and pretty-printing available." OFF)
-option(OQS_MINIMAL_BUILD  "Only build specifically listed algorithms." OFF)
+set(OQS_MINIMAL_BUILD auto CACHE STRING "Only build specifically listed algorithms.")
 option(OQS_PERMIT_UNSUPPORTED_ARCHITECTURE "Permit compilation on an an unsupported architecture." OFF)
 
 set(OQS_OPT_TARGET auto CACHE STRING "The target microarchitecture for optimization.")

--- a/scripts/copy_from_upstream/src/kem/kem.h/algs_length.fragment
+++ b/scripts/copy_from_upstream/src/kem/kem.h/algs_length.fragment
@@ -1,4 +1,4 @@
 {% set unary %}{% for family in instructions['kems'] %}{% for scheme in family['schemes'] %}1{% endfor %}{% endfor %}{% endset %}
 /** Number of algorithm identifiers above. */
-#define OQS_KEM_algs_length {{ unary|length + 25 }}
+#define OQS_KEM_algs_length {{ unary|length + 24 }}
 

--- a/scripts/copy_from_upstream/src/sig/sig.h/algs_length.fragment
+++ b/scripts/copy_from_upstream/src/sig/sig.h/algs_length.fragment
@@ -1,4 +1,4 @@
 {% set unary %}{% for family in instructions['sigs'] %}{% for scheme in family['schemes'] %}1{% endfor %}{% endfor %}{% endset %}
-/** Number of algorithm identifiers above (including default). */
-#define OQS_SIG_algs_length {{ unary|length + 13 }}
+/** Number of algorithm identifiers above. */
+#define OQS_SIG_algs_length {{ unary|length + 12 }}
 

--- a/src/kem/kem.c
+++ b/src/kem/kem.c
@@ -87,8 +87,7 @@ OQS_API int OQS_KEM_alg_count() {
 OQS_API int OQS_KEM_alg_is_enabled(const char *method_name) {
 	if (method_name == NULL) {
 		return 0;
-	}
-	else if (0 == strcasecmp(method_name, OQS_KEM_alg_bike_l1)) {
+	} else if (0 == strcasecmp(method_name, OQS_KEM_alg_bike_l1)) {
 #ifdef OQS_ENABLE_KEM_bike_l1
 		return 1;
 #else

--- a/src/kem/kem.c
+++ b/src/kem/kem.c
@@ -14,7 +14,6 @@
 OQS_API const char *OQS_KEM_alg_identifier(size_t i) {
 	// EDIT-WHEN-ADDING-KEM
 	const char *a[OQS_KEM_algs_length] = {
-		OQS_KEM_alg_default,
 		OQS_KEM_alg_bike_l1,
 		OQS_KEM_alg_bike_l3,
 		///// OQS_COPY_FROM_UPSTREAM_FRAGMENT_ALG_IDENTIFIER_START
@@ -89,9 +88,7 @@ OQS_API int OQS_KEM_alg_is_enabled(const char *method_name) {
 	if (method_name == NULL) {
 		return 0;
 	}
-	if (0 == strcasecmp(method_name, OQS_KEM_alg_default)) {
-		return OQS_KEM_alg_is_enabled(OQS_KEM_DEFAULT);
-	} else if (0 == strcasecmp(method_name, OQS_KEM_alg_bike_l1)) {
+	else if (0 == strcasecmp(method_name, OQS_KEM_alg_bike_l1)) {
 #ifdef OQS_ENABLE_KEM_bike_l1
 		return 1;
 #else
@@ -439,9 +436,7 @@ OQS_API OQS_KEM *OQS_KEM_new(const char *method_name) {
 	if (method_name == NULL) {
 		return NULL;
 	}
-	if (0 == strcasecmp(method_name, OQS_KEM_alg_default)) {
-		return OQS_KEM_new(OQS_KEM_DEFAULT);
-	} else if (0 == strcasecmp(method_name, OQS_KEM_alg_bike_l1)) {
+	if (0 == strcasecmp(method_name, OQS_KEM_alg_bike_l1)) {
 #ifdef OQS_ENABLE_KEM_bike_l1
 		return OQS_KEM_bike_l1_new();
 #else

--- a/src/kem/kem.h
+++ b/src/kem/kem.h
@@ -31,8 +31,6 @@
 extern "C" {
 #endif
 
-/** Algorithm identifier for default KEM algorithm. */
-#define OQS_KEM_alg_default "DEFAULT"
 /** Algorithm identifier for BIKE-L1 KEM (Round-3). */
 #define OQS_KEM_alg_bike_l1 "BIKE-L1"
 /** Algorithm identifier for BIKE-L3 KEM (Round-3). */
@@ -150,7 +148,7 @@ extern "C" {
 // EDIT-WHEN-ADDING-KEM
 ///// OQS_COPY_FROM_UPSTREAM_FRAGMENT_ALGS_LENGTH_START
 /** Number of algorithm identifiers above. */
-#define OQS_KEM_algs_length 57
+#define OQS_KEM_algs_length 56
 ///// OQS_COPY_FROM_UPSTREAM_FRAGMENT_ALGS_LENGTH_END
 
 /**

--- a/src/oqsconfig.h.cmake
+++ b/src/oqsconfig.h.cmake
@@ -11,9 +11,6 @@
 #cmakedefine ARCH_ARM64v8 1
 #cmakedefine ARCH_ARM32v7 1
 
-#cmakedefine OQS_KEM_DEFAULT @OQS_KEM_DEFAULT@
-#cmakedefine OQS_SIG_DEFAULT @OQS_SIG_DEFAULT@
-
 #cmakedefine OQS_USE_OPENSSL 1
 #cmakedefine OQS_USE_AES_OPENSSL 1
 #cmakedefine OQS_USE_SHA2_OPENSSL 1

--- a/src/sig/sig.c
+++ b/src/sig/sig.c
@@ -14,7 +14,6 @@
 OQS_API const char *OQS_SIG_alg_identifier(size_t i) {
 	// EDIT-WHEN-ADDING-SIG
 	const char *a[OQS_SIG_algs_length] = {
-		OQS_SIG_alg_default,
 		///// OQS_COPY_FROM_UPSTREAM_FRAGMENT_ALG_IDENTIFIER_START
 		OQS_SIG_alg_dilithium_2,
 		OQS_SIG_alg_dilithium_3,
@@ -98,8 +97,7 @@ OQS_API int OQS_SIG_alg_is_enabled(const char *method_name) {
 	if (method_name == NULL) {
 		return 0;
 	}
-	if (0 == strcasecmp(method_name, OQS_SIG_alg_default)) {
-		return OQS_SIG_alg_is_enabled(OQS_SIG_DEFAULT);
+	if (0) {
 		///// OQS_COPY_FROM_UPSTREAM_FRAGMENT_ENABLED_CASE_START
 	} else if (0 == strcasecmp(method_name, OQS_SIG_alg_dilithium_2)) {
 #ifdef OQS_ENABLE_SIG_dilithium_2
@@ -502,8 +500,7 @@ OQS_API OQS_SIG *OQS_SIG_new(const char *method_name) {
 	if (method_name == NULL) {
 		return NULL;
 	}
-	if (0 == strcasecmp(method_name, OQS_SIG_alg_default)) {
-		return OQS_SIG_new(OQS_SIG_DEFAULT);
+	if (0) {
 		///// OQS_COPY_FROM_UPSTREAM_FRAGMENT_NEW_CASE_START
 	} else if (0 == strcasecmp(method_name, OQS_SIG_alg_dilithium_2)) {
 #ifdef OQS_ENABLE_SIG_dilithium_2

--- a/src/sig/sig.h
+++ b/src/sig/sig.h
@@ -31,8 +31,6 @@
 extern "C" {
 #endif
 
-/** Algorithm identifier for default SIG algorithm. */
-#define OQS_SIG_alg_default "DEFAULT"
 /** Algorithm identifier for picnic_L1_FS */
 #define OQS_SIG_alg_picnic_L1_FS "picnic_L1_FS"
 /** Algorithm identifier for picnic_L1_UR */
@@ -168,7 +166,7 @@ extern "C" {
 // EDIT-WHEN-ADDING-SIG
 ///// OQS_COPY_FROM_UPSTREAM_FRAGMENT_ALGS_LENGTH_START
 /** Number of algorithm identifiers above (including default). */
-#define OQS_SIG_algs_length 66
+#define OQS_SIG_algs_length 65
 ///// OQS_COPY_FROM_UPSTREAM_FRAGMENT_ALGS_LENGTH_END
 
 /**

--- a/src/sig/sig.h
+++ b/src/sig/sig.h
@@ -165,7 +165,7 @@ extern "C" {
 ///// OQS_COPY_FROM_UPSTREAM_FRAGMENT_ALG_IDENTIFIER_END
 // EDIT-WHEN-ADDING-SIG
 ///// OQS_COPY_FROM_UPSTREAM_FRAGMENT_ALGS_LENGTH_START
-/** Number of algorithm identifiers above (including default). */
+/** Number of algorithm identifiers above. */
 #define OQS_SIG_algs_length 65
 ///// OQS_COPY_FROM_UPSTREAM_FRAGMENT_ALGS_LENGTH_END
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -48,8 +48,7 @@ def available_kems_by_name():
             if line.startswith("#define OQS_KEM_alg_"):
                 kem_name = line.split(' ')[2]
                 kem_name = kem_name[1:-2]
-                if kem_name != "DEFAULT":
-                    available_names.append(kem_name)
+                available_names.append(kem_name)
     return available_names
 
 def is_kem_enabled_by_name(name):
@@ -82,8 +81,7 @@ def available_sigs_by_name():
             if line.startswith("#define OQS_SIG_alg_"):
                 sig_name = line.split(' ')[2]
                 sig_name = sig_name[1:-2]
-                if sig_name != "DEFAULT":
-                    available_names.append(sig_name)
+                available_names.append(sig_name)
     return available_names
 
 def is_sig_enabled_by_name(name):


### PR DESCRIPTION
Begins to address #1043, retaining `OQS_MINIMAL_BUILD´ option: The latter now can be fed with a string of algorithms to be enabled, disabling all others.

Current state meant as intermediate state to check with @jschanck whether this approach is OK. If so, actual removal of DEFAULT algs will be added to this PR.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)
