### PR TITLE
removing BIKE R2 from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Details on each supported algorithm can be found in the [docs/algorithms folder]
 
 #### Key encapsulation mechanisms
 
-- **BIKE**: BIKE1-L1-CPA, BIKE1-L3-CPA, BIKE1-L1-FO, BIKE1-L3-FO
+- **BIKE**: BIKE-L1, BIKE-L3
 - **Classic McEliece**: Classic-McEliece-348864†, Classic-McEliece-348864f†, Classic-McEliece-460896†, Classic-McEliece-460896f†, Classic-McEliece-6688128†, Classic-McEliece-6688128f†, Classic-McEliece-6960119†, Classic-McEliece-6960119f†, Classic-McEliece-8192128†, Classic-McEliece-8192128f†
 - **FrodoKEM**: FrodoKEM-640-AES, FrodoKEM-640-SHAKE, FrodoKEM-976-AES, FrodoKEM-976-SHAKE, FrodoKEM-1344-AES, FrodoKEM-1344-SHAKE
 - **HQC**: HQC-128-1-CCA2, HQC-192-1-CCA2, HQC-192-2-CCA2, HQC-256-1-CCA2†, HQC-256-2-CCA2†, HQC-256-3-CCA2†


### PR DESCRIPTION
Correcting reference removal in #1045.
This intentionally does not fix the equally incorrect https://github.com/open-quantum-safe/liboqs/blob/main/docs/algorithms/kem/bike.md assuming that will be fixed soon by #1030.