### PR TITLE
more code style checks

### DIFF
--- a/tests/run_astyle.sh
+++ b/tests/run_astyle.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 
+rv=0
+
 # check style of non-external code:
 find src tests -name '*.[ch]' | grep -v '/external/' | grep -v 'kem/.*/.*/.*' | grep -v 'sig/.*/.*/.*' | xargs astyle --dry-run --options=.astylerc | grep Format
 if [ $? -ne 1 ]; then
-   echo "Error: Some files need reformatting. Check output above. Exiting."
-   exit -1
+   echo "Error: Some files need reformatting. Check output above."
+   rv=-1
 fi
 
 # check _all_ source files for CRLF line endings:
 find . -name '*.[chS]' -exec file "{}" ";" | grep CRLF
 if [ $? -ne 1 ]; then
-   echo "Error: Files found with non-UNIX line endings. Exiting."
+   echo "Error: Files found with non-UNIX line endings."
    echo "To fix, consider running \"find src tests -name '*.[chS]' | xargs sed -i 's/\r//' \"."
-   exit -1
+   rv=-1
 fi
+
+exit $rv

--- a/tests/run_astyle.sh
+++ b/tests/run_astyle.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 
-find src tests -name '*.[ch]' | grep -v '/external/' | grep -v 'kem/.*/.*/.*' | grep -v 'sig/.*/.*/.*' | xargs astyle --dry-run --options=.astylerc
+# check style of non-external code:
+find src tests -name '*.[ch]' | grep -v '/external/' | grep -v 'kem/.*/.*/.*' | grep -v 'sig/.*/.*/.*' | xargs astyle --dry-run --options=.astylerc | grep Format
+if [ $? -ne 1 ]; then
+   echo "Error: Some files need reformatting. Check output above. Exiting."
+   exit -1
+fi
+
+# check _all_ source files for CRLF line endings:
+find . -name '*.[chS]' -exec file "{}" ";" | grep CRLF
+if [ $? -ne 1 ]; then
+   echo "Error: Files found with non-UNIX line endings. Exiting."
+   echo "To fix, consider running \"find src tests -name '*.[chS]' | xargs sed -i 's/\r//' \"."
+   exit -1
+fi


### PR DESCRIPTION
Fixes #1129 (now also guarding against regressions).

Also, problematic files are highlighted better and advice is output what needs to be done on error.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

