### PR TITLE
skip yamllint test for good

### DIFF
--- a/tests/test_code_conventions.py
+++ b/tests/test_code_conventions.py
@@ -69,17 +69,6 @@ def test_free():
                 print("Suspicious `free` in {}:{}:{}".format(fn,no,line))
     assert okay, "'free' is used in some files.  These should be changed to 'OQS_MEM_secure_free' or 'OQS_MEM_insecure_free' as appropriate. If you are sure you want to use 'free' in a particular spot, add the comment '// IGNORE free-check' on the line where 'free' occurs."
 
-# Ensure that the datasheet .yml files are correctly formatted
-# TODO: Re-enable once yamllint is happy with the output produced by
-# scripts/format_docs_yaml.py (we could also specify a custom profile for
-# yamllint or use a different linter).
-@helpers.filtered_test
-@pytest.mark.skip()
-def test_datasheet_yamllint():
-    helpers.run_subprocess(
-        ['yamllint', 'docs/algorithms']
-    )
-
 if __name__ == "__main__":
     import sys
     pytest.main(sys.argv)

--- a/tests/test_code_conventions.py
+++ b/tests/test_code_conventions.py
@@ -74,7 +74,7 @@ def test_free():
 # scripts/format_docs_yaml.py (we could also specify a custom profile for
 # yamllint or use a different linter).
 @helpers.filtered_test
-@pytest.mark.skip(sys.platform.startswith("win"), reason="yamllint does not agree with current automatic formatting script.")
+@pytest.mark.skip()
 def test_datasheet_yamllint():
     helpers.run_subprocess(
         ['yamllint', 'docs/algorithms']


### PR DESCRIPTION
Fixes #1195.

General question: Why is this `yamllint` test existing at all? It fails, has a TODO mark and is not listed as a build prerequisite -> Better to delete completely? Or create an issue to implement it properly?

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)
