### PR TITLE
Use Github Actions for some CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,56 +118,6 @@ jobs:
       - store_artifacts:
           path: build/test-results
 
-  arm_emulated:
-    description: A template for running liboqs tests on emulated ARM Docker VMs
-    parameters:
-      ARCH:
-        description: "The desired ARM architecture to be emulated."
-        type: string
-      CMAKE_ARGS:
-        description: "Arguments to pass to CMake."
-        type: string
-      PYTEST_ARGS:
-        description: "Arguments to pass to pytest."
-        type: string
-    machine:
-      image: ubuntu-1604:201903-01
-    steps:
-      - checkout
-      - run:
-          name: Install the emulation handlers
-          command: docker run --rm --privileged multiarch/qemu-user-static:register --reset
-      - run:
-          name: Build in an x86_64 container
-          command: |2
-            docker run --rm \
-                       -v `pwd`:`pwd` \
-                       -w `pwd` \
-                       openquantumsafe/ci-debian-buster-amd64:latest /bin/bash \
-                       -c "mkdir build && \
-                           (cd build && \
-                            cmake .. -GNinja << parameters.CMAKE_ARGS >> \
-                                     -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_<< parameters.ARCH >>.cmake && \
-                            cmake -LA .. && \
-                            ninja)"
-      - run:
-          name: Run the tests in an << parameters.ARCH >> container
-          command: |2
-            docker run --rm -e SKIP_TESTS=style,mem_kem,mem_sig \
-                            -v `pwd`:`pwd` \
-                            -w `pwd` \
-                            openquantumsafe/ci-debian-buster-<< parameters.ARCH >>:latest /bin/bash \
-                            -c "mkdir -p tmp && \
-                                python3 -m pytest --verbose \
-                                                  --numprocesses=auto \
-                                                  << parameters.PYTEST_ARGS >> \
-                                                  --ignore=tests/test_code_conventions.py \
-                                                  --junitxml=build/test-results/pytest/test-results.xml"
-      - store_test_results:
-          path: build/test-results
-      - store_artifacts:
-          path: build/test-results
-
   arm_machine:
     description: A template for running liboqs tests on ARM(presently only 64) machines
     parameters:
@@ -339,20 +289,6 @@ workflows:
       #- testapproval:
       #    <<: *require_buildcheck
       #    type: approval
-      - linux_oqs:
-          <<: *require_buildcheck
-          name: alpine-noopenssl
-          context: openquantumsafe
-          CONTAINER: openquantumsafe/ci-alpine-amd64:latest
-          CMAKE_ARGS: -DOQS_USE_OPENSSL=OFF
-          PYTEST_ARGS: --ignore=tests/test_alg_info.py
-      - linux_oqs:
-          <<: *require_buildcheck
-          name: alpine
-          context: openquantumsafe
-          CONTAINER: openquantumsafe/ci-alpine-amd64:latest
-          CMAKE_ARGS: -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON
-          PYTEST_ARGS: --ignore=tests/test_alg_info.py
       # Disabling centos-8 and debian-buster.
       # Re-enable if specific configurations (package versions etc) that need to be tested are identified.
       #- linux_oqs:
@@ -385,17 +321,6 @@ workflows:
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
           CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9
-      - linux_oqs:
-          <<: *require_buildcheck
-          name: address-sanitizer
-          context: openquantumsafe
-          filters:
-            branches:
-              only:
-                - /^audit.*/
-          CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-          CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address
-          PYTEST_ARGS: --ignore=tests/test_portability.py --numprocesses=auto --maxprocesses=10
       - linux_oqs:
           <<: *require_buildcheck
           name: ubuntu-bionic-i386
@@ -436,30 +361,11 @@ workflows:
       #    PYTEST_ARGS: --numprocesses=1
       # SPHINCS exhausts memory on CircleCI servers
       # for these configurations.
-      # don't run ARM64 emulated any more:
-      #- arm_emulated:
-      #    <<: *require_buildcheck
-      #    name: arm64
-      #    ARCH: arm64
-      #    CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_DIST_BUILD=ON
       - arm_machine:
           <<: *require_buildcheck
           name: arm64
           PYTEST_ARGS: --numprocesses=auto --maxprocesses=10
           CMAKE_ARGS: -DOQS_DIST_BUILD=ON
