### PR TITLE
skip more SPHINCS algs from weekly testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,7 +371,7 @@ workflows:
           # check: https://valgrind.org/info/platforms.html
           CMAKE_ARGS: -DOQS_OPT_TARGET=haswell -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
           PYTEST_ARGS: --numprocesses=auto -k 'test_constant_time'
-          SKIP_ALGS: 'SPHINCS\+-SHA256*,Rainbow-V-Compressed'
+          SKIP_ALGS: 'SPHINCS\+-SHA*,Rainbow-V-Compressed'
       - linux_oqs:
           name: undefined-sanitizer
           context: openquantumsafe


### PR DESCRIPTION
Disables SPHINCS+-SHA* tests from weekly tests due to timeouts.

AppVeyor failure most likely transient: Does anyone know how to trigger a re-run of that CI system?

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

