### PR TITLE
add trigger for oqs-provider CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,6 +242,17 @@ jobs:
                  https://circleci.com/api/v2/project/gh/open-quantum-safe/openssh/pipeline | tee curl_out \
             && grep -q "201" curl_out
       - run:
+          name: Trigger oqs-provider CI
+          command: |2
+            curl --silent \
+                 --write-out "\n%{response_code}\n" \
+                 --user ${BUILD_TRIGGER_TOKEN}: \
+                 --request POST \
+                 --header "Content-Type: application/json" \
+                 --data '{ "branch": "main" }' \
+                 https://circleci.com/api/v2/project/gh/open-quantum-safe/oqs-provider/pipeline | tee curl_out \
+            && grep -q "201" curl_out
+      - run:
           name: Trigger liboqs-dotnet CI
           command: |2
             curl --silent \


### PR DESCRIPTION
`oqs-provider` needs to get triggered on merges to `main` to avoid surprising build failures.

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

