### PR TITLE
docs: set license MIT to Falcon Signature

### DIFF
--- a/docs/algorithms/sig/falcon.md
+++ b/docs/algorithms/sig/falcon.md
@@ -9,7 +9,7 @@
 - **Implementation source**: https://github.com/PQClean/PQClean/commit/6a32796212b79a5f9126d0a933e1216313f50c16, which takes it from:
   - https://github.com/jschanck/package-pqclean/tree/cea1fa5a/falcon, which takes it from:
   - supercop-20201018
-- **Implementation license (SPDX-Identifier)**: CC0-1.0.
+- **Implementation license (SPDX-Identifier)**: MIT.
 
 ## Parameter set summary
 

--- a/docs/algorithms/sig/falcon.yml
+++ b/docs/algorithms/sig/falcon.yml
@@ -16,7 +16,7 @@ crypto-assumption: hardness of NTRU lattice problems
 website: https://falcon-sign.info
 nist-round: 3
 spec-version: v1.2
-spdx-license-identifier: CC0-1.0
+spdx-license-identifier: MIT
 upstream: https://github.com/PQClean/PQClean/commit/6a32796212b79a5f9126d0a933e1216313f50c16
 upstream-ancestors:
 - https://github.com/jschanck/package-pqclean/tree/cea1fa5a/falcon


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
https://github.com/open-quantum-safe/liboqs/blob/main/docs/algorithms/sig/falcon.md states **license CC0-1.0**

But the license in the header file at https://falcon-sign.info/impl/falcon.h.html is  ** license MIT** , the same at https://github.com/PQClean/PQClean/blob/master/crypto_sign/falcon-1024/clean/LICENSE

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
No

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
