### PR TITLE
weekly job moved to Sunday [skip ci]

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -2,7 +2,7 @@ name: Weekly constant time tests
 
 on:
   schedule:
-  - cron: "5 0 * * *"
+  - cron: "5 0 * * 0"
 
 jobs:
 


### PR DESCRIPTION
A wonder occurred and the constant time tests all [ran and passed](https://github.com/open-quantum-safe/liboqs/actions/runs/1759247537). Now installing them for good on Sundays.

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)
