### PR TITLE
run optimized constant time tests only on haswell

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,7 +360,10 @@ workflows:
           name: constant-time-x64-extensions
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
-          CMAKE_ARGS: -DOQS_OPT_TARGET=auto -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
+          # building for haswell to avoid generating instructions that valgrind cannot currently handle
+          # TODO: Re-enable target=auto if/when valgrind supports beyond AVX2:
+          # check: https://valgrind.org/info/platforms.html
+          CMAKE_ARGS: -DOQS_OPT_TARGET=haswell -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
           PYTEST_ARGS: --numprocesses=auto -k 'test_constant_time'
       - linux_oqs:
           name: undefined-sanitizer


### PR DESCRIPTION
This should allow regular optimized code constant-time testing to pass despite current Valgrind platform limitations.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)


