### PR TITLE
Updated valgrind constant time exception for picnic

### DIFF
--- a/tests/constant_time/sig/passes/picnic3
+++ b/tests/constant_time/sig/passes/picnic3
@@ -36,10 +36,38 @@
    fun:oqs_sig_picnic_sign
 }
 {
+   debug output on failure
+   Memcheck:Cond
+   src:picnic3_impl.c:625 # fun:sign_picnic3
+   fun:oqs_sig_picnic_impl_sign_picnic3
+}
+{
+   conditional on unitialized value (hash context init in commit)
+   Memcheck:Cond
+   fun:KeccakP1600_AddLanes
+   fun:KeccakP1600_AddBytes
+   fun:keccak_inc_absorb
+   fun:OQS_SHA3_shake*_inc_absorb
+   fun:hash_update
+   src:picnic3_impl.c:107 # fun:commit
+   fun:sign_picnic3
+}
+{
+   use of unitialized value (hash context init in commit)
+   Memcheck:Value8
+   fun:KeccakP1600_AddLanes
+   fun:KeccakP1600_AddBytes
+   fun:keccak_inc_absorb
+   fun:OQS_SHA3_shake*_inc_absorb
+   fun:hash_update
+   src:picnic3_impl.c:107 # fun:commit
+   fun:sign_picnic3
+}
+{
    challengeC is declassified
    Memcheck:Cond
    fun:contains
-   src:picnic3_impl.c:685 # fun:sign_picnic3
+   src:picnic3_impl.c:673 # fun:sign_picnic3
    fun:oqs_sig_picnic_impl_sign_picnic3
    fun:oqs_sig_picnic_sign
 }
@@ -47,28 +75,28 @@
    challengeC is declassified
    Memcheck:Cond
    fun:indexOf
-   src:picnic3_impl.c:687 # fun:sign_picnic3
+   src:picnic3_impl.c:675 # fun:sign_picnic3
    fun:oqs_sig_picnic_impl_sign_picnic3
    fun:oqs_sig_picnic_sign
 }
 {
    challengeP is declassified
    Memcheck:Cond
-   src:picnic3_impl.c:698 # fun:sign_picnic3
+   src:picnic3_impl.c:686 # fun:sign_picnic3
    fun:oqs_sig_picnic_impl_sign_picnic3
    fun:oqs_sig_picnic_sign
 }
 {
    challengeP is declassified
    Memcheck:Value8
-   src:picnic3_impl.c:703 # fun:sign_picnic3
+   src:picnic3_impl.c:691 # fun:sign_picnic3
    fun:oqs_sig_picnic_impl_sign_picnic3
    fun:oqs_sig_picnic_sign
 }
 {
    Index of the unopened party is declassified
    Memcheck:Cond
-   src:picnic3_impl.c:707 # fun:sign_picnic3
+   src:picnic3_impl.c:695 # fun:sign_picnic3
    fun:oqs_sig_picnic_impl_sign_picnic3
    fun:oqs_sig_picnic_sign
 }
@@ -76,7 +104,7 @@
    Index of the unopened party is declassified
    Memcheck:Cond
    fun:oqs_sig_picnic_getLeaf
-   src:picnic3_impl.c:708 # fun:sign_picnic3
+   src:picnic3_impl.c:696 # fun:sign_picnic3
    fun:oqs_sig_picnic_impl_sign_picnic3
    fun:oqs_sig_picnic_sign
 }
@@ -84,7 +112,7 @@
    Index of the unopened party is declassified
    Memcheck:Value8
    fun:oqs_sig_picnic_getLeaf
-   src:picnic3_impl.c:708 # fun:sign_picnic3
+   src:picnic3_impl.c:696 # fun:sign_picnic3
    fun:oqs_sig_picnic_impl_sign_picnic3
    fun:oqs_sig_picnic_sign
 }
@@ -92,7 +120,7 @@
    Index of the unopened party is declassified
    Memcheck:Cond
    fun:oqs_sig_picnic_getLeaf
-   src:picnic3_impl.c:711 # fun:sign_picnic3
+   src:picnic3_impl.c:699 # fun:sign_picnic3
    fun:oqs_sig_picnic_impl_sign_picnic3
    fun:oqs_sig_picnic_sign
 }
@@ -100,7 +128,7 @@
    Index of the unopened party is declassified
    Memcheck:Value8
    fun:oqs_sig_picnic_getLeaf
-   src:picnic3_impl.c:711 # fun:sign_picnic3
+   src:picnic3_impl.c:699 # fun:sign_picnic3
    fun:oqs_sig_picnic_impl_sign_picnic3
    fun:oqs_sig_picnic_sign
 }


### PR DESCRIPTION
Updated valgrind constant time exception for picnic, for new code and code that moved in the file (updated line numbers).

Fix #1118.