-      - arm_emulated:
-          <<: *require_buildcheck
-          name: armhf
-          ARCH: armhf
-          CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
-          PYTEST_ARGS: --ignore=tests/test_alg_info.py
-      # Disabling armel
-      #- arm_emulated:
-      #    <<: *require_buildcheck
-      #    name: armel
-      #    ARCH: armel
-      #    CMAKE_ARGS:  -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
-
       - macOS:
           <<: *require_buildcheck
           name: macOS-noopenssl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,8 +322,11 @@ workflows:
   version: 2.1
   build:
     when:
-      not:
-        equal: [ main, << pipeline.git.branch >> ]
+      and:
+        - not:
+            equal: [ main, << pipeline.git.branch >> ]
+        - not:
+            matches: { pattern: "^ghactionsonly-.*", value: << pipeline.git.branch >> }
     jobs:
       - stylecheck
       - buildcheck:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,11 +1,14 @@
 name: Linux tests
+
 on: [push]
+
 jobs:
+
   stylecheck:
     name: Check code formatting
     container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
     runs-on: ubuntu-latest
-    if: 
+    if: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -13,10 +16,12 @@ jobs:
         run: python3 -m pytest --verbose tests/test_code_conventions.py
       - name: Check that doxygen can parse the documentation
         run: mkdir -p build/docs && doxygen docs/.Doxyfile
+
   buildcheck:
     name: Check that code passes a basic build before starting heavier tests
     container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
     # needs: stylecheck
+    if: false
     runs-on: ubuntu-latest
     env:
       KEM_NAME: kyber_768
@@ -38,3 +43,21 @@ jobs:
       - name: Build
         run: ninja
         working-directory: build
+
+  alpine:
+    container: openquantumsafe/ci-alpine-amd64:latest
+    # needs: [stylecheck, buildcheck]
+    runs-on: ubuntu-latest
+    env:
+      CMAKE_ARGS: -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Configure
+        run: mkdir build && cd build && source ~/.bashrc && cmake -GNinja $CMAKE_ARGS .. && cmake -LA ..
+      - name: Build
+        command: ninja
+        working-directory: build
+      - name: Run tests
+        timeout-minutes: 60
+        run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py $PYTEST_ARGS

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,45 +4,43 @@ on: [push]
 
 jobs:
 
-  stylecheck:
-    name: Check code formatting
-    container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-    runs-on: ubuntu-latest
-    if: false
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Ensure code conventions are upheld
-        run: python3 -m pytest --verbose tests/test_code_conventions.py
-      - name: Check that doxygen can parse the documentation
-        run: mkdir -p build/docs && doxygen docs/.Doxyfile
-
-  buildcheck:
-    name: Check that code passes a basic build before starting heavier tests
-    container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-    # needs: stylecheck
-    if: false
-    runs-on: ubuntu-latest
-    env:
-      KEM_NAME: kyber_768
-      SIG_NAME: dilithium_3
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Configure
-        run: |
-          mkdir build && \
-          cd build && \
-          cmake .. --warn-uninitialized \
-                   -GNinja \
-                   -DOQS_MINIMAL_BUILD="OQS_ENABLE_KEM_$KEM_NAME;OQS_ENABLE_SIG_$SIG_NAME" \
-                   > config.log 2>&1 && \
-          cat config.log && \
-          cmake -LA .. && \
-          ! (grep "uninitialized variable" config.log)
-      - name: Build
-        run: ninja
-        working-directory: build
+  # stylecheck:
+  #   name: Check code formatting
+  #   container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
+  #     - name: Ensure code conventions are upheld
+  #       run: python3 -m pytest --verbose tests/test_code_conventions.py
+  #     - name: Check that doxygen can parse the documentation
+  #       run: mkdir -p build/docs && doxygen docs/.Doxyfile
+  # 
+  # buildcheck:
+  #   name: Check that code passes a basic build before starting heavier tests
+  #   container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+  #   # needs: stylecheck
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     KEM_NAME: kyber_768
+  #     SIG_NAME: dilithium_3
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
+  #     - name: Configure
+  #       run: |
+  #         mkdir build && \
+  #         cd build && \
+  #         cmake .. --warn-uninitialized \
+  #                  -GNinja \
+  #                  -DOQS_MINIMAL_BUILD="OQS_ENABLE_KEM_$KEM_NAME;OQS_ENABLE_SIG_$SIG_NAME" \
+  #                  > config.log 2>&1 && \
+  #         cat config.log && \
+  #         cmake -LA .. && \
+  #         ! (grep "uninitialized variable" config.log)
+  #     - name: Build
+  #       run: ninja
+  #       working-directory: build
 
   alpine:
     container: openquantumsafe/ci-alpine-amd64:latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,6 +3,7 @@ on: [push]
 jobs:
   stylecheck:
     container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,43 +4,45 @@ on: [push]
 
 jobs:
 
