### PR TITLE
Use `SecRandomCopyBytes` for system randomness on iOS (to allow building on iOS)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,6 +80,10 @@ endif()
 if(${OQS_USE_OPENSSL})
     target_link_libraries(oqs PRIVATE ${OPENSSL_CRYPTO_LIBRARY})
 endif()
+if(IOS)
+    find_library(IOS_SECURITY Security)
+    target_link_libraries(oqs PUBLIC ${IOS_SECURITY})
+endif()
 
 target_include_directories(oqs
                            PUBLIC

--- a/src/common/rand/rand.c
+++ b/src/common/rand/rand.c
@@ -9,7 +9,12 @@
 #include <unistd.h>
 #include <strings.h>
 #if defined(__APPLE__)
+#include <TargetConditionals.h>
+#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
+#include <Security/SecRandom.h>
+#else
 #include <sys/random.h>
+#endif
 #else
 #include <unistd.h>
 #endif
@@ -74,8 +79,18 @@ void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
 	}
 }
 #else
+#if defined(__APPLE__) && (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
 void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
+    int status =
+        SecRandomCopyBytes(kSecRandomDefault, bytes_to_read, random_array);
 
+    if (status == errSecSuccess) {
+        perror("OQS_randombytes");
+        exit(EXIT_FAILURE);
+    }
+}
+#else
+void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
 	FILE *handle;
 	size_t bytes_read;
 
@@ -93,6 +108,7 @@ void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
 
 	fclose(handle);
 }
+#endif
 #endif
 #else
 void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {

--- a/src/common/rand/rand.c
+++ b/src/common/rand/rand.c
@@ -81,13 +81,13 @@ void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
 #else
 #if defined(__APPLE__) && (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
 void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
-    int status =
-        SecRandomCopyBytes(kSecRandomDefault, bytes_to_read, random_array);
+	int status =
+	    SecRandomCopyBytes(kSecRandomDefault, bytes_to_read, random_array);
 
-    if (status == errSecSuccess) {
-        perror("OQS_randombytes");
-        exit(EXIT_FAILURE);
-    }
+	if (status == errSecSuccess) {
+		perror("OQS_randombytes");
+		exit(EXIT_FAILURE);
+	}
 }
 #else
 void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

Building on iOS is currently broken (cf. #1217), due to the `rand` functionality attempting to include the `sys/random.h` header (which is not available on iOS).

This series allows building for iOS by:
- Using the `SecRandomCopyBytes` secure system randomness function when building for iOS, rather than using `getentropy` or reading from `urandom`
  - This means we don't include the `sys/random.h` header when building for iOS
  - Note that the CMake check for `getentropy` will already find that `getentropy` is not available on iOS, so otherwise (without this patch) on iOS we would be attempting to read from `urandom` (which is also not allowed on iOS)
- Links against the iOS `Security` "framework", when building for iOS

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

Fixes #1217

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
