### PR TITLE
increase constant time test timeout allowing slow runners to complete [skip ci]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,12 +353,16 @@ workflows:
       - linux_oqs:
           name: constant-time-x64
           context: openquantumsafe
+          # some algorithms _are_ slow:
+          no_output_timeout: 45m
           CONTAINER: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
           CMAKE_ARGS: -DOQS_OPT_TARGET=generic -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
           PYTEST_ARGS: --numprocesses=auto -k 'test_constant_time'
       - linux_oqs:
           name: constant-time-x64-extensions
           context: openquantumsafe
+          # some algorithms _are_ slow:
+          no_output_timeout: 45m
           CONTAINER: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
           # building for haswell to avoid generating instructions that valgrind cannot currently handle
           # TODO: Re-enable target=auto if/when valgrind supports beyond AVX2:


### PR DESCRIPTION
This should allow constant-time testing to pass despite some algorithms being very slow (we won't name them :).

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)
