### PR TITLE
Update to picnic 3.0.11 (fixes #1178)

### DIFF
--- a/docs/algorithms/sig/picnic.md
+++ b/docs/algorithms/sig/picnic.md
@@ -4,8 +4,8 @@
 - **Main cryptographic assumption**: hash function security (ROM/QROM), key recovery attacks on the lowMC block cipher.
 - **Principal submitters**: Greg Zaverucha, Melissa Chase, David Derler, Steven Goldfeder, Claudio Orlandi, Sebastian Ramacher, Christian Rechberger, Daniel Slamanig, Jonathan Katz, Xiao Wang, Vladmir Kolesnikov.
 - **Authors' website**: https://microsoft.github.io/Picnic/
-- **Specification version**: 3.0.10.
-- **Implementation source**: https://github.com/IAIK/Picnic/tree/v3.0.10
+- **Specification version**: 3.0.11.
+- **Implementation source**: https://github.com/IAIK/Picnic/tree/v3.0.11
 - **Implementation license (SPDX-Identifier)**: MIT.
 
 ## Parameter set summary

--- a/docs/algorithms/sig/picnic.yml
+++ b/docs/algorithms/sig/picnic.yml
@@ -16,9 +16,9 @@ crypto-assumption: hash function security (ROM/QROM), key recovery attacks on th
   lowMC block cipher
 website: https://microsoft.github.io/Picnic/
 nist-round: 3
-spec-version: 3.0.10
+spec-version: 3.0.11
 spdx-license-identifier: MIT
-upstream: https://github.com/IAIK/Picnic/tree/v3.0.10
+upstream: https://github.com/IAIK/Picnic/tree/v3.0.11
 parameter-sets:
 - name: picnic_L1_FS
   claimed-nist-level: 1

--- a/src/sig/picnic/external/CHANGELOG.md
+++ b/src/sig/picnic/external/CHANGELOG.md
@@ -1,37 +1,39 @@
-Version 3.0.10 -- 2022-01-08
-----------------------------
+# Changelog for the optimized Picnic implementation
+
+## Version 3.0.11 -- 2022-01-25
+
+* Fix NEON code on M1.
+* Ensure SSE2/AVX2/NEON shift intrinsics with immediate operands are used correctly.
+* Use Boost.Test as unit test framework.
+
+## Version 3.0.10 -- 2022-01-08
 
 * Fix build with llvm on ARM with NEON enabled
 
-Version 3.0.9 -- 2021-12-22
----------------------------
+## Version 3.0.9 -- 2021-12-22
 
 * Unbreak x86-32 build.
 * Fix build on M1 with NEON enabled.
 
-Version 3.0.8 -- 2021-12-18
----------------------------
+## Version 3.0.8 -- 2021-12-18
 
 * Prefix compat function implementations with `picnic_`.
 * Use OQS instruction set checking functions.
 * Use OQS implementations of `aligned_alloc`, `aligned_free`, `explicit_bzero`, and `timingsafe_bcmp`.
 * Install cmake configuration files.
 
-Version 3.0.7 -- 2021-12-15
----------------------------
+## Version 3.0.7 -- 2021-12-15
 
 * Various changes to improve OQS integration.
 * Require cmake version 3.10.
 
-Version 3.0.6 -- 2021-12-14
----------------------------
+## Version 3.0.6 -- 2021-12-14
 
 * Reduce size of global parameters for instance specification to 12 bytes per instance.
 * Provide compat implementation of `clz` on MSVC using `_BitScanReverse`.
 * Do not assume that `aligned_alloc` is available on MSVC.
 
-Version 3.0.5 -- 2021-10-19
----------------------------
+## Version 3.0.5 -- 2021-10-19
 
 * Update SHAKE3 implementation.
 * Fix build with GCC 11.
@@ -39,91 +41,78 @@ Version 3.0.5 -- 2021-10-19
 * Expose `picnic_get_{private,public}key_size` as part of the public API.
 * Add `picnic_get_{private,public}_key_param` to retrieve a key's parameter set.
 
-Version 3.0.4 -- 2020-12-17
----------------------------
+## Version 3.0.4 -- 2020-12-17
 
 * Slightly improve memory consumption.
 * Initial work to support PQClean integration in the future.
 * Add cmake options to control availability of specific LowMC instances.
 
-Version 3.0.3 -- 2020-10-12
----------------------------
+## Version 3.0.3 -- 2020-10-12
 
 * Fix `explicit_bzero` fallback implementation.
 * Remove some unused code.
 
-Version 3.0.2 -- 2020-10-06
----------------------------
+## Version 3.0.2 -- 2020-10-06
 
 * Update SHAKE3 implementation.
 * Add support to check constant time implementation with TIMECOP.
 * Slightly reduce memory consumption.
 * Add support for BSD variants.
 
-Version 3.0.1 -- 2020-08-11
----------------------------
+## Version 3.0.1 -- 2020-08-11
 
 * Expose `picnic_sk_to_pk` as part of the public API.
 * Add `picnic_clear_private_key` to clear the private key.
 
-Version 3.0 -- 2020-04-15
--------------------------
+## Version 3.0 -- 2020-04-15
 
 * Implement new Picnic 3 parameter set. This implementation replaces the Picnic 2 parameter set.
 * Implement new Picnic instances with full Sbox layer.
 * Various small improvements and bug fixes.
 * Remove all optimizations for partial LowMC instances except for OLLE.
 
-Version 2.2 -- 2020-04-08
----------------------------
+## Version 2.2 -- 2020-04-08
 
 * Fix Picnic2 implementation on big endian systems.
 * Add support for SHA3/SHAKE3 instructions on IBM z.
 * Various small improvements and bug fixes.
 * Remove LowMC instances with m=1.
 
-Version 2.1.2 -- 2019-10-03
----------------------------
+## Version 2.1.2 -- 2019-10-03
 
 * Add options to build with ZKB++- or KKW-based instances only.
 * Fix ARM NEON optimizations.
 * Slightly reduce heap usage.
 * Remove more unused code.
 
-Version 2.1.1 -- 2019-08-07
----------------------------
+## Version 2.1.1 -- 2019-08-07
 
 * Various small improvements and bug fixes.
 
-Version 2.1 -- 2019-07-29
--------------------------
+## Version 2.1 -- 2019-07-29
 
 * Remove M4RM-based implementation.
 * Fix input size in Picnic2's commitment implementation.
 * Additional improvements and optimizations of the Picnic2 code.
 
-Version 2.0 -- 2019-04-08
--------------------------
+## Version 2.0 -- 2019-04-08
 
 * Implement Picnic 2.
 * Use 4-times parallel SHAKE3 for faster PRF evaluation, commitment generation, etc.
 * Fix size of salts to 32 bytes.
 
-Version 1.3.1 -- 2018-12-21
----------------------------
+## Version 1.3.1 -- 2018-12-21
 
 * Reduce heap usage.
 
-Version 1.3 -- 2018-12-21
--------------------------
+## Version 1.3 -- 2018-12-21
 
 * Implement linear layer optimizations to speed up LowMC evaluations. Besides the runtime improvements, this optimization also greatly reduces the memory size of the LowMC instances.
 * Provide LowMC instances with m=1 to demonstrate feasibility of those instances.
 * Slightly improve internal storage of matrices to require less memory.
 * Remove unused code and support for dynamic LowMC instances.
 
-Version 1.2 -- 2018-12-05
--------------------------
+## Version 1.2 -- 2018-12-05
 
 * Implement RRKC optimizations for round constants.
 * Compatibility fixes for Mac OS X.
@@ -133,8 +122,7 @@ Version 1.2 -- 2018-12-05
 * Record state before Sbox evaluation and drop one branch of XOR computations. This optimization is based based on an idea by Markus Schofnegger.
 * Add per-signature salt to random tapes generation. Prevents a seed-guessing attack reported by Itai Dinur.
 
-Version 1.1 -- 2018-06-29
--------------------------
+## Version 1.1 -- 2018-06-29
 
 * Compatibility fixes for Visual Studio, clang and MinGW.
 * Various improvements to the SIMD versions of the matrix operations.
@@ -142,8 +130,7 @@ Version 1.1 -- 2018-06-29
 * Add option to feed extra randomness to initial seed expansion to counter fault attacks.
 * Version submitted for inclusion in SUPERCOP.
 
-Version 1.0 -- 2017-11-28
--------------------------
+## Version 1.0 -- 2017-11-28
 
 * Initial release.
 * Version submitted to the NIST PQC project.

--- a/src/sig/picnic/external/macros.h
+++ b/src/sig/picnic/external/macros.h
@@ -171,7 +171,7 @@
 /* target attribute */
 #if defined(__GNUC__) || __has_attribute(target)
 #define ATTR_TARGET(x) __attribute__((target((x))))
-#define ATTR_TARGET_AVX2 __attribute__((target("avx2,bmi2")))
+#define ATTR_TARGET_AVX2 __attribute__((target("avx2,bmi2,sse2")))
 #define ATTR_TARGET_SSE2 __attribute__((target("sse2")))
 #else
 #define ATTR_TARGET(x)
@@ -184,6 +184,20 @@
 #define ATTR_ARTIFICIAL __attribute__((__artificial__))
 #else
 #define ATTR_ARTIFICIAL
+#endif
+
+/* may_alias attribute */
+#if GNUC_CHECK(3, 3) || __has_attribute(__may_alias__)
+#define ATTR_MAY_ALIAS __attribute__((__may_alias__))
+#else
+#define ATTR_MAY_ALIAS
+#endif
+
+/* vector_size attribute */
+#if GNUC_CHECK(4, 8) || __has_attribute(__vector_size__)
+#define ATTR_VECTOR_SIZE(s) __attribute__((__vector_size__(s)))
+#else
+#define ATTR_VECTOR_SIZE(s)
 #endif
 
 #define FN_ATTRIBUTES_AVX2 ATTR_ARTIFICIAL ATTR_ALWAYS_INLINE ATTR_TARGET_AVX2

--- a/src/sig/picnic/external/mpc_lowmc.c
+++ b/src/sig/picnic/external/mpc_lowmc.c
@@ -466,8 +466,8 @@ static void mpc_sbox_verify_uint64_lowmc_255_255_4(mzd_local_t* out, const mzd_l
 #if defined(WITH_OPT)
 #define NROLR(a, b, c)                                                                             \
   do {                                                                                             \
-    (void)a;                                                                                       \
-    (void)b;                                                                                       \
+    a[0] = b[0];                                                                                   \
+    a[1] = b[1];                                                                                   \
     (void)c;                                                                                       \
   } while (0)
 

--- a/src/sig/picnic/external/picnic3_simulate.c
+++ b/src/sig/picnic/external/picnic3_simulate.c
@@ -240,17 +240,17 @@ static void picnic3_mpc_sbox_uint64_lowmc_255_255_4(mzd_local_t* statein, random
     /* a & b */                                                                                    \
     AND(s_ab, a, b);                                                                               \
     for (int i = 0; i < 16; i++) {                                                                 \
-      mzd_local_t tmp[1];                                                                          \
+      word128 tmp[2] ATTR_ALIGNED(alignof(word128));                                               \
       bitstream_t party_msgs = {{msgs->msgs[i]}, msgs->pos};                                       \
       if (i == msgs->unopened) {                                                                   \
         /* we are in verify, just grab the broadcast s from the msgs array */                      \
-        mzd_from_bitstream(&party_msgs, tmp, (LOWMC_N + 63) / (sizeof(uint64_t) * 8), LOWMC_N);    \
+        w128_from_bitstream(&party_msgs, tmp, (LOWMC_N + 63) / (sizeof(uint64_t) * 8), LOWMC_N);   \
         /* a */                                                                                    \
-        AND(t0, bitmask_a->w128, tmp->w128);                                                       \
+        AND(t0, bitmask_a->w128, tmp);                                                             \
         /* b */                                                                                    \
-        AND(t1, bitmask_b->w128, tmp->w128);                                                       \
+        AND(t1, bitmask_b->w128, tmp);                                                             \
         /* c */                                                                                    \
-        AND(t2, bitmask_c->w128, tmp->w128);                                                       \
+        AND(t2, bitmask_c->w128, tmp);                                                             \
         SHL(t0, t0, 2);                                                                            \
         SHL(t1, t1, 1);                                                                            \
         XOR(s_ab, t2, s_ab);                                                                       \
@@ -264,13 +264,13 @@ static void picnic3_mpc_sbox_uint64_lowmc_255_255_4(mzd_local_t* statein, random
       word128 mask_a[2] ATTR_ALIGNED(alignof(word128));                                            \
       word128 mask_b[2] ATTR_ALIGNED(alignof(word128));                                            \
       word128 mask_c[2] ATTR_ALIGNED(alignof(word128));                                            \
-      mzd_from_bitstream(&party_tape, tmp, (LOWMC_N + 63) / (sizeof(uint64_t) * 8), LOWMC_N);      \
+      w128_from_bitstream(&party_tape, tmp, (LOWMC_N + 63) / (sizeof(uint64_t) * 8), LOWMC_N);     \
       /* a */                                                                                      \
-      AND(mask_a, bitmask_a->w128, tmp->w128);                                                     \
+      AND(mask_a, bitmask_a->w128, tmp);                                                           \
       /* b */                                                                                      \
-      AND(mask_b, bitmask_b->w128, tmp->w128);                                                     \
+      AND(mask_b, bitmask_b->w128, tmp);                                                           \
       /* c */                                                                                      \
-      AND(mask_c, bitmask_c->w128, tmp->w128);                                                     \
+      AND(mask_c, bitmask_c->w128, tmp);                                                           \
       SHL(mask_a, mask_a, 2);                                                                      \
       SHL(mask_b, mask_b, 1);                                                                      \
                                                                                                    \
@@ -278,13 +278,13 @@ static void picnic3_mpc_sbox_uint64_lowmc_255_255_4(mzd_local_t* statein, random
       word128 and_helper_ab[2] ATTR_ALIGNED(alignof(word128));                                     \
       word128 and_helper_bc[2] ATTR_ALIGNED(alignof(word128));                                     \
       word128 and_helper_ca[2] ATTR_ALIGNED(alignof(word128));                                     \
-      mzd_from_bitstream(&party_tape, tmp, (LOWMC_N + 63) / (sizeof(uint64_t) * 8), LOWMC_N);      \
+      w128_from_bitstream(&party_tape, tmp, (LOWMC_N + 63) / (sizeof(uint64_t) * 8), LOWMC_N);     \
       /* a */                                                                                      \
-      AND(and_helper_ab, bitmask_c->w128, tmp->w128);                                              \
+      AND(and_helper_ab, bitmask_c->w128, tmp);                                                    \
       /* b */                                                                                      \
-      AND(and_helper_bc, bitmask_b->w128, tmp->w128);                                              \
+      AND(and_helper_bc, bitmask_b->w128, tmp);                                                    \
       /* c */                                                                                      \
-      AND(and_helper_ca, bitmask_a->w128, tmp->w128);                                              \
+      AND(and_helper_ca, bitmask_a->w128, tmp);                                                    \
       SHL(and_helper_ca, and_helper_ca, 2);                                                        \
       SHL(and_helper_bc, and_helper_bc, 1);                                                        \
                                                                                                    \
@@ -292,8 +292,8 @@ static void picnic3_mpc_sbox_uint64_lowmc_255_255_4(mzd_local_t* statein, random
       AND(t0, a, mask_b);                                                                          \
       AND(t1, b, mask_a);                                                                          \
       XOR(t0, t0, t1);                                                                             \
-      XOR(tmp->w128, t0, and_helper_ab);                                                           \
-      XOR(s_ab, tmp->w128, s_ab);                                                                  \
+      XOR(tmp, t0, and_helper_ab);                                                                 \
+      XOR(s_ab, tmp, s_ab);                                                                        \
       /* s_bc */                                                                                   \
       AND(t0, b, mask_c);                                                                          \
       AND(t1, c, mask_b);                                                                          \
@@ -302,7 +302,7 @@ static void picnic3_mpc_sbox_uint64_lowmc_255_255_4(mzd_local_t* statein, random
       XOR(s_bc, t0, s_bc);                                                                         \
                                                                                                    \
       SHR(t0, t0, 1);                                                                              \
-      XOR(tmp->w128, tmp->w128, t0);                                                               \
+      XOR(tmp, tmp, t0);                                                                           \
       /* s_ca */                                                                                   \
       AND(t0, c, mask_a);                                                                          \
       AND(t1, a, mask_c);                                                                          \
@@ -311,8 +311,8 @@ static void picnic3_mpc_sbox_uint64_lowmc_255_255_4(mzd_local_t* statein, random
       XOR(s_ca, t0, s_ca);                                                                         \
                                                                                                    \
       SHR(t0, t0, 2);                                                                              \
-      XOR(tmp->w128, tmp->w128, t0);                                                               \
-      mzd_to_bitstream(&party_msgs, tmp, (LOWMC_N + 63) / (sizeof(uint64_t) * 8), LOWMC_N);        \
+      XOR(tmp, tmp, t0);                                                                           \
+      w128_to_bitstream(&party_msgs, tmp, (LOWMC_N + 63) / (sizeof(uint64_t) * 8), LOWMC_N);       \
     }                                                                                              \
     tapes->pos += LOWMC_N;                                                                         \
     tapes->pos += LOWMC_N;                                                                         \
@@ -421,17 +421,17 @@ static void picnic3_mpc_sbox_s128_lowmc_255_255_4(mzd_local_t* statein, randomTa
     /* a & b */                                                                                    \
     s_ab = AND(a, b);                                                                              \
     for (int i = 0; i < 16; i++) {                                                                 \
-      mzd_local_t tmp[1];                                                                          \
+      word256 tmp ATTR_ALIGNED(alignof(word256));                                                  \
       bitstream_t party_msgs = {{msgs->msgs[i]}, msgs->pos};                                       \
       if (i == msgs->unopened) {                                                                   \
         /* we are in verify, just grab the broadcast s from the msgs array */                      \
-        mzd_from_bitstream(&party_msgs, tmp, (LOWMC_N + 63) / (sizeof(uint64_t) * 8), LOWMC_N);    \
+        tmp = w256_from_bitstream(&party_msgs, (LOWMC_N + 63) / (sizeof(uint64_t) * 8), LOWMC_N);  \
         /* a */                                                                                    \
-        t0 = AND(bitmask_a->w256, tmp->w256);                                                      \
+        t0 = AND(bitmask_a->w256, tmp);                                                            \
         /* b */                                                                                    \
-        t1 = AND(bitmask_b->w256, tmp->w256);                                                      \
+        t1 = AND(bitmask_b->w256, tmp);                                                            \
         /* c */                                                                                    \
-        t2   = AND(bitmask_c->w256, tmp->w256);                                                    \
+        t2   = AND(bitmask_c->w256, tmp);                                                          \
         t0   = ROL(t0, 2);                                                                         \
         t1   = ROL(t1, 1);                                                                         \
         s_ab = XOR(t2, s_ab);                                                                      \
@@ -445,13 +445,13 @@ static void picnic3_mpc_sbox_s128_lowmc_255_255_4(mzd_local_t* statein, randomTa
       word256 mask_a ATTR_ALIGNED(alignof(word256));                                               \
       word256 mask_b ATTR_ALIGNED(alignof(word256));                                               \
       word256 mask_c ATTR_ALIGNED(alignof(word256));                                               \
-      mzd_from_bitstream(&party_tape, tmp, (LOWMC_N + 63) / (sizeof(uint64_t) * 8), LOWMC_N);      \
+      tmp = w256_from_bitstream(&party_tape, (LOWMC_N + 63) / (sizeof(uint64_t) * 8), LOWMC_N);    \
       /* a */                                                                                      \
-      mask_a = AND(bitmask_a->w256, tmp->w256);                                                    \
+      mask_a = AND(bitmask_a->w256, tmp);                                                          \
       /* b */                                                                                      \
-      mask_b = AND(bitmask_b->w256, tmp->w256);                                                    \
+      mask_b = AND(bitmask_b->w256, tmp);                                                          \
       /* c */                                                                                      \
-      mask_c = AND(bitmask_c->w256, tmp->w256);                                                    \
+      mask_c = AND(bitmask_c->w256, tmp);                                                          \
       mask_a = ROL(mask_a, 2);                                                                     \
       mask_b = ROL(mask_b, 1);                                                                     \
                                                                                                    \
@@ -459,22 +459,22 @@ static void picnic3_mpc_sbox_s128_lowmc_255_255_4(mzd_local_t* statein, randomTa
       word256 and_helper_ab ATTR_ALIGNED(alignof(word256));                                        \
       word256 and_helper_bc ATTR_ALIGNED(alignof(word256));                                        \
       word256 and_helper_ca ATTR_ALIGNED(alignof(word256));                                        \
-      mzd_from_bitstream(&party_tape, tmp, (LOWMC_N + 63) / (sizeof(uint64_t) * 8), LOWMC_N);      \
+      tmp = w256_from_bitstream(&party_tape, (LOWMC_N + 63) / (sizeof(uint64_t) * 8), LOWMC_N);    \
       /* a */                                                                                      \
-      and_helper_ab = AND(bitmask_c->w256, tmp->w256);                                             \
+      and_helper_ab = AND(bitmask_c->w256, tmp);                                                   \
       /* b */                                                                                      \
-      and_helper_bc = AND(bitmask_b->w256, tmp->w256);                                             \
+      and_helper_bc = AND(bitmask_b->w256, tmp);                                                   \
       /* c */                                                                                      \
-      and_helper_ca = AND(bitmask_a->w256, tmp->w256);                                             \
+      and_helper_ca = AND(bitmask_a->w256, tmp);                                                   \
       and_helper_ca = ROL(and_helper_ca, 2);                                                       \
       and_helper_bc = ROL(and_helper_bc, 1);                                                       \
                                                                                                    \
       /* s_ab */                                                                                   \
-      t0        = AND(a, mask_b);                                                                  \
-      t1        = AND(b, mask_a);                                                                  \
-      t0        = XOR(t0, t1);                                                                     \
-      tmp->w256 = XOR(t0, and_helper_ab);                                                          \
-      s_ab      = XOR(tmp->w256, s_ab);                                                            \
+      t0   = AND(a, mask_b);                                                                       \
+      t1   = AND(b, mask_a);                                                                       \
+      t0   = XOR(t0, t1);                                                                          \
+      tmp  = XOR(t0, and_helper_ab);                                                               \
+      s_ab = XOR(tmp, s_ab);                                                                       \
       /* s_bc */                                                                                   \
       t0   = AND(b, mask_c);                                                                       \
       t1   = AND(c, mask_b);                                                                       \
@@ -482,8 +482,8 @@ static void picnic3_mpc_sbox_s128_lowmc_255_255_4(mzd_local_t* statein, randomTa
       t0   = XOR(t0, and_helper_bc);                                                               \
       s_bc = XOR(t0, s_bc);                                                                        \
                                                                                                    \
-      t0        = ROR(t0, 1);                                                                      \
-      tmp->w256 = XOR(tmp->w256, t0);                                                              \
+      t0  = ROR(t0, 1);                                                                            \
+      tmp = XOR(tmp, t0);                                                                          \
       /* s_ca */                                                                                   \
       t0   = AND(c, mask_a);                                                                       \
       t1   = AND(a, mask_c);                                                                       \
@@ -491,9 +491,9 @@ static void picnic3_mpc_sbox_s128_lowmc_255_255_4(mzd_local_t* statein, randomTa
       t0   = XOR(t0, and_helper_ca);                                                               \
       s_ca = XOR(t0, s_ca);                                                                        \
                                                                                                    \
-      t0        = ROR(t0, 2);                                                                      \
-      tmp->w256 = XOR(tmp->w256, t0);                                                              \
-      mzd_to_bitstream(&party_msgs, tmp, (LOWMC_N + 63) / (sizeof(uint64_t) * 8), LOWMC_N);        \
+      t0  = ROR(t0, 2);                                                                            \
+      tmp = XOR(tmp, t0);                                                                          \
+      w256_to_bitstream(&party_msgs, tmp, (LOWMC_N + 63) / (sizeof(uint64_t) * 8), LOWMC_N);       \
     }                                                                                              \
     tapes->pos += LOWMC_N;                                                                         \
     tapes->pos += LOWMC_N;                                                                         \

--- a/src/sig/picnic/sig_picnic.c
+++ b/src/sig/picnic/sig_picnic.c
@@ -125,7 +125,7 @@ OQS_SIG *OQS_SIG_picnic_L1_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.10";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.11";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -164,7 +164,7 @@ OQS_SIG *OQS_SIG_picnic_L1_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.10";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.11";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -203,7 +203,7 @@ OQS_SIG *OQS_SIG_picnic_L1_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.10";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.11";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -242,7 +242,7 @@ OQS_SIG *OQS_SIG_picnic_L3_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.10";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.11";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -281,7 +281,7 @@ OQS_SIG *OQS_SIG_picnic_L3_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.10";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.11";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -320,7 +320,7 @@ OQS_SIG *OQS_SIG_picnic_L3_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.10";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.11";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -359,7 +359,7 @@ OQS_SIG *OQS_SIG_picnic_L5_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.10";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.11";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -399,7 +399,7 @@ OQS_SIG *OQS_SIG_picnic_L5_UR_new() {
 	}
 
 	sig->method_name = OQS_SIG_alg_picnic_L5_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.10";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.11";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -438,7 +438,7 @@ OQS_SIG *OQS_SIG_picnic_L5_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.10";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.11";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -475,7 +475,7 @@ OQS_SIG *OQS_SIG_picnic3_L1_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L1;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.10";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.11";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -513,7 +513,7 @@ OQS_SIG *OQS_SIG_picnic3_L3_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L3;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.10";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.11";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -551,7 +551,7 @@ OQS_SIG *OQS_SIG_picnic3_L5_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L5;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.10";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.11";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;


### PR DESCRIPTION
This update fixes Picnic built with GCC on M1 (#1178).

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)
