### PR TITLE
Fix a bug where intrinsics were ignored when compiling for apple silicon

### DIFF
--- a/.CMake/detect_gcc_clang_intrinsics.c
+++ b/.CMake/detect_gcc_clang_intrinsics.c
@@ -54,7 +54,7 @@ int main(void) {
 #if defined(__ARM_FEATURE_AES)
 	printf("ARM_AES;");
 #endif
-#if defined(__ARM_FEATURE_SHA2)
+#if (defined(__APPLE__) && defined(__aarch64__)) || defined(__ARM_FEATURE_SHA2)
 	printf("ARM_SHA2;");
 #endif
 #if defined(__ARM_FEATURE_SHA3)

--- a/tests/system_info.c
+++ b/tests/system_info.c
@@ -186,6 +186,8 @@ static void print_oqs_configuration(void) {
 #endif
 #if defined(OQS_USE_SHA2_OPENSSL)
 	printf("SHA-2:            OpenSSL\n");
+#elif defined(OQS_USE_ARM_SHA2_INSTRUCTIONS)
+	printf("SHA-2:            C and ARM CRYPTO extensions\n");
 #else
 	printf("SHA-2:            C\n");
 #endif


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
This pr fixes an issue for apple silicon compile-time feature detection.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
Replaces #1073.
