### PR TITLE
enabling flexible build dir name in testing

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,7 +112,7 @@ add_definitions(-DOQS_COMPILE_OPTIONS="[${OQS_COMPILE_OPTIONS}]")
 # for DLL builds.
 add_custom_target(
     run_tests
-    COMMAND ${PYTHON3_EXEC} -m pytest --verbose --numprocesses=auto
+    COMMAND ${CMAKE_COMMAND} -E env OQS_BUILD_DIR=${CMAKE_BINARY_DIR} ${PYTHON3_EXEC} -m pytest --verbose --numprocesses=auto
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     DEPENDS oqs example_kem kat_kem test_kem example_sig kat_sig test_sig test_sig_mem test_kem_mem ${UNIX_TESTS}
     USES_TERMINAL)

--- a/tests/test_mem.py
+++ b/tests/test_mem.py
@@ -10,7 +10,7 @@ def test_mem_kem(kem_name):
     if not(helpers.is_kem_enabled_by_name(kem_name)):
         pytest.skip('Not enabled')
 
-    Path('build/mem-benchmark').mkdir(parents=True, exist_ok=True)
+    Path(helpers.get_current_build_dir_name()+'/mem-benchmark').mkdir(parents=True, exist_ok=True)
 
     for i in range(3):
        helpers.run_subprocess([helpers.path_to_executable('test_kem_mem'), kem_name, str(i)])
@@ -21,7 +21,7 @@ def test_mem_sig(sig_name):
     if not(helpers.is_sig_enabled_by_name(sig_name)):
         pytest.skip('Not enabled')
 
-    Path('build/mem-benchmark').mkdir(parents=True, exist_ok=True)
+    Path(helpers.get_current_build_dir_name()+'/mem-benchmark').mkdir(parents=True, exist_ok=True)
 
     for i in range(3):
        helpers.run_subprocess([helpers.path_to_executable('test_sig_mem'), sig_name, str(i)])

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -11,12 +11,12 @@ import glob
 @helpers.filtered_test
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Not needed on Windows")
 def test_namespace():
-    liboqs = glob.glob('build/lib/liboqs.*')[0]
-    if liboqs == 'build/lib/liboqs.dylib':
+    liboqs = glob.glob(helpers.get_current_build_dir_name()+'/lib/liboqs.*')[0]
+    if liboqs == helpers.get_current_build_dir_name()+'/lib/liboqs.dylib':
         out = helpers.run_subprocess(
             ['nm', '-g', liboqs]
         )
-    elif liboqs == 'build/lib/liboqs.so':
+    elif liboqs == helpers.get_current_build_dir_name()+'/lib/liboqs.so':
         out = helpers.run_subprocess(
             ['nm', '-D', liboqs]
         )


### PR DESCRIPTION
So far, all test executions were contingent upon the availability of the (hard-coded) build directory "build". This proves cumbersome if using differently named build directories, e.g., for different build options or build targets (e.g., `liboqs` binaries for openssh static build, openssl shared build, etc.).

This PR does away with this limitation, using the `cmake` variable `CMAKE_BINARY_DIR` instead.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)
