### PR TITLE
Skip non-enabled algs in constant time tests

### DIFF
--- a/tests/test_constant_time.py
+++ b/tests/test_constant_time.py
@@ -230,10 +230,6 @@ def get_ct_issues(t, name):
 @pytest.mark.parametrize('kem_name', helpers.available_kems_by_name())
 def test_constant_time_kem(kem_name):
     if not(helpers.is_kem_enabled_by_name(kem_name)): pytest.skip('Not enabled')
-    if ('SKIP_ALGS' in os.environ) and len(os.environ['SKIP_ALGS'])>0:
-        for algexp in os.environ['SKIP_ALGS'].split(','):
-            if len(re.findall(algexp, kem_name))>0:
-               pytest.skip("Test disabled by alg filter")
     passes = get_ct_passes('kem', kem_name)
     issues = get_ct_issues('kem', kem_name)
     output = helpers.run_subprocess(
@@ -251,10 +247,6 @@ def test_constant_time_kem(kem_name):
 @pytest.mark.parametrize('sig_name', helpers.available_sigs_by_name())
 def test_constant_time_sig(sig_name):
     if not(helpers.is_sig_enabled_by_name(sig_name)): pytest.skip('Not enabled')
-    if ('SKIP_ALGS' in os.environ) and len(os.environ['SKIP_ALGS'])>0:
-        for algexp in os.environ['SKIP_ALGS'].split(','):
-            if len(re.findall(algexp, sig_name))>0:
-               pytest.skip("Test disabled by alg filter")
     passes = get_ct_passes('sig', sig_name)
     issues = get_ct_issues('sig', sig_name)
     output = helpers.run_subprocess(

--- a/tests/test_constant_time.py
+++ b/tests/test_constant_time.py
@@ -229,6 +229,7 @@ def get_ct_issues(t, name):
 @helpers.test_requires_valgrind_version_at_least(*MIN_VALGRIND_VERSION)
 @pytest.mark.parametrize('kem_name', helpers.available_kems_by_name())
 def test_constant_time_kem(kem_name):
+    if not(helpers.is_kem_enabled_by_name(kem_name)): pytest.skip('Not enabled')
     if ('SKIP_ALGS' in os.environ) and len(os.environ['SKIP_ALGS'])>0:
         for algexp in os.environ['SKIP_ALGS'].split(','):
             if len(re.findall(algexp, kem_name))>0:
@@ -249,6 +250,7 @@ def test_constant_time_kem(kem_name):
 @helpers.test_requires_valgrind_version_at_least(*MIN_VALGRIND_VERSION)
 @pytest.mark.parametrize('sig_name', helpers.available_sigs_by_name())
 def test_constant_time_sig(sig_name):
+    if not(helpers.is_sig_enabled_by_name(sig_name)): pytest.skip('Not enabled')
     if ('SKIP_ALGS' in os.environ) and len(os.environ['SKIP_ALGS'])>0:
         for algexp in os.environ['SKIP_ALGS'].split(','):
             if len(re.findall(algexp, sig_name))>0:

--- a/tests/test_constant_time.py
+++ b/tests/test_constant_time.py
@@ -230,6 +230,10 @@ def get_ct_issues(t, name):
 @pytest.mark.parametrize('kem_name', helpers.available_kems_by_name())
 def test_constant_time_kem(kem_name):
     if not(helpers.is_kem_enabled_by_name(kem_name)): pytest.skip('Not enabled')
+    if ('SKIP_ALGS' in os.environ) and len(os.environ['SKIP_ALGS'])>0:
+        for algexp in os.environ['SKIP_ALGS'].split(','):
+            if len(re.findall(algexp, kem_name))>0:
+               pytest.skip("Test disabled by alg filter")
     passes = get_ct_passes('kem', kem_name)
     issues = get_ct_issues('kem', kem_name)
     output = helpers.run_subprocess(
@@ -247,6 +251,10 @@ def test_constant_time_kem(kem_name):
 @pytest.mark.parametrize('sig_name', helpers.available_sigs_by_name())
 def test_constant_time_sig(sig_name):
     if not(helpers.is_sig_enabled_by_name(sig_name)): pytest.skip('Not enabled')
+    if ('SKIP_ALGS' in os.environ) and len(os.environ['SKIP_ALGS'])>0:
+        for algexp in os.environ['SKIP_ALGS'].split(','):
+            if len(re.findall(algexp, sig_name))>0:
+               pytest.skip("Test disabled by alg filter")
     passes = get_ct_passes('sig', sig_name)
     issues = get_ct_issues('sig', sig_name)
     output = helpers.run_subprocess(


### PR DESCRIPTION
Skip non-enabled algs in constant time tests.

The current script depended on a `SKIP_ALGS` variable, that isn't documented and isn't set by cmake when using the `OQS_MINIMAL_BUILD ` build macro. I'm not sure if that code can safely replaced by the common helper check (as this PR does), or if it has a deeper purpose I don't understand. (@jschanck?)