### PR TITLE
remove picnic from cygwin build

### DIFF
--- a/appveyor_build.bat
+++ b/appveyor_build.bat
@@ -2,7 +2,7 @@
 IF %COMPILER%==cygwin (
     @echo on
     SET "PATH=C:\cywin64\bin;c:\cygwin64;%PATH%"
-    c:\cygwin64\bin\bash.exe -lc "setup-x86_64.exe -qnNdO -R C:/cygwin64 -l C:/cygwin/var/cache/setup -P openssl -P libssl-devel -P ninja -P cmake -P gcc && cd ${APPVEYOR_BUILD_FOLDER} && openssl version && cygcheck -c && pwd && mkdir build && cd build && cmake .. -GNinja -DCMAKE_C_COMPILER=gcc -DOQS_DIST_BUILD=ON -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_ENABLE_SIG_RAINBOW=OFF -DBUILD_SHARED_LIBS=%BUILD_SHARED% -DOQS_USE_OPENSSL=%OQS_USE_OPENSSL% && ninja "
+    c:\cygwin64\bin\bash.exe -lc "setup-x86_64.exe -qnNdO -R C:/cygwin64 -l C:/cygwin/var/cache/setup -P openssl -P libssl-devel -P ninja -P cmake -P gcc && cd ${APPVEYOR_BUILD_FOLDER} && openssl version && cygcheck -c && pwd && mkdir build && cd build && cmake .. -GNinja -DCMAKE_C_COMPILER=gcc -DOQS_DIST_BUILD=ON -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_ENABLE_SIG_RAINBOW=OFF -DOQS_ENABLE_SIG_PICNIC=OFF -DBUILD_SHARED_LIBS=%BUILD_SHARED% -DOQS_USE_OPENSSL=%OQS_USE_OPENSSL% && ninja "
 )
 IF %COMPILER%==msys2 (
     @echo on

--- a/docs/algorithms/sig/picnic.md
+++ b/docs/algorithms/sig/picnic.md
@@ -53,7 +53,7 @@ Are implementations chosen based on runtime CPU feature detection? **No**.
 |:------------------------:|:----------------------------|:--------------------------------|:------------------------|:-----------------------------------|:-----------------------------------------------|:---------------------|
 |          master          | All                         | All                             | None                    | True                               | True                                           | False                |
 |          master          | x86\_64                     | Linux                           | AVX2,SSE2               | True                               | True                                           | False                |
-|          master          | x86\_64                     | Darwin,Windows                  | SSE2                    | True                               | True                                           | False                |
+|          master          | x86\_64                     | Darwin,Windows (except cygwin)  | SSE2                    | True                               | True                                           | False                |
 
 Are implementations chosen based on runtime CPU feature detection? **No**.
 
@@ -83,7 +83,7 @@ Are implementations chosen based on runtime CPU feature detection? **No**.
 |:------------------------:|:----------------------------|:--------------------------------|:------------------------|:-----------------------------------|:-----------------------------------------------|:---------------------|
 |          master          | All                         | All                             | None                    | True                               | True                                           | False                |
 |          master          | x86\_64                     | Linux                           | AVX2,SSE2               | True                               | True                                           | False                |
-|          master          | x86\_64                     | Darwin,Windows                  | SSE2                    | True                               | True                                           | False                |
+|          master          | x86\_64                     | Darwin,Windows (except cygwin)  | SSE2                    | True                               | True                                           | False                |
 
 Are implementations chosen based on runtime CPU feature detection? **No**.
 
@@ -113,7 +113,7 @@ Are implementations chosen based on runtime CPU feature detection? **No**.
 |:------------------------:|:----------------------------|:--------------------------------|:------------------------|:-----------------------------------|:-----------------------------------------------|:---------------------|
 |          master          | All                         | All                             | None                    | True                               | True                                           | False                |
 |          master          | x86\_64                     | Linux                           | AVX2,SSE2               | True                               | True                                           | False                |
-|          master          | x86\_64                     | Darwin,Windows                  | SSE2                    | True                               | True                                           | False                |
+|          master          | x86\_64                     | Darwin,Windows (except cygwin)  | SSE2                    | True                               | True                                           | False                |
 
 Are implementations chosen based on runtime CPU feature detection? **No**.
 

--- a/docs/algorithms/sig/picnic.yml
+++ b/docs/algorithms/sig/picnic.yml
@@ -114,7 +114,7 @@ parameter-sets:
     - architecture: x86_64
       operating_systems:
       - Darwin
-      - Windows
+      - Windows (except cygwin)
       required_flags:
       - sse2
     common-crypto:
@@ -216,7 +216,7 @@ parameter-sets:
     - architecture: x86_64
       operating_systems:
       - Darwin
-      - Windows
+      - Windows (except cygwin)
       required_flags:
       - sse2
     common-crypto:
@@ -318,7 +318,7 @@ parameter-sets:
     - architecture: x86_64
       operating_systems:
       - Darwin
-      - Windows
+      - Windows (except cygwin)
       required_flags:
       - sse2
     common-crypto:


### PR DESCRIPTION
Workaround for #1163. 

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