-  # stylecheck:
-  #   name: Check code formatting
-  #   container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
-  #     - name: Ensure code conventions are upheld
-  #       run: python3 -m pytest --verbose tests/test_code_conventions.py
-  #     - name: Check that doxygen can parse the documentation
-  #       run: mkdir -p build/docs && doxygen docs/.Doxyfile
-  # 
-  # buildcheck:
-  #   name: Check that code passes a basic build before starting heavier tests
-  #   container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-  #   # needs: stylecheck
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     KEM_NAME: kyber_768
-  #     SIG_NAME: dilithium_3
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
-  #     - name: Configure
-  #       run: |
-  #         mkdir build && \
-  #         cd build && \
-  #         cmake .. --warn-uninitialized \
-  #                  -GNinja \
-  #                  -DOQS_MINIMAL_BUILD="OQS_ENABLE_KEM_$KEM_NAME;OQS_ENABLE_SIG_$SIG_NAME" \
-  #                  > config.log 2>&1 && \
-  #         cat config.log && \
-  #         cmake -LA .. && \
-  #         ! (grep "uninitialized variable" config.log)
-  #     - name: Build
-  #       run: ninja
-  #       working-directory: build
+  stylecheck:
+    name: Check code formatting
+    container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+    runs-on: ubuntu-latest
+    if: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Ensure code conventions are upheld
+        run: python3 -m pytest --verbose tests/test_code_conventions.py
+      - name: Check that doxygen can parse the documentation
+        run: mkdir -p build/docs && doxygen docs/.Doxyfile
+
+  buildcheck:
+    name: Check that code passes a basic build before starting heavier tests
+    container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+    # needs: stylecheck
+    if: false
+    runs-on: ubuntu-latest
+    env:
+      KEM_NAME: kyber_768
+      SIG_NAME: dilithium_3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Configure
+        run: |
+          mkdir build && \
+          cd build && \
+          cmake .. --warn-uninitialized \
+                   -GNinja \
+                   -DOQS_MINIMAL_BUILD="OQS_ENABLE_KEM_$KEM_NAME;OQS_ENABLE_SIG_$SIG_NAME" \
+                   > config.log 2>&1 && \
+          cat config.log && \
+          cmake -LA .. && \
+          ! (grep "uninitialized variable" config.log)
+      - name: Build
+        run: ninja
+        working-directory: build
 
   alpine:
     container: openquantumsafe/ci-alpine-amd64:latest
@@ -54,7 +56,7 @@ jobs:
       - name: Configure
         run: mkdir build && cd build && source ~/.bashrc && cmake -GNinja $CMAKE_ARGS .. && cmake -LA ..
       - name: Build
-        command: ninja
+        run: ninja
         working-directory: build
       - name: Run tests
         timeout-minutes: 60

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,19 +2,6 @@ name: Linux tests
 
 on: [push]
 
-template_linux_build_steps:
-  steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Configure
-      run: mkdir build && cd build && cmake -GNinja $CMAKE_ARGS .. && cmake -LA ..
-    - name: Build
-      run: ninja
-      working-directory: build
-    - name: Run tests
-      timeout-minutes: 60
-      run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py $PYTEST_ARGS
-
 jobs:
 
   stylecheck:
@@ -61,14 +48,19 @@ jobs:
     container: openquantumsafe/ci-alpine-amd64:latest
     # needs: [stylecheck, buildcheck]
     runs-on: ubuntu-latest
