### PR TITLE
release performance regression test

### DIFF
--- a/scripts/noregress.py
+++ b/scripts/noregress.py
@@ -1,0 +1,18 @@
+import json
+import sys
+import os
+
+cutoffpercent = 15
+
+with open(sys.argv[1], 'r') as json_file:
+   d1 = json.load(json_file)
+with open(sys.argv[2], 'r') as json_file:
+   d2 = json.load(json_file)
+
+for k in d1.keys(): # algs
+      if k != "config" and k != "cpuinfo":
+          if k in d2.keys():
+            for op in d1[k]:
+              diff = 100.0*(float(d1[k][op]) - float(d2[k][op]))/float(d1[k][op])
+              if (abs(diff) > cutoffpercent):
+                 print("Alg: %s, Op: %s, Val1: %s; Val2: %s; diff: %2.2f%%" % (k, op, d1[k][op], d2[k][op], diff))

--- a/scripts/noregress.sh
+++ b/scripts/noregress.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]; then
+   echo "Usage: $0 <liboqs-release to test regression against>. Exiting."
+   exit -1
+fi
+
+# Approach: Check out $1 into tmp folder, build, run speed_kem|sig and compare results
+
+mkdir tmp && cd tmp && git clone --depth 1 --branch $1 https://github.com/open-quantum-safe/liboqs && cd liboqs && mkdir build && cd build && cmake -GNinja .. && ninja && ./tests/speed_kem > ../../speed_kem.log && ./tests/speed_sig > ../../speed_sig.log && cd ../../..
+
+# transform results into JSON files for simple comparison
+
+cd tmp && git clone --depth 1 https://github.com/open-quantum-safe/profiling.git && python3 profiling/perf/scripts/parse_liboqs_speed.py speed_kem.log && python3 profiling/perf/scripts/parse_liboqs_speed.py speed_sig.log && cd ..
+
+# obtain current base speed results
+rm -rf build && mkdir build && cd build && cmake -GNinja .. && ninja && ./tests/speed_kem > speed_kem.log && ./tests/speed_sig > speed_sig.log && python3 ../tmp/profiling/perf/scripts/parse_liboqs_speed.py speed_kem.log && python3 ../tmp/profiling/perf/scripts/parse_liboqs_speed.py speed_sig.log && cd ..
+
+# now compare results using old/tmp runs as baseline (for list of algorithms)
+python3 scripts/noregress.py tmp/speed_kem.json build/speed_kem.json && python3 scripts/noregress.py tmp/speed_sig.json build/speed_sig.json

--- a/scripts/noregress.sh
+++ b/scripts/noregress.sh
@@ -1,20 +1,41 @@
 #!/bin/bash
 
-if [ $# -ne 1 ]; then
-   echo "Usage: $0 <liboqs-release to test regression against>. Exiting."
+if [ $# -lt 1 ]; then
+   echo "Usage: $0 <liboqs-release to test regression against> [<cmake opts> [<make cmd>]]. Exiting."
    exit -1
+fi
+
+if [ $# -lt 3 ]; then
+   MAKECMD="make -j 2"
+else
+   MAKECMD=$3
 fi
 
 # Approach: Check out $1 into tmp folder, build, run speed_kem|sig and compare results
 
-mkdir tmp && cd tmp && git clone --depth 1 --branch $1 https://github.com/open-quantum-safe/liboqs && cd liboqs && mkdir build && cd build && cmake -GNinja .. && ninja && ./tests/speed_kem > ../../speed_kem.log && ./tests/speed_sig > ../../speed_sig.log && cd ../../..
+mkdir tmp && cd tmp && git clone --depth 1 --branch $1 https://github.com/open-quantum-safe/liboqs && cd liboqs && mkdir build && cd build && cmake $2 .. && $MAKECMD && ./tests/speed_kem > ../../speed_kem.log && ./tests/speed_sig > ../../speed_sig.log && cd ../../..
+
+if [ $? -ne 0 ]; then
+   echo "Build and test of baseline $1 failed. Exiting."
+   exit -1
+fi
 
 # transform results into JSON files for simple comparison
 
 cd tmp && git clone --depth 1 https://github.com/open-quantum-safe/profiling.git && python3 profiling/perf/scripts/parse_liboqs_speed.py speed_kem.log && python3 profiling/perf/scripts/parse_liboqs_speed.py speed_sig.log && cd ..
 
+if [ $? -ne 0 ]; then
+   echo "Failure converting results. Exiting."
+   exit -1
+fi
+
 # obtain current base speed results
-rm -rf build && mkdir build && cd build && cmake -GNinja .. && ninja && ./tests/speed_kem > speed_kem.log && ./tests/speed_sig > speed_sig.log && python3 ../tmp/profiling/perf/scripts/parse_liboqs_speed.py speed_kem.log && python3 ../tmp/profiling/perf/scripts/parse_liboqs_speed.py speed_sig.log && cd ..
+rm -rf build && mkdir build && cd build && cmake $2 .. && $MAKECMD && ./tests/speed_kem > speed_kem.log && ./tests/speed_sig > speed_sig.log && python3 ../tmp/profiling/perf/scripts/parse_liboqs_speed.py speed_kem.log && python3 ../tmp/profiling/perf/scripts/parse_liboqs_speed.py speed_sig.log && cd ..
+
+if [ $? -ne 0 ]; then
+   echo "Failure creating current results. Exiting."
+   exit -1
+fi
 
 # now compare results using old/tmp runs as baseline (for list of algorithms)
 python3 scripts/noregress.py tmp/speed_kem.json build/speed_kem.json && python3 scripts/noregress.py tmp/speed_sig.json build/speed_sig.json


### PR DESCRIPTION
This script uses code from `profiling` to compare execution performance between the current code and a `liboqs` release. It outputs only significant (>15%) deviations. It has been tested successfully on `x86_64` and `aarch64` platforms comparing `0.7.1-rc1` vs `0.7.0` and `0.6.0`. Documentation is available in [release process](https://github.com/open-quantum-safe/liboqs/wiki/Release-process#performance).

