### PR TITLE
correct out-of-source build-and-test

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -120,13 +120,10 @@ def filtered_test(func):
 
 # So far, build dir name has been hard coded to "build".
 # This function makes it dependent on the availability of the environment variable OQS_BUILD_DIR:
-# OQS_BUILD_DIR must be below current working dir; if not, behave as before
-# If OQS_BUILD_DIR is not set, behave as before, returning hard-coded build name
+# If OQS_BUILD_DIR is not set, behave as before, returning hard-coded build name set as per README
 def get_current_build_dir_name():
     if 'OQS_BUILD_DIR' in os.environ:
-        # assure this is within current dir:
-        if os.environ['OQS_BUILD_DIR'].startswith(os.getcwd()):
-            return os.environ['OQS_BUILD_DIR'][len(os.getcwd())+1:]
+        return os.environ['OQS_BUILD_DIR']
     return 'build'
 
 def path_to_executable(program_name):


### PR DESCRIPTION
Removing unnecessary test addressing/resolving https://github.com/open-quantum-safe/liboqs/pull/1091#issuecomment-922370718

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

