### PR TITLE
Enabling out-of-source build-and-test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,9 @@ tags
 *~
 .tags*
 
-# CMake
+# CMake & testing
 /build*
+/tmp*
 
 # MSVC
 .vs

--- a/tests/test_kem_mem.c
+++ b/tests/test_kem_mem.c
@@ -208,9 +208,9 @@ int main(int argc, char **argv) {
 	// Use system RNG in this program
 	OQS_randombytes_switch_algorithm(OQS_RAND_alg_system);
 
-	OQS_STATUS rc;
+	oqs_fstore_init();
 
-	rc = kem_test_correctness(alg_name, (unsigned int)atoi(argv[2]));
+	OQS_STATUS rc = kem_test_correctness(alg_name, (unsigned int)atoi(argv[2]));
 
 	if (rc != OQS_SUCCESS) {
 		return EXIT_FAILURE;

--- a/tests/test_sig_mem.c
+++ b/tests/test_sig_mem.c
@@ -188,6 +188,8 @@ int main(int argc, char **argv) {
 	// Use system RNG in this program
 	OQS_randombytes_switch_algorithm(OQS_RAND_alg_system);
 
+	oqs_fstore_init();
+
 	OQS_STATUS rc = sig_test_correctness(alg_name, (unsigned int)atoi(argv[2]));
 
 	if (rc != OQS_SUCCESS) {

--- a/tests/test_spdx.sh
+++ b/tests/test_spdx.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 
-find . \( -name '*.[chsS]' -or -name '*.cmake' -or -name '*.py' -or -name '*.sh' -or -name 'CMakeLists.txt' \) -and -type f | grep -v '/external/' | grep -v 'kem/.*/.*/.*' | grep -v 'sig/.*/.*/.*' | grep -v 'build' | grep -v 'xkcp_low' | grep -v 'patches' | xargs grep -L 'SPDX-License-Identifier' | sort
+BD=${OQS_BUILD_DIR:-build}
+find . \( -name '*.[chsS]' -or -name '*.cmake' -or -name '*.py' -or -name '*.sh' -or -name 'CMakeLists.txt' \) -and -type f | grep -v '/external/' | grep -v 'kem/.*/.*/.*' | grep -v 'sig/.*/.*/.*' | grep -v 'xkcp_low' | grep -v 'patches' | grep -v `basename $BD` | xargs grep -L 'SPDX-License-Identifier' | sort

--- a/tests/tmp_store.c
+++ b/tests/tmp_store.c
@@ -18,21 +18,21 @@ static OQS_STATUS oqs_fstore_init(void) {
 
 /* Activate when tmp folder cleanup desirable; only call after _all_ tests have completed!
 static OQS_STATUS oqs_fstore_cleanup(void) {
-	char fpath[MAXPATHLEN];
-	struct dirent *entry;
-	DIR *dir = opendir(OQS_STORE_DIR);
-	// first delete all files in OQS_STORE_DIR
-	while ((entry = readdir(dir)) != NULL) {
-		if (strcmp(entry->d_name, ".") && strcmp(entry->d_name, "..")) {
-			strcpy(fpath, OQS_STORE_DIR);
-			strcat(fpath, "/"); // tests only run under UNIX
-			strcat(fpath, entry->d_name);
-			if (unlink(fpath) != 0) {
-				fprintf(stderr, "Warning: Couldn't remove %s.\n", fpath);
-			}
-		}
-	}
-	return rmdir(OQS_STORE_DIR); // will return failure if some files could not be removed
+    char fpath[MAXPATHLEN];
+    struct dirent *entry;
+    DIR *dir = opendir(OQS_STORE_DIR);
+    // first delete all files in OQS_STORE_DIR
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") && strcmp(entry->d_name, "..")) {
+            strcpy(fpath, OQS_STORE_DIR);
+            strcat(fpath, "/"); // tests only run under UNIX
+            strcat(fpath, entry->d_name);
+            if (unlink(fpath) != 0) {
+                fprintf(stderr, "Warning: Couldn't remove %s.\n", fpath);
+            }
+        }
+    }
+    return rmdir(OQS_STORE_DIR); // will return failure if some files could not be removed
 }
 */
 

--- a/tests/tmp_store.c
+++ b/tests/tmp_store.c
@@ -3,15 +3,46 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
-#define STORE_PREFIX "build/mem-benchmark/oqs-temp-file-"
+#define OQS_STORE_DIR "tmp"
+#define OQS_STORE_PREFIX "/oqs-temp-file-"
 #define MAXPATHLEN 128
+
+static OQS_STATUS oqs_fstore_init(void) {
+	return mkdir(OQS_STORE_DIR, 0755);
+}
+
+/* Activate when tmp folder cleanup desirable; only call after _all_ tests have completed!
+static OQS_STATUS oqs_fstore_cleanup(void) {
+	char fpath[MAXPATHLEN];
+	struct dirent *entry;
+	DIR *dir = opendir(OQS_STORE_DIR);
+	// first delete all files in OQS_STORE_DIR
+	while ((entry = readdir(dir)) != NULL) {
+		if (strcmp(entry->d_name, ".") && strcmp(entry->d_name, "..")) {
+			strcpy(fpath, OQS_STORE_DIR);
+			strcat(fpath, "/"); // tests only run under UNIX
+			strcat(fpath, entry->d_name);
+			if (unlink(fpath) != 0) {
+				fprintf(stderr, "Warning: Couldn't remove %s.\n", fpath);
+			}
+		}
+	}
+	return rmdir(OQS_STORE_DIR); // will return failure if some files could not be removed
+}
+*/
 
 static OQS_STATUS oqs_fstore(const char *fname, const char *mname, uint8_t *data, size_t len) {
 	char fpath[MAXPATHLEN];
-	strcpy(fpath, STORE_PREFIX);
+	strcpy(fpath, OQS_STORE_DIR);
+	strcat(fpath, OQS_STORE_PREFIX);
 	strcat(fpath, mname);
-	FILE *fp = fopen(strcat(fpath, fname), "wb");
+	strcat(fpath, fname);
+	FILE *fp = fopen(fpath, "wb");
 	if (!fp) {
 		fprintf(stderr, "Couldn't open %s for writing.\n", fpath);
 		return OQS_ERROR;
@@ -25,9 +56,11 @@ static OQS_STATUS oqs_fload(const char *fname, const char *mname, uint8_t *data,
 	size_t len_read = 0, r = 0;
 	uint8_t *dr = NULL;
 	char fpath[MAXPATHLEN];
-	strcpy(fpath, STORE_PREFIX);
+	strcpy(fpath, OQS_STORE_DIR);
+	strcat(fpath, OQS_STORE_PREFIX);
 	strcat(fpath, mname);
-	FILE *fp = fopen(strcat(fpath, fname), "rb");
+	strcat(fpath, fname);
+	FILE *fp = fopen(fpath, "rb");
 	if (!fp) {
 		fprintf(stderr, "Couldn't open %s for reading.\n", fpath);
 		return OQS_ERROR;

--- a/tests/tmp_store.c
+++ b/tests/tmp_store.c
@@ -5,7 +5,6 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 #define OQS_STORE_DIR "tmp"
 #define OQS_STORE_PREFIX "/oqs-temp-file-"

--- a/tests/tmp_store.c
+++ b/tests/tmp_store.c
@@ -4,7 +4,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <dirent.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -15,26 +14,6 @@
 static OQS_STATUS oqs_fstore_init(void) {
 	return mkdir(OQS_STORE_DIR, 0755);
 }
-
-/* Activate when tmp folder cleanup desirable; only call after _all_ tests have completed!
-static OQS_STATUS oqs_fstore_cleanup(void) {
-    char fpath[MAXPATHLEN];
-    struct dirent *entry;
-    DIR *dir = opendir(OQS_STORE_DIR);
-    // first delete all files in OQS_STORE_DIR
-    while ((entry = readdir(dir)) != NULL) {
-        if (strcmp(entry->d_name, ".") && strcmp(entry->d_name, "..")) {
-            strcpy(fpath, OQS_STORE_DIR);
-            strcat(fpath, "/"); // tests only run under UNIX
-            strcat(fpath, entry->d_name);
-            if (unlink(fpath) != 0) {
-                fprintf(stderr, "Warning: Couldn't remove %s.\n", fpath);
-            }
-        }
-    }
-    return rmdir(OQS_STORE_DIR); // will return failure if some files could not be removed
-}
-*/
 
 static OQS_STATUS oqs_fstore(const char *fname, const char *mname, uint8_t *data, size_t len) {
 	char fpath[MAXPATHLEN];

--- a/tests/tmp_store.c
+++ b/tests/tmp_store.c
@@ -10,6 +10,10 @@
 #define OQS_STORE_PREFIX "/oqs-temp-file-"
 #define MAXPATHLEN 128
 
+#if (defined(_WIN32) || defined(__WIN32__))
+#define mkdir(A, B) mkdir(A)
+#endif
+
 static OQS_STATUS oqs_fstore_init(void) {
 	return mkdir(OQS_STORE_DIR, 0755);
 }


### PR DESCRIPTION
Provides fix to #1090 and enhances/completes #1080. CI failures still due to #1035.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

