### PR TITLE
Add instructions on how to build shared/dynamic library to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Various `cmake` build options to customize the resultant artifacts are available
 
 The following instructions assume we are in `build`.
 
-3. The main build result is `lib/liboqs.a`, a static library. If you want to build a shared/dynamic library, append `-DBUILD_SHARED_LIBS=ON` to the `cmake -GNinja ..` command above and the result will be `lib/liboqs.so|dylib|dll`. The public headers are located in the `include` directory. There are also a variety of programs built under the `tests` directory:
+3. By default the main build result is `lib/liboqs.a`, a static library. If you want to build a shared/dynamic library, append [`-DBUILD_SHARED_LIBS=ON`](https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs#build_shared_libs) to the `cmake -GNinja ..` command above and the result will be `lib/liboqs.so|dylib|dll`. The public headers are located in the `include` directory. There are also a variety of programs built under the `tests` directory:
 
 	- `test_kem`: Simple test harness for key encapsulation mechanisms
 	- `test_sig`: Simple test harness for key signature schemes

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Various `cmake` build options to customize the resultant artifacts are available
 
 The following instructions assume we are in `build`.
 
-3. The main build result is `lib/liboqs.a`, a static library. The public headers are located in the `include` directory. There are also a variety of programs built under the `tests` directory:
+3. The main build result is `lib/liboqs.a`, a static library. If you want to build a shared/dynamic library, append `-DBUILD_SHARED_LIBS=ON` to the `cmake -GNinja ..` command above and the result will be `lib/liboqs.so|dylib|dll`. The public headers are located in the `include` directory. There are also a variety of programs built under the `tests` directory:
 
 	- `test_kem`: Simple test harness for key encapsulation mechanisms
 	- `test_sig`: Simple test harness for key signature schemes


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
I was trying to build the .NET (C#) wrapper project (liboqs-dotnet) and its README referenced this repo/README to build the oqs shared library but I noticed the README only mentioned that a static library was built. The Golang wrapper did have instructions on how to do so, so for consistency and benefit to future readers, I updated this repo's one too.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
No

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
