### PR TITLE
Tweaks to benchmarking code

### DIFF
--- a/tests/ds_benchmark.h
+++ b/tests/ds_benchmark.h
@@ -254,19 +254,19 @@ static void _bench_init_perfcounters(void) {
     _bench_cycles_delta = _bench_cycles_x - _bench_cycles_mean;                                                                                                             \
     _bench_cycles_mean += _bench_cycles_delta / (double) _bench_iterations;                                                                                                 \
     _bench_cycles_M2 += _bench_cycles_delta * (_bench_cycles_x - _bench_cycles_mean);                                                                                       \
-    _bench_time_x = (double) ((_bench_timeval_end.tv_sec * 1000000 + _bench_timeval_end.tv_usec) - (_bench_timeval_start.tv_sec * 1000000 + _bench_timeval_start.tv_usec)); \
+    _bench_time_x = (double) ((((uint64_t) _bench_timeval_end.tv_sec) * 1000000 + (uint64_t) _bench_timeval_end.tv_usec) - (((uint64_t) _bench_timeval_start.tv_sec) * 1000000 + (uint64_t) _bench_timeval_start.tv_usec)); \
     _bench_time_delta = _bench_time_x - _bench_time_mean;                                                                                                                   \
     _bench_time_mean += _bench_time_delta / (double) _bench_iterations;                                                                                                     \
     _bench_time_M2 += _bench_time_delta * (_bench_time_x - _bench_time_mean);                                                                                               \
     _bench_time_cumulative += (uint64_t) _bench_time_x;
 
 #define FINALIZE_TIMER                                                             \
-    if (_bench_iterations == 2) {                                                  \
+    if (_bench_iterations < 2) {                                                   \
         _bench_cycles_stdev = 0.0;                                                 \
     } else {                                                                       \
         _bench_cycles_stdev = sqrt(_bench_cycles_M2 / (double) _bench_iterations); \
     }                                                                              \
-    if (_bench_iterations == 2) {                                                  \
+    if (_bench_iterations < 2) {                                                   \
         _bench_time_stdev = 0.0;                                                   \
     } else {                                                                       \
         _bench_time_stdev = sqrt(_bench_time_M2 / (double) _bench_iterations);     \


### PR DESCRIPTION
- Fix bug in standard deviation calculation
- Cast values to protect against overflows (as suggested by https://github.com/open-quantum-safe/liboqs/pull/1141#issuecomment-989708501)

* [No] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [No] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)
