### PR TITLE
Resolves an issue when building sha2 using arm crypto extensions with gcc11

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -40,6 +40,9 @@ else()
     elseif (OQS_USE_ARM_SHA2_INSTRUCTIONS)
        # Assume we are compiling native
        set(SHA2_IMPL ${SHA2_IMPL} sha2/sha2_ni.c)
+       if ((CMAKE_SYSTEM_NAME MATCHES "Darwin") AND (${CMAKE_C_COMPILER_ID} STREQUAL "GNU"))
+         set_source_files_properties(sha2/sha2_ni.c PROPERTIES COMPILE_FLAGS -march=armv8-a+crypto)
+       endif()
     endif()
 endif()
 

--- a/src/common/sha2/sha2_local.h
+++ b/src/common/sha2/sha2_local.h
@@ -1,5 +1,5 @@
 /**
- * \file sha2.h
+ * \file sha2_local.h
  * \brief Internal SHA2 functions that enable easy switching between native instructions
  *        and c implementations
  *


### PR DESCRIPTION
This PR resolves a build issue when using gcc11 on Darwin.

The issue is resolved by specifying the architecture version and explicitly enabling crypto extensions. After running `speed_common`, it appeared that there were no significant performance differences between armv8-a and armv8.5-a, so armv8-a was used to maximize compatibility.

