### PR TITLE
skip more ClassicMcEliece weekly CI constant time tests [skip ci]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,6 +362,7 @@ workflows:
           CONTAINER: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
           CMAKE_ARGS: -DOQS_OPT_TARGET=generic -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
           PYTEST_ARGS: --numprocesses=auto -k 'test_constant_time'
+          SKIP_ALGS: 'SPHINCS\+-SHA*,Rainbow-V-Compressed,Classic-McEliece-6(.)*'
       - linux_oqs:
           name: constant-time-x64-extensions
           context: openquantumsafe
@@ -371,7 +372,7 @@ workflows:
           # check: https://valgrind.org/info/platforms.html
           CMAKE_ARGS: -DOQS_OPT_TARGET=haswell -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
           PYTEST_ARGS: --numprocesses=auto -k 'test_constant_time'
-          SKIP_ALGS: 'SPHINCS\+-SHA*,Rainbow-V-Compressed'
+          SKIP_ALGS: 'SPHINCS\+-SHA*,Rainbow-V-Compressed,Classic-McEliece-6(.)*'
       - linux_oqs:
           name: undefined-sanitizer
           context: openquantumsafe


### PR DESCRIPTION
Fixes #1132 

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

