### PR TITLE
Deal with some issues identified by clang scan-build

### DIFF
--- a/src/kem/sike/external/ec_isogeny.c
+++ b/src/kem/sike/external/ec_isogeny.c
@@ -655,7 +655,6 @@ static void Ladder(const point_proj_t P, const digit_t* m, const f2elm_t A, cons
     fp2div2(A24, A24);  // A24 = (A+2)/4          
 
     j = order_bits - 1;
-    bit = (m[j >> LOG2RADIX] >> (j & (RADIX-1))) & 1;
 
     // R0 <- P, R1 <- 2P
     fp2copy(P->X, R0->X);

--- a/tests/speed_common.c
+++ b/tests/speed_common.c
@@ -29,8 +29,13 @@ static OQS_STATUS speed_aes128(uint64_t duration, size_t message_len) {
 	void *schedule = NULL;
 
 	message = malloc(message_len);
+	if (message == NULL) {
+		fprintf(stderr, "ERROR: malloc failed\n");
+		return OQS_ERROR;
+	}
 	ciphertext = malloc(message_len);
-	if ((message == NULL) || (ciphertext == NULL)) {
+	if (ciphertext == NULL) {
+		OQS_MEM_insecure_free(message);
 		fprintf(stderr, "ERROR: malloc failed\n");
 		return OQS_ERROR;
 	}
@@ -56,8 +61,13 @@ static OQS_STATUS speed_aes256(uint64_t duration, size_t message_len) {
 	void *schedule = NULL;
 
 	message = malloc(message_len);
+	if (message == NULL) {
+		fprintf(stderr, "ERROR: malloc failed\n");
+		return OQS_ERROR;
+	}
 	ciphertext = malloc(message_len);
-	if ((message == NULL) || (ciphertext == NULL)) {
+	if (ciphertext == NULL) {
+		OQS_MEM_insecure_free(message);
 		fprintf(stderr, "ERROR: malloc failed\n");
 		return OQS_ERROR;
 	}
@@ -73,6 +83,7 @@ static OQS_STATUS speed_aes256(uint64_t duration, size_t message_len) {
 	OQS_AES256_free_schedule(schedule);
 
 	OQS_MEM_insecure_free(message);
+	OQS_MEM_insecure_free(ciphertext);
 
 	return OQS_SUCCESS;
 }
@@ -171,8 +182,13 @@ static OQS_STATUS speed_shake128(uint64_t duration, size_t message_len, size_t o
 	uint8_t *output = NULL;
 
 	message = malloc(message_len);
+	if (message == NULL) {
+		fprintf(stderr, "ERROR: malloc failed\n");
+		return OQS_ERROR;
+	}
 	output = malloc(output_len);
-	if ((message == NULL) || (output == NULL)) {
+	if (output == NULL) {
+		OQS_MEM_insecure_free(message);
 		fprintf(stderr, "ERROR: malloc failed\n");
 		return OQS_ERROR;
 	}
@@ -193,8 +209,13 @@ static OQS_STATUS speed_shake256(uint64_t duration, size_t message_len, size_t o
 	uint8_t *output = NULL;
 
 	message = malloc(message_len);
+	if (message == NULL) {
+		fprintf(stderr, "ERROR: malloc failed\n");
+		return OQS_ERROR;
+	}
 	output = malloc(output_len);
-	if ((message == NULL) || (output == NULL)) {
+	if (output == NULL) {
+		OQS_MEM_insecure_free(message);
 		fprintf(stderr, "ERROR: malloc failed\n");
 		return OQS_ERROR;
 	}


### PR DESCRIPTION
In hopes of eventually closing #194, I ran clang scan-build and it found a few minor issues.  This PR deals with some of them, I'll create an issue for the rest.

scan-build can be run as follows:
```bash
cd liboqs
mkdir build-analyze && cd build-analyze
scan-build cmake -GNinja ..
scan-build ninja
```

On macOS, I don't know where Apple's version of scan-build is (it's not in the path), but you can do `brew install llvm@11` and then use `/usr/local/Cellar/llvm@11/11.1.0_4/bin/scan-build` (since brew doesn't add llvm's files to the path to avoid conflicting with the Apple versions).