### PR TITLE
Updated SIKE to latest upstream commit

### DIFF
--- a/docs/algorithms/kem/sike.md
+++ b/docs/algorithms/kem/sike.md
@@ -5,7 +5,7 @@
 - **Principal submitters**: David Jao, Reza Azarderakhsh, Matthew Campagna, Craig Costello, Luca De Feo, Basil Hess, Amir Jalali, Brian Koziel, Brian LaMacchia, Patrick Longa, Michael Naehrig, Joost Renes, Vladimir Soukharev, David Urbanik.
 - **Authors' website**: https://sike.org
 - **Specification version**: NIST Round 3 submission.
-- **Implementation source**: https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd
+- **Implementation source**: https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78
 - **Implementation license (SPDX-Identifier)**: MIT.
 
 ## Parameter set summary

--- a/docs/algorithms/kem/sike.yml
+++ b/docs/algorithms/kem/sike.yml
@@ -20,7 +20,7 @@ website: https://sike.org
 nist-round: 3
 spec-version: NIST Round 3 submission
 spdx-license-identifier: MIT
-upstream: https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd
+upstream: https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78
 parameter-sets:
 - name: SIDH-p434
   claimed-nist-level: 1

--- a/src/kem/sike/external/P434/AMD64/fp_x64.c
+++ b/src/kem/sike/external/P434/AMD64/fp_x64.c
@@ -15,7 +15,7 @@ extern const uint64_t p434x2[NWORDS_FIELD];
 extern const uint64_t p434x4[NWORDS_FIELD];
 */
 