-    env:
-      CMAKE_ARGS: -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON
-    <<: *template_linux_build_steps
-
-  alpine-noopenssl:
-    container: openquantumsafe/ci-alpine-amd64:latest
-    # needs: [stylecheck, buildcheck]
-    runs-on: ubuntu-latest
-    env:
-      CMAKE_ARGS: -DOQS_USE_OPENSSL=OFF
-    <<: *template_linux_build_steps
+    strategy:
+      matrix:
+        CMAKE_ARGS:
+          - "-DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON"
+          - "-DOQS_USE_OPENSSL=OFF"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Configure
+        run: mkdir build && cd build && cmake -GNinja $CMAKE_ARGS .. && cmake -LA ..
+      - name: Build
+        run: ninja
+        working-directory: build
+      - name: Run tests
+        timeout-minutes: 60
+        run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py $PYTEST_ARGS

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Configure
-        run: mkdir build && cd build && cmake -GNinja $CMAKE_ARGS .. && cmake -LA ..
+        run: mkdir build && cd build && cmake -GNinja ${{ matrix.CMAKE_ARGS }} .. && cmake -LA ..
       - name: Build
         run: ninja
         working-directory: build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -46,8 +46,10 @@ jobs:
 
   linux_intel:
     # needs: [stylecheck, buildcheck]
+    if: false
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: alpine
@@ -58,10 +60,11 @@ jobs:
             container: openquantumsafe/ci-alpine-amd64:latest
             CMAKE_ARGS: -DOQS_USE_OPENSSL=OFF
             PYTEST_ARGS: ""
-          - name: address-sanitizer
-            container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-            CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address
-            PYTEST_ARGS: --ignore=tests/test_portability.py --numprocesses=auto --maxprocesses=10
+          # disabled until #1067 lands
+          # - name: address-sanitizer
+          #   container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+          #   CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address
+          #   PYTEST_ARGS: --ignore=tests/test_portability.py --numprocesses=auto --maxprocesses=10
     container:
       image: ${{ matrix.container }}
     steps:
@@ -75,3 +78,45 @@ jobs:
       - name: Run tests
         timeout-minutes: 60
         run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}
+
+  linux_arm_emulated:
+    # needs: [stylecheck, buildcheck]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: armhf
+            ARCH: armhf
+            CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
+          # - name: armel
+          #   ARCH: armel
+          #   CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install the emulation handlers
+        run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      - name: Build in an x86_64 container
+        run: |
+          docker run --rm \
+                     -v `pwd`:`pwd` \
+                     -w `pwd` \
+                     openquantumsafe/ci-debian-buster-amd64:latest /bin/bash \
+                     -c "mkdir build && \
+                         (cd build && \
+                          cmake .. -GNinja ${{ matrix.CMAKE_ARGS }} \
+                                   -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_${{ matrix.ARCH }}.cmake && \
+                          cmake -LA .. && \
+                          ninja)"
+      - name: Run the tests in an ${{ matrix.ARCH }} container
+        timeout-minutes: 60
+        run: |
+          docker run --rm -e SKIP_TESTS=style,mem_kem,mem_sig \
+                          -v `pwd`:`pwd` \
+                          -w `pwd` \
+                          openquantumsafe/ci-debian-buster-${{ matrix.ARCH }}:latest /bin/bash \
+                          -c "mkdir -p tmp && \
+                              python3 -m pytest --verbose \
+                                                --numprocesses=auto \
+                                                --ignore=tests/test_code_conventions.py"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Configure
-        run: mkdir build && cd build && source ~/.bashrc && cmake -GNinja $CMAKE_ARGS .. && cmake -LA ..
+        run: mkdir build && cd build && cmake -GNinja $CMAKE_ARGS .. && cmake -LA ..
       - name: Build
         run: ninja
         working-directory: build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,4 +34,4 @@ jobs:
           cmake -LA .. && ! (grep "uninitialized variable" config.log)
       - name: Build
         run: ninja
-        working_directory: build
+        working-directory: build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,19 @@ name: Linux tests
 
 on: [push]
 
+template_linux_build_steps:
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Configure
+      run: mkdir build && cd build && cmake -GNinja $CMAKE_ARGS .. && cmake -LA ..
+    - name: Build
+      run: ninja
+      working-directory: build
+    - name: Run tests
+      timeout-minutes: 60
+      run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py $PYTEST_ARGS
+
 jobs:
 
   stylecheck:
