### PR TITLE
disable BIKE on all 32bitters except x86

### DIFF
--- a/.CMake/alg_support.cmake
+++ b/.CMake/alg_support.cmake
@@ -29,6 +29,10 @@ endif()
 
 # BIKE is not supported on Windows, 32-bit ARM, S390X (big endian) and PPC64 (big endian)
 cmake_dependent_option(OQS_ENABLE_KEM_BIKE "Enable BIKE algorithm family" ON "NOT WIN32; NOT ARCH_ARM32v7; NOT ARCH_X86; NOT ARCH_S390X; NOT ARCH_PPC64" OFF)
+# BIKE doesn't work on any 32bit platform except x86:
+if(CMAKE_SIZEOF_VOID_P MATCHES "4" AND NOT ARCH_X86)
+set(OQS_ENABLE_KEM_BIKE OFF)
+endif()
 cmake_dependent_option(OQS_ENABLE_KEM_bike_l1 "" ON "OQS_ENABLE_KEM_BIKE" OFF)
 cmake_dependent_option(OQS_ENABLE_KEM_bike_l3 "" ON "OQS_ENABLE_KEM_BIKE" OFF)
 


### PR DESCRIPTION
Fixes #1179 (known failure due to #1178)

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