-__inline void mp_sub434_p2(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub434_p2(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 2*p, c = a-b+2p.
 #if (OS_TARGET == OS_WIN) || defined(GENERIC_IMPLEMENTATION) || (TARGET == TARGET_ARM) || (TARGET == TARGET_ARM64 && NBITS_FIELD == 610)
   unsigned int i, borrow = 0;
@@ -37,7 +37,7 @@ __inline void mp_sub434_p2(const digit_t* a, const digit_t* b, digit_t* c)
 }
 
 
-__inline void mp_sub434_p4(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub434_p4(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 4*p, c = a-b+4p.
 #if (OS_TARGET == OS_WIN) || defined(GENERIC_IMPLEMENTATION) || (TARGET == TARGET_ARM) || (TARGET == TARGET_ARM64 && NBITS_FIELD == 610)
   unsigned int i, borrow = 0;
@@ -58,7 +58,7 @@ __inline void mp_sub434_p4(const digit_t* a, const digit_t* b, digit_t* c)
   #endif
 }
 
-__inline void fpadd434(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p434.
+inline void fpadd434(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p434.
 	// Inputs: a, b in [0, 2*p434-1]
 	// Output: c in [0, 2*p434-1]
 
@@ -88,7 +88,7 @@ __inline void fpadd434(const digit_t *a, const digit_t *b, digit_t *c) { // Modu
 #endif
 }
 
-__inline void fpsub434(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p434.
+inline void fpsub434(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p434.
 	// Inputs: a, b in [0, 2*p434-1]
 	// Output: c in [0, 2*p434-1]
 
@@ -113,7 +113,7 @@ __inline void fpsub434(const digit_t *a, const digit_t *b, digit_t *c) { // Modu
 #endif
 }
 
-__inline void fpneg434(digit_t *a) { // Modular negation, a = -a mod p434.
+inline void fpneg434(digit_t *a) { // Modular negation, a = -a mod p434.
 	// Input/output: a in [0, 2*p434-1]
 	unsigned int i, borrow = 0;
 

--- a/src/kem/sike/external/P434/ARM64/fp_arm64.c
+++ b/src/kem/sike/external/P434/ARM64/fp_arm64.c
@@ -14,21 +14,21 @@ extern const uint64_t p434x2[NWORDS_FIELD];
 extern const uint64_t p434x4[NWORDS_FIELD];
 */
 
-__inline void mp_sub434_p2(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub434_p2(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 2*p, c = a-b+2p. 
     
     oqs_kem_sike_mp_sub434_p2_asm(a, b, c); 
 } 
 
 
-__inline void mp_sub434_p4(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub434_p4(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 4*p, c = a-b+4p. 
     
     oqs_kem_sike_mp_sub434_p4_asm(a, b, c);
 }
 
 
-__inline void fpadd434(const digit_t* a, const digit_t* b, digit_t* c)
+inline void fpadd434(const digit_t* a, const digit_t* b, digit_t* c)
 { // Modular addition, c = a+b mod p434.
   // Inputs: a, b in [0, 2*p434-1] 
   // Output: c in [0, 2*p434-1]
@@ -37,7 +37,7 @@ __inline void fpadd434(const digit_t* a, const digit_t* b, digit_t* c)
 } 
 
 
-__inline void fpsub434(const digit_t* a, const digit_t* b, digit_t* c)
+inline void fpsub434(const digit_t* a, const digit_t* b, digit_t* c)
 { // Modular subtraction, c = a-b mod p434.
   // Inputs: a, b in [0, 2*p434-1] 
   // Output: c in [0, 2*p434-1] 
@@ -46,7 +46,7 @@ __inline void fpsub434(const digit_t* a, const digit_t* b, digit_t* c)
 }
 
 
-__inline void fpneg434(digit_t* a)
+inline void fpneg434(digit_t* a)
 { // Modular negation, a = -a mod p434.
   // Input/output: a in [0, 2*p434-1] 
     unsigned int i, borrow = 0;

--- a/src/kem/sike/external/P434/generic/fp_generic.c
+++ b/src/kem/sike/external/P434/generic/fp_generic.c
@@ -15,7 +15,7 @@ extern const uint64_t p434x2[NWORDS64_FIELD];
 extern const uint64_t p434x4[NWORDS64_FIELD];
 */
 
-__inline void mp_sub434_p2(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub434_p2(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 2*p, c = a-b+2p. 
     unsigned int i, borrow = 0;
 
@@ -30,7 +30,7 @@ __inline void mp_sub434_p2(const digit_t* a, const digit_t* b, digit_t* c)
 } 
 
 
-__inline void mp_sub434_p4(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub434_p4(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 4*p, c = a-b+4p. 
     unsigned int i, borrow = 0;
 
@@ -44,7 +44,7 @@ __inline void mp_sub434_p4(const digit_t* a, const digit_t* b, digit_t* c)
     }
 } 
 
-__inline void fpadd434(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p434.
+inline void fpadd434(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p434.
 	// Inputs: a, b in [0, 2*p434-1]
 	// Output: c in [0, 2*p434-1]
 	unsigned int i, carry = 0;
@@ -66,7 +66,7 @@ __inline void fpadd434(const digit_t *a, const digit_t *b, digit_t *c) { // Modu
 	}
 }
 
-__inline void fpsub434(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p434.
+inline void fpsub434(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p434.
 	// Inputs: a, b in [0, 2*p434-1]
 	// Output: c in [0, 2*p434-1]
 	unsigned int i, borrow = 0;
@@ -83,7 +83,7 @@ __inline void fpsub434(const digit_t *a, const digit_t *b, digit_t *c) { // Modu
 	}
 }
 
-__inline void fpneg434(digit_t *a) { // Modular negation, a = -a mod p434.
+inline void fpneg434(digit_t *a) { // Modular negation, a = -a mod p434.
 	// Input/output: a in [0, 2*p434-1]
 	unsigned int i, borrow = 0;
 

--- a/src/kem/sike/external/P503/AMD64/fp_x64.c
+++ b/src/kem/sike/external/P503/AMD64/fp_x64.c
@@ -15,7 +15,7 @@ extern const uint64_t p503x2[NWORDS_FIELD];
 extern const uint64_t p503x4[NWORDS_FIELD];
 */
 
-__inline void mp_sub503_p2(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub503_p2(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 2*p, c = a-b+2p.    
 #if (OS_TARGET == OS_WIN) || defined(GENERIC_IMPLEMENTATION) || (TARGET == TARGET_ARM) || (TARGET == TARGET_ARM64 && NBITS_FIELD == 610)
     unsigned int i, borrow = 0;
@@ -37,7 +37,7 @@ __inline void mp_sub503_p2(const digit_t* a, const digit_t* b, digit_t* c)
 } 
 
 
-__inline void mp_sub503_p4(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub503_p4(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 4*p, c = a-b+4p.    
 #if (OS_TARGET == OS_WIN) || defined(GENERIC_IMPLEMENTATION) || (TARGET == TARGET_ARM) || (TARGET == TARGET_ARM64 && NBITS_FIELD == 610)
     unsigned int i, borrow = 0;
@@ -58,7 +58,7 @@ __inline void mp_sub503_p4(const digit_t* a, const digit_t* b, digit_t* c)
 #endif
 } 
 
-__inline void fpadd503(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p503.
+inline void fpadd503(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p503.
 	// Inputs: a, b in [0, 2*p503-1]
 	// Output: c in [0, 2*p503-1]
 
@@ -88,7 +88,7 @@ __inline void fpadd503(const digit_t *a, const digit_t *b, digit_t *c) { // Modu
 #endif
 }
 
-__inline void fpsub503(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p503.
+inline void fpsub503(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p503.
 	// Inputs: a, b in [0, 2*p503-1]
 	// Output: c in [0, 2*p503-1]
 
@@ -113,7 +113,7 @@ __inline void fpsub503(const digit_t *a, const digit_t *b, digit_t *c) { // Modu
 #endif
 }
 
-__inline void fpneg503(digit_t *a) { // Modular negation, a = -a mod p503.
+inline void fpneg503(digit_t *a) { // Modular negation, a = -a mod p503.
 	// Input/output: a in [0, 2*p503-1]
 	unsigned int i, borrow = 0;
 

--- a/src/kem/sike/external/P503/ARM64/fp_arm64.c
+++ b/src/kem/sike/external/P503/ARM64/fp_arm64.c
@@ -13,33 +13,33 @@ extern const uint64_t p503x2[NWORDS_FIELD];
 extern const uint64_t p503x4[NWORDS_FIELD];
 */
 
-__inline void mp_sub503_p2(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub503_p2(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 2*p, c = a-b+2p. 
     
     oqs_kem_sike_mp_sub503_p2_asm(a, b, c); 
 } 
 
-__inline void mp_sub503_p4(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub503_p4(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 4*p, c = a-b+4p. 
     
     oqs_kem_sike_mp_sub503_p4_asm(a, b, c);
 }
 
-__inline void fpadd503(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p503.
+inline void fpadd503(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p503.
 	// Inputs: a, b in [0, 2*p503-1]
 	// Output: c in [0, 2*p503-1]
 
 	oqs_kem_sike_fpadd503_asm(a, b, c);
 }
 
-__inline void fpsub503(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p503.
+inline void fpsub503(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p503.
 	// Inputs: a, b in [0, 2*p503-1]
 	// Output: c in [0, 2*p503-1]
 
 	oqs_kem_sike_fpsub503_asm(a, b, c);
 }
 
-__inline void fpneg503(digit_t *a) { // Modular negation, a = -a mod p503.
+inline void fpneg503(digit_t *a) { // Modular negation, a = -a mod p503.
 	// Input/output: a in [0, 2*p503-1]
 	unsigned int i, borrow = 0;
 

--- a/src/kem/sike/external/P503/generic/fp_generic.c
+++ b/src/kem/sike/external/P503/generic/fp_generic.c
@@ -15,7 +15,7 @@ extern const uint64_t p503x2[NWORDS64_FIELD];
 extern const uint64_t p503x4[NWORDS64_FIELD];
 */
 
-__inline void mp_sub503_p2(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub503_p2(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 2*p, c = a-b+2p.
     unsigned int i, borrow = 0;
 
@@ -30,7 +30,7 @@ __inline void mp_sub503_p2(const digit_t* a, const digit_t* b, digit_t* c)
 } 
 
 
-__inline void mp_sub503_p4(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub503_p4(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 4*p, c = a-b+4p.
     unsigned int i, borrow = 0;
 
@@ -44,7 +44,7 @@ __inline void mp_sub503_p4(const digit_t* a, const digit_t* b, digit_t* c)
     }
 } 
 
-__inline void fpadd503(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p503.
+inline void fpadd503(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p503.
 	// Inputs: a, b in [0, 2*p503-1]
 	// Output: c in [0, 2*p503-1]
 	unsigned int i, carry = 0;
@@ -66,7 +66,7 @@ __inline void fpadd503(const digit_t *a, const digit_t *b, digit_t *c) { // Modu
 	}
 }
 
-__inline void fpsub503(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p503.
+inline void fpsub503(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p503.
 	// Inputs: a, b in [0, 2*p503-1]
 	// Output: c in [0, 2*p503-1]
 	unsigned int i, borrow = 0;
@@ -83,7 +83,7 @@ __inline void fpsub503(const digit_t *a, const digit_t *b, digit_t *c) { // Modu
 	}
 }
 
-__inline void fpneg503(digit_t *a) { // Modular negation, a = -a mod p503.
+inline void fpneg503(digit_t *a) { // Modular negation, a = -a mod p503.
 	// Input/output: a in [0, 2*p503-1]
 	unsigned int i, borrow = 0;
 

--- a/src/kem/sike/external/P610/AMD64/fp_x64.c
+++ b/src/kem/sike/external/P610/AMD64/fp_x64.c
@@ -15,7 +15,7 @@ extern const uint64_t p610x2[NWORDS_FIELD];
 extern const uint64_t p610x4[NWORDS_FIELD];
 */
 
-__inline void mp_sub610_p2(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub610_p2(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 2*p, c = a-b+2p.    
 #if (OS_TARGET == OS_WIN) || defined(GENERIC_IMPLEMENTATION) || (TARGET == TARGET_ARM) || (TARGET == TARGET_ARM64 && NBITS_FIELD == 610)
     unsigned int i, borrow = 0;
@@ -37,7 +37,7 @@ __inline void mp_sub610_p2(const digit_t* a, const digit_t* b, digit_t* c)
 } 
 
 
-__inline void mp_sub610_p4(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub610_p4(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 4*p, c = a-b+4p.    
 #if (OS_TARGET == OS_WIN) || defined(GENERIC_IMPLEMENTATION) || (TARGET == TARGET_ARM) || (TARGET == TARGET_ARM64 && NBITS_FIELD == 610)
     unsigned int i, borrow = 0;
@@ -58,7 +58,7 @@ __inline void mp_sub610_p4(const digit_t* a, const digit_t* b, digit_t* c)
 #endif
 } 
 
-__inline void fpadd610(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p610.
+inline void fpadd610(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p610.
 	// Inputs: a, b in [0, 2*p610-1]
 	// Output: c in [0, 2*p610-1]
 
@@ -88,7 +88,7 @@ __inline void fpadd610(const digit_t *a, const digit_t *b, digit_t *c) { // Modu
 #endif
 }
 
-__inline void fpsub610(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p610.
+inline void fpsub610(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p610.
 	// Inputs: a, b in [0, 2*p610-1]
 	// Output: c in [0, 2*p610-1]
 
@@ -113,7 +113,7 @@ __inline void fpsub610(const digit_t *a, const digit_t *b, digit_t *c) { // Modu
 #endif
 }
 
-__inline void fpneg610(digit_t *a) { // Modular negation, a = -a mod p610.
+inline void fpneg610(digit_t *a) { // Modular negation, a = -a mod p610.
 	// Input/output: a in [0, 2*p610-1]
 	unsigned int i, borrow = 0;
 

--- a/src/kem/sike/external/P610/ARM64/fp_arm64.c
+++ b/src/kem/sike/external/P610/ARM64/fp_arm64.c
@@ -14,21 +14,21 @@ extern const uint64_t p610x2[NWORDS_FIELD];
 extern const uint64_t p610x4[NWORDS_FIELD];
 */
 
-__inline void mp_sub610_p2(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub610_p2(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 2*p, c = a-b+2p. 
     
     oqs_kem_sike_mp_sub610_p2_asm(a, b, c); 
 } 
 
 
-__inline void mp_sub610_p4(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub610_p4(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 4*p, c = a-b+4p. 
     
     oqs_kem_sike_mp_sub610_p4_asm(a, b, c);
 }
 
 
-__inline void fpadd610(const digit_t* a, const digit_t* b, digit_t* c)
+inline void fpadd610(const digit_t* a, const digit_t* b, digit_t* c)
 { // Modular addition, c = a+b mod p610.
   // Inputs: a, b in [0, 2*p610-1] 
   // Output: c in [0, 2*p610-1]
@@ -37,7 +37,7 @@ __inline void fpadd610(const digit_t* a, const digit_t* b, digit_t* c)
 } 
 
 
-__inline void fpsub610(const digit_t* a, const digit_t* b, digit_t* c)
+inline void fpsub610(const digit_t* a, const digit_t* b, digit_t* c)
 { // Modular subtraction, c = a-b mod p610.
   // Inputs: a, b in [0, 2*p610-1] 
   // Output: c in [0, 2*p610-1] 
@@ -46,7 +46,7 @@ __inline void fpsub610(const digit_t* a, const digit_t* b, digit_t* c)
 }
 
 
-__inline void fpneg610(digit_t* a)
+inline void fpneg610(digit_t* a)
 { // Modular negation, a = -a mod p610.
   // Input/output: a in [0, 2*p610-1] 
     unsigned int i, borrow = 0;

--- a/src/kem/sike/external/P610/generic/fp_generic.c
+++ b/src/kem/sike/external/P610/generic/fp_generic.c
@@ -15,7 +15,7 @@ extern const uint64_t p610x2[NWORDS64_FIELD];
 extern const uint64_t p610x4[NWORDS64_FIELD];
 */
 
-__inline void mp_sub610_p2(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub610_p2(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 2*p, c = a-b+2p. 
     unsigned int i, borrow = 0;
 
@@ -30,7 +30,7 @@ __inline void mp_sub610_p2(const digit_t* a, const digit_t* b, digit_t* c)
 } 
 
 
-__inline void mp_sub610_p4(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub610_p4(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 4*p, c = a-b+4p.
     unsigned int i, borrow = 0;
 
@@ -44,7 +44,7 @@ __inline void mp_sub610_p4(const digit_t* a, const digit_t* b, digit_t* c)
     }
 } 
 
-__inline void fpadd610(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p610.
+inline void fpadd610(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p610.
 	// Inputs: a, b in [0, 2*p610-1]
 	// Output: c in [0, 2*p610-1]
 	unsigned int i, carry = 0;
@@ -66,7 +66,7 @@ __inline void fpadd610(const digit_t *a, const digit_t *b, digit_t *c) { // Modu
 	}
 }
 
-__inline void fpsub610(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p610.
+inline void fpsub610(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p610.
 	// Inputs: a, b in [0, 2*p610-1]
 	// Output: c in [0, 2*p610-1]
 	unsigned int i, borrow = 0;
@@ -83,7 +83,7 @@ __inline void fpsub610(const digit_t *a, const digit_t *b, digit_t *c) { // Modu
 	}
 }
 
-__inline void fpneg610(digit_t *a) { // Modular negation, a = -a mod p610.
+inline void fpneg610(digit_t *a) { // Modular negation, a = -a mod p610.
 	// Input/output: a in [0, 2*p610-1]
 	unsigned int i, borrow = 0;
 

--- a/src/kem/sike/external/P751/AMD64/fp_x64.c
+++ b/src/kem/sike/external/P751/AMD64/fp_x64.c
@@ -15,7 +15,7 @@ extern const uint64_t p751x2[NWORDS_FIELD];
 extern const uint64_t p751x4[NWORDS_FIELD];
 */
 
-__inline void mp_sub751_p2(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub751_p2(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 2*p, c = a-b+2p.    
 #if (OS_TARGET == OS_WIN) || defined(GENERIC_IMPLEMENTATION) || (TARGET == TARGET_ARM) || (TARGET == TARGET_ARM64 && NBITS_FIELD == 751)
     unsigned int i, borrow = 0;
@@ -37,7 +37,7 @@ __inline void mp_sub751_p2(const digit_t* a, const digit_t* b, digit_t* c)
 } 
 
 
-__inline void mp_sub751_p4(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub751_p4(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 4*p, c = a-b+4p.    
 #if (OS_TARGET == OS_WIN) || defined(GENERIC_IMPLEMENTATION) || (TARGET == TARGET_ARM) || (TARGET == TARGET_ARM64 && NBITS_FIELD == 751)
     unsigned int i, borrow = 0;
@@ -58,7 +58,7 @@ __inline void mp_sub751_p4(const digit_t* a, const digit_t* b, digit_t* c)
 #endif
 }  
 
-__inline void fpadd751(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p751.
+inline void fpadd751(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p751.
 	// Inputs: a, b in [0, 2*p751-1]
 	// Output: c in [0, 2*p751-1]
 
@@ -88,7 +88,7 @@ __inline void fpadd751(const digit_t *a, const digit_t *b, digit_t *c) { // Modu
 #endif
 }
 
-__inline void fpsub751(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p751.
+inline void fpsub751(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p751.
 	// Inputs: a, b in [0, 2*p751-1]
 	// Output: c in [0, 2*p751-1]
 
@@ -113,7 +113,7 @@ __inline void fpsub751(const digit_t *a, const digit_t *b, digit_t *c) { // Modu
 #endif
 }
 
-__inline void fpneg751(digit_t *a) { // Modular negation, a = -a mod p751.
+inline void fpneg751(digit_t *a) { // Modular negation, a = -a mod p751.
 	// Input/output: a in [0, 2*p751-1]
 	unsigned int i, borrow = 0;
 

--- a/src/kem/sike/external/P751/ARM64/fp_arm64.c
+++ b/src/kem/sike/external/P751/ARM64/fp_arm64.c
@@ -14,34 +14,34 @@ extern const uint64_t p751x2[NWORDS_FIELD];
 extern const uint64_t p751x4[NWORDS_FIELD];
 */
 
-__inline void mp_sub751_p2(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub751_p2(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 2*p, c = a-b+2p. 
     
     oqs_kem_sike_mp_sub751_p2_asm(a, b, c); 
 } 
 
 
-__inline void mp_sub751_p4(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub751_p4(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 4*p, c = a-b+4p. 
     
     oqs_kem_sike_mp_sub751_p4_asm(a, b, c);
 }
 
-__inline void fpadd751(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p751.
+inline void fpadd751(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p751.
 	// Inputs: a, b in [0, 2*p751-1]
 	// Output: c in [0, 2*p751-1]
 
 	oqs_kem_sike_fpadd751_asm(a, b, c);
 }
 
-__inline void fpsub751(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p751.
+inline void fpsub751(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p751.
 	// Inputs: a, b in [0, 2*p751-1]
 	// Output: c in [0, 2*p751-1]
 
 	oqs_kem_sike_fpsub751_asm(a, b, c);
 }
 
-__inline void fpneg751(digit_t *a) { // Modular negation, a = -a mod p751.
+inline void fpneg751(digit_t *a) { // Modular negation, a = -a mod p751.
 	// Input/output: a in [0, 2*p751-1]
 	unsigned int i, borrow = 0;
 

--- a/src/kem/sike/external/P751/generic/fp_generic.c
+++ b/src/kem/sike/external/P751/generic/fp_generic.c
@@ -15,7 +15,7 @@ extern const uint64_t p751x2[NWORDS64_FIELD];
 extern const uint64_t p751x4[NWORDS64_FIELD];
 */
 
-__inline void mp_sub751_p2(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub751_p2(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 2*p, c = a-b+2p.
     unsigned int i, borrow = 0;
 
@@ -30,7 +30,7 @@ __inline void mp_sub751_p2(const digit_t* a, const digit_t* b, digit_t* c)
 } 
 
 
-__inline void mp_sub751_p4(const digit_t* a, const digit_t* b, digit_t* c)
+inline void mp_sub751_p4(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction with correction with 4*p, c = a-b+4p.
     unsigned int i, borrow = 0;
 
@@ -44,7 +44,7 @@ __inline void mp_sub751_p4(const digit_t* a, const digit_t* b, digit_t* c)
     }
 }   
 
-__inline void fpadd751(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p751.
+inline void fpadd751(const digit_t *a, const digit_t *b, digit_t *c) { // Modular addition, c = a+b mod p751.
 	// Inputs: a, b in [0, 2*p751-1]
 	// Output: c in [0, 2*p751-1]
 	unsigned int i, carry = 0;
@@ -66,7 +66,7 @@ __inline void fpadd751(const digit_t *a, const digit_t *b, digit_t *c) { // Modu
 	}
 }
 
-__inline void fpsub751(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p751.
+inline void fpsub751(const digit_t *a, const digit_t *b, digit_t *c) { // Modular subtraction, c = a-b mod p751.
 	// Inputs: a, b in [0, 2*p751-1]
 	// Output: c in [0, 2*p751-1]
 	unsigned int i, borrow = 0;
@@ -83,7 +83,7 @@ __inline void fpsub751(const digit_t *a, const digit_t *b, digit_t *c) { // Modu
 	}
 }
 
-__inline void fpneg751(digit_t *a) { // Modular negation, a = -a mod p751.
+inline void fpneg751(digit_t *a) { // Modular negation, a = -a mod p751.
 	// Input/output: a in [0, 2*p751-1]
 	unsigned int i, borrow = 0;
 

--- a/src/kem/sike/external/config.h
+++ b/src/kem/sike/external/config.h
@@ -137,15 +137,15 @@ typedef uint64_t uint128_t[2];
 
 // The following functions return 1 (TRUE) if condition is true, 0 (FALSE) otherwise
 
-__inline unsigned int is_digit_nonzero_ct(digit_t x) { // Is x != 0?
+inline unsigned int is_digit_nonzero_ct(digit_t x) { // Is x != 0?
 	return (unsigned int) ((x | (0 - x)) >> (RADIX - 1));
 }
 
-__inline unsigned int is_digit_zero_ct(digit_t x) { // Is x = 0?
+inline unsigned int is_digit_zero_ct(digit_t x) { // Is x = 0?
 	return (unsigned int) (1 ^ is_digit_nonzero_ct(x));
 }
 
-__inline unsigned int is_digit_lessthan_ct(digit_t x, digit_t y) { // Is x < y?
+inline unsigned int is_digit_lessthan_ct(digit_t x, digit_t y) { // Is x < y?
 	return (unsigned int) ((x ^ ((x ^ y) | ((x - y) ^ y))) >> (RADIX - 1));
 }
 

--- a/src/kem/sike/external/fpx.c
+++ b/src/kem/sike/external/fpx.c
@@ -38,7 +38,7 @@ static void ct_cmov(uint8_t *r, const uint8_t *a, unsigned int len, int8_t selec
 }
 
 
-__inline static void encode_to_bytes(const digit_t* x, unsigned char* enc, int nbytes)
+inline static void encode_to_bytes(const digit_t* x, unsigned char* enc, int nbytes)
 { // Encoding digits to bytes according to endianness
 #ifdef _BIG_ENDIAN_
     int ndigits = nbytes / sizeof(digit_t);
@@ -56,7 +56,7 @@ __inline static void encode_to_bytes(const digit_t* x, unsigned char* enc, int n
 }
 
 
-__inline static void decode_to_digits(const unsigned char* x, digit_t* dec, int nbytes, int ndigits)
+inline static void decode_to_digits(const unsigned char* x, digit_t* dec, int nbytes, int ndigits)
 { // Decoding bytes to digits according to endianness
 
     dec[ndigits - 1] = 0;
@@ -87,7 +87,7 @@ static void fp2_decode(const unsigned char *x, f2elm_t dec)
 }
 
 
-__inline void fpcopy(const digit_t* a, digit_t* c)
+inline void fpcopy(const digit_t* a, digit_t* c)
 { // Copy a field element, c = a.
     unsigned int i;
 
@@ -96,7 +96,7 @@ __inline void fpcopy(const digit_t* a, digit_t* c)
 }
 
 
-__inline void fpzero(digit_t* a)
+inline void fpzero(digit_t* a)
 { // Zero a field element, a = 0.
     unsigned int i;
 
@@ -185,14 +185,14 @@ static void fp2neg(f2elm_t a)
 }
 
 
-__inline void fp2add(const f2elm_t a, const f2elm_t b, f2elm_t c)           
+inline void fp2add(const f2elm_t a, const f2elm_t b, f2elm_t c)           
 { // GF(p^2) addition, c = a+b in GF(p^2).
     fpadd(a[0], b[0], c[0]);
     fpadd(a[1], b[1], c[1]);
 }
 
 
-__inline void fp2sub(const f2elm_t a, const f2elm_t b, f2elm_t c)          
+inline void fp2sub(const f2elm_t a, const f2elm_t b, f2elm_t c)          
 { // GF(p^2) subtraction, c = a-b in GF(p^2).
     fpsub(a[0], b[0], c[0]);
     fpsub(a[1], b[1], c[1]);
@@ -213,7 +213,7 @@ static void fp2correction(f2elm_t a)
 }
 
 
-__inline static void mp_addfast(const digit_t* a, const digit_t* b, digit_t* c)
+inline static void mp_addfast(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision addition, c = a+b.    
 #if !defined(USE_SIKE_ASM)
 
@@ -227,21 +227,21 @@ __inline static void mp_addfast(const digit_t* a, const digit_t* b, digit_t* c)
 }
 
 
-__inline static void mp2_add(const f2elm_t a, const f2elm_t b, f2elm_t c)       
+inline static void mp2_add(const f2elm_t a, const f2elm_t b, f2elm_t c)       
 { // GF(p^2) addition without correction, c = a+b in GF(p^2). 
     mp_addfast(a[0], b[0], c[0]);
     mp_addfast(a[1], b[1], c[1]);
 }
 
 
-__inline static void mp2_sub_p2(const f2elm_t a, const f2elm_t b, f2elm_t c)       
+inline static void mp2_sub_p2(const f2elm_t a, const f2elm_t b, f2elm_t c)       
 { // GF(p^2) subtraction with correction with 2*p, c = a-b+2p in GF(p^2).    
     mp_sub_p2(a[0], b[0], c[0]);  
     mp_sub_p2(a[1], b[1], c[1]);
 }
 
 
-__inline unsigned int mp_add(const digit_t* a, const digit_t* b, digit_t* c, const unsigned int nwords)
+inline unsigned int mp_add(const digit_t* a, const digit_t* b, digit_t* c, const unsigned int nwords)
 { // Multiprecision addition, c = a+b, where lng(a) = lng(b) = nwords. Returns the carry bit.
     unsigned int i, carry = 0;
         
@@ -267,7 +267,7 @@ static void fp2sqr_mont(const f2elm_t a, f2elm_t c)
 }
 
 
-__inline unsigned int mp_sub(const digit_t* a, const digit_t* b, digit_t* c, const unsigned int nwords)
+inline unsigned int mp_sub(const digit_t* a, const digit_t* b, digit_t* c, const unsigned int nwords)
 { // Multiprecision subtraction, c = a-b, where lng(a) = lng(b) = nwords. Returns the borrow bit.
     unsigned int i, borrow = 0;
 
@@ -278,7 +278,7 @@ __inline unsigned int mp_sub(const digit_t* a, const digit_t* b, digit_t* c, con
 }
 
 
-__inline static void mp_subaddfast(const digit_t* a, const digit_t* b, digit_t* c)
+inline static void mp_subaddfast(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction followed by addition with p*2^MAXBITS_FIELD, c = a-b+(p*2^MAXBITS_FIELD) if a-b < 0, otherwise c=a-b. 
 #if !defined(USE_SIKE_ASM)
     felm_t t1;
@@ -296,7 +296,7 @@ __inline static void mp_subaddfast(const digit_t* a, const digit_t* b, digit_t* 
 }
 
 
-__inline static void mp_dblsubfast(const digit_t* a, const digit_t* b, digit_t* c)
+inline static void mp_dblsubfast(const digit_t* a, const digit_t* b, digit_t* c)
 { // Multiprecision subtraction, c = c-a-b, where lng(a) = lng(b) = 2*NWORDS_FIELD.
 #if !defined(USE_SIKE_ASM)
 
@@ -823,7 +823,7 @@ static void mp_shiftl1(digit_t* x, const unsigned int nwords)
 
 #ifdef COMPRESS
 
-static __inline unsigned int is_felm_zero(const felm_t x)
+static inline unsigned int is_felm_zero(const felm_t x)
 { // Is x = 0? return 1 (TRUE) if condition is true, 0 (FALSE) otherwise.
   // SECURITY NOTE: This function does not run in constant-time.
     unsigned int i;
@@ -834,7 +834,7 @@ static __inline unsigned int is_felm_zero(const felm_t x)
     return 1;
 }
 
-static __inline unsigned int is_felm_one(const felm_t x)
+static inline unsigned int is_felm_one(const felm_t x)
 { // Is x = 0? return 1 (TRUE) if condition is true, 0 (FALSE) otherwise.
   // SECURITY NOTE: This function does not run in constant-time.
     unsigned int i;
@@ -1007,7 +1007,7 @@ static void sqrt_Fp2(const f2elm_t u, f2elm_t y)
 }
 
 
-static __inline void power2_setup(digit_t* x, int mark, const unsigned int nwords)
+static inline void power2_setup(digit_t* x, int mark, const unsigned int nwords)
 { // Set up the value 2^mark.
     unsigned int i;
 
@@ -1042,13 +1042,13 @@ static int8_t cmp_f2elm(const f2elm_t x, const f2elm_t y)
 }
 
 
-static __inline unsigned int is_felm_even(const felm_t x)
+static inline unsigned int is_felm_even(const felm_t x)
 { // Is x even? return 1 (TRUE) if condition is true, 0 (FALSE) otherwise.
     return (unsigned int)((x[0] & 1) ^ 1);
 }
 
 
-static __inline unsigned int is_felm_lt(const felm_t x, const felm_t y)
+static inline unsigned int is_felm_lt(const felm_t x, const felm_t y)
 { // Is x < y? return 1 (TRUE) if condition is true, 0 (FALSE) otherwise.
   // SECURITY NOTE: This function does not run in constant-time.
 
@@ -1063,7 +1063,7 @@ static __inline unsigned int is_felm_lt(const felm_t x, const felm_t y)
 }
 
 
-static __inline unsigned int is_orderelm_lt(const digit_t *x, const digit_t *y)
+static inline unsigned int is_orderelm_lt(const digit_t *x, const digit_t *y)
 { // Is x < y? return 1 (TRUE) if condition is true, 0 (FALSE) otherwise.
   // SECURITY NOTE: This function does not run in constant-time.
 
@@ -1078,7 +1078,7 @@ static __inline unsigned int is_orderelm_lt(const digit_t *x, const digit_t *y)
 }
 
 
-static __inline void fpinv_mont_bingcd_partial(const felm_t a, felm_t x1, unsigned int* k)
+static inline void fpinv_mont_bingcd_partial(const felm_t a, felm_t x1, unsigned int* k)
 { // Partial Montgomery inversion via the binary GCD algorithm.
     felm_t u, v, x2;
     unsigned int cwords;  // Number of words necessary for x1, x2
@@ -1285,7 +1285,7 @@ static void from_Montgomery_mod_order(const digit_t* ma, digit_t* c, const digit
 }
 
 
-static __inline unsigned int is_zero_mod_order(const digit_t* x)
+static inline unsigned int is_zero_mod_order(const digit_t* x)
 { // Is x = 0? return 1 (TRUE) if condition is true, 0 (FALSE) otherwise
   // SECURITY NOTE: This function does not run in constant time.
     unsigned int i;
@@ -1297,13 +1297,13 @@ static __inline unsigned int is_zero_mod_order(const digit_t* x)
 }
 
 
-static __inline unsigned int is_even_mod_order(const digit_t* x)
+static inline unsigned int is_even_mod_order(const digit_t* x)
 { // Is x even? return 1 (TRUE) if condition is true, 0 (FALSE) otherwise.
     return (unsigned int)((x[0] & 1) ^ 1);
 }
 
 
-static __inline unsigned int is_lt_mod_order(const digit_t* x, const digit_t* y)
+static inline unsigned int is_lt_mod_order(const digit_t* x, const digit_t* y)
 { // Is x < y? return 1 (TRUE) if condition is true, 0 (FALSE) otherwise.
   // SECURITY NOTE: This function does not run in constant time.
     int i;
@@ -1319,7 +1319,7 @@ static __inline unsigned int is_lt_mod_order(const digit_t* x, const digit_t* y)
 }
 
 
-static __inline void Montgomery_inversion_mod_order_bingcd_partial(const digit_t* a, digit_t* x1, unsigned int* k, const digit_t* order)
+static inline void Montgomery_inversion_mod_order_bingcd_partial(const digit_t* a, digit_t* x1, unsigned int* k, const digit_t* order)
 { // Partial Montgomery inversion modulo order.
     digit_t u[NWORDS_ORDER], v[NWORDS_ORDER], x2[NWORDS_ORDER] = {0};
     unsigned int cwords;  // number of words necessary for x1, x2

--- a/src/kem/sike/kem_sike.c
+++ b/src/kem/sike/kem_sike.c
@@ -15,7 +15,7 @@ OQS_KEM *OQS_KEM_sike_p434_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sike_p434;
-	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd";
+	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -45,7 +45,7 @@ OQS_KEM *OQS_KEM_sike_p434_compressed_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sike_p434_compressed;
-	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd";
+	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = true;
@@ -75,7 +75,7 @@ OQS_KEM *OQS_KEM_sike_p503_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sike_p503;
-	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd";
+	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78";
 
 	kem->claimed_nist_level = 2;
 	kem->ind_cca = true;
@@ -105,7 +105,7 @@ OQS_KEM *OQS_KEM_sike_p503_compressed_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sike_p503_compressed;
-	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd";
+	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78";
 
 	kem->claimed_nist_level = 2;
 	kem->ind_cca = true;
@@ -135,7 +135,7 @@ OQS_KEM *OQS_KEM_sike_p610_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sike_p610;
-	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd";
+	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78";
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = true;
@@ -165,7 +165,7 @@ OQS_KEM *OQS_KEM_sike_p610_compressed_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sike_p610_compressed;
-	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd";
+	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78";
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = true;
@@ -195,7 +195,7 @@ OQS_KEM *OQS_KEM_sike_p751_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sike_p751;
-	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd";
+	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = true;
@@ -225,7 +225,7 @@ OQS_KEM *OQS_KEM_sike_p751_compressed_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sike_p751_compressed;
-	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd";
+	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = true;
@@ -255,7 +255,7 @@ OQS_KEM *OQS_KEM_sidh_p434_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sidh_p434;
-	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd";
+	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = false;
@@ -325,7 +325,7 @@ OQS_KEM *OQS_KEM_sidh_p434_compressed_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sidh_p434_compressed;
-	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd";
+	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78";
 
 	kem->claimed_nist_level = 1;
 	kem->ind_cca = false;
@@ -395,7 +395,7 @@ OQS_KEM *OQS_KEM_sidh_p503_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sidh_p503;
-	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd";
+	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78";
 
 	kem->claimed_nist_level = 2;
 	kem->ind_cca = false;
@@ -465,7 +465,7 @@ OQS_KEM *OQS_KEM_sidh_p503_compressed_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sidh_p503_compressed;
-	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd";
+	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78";
 
 	kem->claimed_nist_level = 2;
 	kem->ind_cca = false;
@@ -535,7 +535,7 @@ OQS_KEM *OQS_KEM_sidh_p610_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sidh_p610;
-	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd";
+	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78";
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = false;
@@ -605,7 +605,7 @@ OQS_KEM *OQS_KEM_sidh_p610_compressed_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sidh_p610_compressed;
-	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd";
+	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78";
 
 	kem->claimed_nist_level = 3;
 	kem->ind_cca = false;
@@ -675,7 +675,7 @@ OQS_KEM *OQS_KEM_sidh_p751_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sidh_p751;
-	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd";
+	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = false;
@@ -745,7 +745,7 @@ OQS_KEM *OQS_KEM_sidh_p751_compressed_new() {
 		return NULL;
 	}
 	kem->method_name = OQS_KEM_alg_sidh_p751_compressed;
-	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/28b4b5d0a7926e0e7eb4f9c03f75887236e1cebd";
+	kem->alg_version = "https://github.com/microsoft/PQCrypto-SIDH/commit/effa607f244768cdd38f930887076373604eaa78";
 
 	kem->claimed_nist_level = 5;
 	kem->ind_cca = false;


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

Updated SIKE to upstream commit effa60, addressing issue 1056: replaces `__inline` with `inline`; upstream also catches up to some changes already in OQS (for Apple M1 support).

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

Fixes #1056.
