### PR TITLE
Compile-time guard for some BIKE AVX2 and AVX512 code

### DIFF
--- a/src/kem/bike/CMakeLists.txt
+++ b/src/kem/bike/CMakeLists.txt
@@ -66,6 +66,8 @@ if(OQS_ENABLE_KEM_bike_l1 OR OQS_ENABLE_KEM_bike_l3)
         else()
             set(CPP_DEFS_R3 ${CPP_DEFS_R3} DISABLE_VPCLMUL)
         endif()
+    else()
+        set(CPP_DEFS_R3 ${CPP_DEFS_R3} DISABLE_VPCLMUL)
     endif()
 
     if(ARCH_X86_64)

--- a/src/kem/bike/additional_r3/decode_internal.h
+++ b/src/kem/bike/additional_r3/decode_internal.h
@@ -61,12 +61,15 @@ typedef struct decode_ctx_st {
 _INLINE_ void decode_ctx_init(decode_ctx *ctx)
 {
 #if defined(X86_64)
+#if defined(OQS_DIST_X86_64_BUILD) || defined(OQS_USE_AVX512_INSTRUCTIONS)
   if(is_avx512_enabled()) {
     ctx->rotate_right            = rotate_right_avx512;
     ctx->dup                     = dup_avx512;
     ctx->bit_sliced_adder        = bit_sliced_adder_avx512;
     ctx->bit_slice_full_subtract = bit_slice_full_subtract_avx512;
-  } else if(is_avx2_enabled()) {
+  } else 
+#endif
+  if(is_avx2_enabled()) {
     ctx->rotate_right            = rotate_right_avx2;
     ctx->dup                     = dup_avx2;
     ctx->bit_sliced_adder        = bit_sliced_adder_avx2;

--- a/src/kem/bike/additional_r3/decode_internal.h
+++ b/src/kem/bike/additional_r3/decode_internal.h
@@ -69,12 +69,14 @@ _INLINE_ void decode_ctx_init(decode_ctx *ctx)
     ctx->bit_slice_full_subtract = bit_slice_full_subtract_avx512;
   } else 
 #endif
+#if defined(OQS_DIST_X86_64_BUILD) || defined(OQS_USE_AVX2_INSTRUCTIONS)
   if(is_avx2_enabled()) {
     ctx->rotate_right            = rotate_right_avx2;
     ctx->dup                     = dup_avx2;
     ctx->bit_sliced_adder        = bit_sliced_adder_avx2;
     ctx->bit_slice_full_subtract = bit_slice_full_subtract_avx2;
   } else
+#endif
 #endif
   {
     ctx->rotate_right            = rotate_right_port;

--- a/src/kem/bike/additional_r3/gf2x_internal.h
+++ b/src/kem/bike/additional_r3/gf2x_internal.h
@@ -131,13 +131,16 @@ void gf2x_mod_mul_with_ctx(OUT pad_r_t *c,
 _INLINE_ void gf2x_ctx_init(gf2x_ctx *ctx)
 {
 #if defined(X86_64)
+#if defined(OQS_DIST_X86_64_BUILD) || defined(OQS_USE_AVX512_INSTRUCTIONS)
   if(is_avx512_enabled()) {
     ctx->karatzuba_add1 = karatzuba_add1_avx512;
     ctx->karatzuba_add2 = karatzuba_add2_avx512;
     ctx->karatzuba_add3 = karatzuba_add3_avx512;
     ctx->k_sqr          = k_sqr_avx512;
     ctx->red            = gf2x_red_avx512;
-  } else if(is_avx2_enabled()) {
+  } else
+#endif
+  if(is_avx2_enabled()) {
     ctx->karatzuba_add1 = karatzuba_add1_avx2;
     ctx->karatzuba_add2 = karatzuba_add2_avx2;
     ctx->karatzuba_add3 = karatzuba_add3_avx2;

--- a/src/kem/bike/additional_r3/gf2x_internal.h
+++ b/src/kem/bike/additional_r3/gf2x_internal.h
@@ -140,6 +140,7 @@ _INLINE_ void gf2x_ctx_init(gf2x_ctx *ctx)
     ctx->red            = gf2x_red_avx512;
   } else
 #endif
+#if defined(OQS_DIST_X86_64_BUILD) || defined(OQS_USE_AVX2_INSTRUCTIONS)
   if(is_avx2_enabled()) {
     ctx->karatzuba_add1 = karatzuba_add1_avx2;
     ctx->karatzuba_add2 = karatzuba_add2_avx2;
@@ -147,6 +148,7 @@ _INLINE_ void gf2x_ctx_init(gf2x_ctx *ctx)
     ctx->k_sqr          = k_sqr_avx2;
     ctx->red            = gf2x_red_avx2;
   } else
+#endif
 #endif
   {
     ctx->karatzuba_add1 = karatzuba_add1_port;
@@ -164,11 +166,13 @@ _INLINE_ void gf2x_ctx_init(gf2x_ctx *ctx)
     ctx->sqr             = gf2x_sqr_vpclmul;
   } else
 #  endif // DISABLE_VPCLMUL
+#if defined(OQS_DIST_X86_64_BUILD) || defined(OQS_USE_PCLMUL_INSTRUCTIONS)
   if(is_pclmul_enabled()) {
     ctx->mul_base_qwords = GF2X_PCLMUL_BASE_QWORDS;
     ctx->mul_base        = gf2x_mul_base_pclmul;
     ctx->sqr             = gf2x_sqr_pclmul;
   } else
+#endif
 #endif
   {
     ctx->mul_base_qwords = GF2X_PORT_BASE_QWORDS;

--- a/src/kem/bike/additional_r3/gf2x_internal.h
+++ b/src/kem/bike/additional_r3/gf2x_internal.h
@@ -166,7 +166,7 @@ _INLINE_ void gf2x_ctx_init(gf2x_ctx *ctx)
     ctx->sqr             = gf2x_sqr_vpclmul;
   } else
 #  endif // DISABLE_VPCLMUL
-#if defined(OQS_DIST_X86_64_BUILD) || defined(OQS_USE_PCLMUL_INSTRUCTIONS)
+#if defined(OQS_DIST_X86_64_BUILD) || defined(OQS_USE_PCLMULQDQ_INSTRUCTIONS)
   if(is_pclmul_enabled()) {
     ctx->mul_base_qwords = GF2X_PCLMUL_BASE_QWORDS;
     ctx->mul_base        = gf2x_mul_base_pclmul;

--- a/src/kem/bike/additional_r3/sampling_internal.h
+++ b/src/kem/bike/additional_r3/sampling_internal.h
@@ -52,10 +52,12 @@ _INLINE_ void sampling_ctx_init(sampling_ctx *ctx)
     ctx->is_new          = is_new_avx512;
   } else
 #endif
+#if defined(OQS_DIST_X86_64_BUILD) || defined(OQS_USE_AVX2_INSTRUCTIONS)
   if(is_avx2_enabled()) {
     ctx->secure_set_bits = secure_set_bits_avx2;
     ctx->is_new          = is_new_avx2;
   } else
+#endif
 #endif
   {
     ctx->secure_set_bits = secure_set_bits_port;

--- a/src/kem/bike/additional_r3/sampling_internal.h
+++ b/src/kem/bike/additional_r3/sampling_internal.h
@@ -46,10 +46,13 @@ typedef struct sampling_ctx_st {
 _INLINE_ void sampling_ctx_init(sampling_ctx *ctx)
 {
 #if defined(X86_64)
+#if defined(OQS_DIST_X86_64_BUILD) || defined(OQS_USE_AVX512_INSTRUCTIONS)
   if(is_avx512_enabled()) {
     ctx->secure_set_bits = secure_set_bits_avx512;
     ctx->is_new          = is_new_avx512;
-  } else if(is_avx2_enabled()) {
+  } else
+#endif
+  if(is_avx2_enabled()) {
     ctx->secure_set_bits = secure_set_bits_avx2;
     ctx->is_new          = is_new_avx2;
   } else


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
I encountered a BIKE build failure on a non-AVX512 platform. BIKE's run-time dispatch protects against calls to a AVX512-dependent function, but the reference to that AVX512-dependent function is present despite that function not being compiled, which was leading to a linker error.

@dkostic Can you review?