@@ -50,14 +63,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CMAKE_ARGS: -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Configure
-        run: mkdir build && cd build && cmake -GNinja $CMAKE_ARGS .. && cmake -LA ..
-      - name: Build
-        run: ninja
-        working-directory: build
-      - name: Run tests
-        timeout-minutes: 60
-        run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py $PYTEST_ARGS
+    <<: *template_linux_build_steps
+
+  alpine-noopenssl:
+    container: openquantumsafe/ci-alpine-amd64:latest
+    # needs: [stylecheck, buildcheck]
+    runs-on: ubuntu-latest
+    env:
+      CMAKE_ARGS: -DOQS_USE_OPENSSL=OFF
+    <<: *template_linux_build_steps

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,6 @@ jobs:
     name: Check code formatting
     container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
     runs-on: ubuntu-latest
-    if: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -20,8 +19,7 @@ jobs:
   buildcheck:
     name: Check that code passes a basic build before starting heavier tests
     container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-    # needs: stylecheck
-    if: false
+    needs: stylecheck
     runs-on: ubuntu-latest
     env:
       KEM_NAME: kyber_768
@@ -45,8 +43,7 @@ jobs:
         working-directory: build
 
   linux_intel:
-    # needs: [stylecheck, buildcheck]
-    if: false
+    needs: [stylecheck, buildcheck]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -55,11 +52,11 @@ jobs:
           - name: alpine
             container: openquantumsafe/ci-alpine-amd64:latest
             CMAKE_ARGS: -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON
-            PYTEST_ARGS: ""
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py
           - name: alpine-noopenssl
             container: openquantumsafe/ci-alpine-amd64:latest
             CMAKE_ARGS: -DOQS_USE_OPENSSL=OFF
-            PYTEST_ARGS: ""
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py
           # disabled until #1067 lands
           # - name: address-sanitizer
           #   container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
@@ -80,7 +77,7 @@ jobs:
         run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}
 
   linux_arm_emulated:
-    # needs: [stylecheck, buildcheck]
+    needs: [stylecheck, buildcheck]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -89,6 +86,7 @@ jobs:
           - name: armhf
             ARCH: armhf
             CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
+          # no longer supporting armel
           # - name: armel
           #   ARCH: armel
           #   CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -44,15 +44,26 @@ jobs:
         run: ninja
         working-directory: build
 
-  alpine:
-    container: openquantumsafe/ci-alpine-amd64:latest
+  linux_intel:
     # needs: [stylecheck, buildcheck]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        CMAKE_ARGS:
-          - "-DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON"
-          - "-DOQS_USE_OPENSSL=OFF"
+        include:
+          - name: alpine
+            container: openquantumsafe/ci-alpine-amd64:latest
+            CMAKE_ARGS: -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON
+            PYTEST_ARGS: ""
+          - name: alpine-noopenssl
+            container: openquantumsafe/ci-alpine-amd64:latest
+            CMAKE_ARGS: -DOQS_USE_OPENSSL=OFF
+            PYTEST_ARGS: ""
+          - name: address-sanitizer
+            container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+            CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address
+            PYTEST_ARGS: --ignore=tests/test_portability.py --numprocesses=auto --maxprocesses=10
+    container:
+      image: ${{ matrix.container }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -63,4 +74,4 @@ jobs:
         working-directory: build
       - name: Run tests
         timeout-minutes: 60
-        run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py $PYTEST_ARGS
+        run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,7 @@ name: Linux tests
 on: [push]
 jobs:
   stylecheck:
+    name: Check code formatting
     container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
     runs-on: ubuntu-latest
     steps:
@@ -11,3 +12,26 @@ jobs:
         run: python3 -m pytest --verbose tests/test_code_conventions.py
       - name: Check that doxygen can parse the documentation
         run: mkdir -p build/docs && doxygen docs/.Doxyfile
+  buildcheck:
+    name: Check that code passes a basic build before starting heavier tests
+    container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+    needs: stylecheck
+    runs-on: ubuntu-latest
+    env:
+      KEM_NAME: kyber_768
+      SIG_NAME: dilithium_3
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Configure
+        run: |
+          mkdir build && cd build && source ~/.bashrc && \
+          cmake .. --warn-uninitialized \
+                   -GNinja << parameters.CMAKE_ARGS >> \
+                   -DOQS_MINIMAL_BUILD="OQS_ENABLE_KEM_${KEM_NAME};OQS_ENABLE_SIG_${SIG_NAME}" \
+                   > config.log 2>&1 && \
+          cat config.log && \
+          cmake -LA .. && ! (grep "uninitialized variable" config.log)
+      - name: Build
+        run: ninja
+        working_directory: build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -86,6 +86,7 @@ jobs:
           - name: armhf
             ARCH: armhf
             CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py
           # no longer supporting armel
           # - name: armel
           #   ARCH: armel
@@ -117,4 +118,4 @@ jobs:
                           -c "mkdir -p tmp && \
                               python3 -m pytest --verbose \
                                                 --numprocesses=auto \
-                                                --ignore=tests/test_code_conventions.py"
+                                                --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,12 @@
+name: Linux tests
+on: [push]
+jobs:
+  stylecheck:
+    container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Ensure code conventions are upheld
+        run: python3 -m pytest --verbose tests/test_code_conventions.py
+      - name: Check that doxygen can parse the documentation
+        run: mkdir -p build/docs && doxygen docs/.Doxyfile

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,6 +5,7 @@ jobs:
     name: Check code formatting
     container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
     runs-on: ubuntu-latest
+    if: 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -28,7 +29,7 @@ jobs:
           mkdir build && \
           cd build && \
           cmake .. --warn-uninitialized \
-                   -GNinja << parameters.CMAKE_ARGS >> \
+                   -GNinja \
                    -DOQS_MINIMAL_BUILD="OQS_ENABLE_KEM_$KEM_NAME;OQS_ENABLE_SIG_$SIG_NAME" \
                    > config.log 2>&1 && \
           cat config.log && \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ jobs:
   buildcheck:
     name: Check that code passes a basic build before starting heavier tests
     container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-    needs: stylecheck
+    # needs: stylecheck
     runs-on: ubuntu-latest
     env:
       KEM_NAME: kyber_768
@@ -25,13 +25,15 @@ jobs:
         uses: actions/checkout@v2
       - name: Configure
         run: |
-          mkdir build && cd build && source ~/.bashrc && \
+          mkdir build && \
+          cd build && \
           cmake .. --warn-uninitialized \
                    -GNinja << parameters.CMAKE_ARGS >> \
                    -DOQS_MINIMAL_BUILD="OQS_ENABLE_KEM_${KEM_NAME};OQS_ENABLE_SIG_${SIG_NAME}" \
                    > config.log 2>&1 && \
           cat config.log && \
-          cmake -LA .. && ! (grep "uninitialized variable" config.log)
+          cmake -LA .. && \
+          ! (grep "uninitialized variable" config.log)
       - name: Build
         run: ninja
         working-directory: build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ jobs:
           cd build && \
           cmake .. --warn-uninitialized \
                    -GNinja << parameters.CMAKE_ARGS >> \
-                   -DOQS_MINIMAL_BUILD="OQS_ENABLE_KEM_${KEM_NAME};OQS_ENABLE_SIG_${SIG_NAME}" \
+                   -DOQS_MINIMAL_BUILD="OQS_ENABLE_KEM_$KEM_NAME;OQS_ENABLE_SIG_$SIG_NAME" \
                    > config.log 2>&1 && \
           cat config.log && \
           cmake -LA .. && \

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ jobs:
       os: linux             # required for arch different than amd64
       dist: focal           # or bionic | xenial with xenial as default
       compiler: gcc
+      if: NOT branch =~ /^ghactionsonly-/
       script:
         - mkdir build && cd build && cmake -GNinja .. && cmake -LA .. && ninja
         - cd build & ninja run_tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ platform: x64
 branches:
   except:
     - /main-new-.*/
+    - /ghactionsonly-.*/
 
 environment:
   matrix:


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
In hopes of partially alleviating pressure on our CircleCI quota as per #1025, this PR switches some jobs to use Github Actions rather than CircleCI.  In particular, I've started off with more "standalone" type jobs, which include:
- alpine (2 jobs - with OpenSSL and without)
- address sanitizer (1 job) (currently disabled until #1067 lands)
- ARM emulation jobs (1 job - armhf)

Nothing stops us from moving other jobs over as well, such as the main Ubuntu x86_64 and i386 jobs, or the macOS jobs, or even the Windows jobs.  But I wanted to get initial feedback and discussion of strategy.  This currently doesn't affect triggering of downstream jobs (when a merge to main happens) or Travis/Appveyor (except for filtering branches of the form `ghactionsonly-*` from being run on those other CI platforms, allowing us to test just this one CI system).

Although the build shows as red, if the only failure is CircleCI, then that's due to there being no jobs that are meant to be run on CircleCI due to the `ghactionsonly-*` filtering currently going on.  That problem should not be present on other branches.