### PR TITLE
Added seeds for Falcon 1024 and 512

### DIFF
--- a/src/sig/falcon/pqclean_falcon-1024_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-1024_avx2/api.h
@@ -19,7 +19,7 @@
  * Return value: 0 on success, -1 on error.
  */
 int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(
-    uint8_t *pk, uint8_t *sk);
+    uint8_t *pk, uint8_t *sk, uint8_t *seed, size_t seedlen);
 
 /*
  * Compute a signature on a provided message (m, mlen), with a given

--- a/src/sig/falcon/pqclean_falcon-1024_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-1024_avx2/pqclean.c
@@ -41,7 +41,7 @@
 
 /* see api.h */
 int
-PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(unsigned char *pk, unsigned char *sk) {
+PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(unsigned char *pk, unsigned char *sk, unsigned char *seed, size_t seedlen) {
     union {
         uint8_t b[28 * 1024];
         uint64_t dummy_u64;
@@ -49,7 +49,6 @@ PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(unsigned char *pk, unsigned char *sk
     } tmp;
     int8_t f[1024], g[1024], F[1024], G[1024];
     uint16_t h[1024];
-    unsigned char seed[SEEDLEN];
     inner_shake256_context rng;
     size_t u, v;
 
@@ -57,9 +56,8 @@ PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(unsigned char *pk, unsigned char *sk
     /*
      * Generate key pair.
      */
-    randombytes(seed, sizeof seed);
     inner_shake256_init(&rng);
-    inner_shake256_inject(&rng, seed, sizeof seed);
+    inner_shake256_inject(&rng, seed, seedlen);
     inner_shake256_flip(&rng);
     PQCLEAN_FALCON1024_AVX2_keygen(&rng, f, g, F, G, h, 10, tmp.b);
     inner_shake256_ctx_release(&rng);

--- a/src/sig/falcon/pqclean_falcon-1024_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-1024_clean/api.h
@@ -19,7 +19,7 @@
  * Return value: 0 on success, -1 on error.
  */
 int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(
-    uint8_t *pk, uint8_t *sk);
+    uint8_t *pk, uint8_t *sk, uint8_t *seed, size_t seedlen);
 
 /*
  * Compute a signature on a provided message (m, mlen), with a given

--- a/src/sig/falcon/pqclean_falcon-1024_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-1024_clean/pqclean.c
@@ -41,7 +41,7 @@
 
 /* see api.h */
 int
-PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(unsigned char *pk, unsigned char *sk) {
+PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(unsigned char *pk, unsigned char *sk, unsigned char *seed, size_t seedlen) {
     union {
         uint8_t b[28 * 1024];
         uint64_t dummy_u64;
@@ -49,7 +49,6 @@ PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(unsigned char *pk, unsigned char *s
     } tmp;
     int8_t f[1024], g[1024], F[1024], G[1024];
     uint16_t h[1024];
-    unsigned char seed[SEEDLEN];
     inner_shake256_context rng;
     size_t u, v;
 
@@ -57,9 +56,8 @@ PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(unsigned char *pk, unsigned char *s
     /*
      * Generate key pair.
      */
-    randombytes(seed, sizeof seed);
     inner_shake256_init(&rng);
-    inner_shake256_inject(&rng, seed, sizeof seed);
+    inner_shake256_inject(&rng, seed, seedlen);
     inner_shake256_flip(&rng);
     PQCLEAN_FALCON1024_CLEAN_keygen(&rng, f, g, F, G, h, 10, tmp.b);
     inner_shake256_ctx_release(&rng);

--- a/src/sig/falcon/pqclean_falcon-512_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-512_avx2/api.h
@@ -19,7 +19,7 @@
  * Return value: 0 on success, -1 on error.
  */
 int PQCLEAN_FALCON512_AVX2_crypto_sign_keypair(
-    uint8_t *pk, uint8_t *sk);
+    uint8_t *pk, uint8_t *sk, uint8_t *seed, size_t seedlen);
 
 /*
  * Compute a signature on a provided message (m, mlen), with a given

--- a/src/sig/falcon/pqclean_falcon-512_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-512_avx2/pqclean.c
@@ -41,7 +41,7 @@
 
 /* see api.h */
 int
-PQCLEAN_FALCON512_AVX2_crypto_sign_keypair(unsigned char *pk, unsigned char *sk) {
+PQCLEAN_FALCON512_AVX2_crypto_sign_keypair(unsigned char *pk, unsigned char *sk, unsigned char* seed, size_t seedlen) {
     union {
         uint8_t b[FALCON_KEYGEN_TEMP_9];
         uint64_t dummy_u64;
@@ -49,16 +49,14 @@ PQCLEAN_FALCON512_AVX2_crypto_sign_keypair(unsigned char *pk, unsigned char *sk)
     } tmp;
     int8_t f[512], g[512], F[512];
     uint16_t h[512];
-    unsigned char seed[SEEDLEN];
     inner_shake256_context rng;
     size_t u, v;
 
     /*
      * Generate key pair.
      */
-    randombytes(seed, sizeof seed);
     inner_shake256_init(&rng);
-    inner_shake256_inject(&rng, seed, sizeof seed);
+    inner_shake256_inject(&rng, seed, seedlen);
     inner_shake256_flip(&rng);
     PQCLEAN_FALCON512_AVX2_keygen(&rng, f, g, F, NULL, h, 9, tmp.b);
     inner_shake256_ctx_release(&rng);

--- a/src/sig/falcon/pqclean_falcon-512_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-512_clean/api.h
@@ -19,7 +19,7 @@
  * Return value: 0 on success, -1 on error.
  */
 int PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(
-    uint8_t *pk, uint8_t *sk);
+    uint8_t *pk, uint8_t *sk, uint8_t *seed, size_t seedlen);
 
 /*
  * Compute a signature on a provided message (m, mlen), with a given

--- a/src/sig/falcon/pqclean_falcon-512_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-512_clean/pqclean.c
@@ -41,7 +41,7 @@
 
 /* see api.h */
 int
-PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(unsigned char *pk, unsigned char *sk) {
+PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(unsigned char *pk, unsigned char *sk, unsigned char* seed, size_t seedlen) {
     union {
         uint8_t b[FALCON_KEYGEN_TEMP_9];
         uint64_t dummy_u64;
@@ -49,16 +49,14 @@ PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(unsigned char *pk, unsigned char *sk
     } tmp;
     int8_t f[512], g[512], F[512];
     uint16_t h[512];
-    unsigned char seed[SEEDLEN];
     inner_shake256_context rng;
     size_t u, v;
 
     /*
      * Generate key pair.
      */
-    randombytes(seed, sizeof seed);
     inner_shake256_init(&rng);
-    inner_shake256_inject(&rng, seed, sizeof seed);
+    inner_shake256_inject(&rng, seed, seedlen);
     inner_shake256_flip(&rng);
     PQCLEAN_FALCON512_CLEAN_keygen(&rng, f, g, F, NULL, h, 9, tmp.b);
     inner_shake256_ctx_release(&rng);

--- a/src/sig/falcon/sig_falcon.h
+++ b/src/sig/falcon/sig_falcon.h
@@ -12,6 +12,7 @@
 
 OQS_SIG *OQS_SIG_falcon_512_new(void);
 OQS_API OQS_STATUS OQS_SIG_falcon_512_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_falcon_512_keypair_seed(uint8_t *public_key, uint8_t *secret_key, uint8_t *seed, size_t seedlen);
 OQS_API OQS_STATUS OQS_SIG_falcon_512_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_512_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 #endif
@@ -23,6 +24,7 @@ OQS_API OQS_STATUS OQS_SIG_falcon_512_verify(const uint8_t *message, size_t mess
 
 OQS_SIG *OQS_SIG_falcon_1024_new(void);
 OQS_API OQS_STATUS OQS_SIG_falcon_1024_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_falcon_1024_keypair_seed(uint8_t *public_key, uint8_t *secret_key, uint8_t *seed, size_t seedlen);
 OQS_API OQS_STATUS OQS_SIG_falcon_1024_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_1024_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 #endif

--- a/src/sig/falcon/sig_falcon_1024.c
+++ b/src/sig/falcon/sig_falcon_1024.c
@@ -4,6 +4,8 @@
 
 #include <oqs/sig_falcon.h>
 
+#include "randombytes.h"
+
 #if defined(OQS_ENABLE_SIG_falcon_1024)
 
 OQS_SIG *OQS_SIG_falcon_1024_new() {
@@ -29,29 +31,38 @@ OQS_SIG *OQS_SIG_falcon_1024_new() {
 	return sig;
 }
 
-extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk, uint8_t *seed, size_t seedlen);
 extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_falcon_1024_avx2)
-extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk, uint8_t *seed, size_t seedlen);
 extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
 
-OQS_API OQS_STATUS OQS_SIG_falcon_1024_keypair(uint8_t *public_key, uint8_t *secret_key) {
+OQS_API OQS_STATUS OQS_SIG_falcon_1024_keypair(uint8_t *public_key, uint8_t *secret_key)
+{
+	uint8_t seed[48];
+
+	randombytes(seed, sizeof seed);
+
+	return OQS_SIG_falcon_1024_keypair_seed(public_key, secret_key, seed, sizeof seed);
+}
+		
+OQS_API OQS_STATUS OQS_SIG_falcon_1024_keypair_seed(uint8_t *public_key, uint8_t *secret_key, uint8_t *seed, size_t seedlen) {
 #if defined(OQS_ENABLE_SIG_falcon_1024_avx2)
 #if defined(OQS_DIST_BUILD)
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
 #endif /* OQS_DIST_BUILD */
-		return (OQS_STATUS) PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(public_key, secret_key);
+		return (OQS_STATUS) PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(public_key, secret_key, seed, seedlen);
 #if defined(OQS_DIST_BUILD)
 	} else {
-		return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(public_key, secret_key);
+		return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(public_key, secret_key, seed, seedlen);
 	}
 #endif /* OQS_DIST_BUILD */
 #else
-	return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(public_key, secret_key);
+	return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(public_key, secret_key, seed, seedlen);
 #endif
 }
 


### PR DESCRIPTION
I wanted to be able to generate Falcon 512 and Falcon 1024 keypairs from seeds. This gives extra functionality to shrink the "key pair" to a much smaller size. 

* [ ] These changes don't change the behaviour of Falcon 512 and Falcon 1024 during "normal" use, but they do add the ability to change the seed used from a randomly generated one to one passed as a parameter. 
* [ ] These changes don't add any new algorithms to OQS. 
