### PR TITLE
skip algorithms for constant_time tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,10 @@ jobs:
         # Not every executor handles --numprocesses=auto being passed to pytest well
         # See https://github.com/open-quantum-safe/liboqs/issues/738#issuecomment-621394744
         default: --numprocesses=auto
+      SKIP_ALGS:
+        description: "Algorithms not to test in test_constant_time."
+        type: string
+        default: ''
     docker:
       - image: << parameters.CONTAINER >>
 # Re-enable iff docker enforces rate limitations without auth:
@@ -113,6 +117,8 @@ jobs:
           name: Run tests
           no_output_timeout: 1h
           command: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --junitxml=build/test-results/pytest/test-results.xml << parameters.PYTEST_ARGS >>
+          environment:
+             SKIP_ALGS: << parameters.SKIP_ALGS >>
       - store_test_results: # Note that this command will fail when running CircleCI locally, that is expected behaviour
           path: build/test-results
       - store_artifacts:
@@ -356,6 +362,7 @@ workflows:
           CONTAINER: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
           CMAKE_ARGS: -DOQS_OPT_TARGET=generic -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
           PYTEST_ARGS: --numprocesses=auto -k 'test_constant_time'
+          SKIP_ALGS: 'SPHINCS\+-SHA256*,Rainbow-V-Compressed'
       - linux_oqs:
           name: constant-time-x64-extensions
           context: openquantumsafe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,7 +362,6 @@ workflows:
           CONTAINER: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
           CMAKE_ARGS: -DOQS_OPT_TARGET=generic -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
           PYTEST_ARGS: --numprocesses=auto -k 'test_constant_time'
-          SKIP_ALGS: 'SPHINCS\+-SHA256*,Rainbow-V-Compressed'
       - linux_oqs:
           name: constant-time-x64-extensions
           context: openquantumsafe
@@ -372,6 +371,7 @@ workflows:
           # check: https://valgrind.org/info/platforms.html
           CMAKE_ARGS: -DOQS_OPT_TARGET=haswell -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
           PYTEST_ARGS: --numprocesses=auto -k 'test_constant_time'
+          SKIP_ALGS: 'SPHINCS\+-SHA256*,Rainbow-V-Compressed'
       - linux_oqs:
           name: undefined-sanitizer
           context: openquantumsafe

--- a/tests/test_constant_time.py
+++ b/tests/test_constant_time.py
@@ -177,6 +177,7 @@ import json
 import os
 import pytest
 import sys
+import re
 
 REQ_LIBOQS_BUILD_OPTS = ['OQS_ENABLE_TEST_CONSTANT_TIME',
                          'OQS_DEBUG_BUILD']
@@ -228,6 +229,10 @@ def get_ct_issues(t, name):
 @helpers.test_requires_valgrind_version_at_least(*MIN_VALGRIND_VERSION)
 @pytest.mark.parametrize('kem_name', helpers.available_kems_by_name())
 def test_constant_time_kem(kem_name):
+    if ('SKIP_ALGS' in os.environ) and len(os.environ['SKIP_ALGS'])>0:
+        for algexp in os.environ['SKIP_ALGS'].split(','):
+            if len(re.findall(algexp, kem_name))>0:
+               pytest.skip("Test disabled by alg filter")
     passes = get_ct_passes('kem', kem_name)
     issues = get_ct_issues('kem', kem_name)
     output = helpers.run_subprocess(
@@ -244,6 +249,10 @@ def test_constant_time_kem(kem_name):
 @helpers.test_requires_valgrind_version_at_least(*MIN_VALGRIND_VERSION)
 @pytest.mark.parametrize('sig_name', helpers.available_sigs_by_name())
 def test_constant_time_sig(sig_name):
+    if ('SKIP_ALGS' in os.environ) and len(os.environ['SKIP_ALGS'])>0:
+        for algexp in os.environ['SKIP_ALGS'].split(','):
+            if len(re.findall(algexp, sig_name))>0:
+               pytest.skip("Test disabled by alg filter")
     passes = get_ct_passes('sig', sig_name)
     issues = get_ct_issues('sig', sig_name)
     output = helpers.run_subprocess(


### PR DESCRIPTION
Fixes #1087. [Release documentation](https://github.com/open-quantum-safe/liboqs/wiki/Release-process) also updated.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)
