### PR TITLE
Option to use PMU for benchmarking on ARM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,8 @@ else()
     set(OQS_DEBUG_BUILD OFF)
 endif()
 
+option(OQS_SPEED_USE_ARM_PMU "Use ARM Performance Monitor Unit during benchmarking" OFF)
+
 if(WIN32)
     set(CMAKE_GENERATOR_CC cl)
 endif()

--- a/src/oqsconfig.h.cmake
+++ b/src/oqsconfig.h.cmake
@@ -39,6 +39,8 @@
 #cmakedefine OQS_USE_ARM_SHA3_INSTRUCTIONS 1
 #cmakedefine OQS_USE_ARM_NEON_INSTRUCTIONS 1
 
+#cmakedefine OQS_SPEED_USE_ARM_PMU 1
+
 #cmakedefine OQS_ENABLE_TEST_CONSTANT_TIME 1
 
 #cmakedefine OQS_ENABLE_SHA3_xkcp_low_avx2 1

--- a/tests/speed_kem.c
+++ b/tests/speed_kem.c
@@ -11,6 +11,9 @@
 #if defined(USE_RASPBERRY_PI)
 #define _RASPBERRY_PI
 #endif
+#if defined(OQS_SPEED_USE_ARM_PMU)
+#define SPEED_USE_ARM_PMU
+#endif
 #include "ds_benchmark.h"
 #include "system_info.c"
 

--- a/tests/speed_sig.c
+++ b/tests/speed_sig.c
@@ -11,6 +11,9 @@
 #if defined(USE_RASPBERRY_PI)
 #define _RASPBERRY_PI
 #endif
+#if defined(OQS_SPEED_USE_ARM_PMU)
+#define SPEED_USE_ARM_PMU
+#endif
 #include "ds_benchmark.h"
 #include "system_info.c"
 

--- a/tests/test_aes.c
+++ b/tests/test_aes.c
@@ -10,6 +10,9 @@
 #if defined(USE_RASPBERRY_PI)
 #define _RASPBERRY_PI
 #endif
+#if defined(OQS_SPEED_USE_ARM_PMU)
+#define SPEED_USE_ARM_PMU
+#endif
 #include "ds_benchmark.h"
 #include "system_info.c"
 


### PR DESCRIPTION
#1141 didn't merge to main, so this fixes that.