### PR TITLE
Enabling use of ARM PMU for benchmarking when compiler flag is enabled

### DIFF
--- a/tests/ds_benchmark.h
+++ b/tests/ds_benchmark.h
@@ -181,6 +181,15 @@ static void _bench_init_perfcounters(int32_t do_reset, int32_t enable_divider) {
 	__asm__ volatile("mcr p15, 0, %0, c9, c12, 3\t\n" ::"r"(0x8000000f));
 }
 #elif defined(SPEED_USE_ARM_PMU)
+
+/* Enabling access to ARMv8's Performance Monitoring Unit
+ * cannot be done from user mode. A kernel module to
+ * enable access must be loaded. This generally will
+ * require superuser permissions. A module that has
+ * been found to work on some platforms can be found at
+ * https://github.com/mupq/pqax#enable-access-to-performance-counters
+ */
+
 static void _bench_init_perfcounters(void) {
 	__asm__ volatile("MSR PMCR_EL0, %0" ::"r"(1));
 	__asm__ volatile("MSR PMCNTENSET_EL0, %0" ::"r"(0x80000000));

--- a/tests/ds_benchmark.h
+++ b/tests/ds_benchmark.h
@@ -135,6 +135,12 @@ static uint64_t _bench_rdtsc(void) {
 	__asm__ volatile("mrc p15, 0, %0, c9, c13, 0\t\n"
 	                 : "=r"(value));
 	return value;
+#elif defined(SPEED_USE_ARM_PMU)
+	/* Use the Performance Monitoring Unit */
+	uint64_t value;
+	/* Read the PMU register */
+	__asm__ volatile("mrs %0, PMCCNTR_EL0" : "=r" (value));
+	return value;
 #elif defined(__s390x__)
 #define USING_TIME_RATHER_THAN_CYCLES
 	uint64_t tod;
@@ -174,6 +180,11 @@ static void _bench_init_perfcounters(int32_t do_reset, int32_t enable_divider) {
 	/* Clear overflows */
 	__asm__ volatile("mcr p15, 0, %0, c9, c12, 3\t\n" ::"r"(0x8000000f));
 }
+#elif defined(SPEED_USE_ARM_PMU)
+static void _bench_init_perfcounters(void) {
+	__asm__ volatile("MSR PMCR_EL0, %0" ::"r"(1));
+	__asm__ volatile("MSR PMCNTENSET_EL0, %0" ::"r"(0x80000000));
+}
 #endif
 
 #define DEFINE_TIMER_VARIABLES                                                                              \
@@ -193,6 +204,15 @@ static void _bench_init_perfcounters(int32_t do_reset, int32_t enable_divider) {
     _bench_cycles_M2 = 0.0;         \
     _bench_time_cumulative = 0;     \
     _bench_time_mean = 0.0;         \
+    _bench_time_M2 = 0.0;
+#elif defined(SPEED_USE_ARM_PMU)
+#define INITIALIZE_TIMER        \
+    _bench_init_perfcounters(); \
+    _bench_iterations = 0;      \
+    _bench_cycles_mean = 0.0;   \
+    _bench_cycles_M2 = 0.0;     \
+    _bench_time_cumulative = 0; \
+    _bench_time_mean = 0.0;     \
     _bench_time_M2 = 0.0;
 #else
 #define INITIALIZE_TIMER        \

--- a/tests/speed_kem.c
+++ b/tests/speed_kem.c
@@ -11,6 +11,9 @@
 #if defined(USE_RASPBERRY_PI)
 #define _RASPBERRY_PI
 #endif
+#if defined(OQS_SPEED_USE_ARM_PMU)
+#define SPEED_USE_ARM_PMU
+#endif
 #include "ds_benchmark.h"
 #include "system_info.c"
 

--- a/tests/speed_sig.c
+++ b/tests/speed_sig.c
@@ -11,6 +11,9 @@
 #if defined(USE_RASPBERRY_PI)
 #define _RASPBERRY_PI
 #endif
+#if defined(OQS_SPEED_USE_ARM_PMU)
+#define SPEED_USE_ARM_PMU
+#endif
 #include "ds_benchmark.h"
 #include "system_info.c"
 

--- a/tests/test_aes.c
+++ b/tests/test_aes.c
@@ -10,6 +10,9 @@
 #if defined(USE_RASPBERRY_PI)
 #define _RASPBERRY_PI
 #endif
+#if defined(OQS_SPEED_USE_ARM_PMU)
+#define SPEED_USE_ARM_PMU
+#endif
 #include "ds_benchmark.h"
 #include "system_info.c"
 


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

This pull request enables the use of ARMv8's performance monitoring unit (PMU) in the benchmarking script to allow for a more precise cycle count on that architecture when possible. It is enabled by the OQS_SPEED_USE_ARM_PMU compiler flag. Note that loading a kernel module (such as https://github.com/mupq/pqax#enable-access-to-performance-counters ) is required to access the PMU from user mode.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
