### PR TITLE
adding memory leak testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,7 +363,7 @@ workflows:
           name: ubuntu-focal-clang14
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-          CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-14
+          CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-14 -DOQS_OPT_TARGET=skylake
       - linux_oqs:
           <<: *require_buildcheck
           name: ubuntu-bionic-i386

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,13 +350,14 @@ workflows:
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
           CMAKE_ARGS: -DCMAKE_C_COMPILER=gcc-8 -DOQS_USE_OPENSSL=OFF
+          PYTEST_ARGS: --ignore=tests/test_leaks.py
       - linux_oqs:
           <<: *require_buildcheck
           name: ubuntu-focal-shared-noopenssl
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
           CMAKE_ARGS: -DCMAKE_C_COMPILER=gcc-7 -DOQS_DIST_BUILD=ON -DOQS_USE_OPENSSL=OFF -DBUILD_SHARED_LIBS=ON
-          PYTEST_ARGS: --ignore=tests/test_namespace.py --numprocesses=auto
+          PYTEST_ARGS: --ignore=tests/test_namespace.py --ignore=tests/test_leaks.py --numprocesses=auto
       - linux_oqs:
           <<: *require_buildcheck
           name: ubuntu-focal-clang14
@@ -369,6 +370,7 @@ workflows:
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-ubuntu-bionic-i386:latest
           CMAKE_ARGS: -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_x86.cmake
+          PYTEST_ARGS: --ignore=tests/test_leaks.py
       - arm_machine:
           <<: *require_buildcheck
           name: arm64

--- a/docs/algorithms/kem/classic_mceliece.md
+++ b/docs/algorithms/kem/classic_mceliece.md
@@ -109,6 +109,8 @@ Are implementations chosen based on runtime CPU feature detection? **Yes**.
 
 Are implementations chosen based on runtime CPU feature detection? **Yes**.
 
+*Note: This algorithm is known to fail memory leak testing on x86_64.*
+
 ## Classic-McEliece-8192128f implementation characteristics
 
 |       Implementation source       | Identifier in upstream   | Supported architecture(s)   | Supported operating system(s)   | CPU extension(s) used   | No branching-on-secrets claimed?   | No branching-on-secrets checked by valgrind?   | Large stack usage?   |

--- a/tests/run_astyle.sh
+++ b/tests/run_astyle.sh
@@ -10,8 +10,8 @@ if [ $? -ne 1 ]; then
    rv=-1
 fi
 
-# check _all_ source files for CRLF line endings:
-find . -name '*.[chS]' -exec file "{}" ";" | grep CRLF
+# check _all_ source files for CRLF line endings (except in repos directory):
+find . \( -type d -name repos -prune \) -o -name '*.[chS]' -exec file "{}" ";" | grep CRLF
 if [ $? -ne 1 ]; then
    echo "Error: Files found with non-UNIX line endings."
    echo "To fix, consider running \"find src tests -name '*.[chS]' | xargs sed -i 's/\r//' \"."

--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -10,6 +10,7 @@ import sys
 def test_kem_leak(kem_name):
     if not(helpers.is_kem_enabled_by_name(kem_name)): pytest.skip('Not enabled')
     if sys.platform != "linux" or os.system("grep ubuntu /etc/os-release") != 0 or os.system("uname -a | grep x86_64") != 0: pytest.skip('Leak testing not supported on this platform')
+    if kem_name == "Classic-McEliece-8192128": pytest.skip("Classic-McEliece-8192128 known to fail memory leak testing")
     helpers.run_subprocess(
         ["valgrind", "-s", "--error-exitcode=1", "--leak-check=full", "--show-leak-kinds=all", helpers.path_to_executable('test_kem'), kem_name],
     )

--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -9,8 +9,7 @@ import sys
 @pytest.mark.parametrize('kem_name', helpers.available_kems_by_name())
 def test_kem_leak(kem_name):
     if not(helpers.is_kem_enabled_by_name(kem_name)): pytest.skip('Not enabled')
-    if sys.platform.startswith("win") or sys.platform.startswith("darwin"): pytest.skip('Leak testing not supported on this platform')
-    if kem_name == 'Classic-McEliece-8192128' : pytest.skip("Classic-McEliece-8192128 known to have memory leaks")
+    if sys.platform != "linux" or os.system("grep ubuntu /etc/os-release") != 0: pytest.skip('Leak testing not supported on this platform')
     helpers.run_subprocess(
         ["valgrind", "-s", "--error-exitcode=1", "--leak-check=full", "--show-leak-kinds=all", helpers.path_to_executable('test_kem'), kem_name],
     )
@@ -19,7 +18,7 @@ def test_kem_leak(kem_name):
 @pytest.mark.parametrize('sig_name', helpers.available_sigs_by_name())
 def test_sig_leak(sig_name):
     if not(helpers.is_sig_enabled_by_name(sig_name)): pytest.skip('Not enabled')
-    if sys.platform.startswith("win") or sys.platform.startswith("darwin"): pytest.skip('Leak testing not supported on this platform')
+    if sys.platform != "linux" or os.system("grep ubuntu /etc/os-release") != 0: pytest.skip('Leak testing not supported on this platform')
     helpers.run_subprocess(
         ["valgrind", "-s", "--error-exitcode=1", "--leak-check=full", "--show-leak-kinds=all", helpers.path_to_executable('test_sig'), sig_name],
     )

--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+
+import helpers
+import os
+import pytest
+import sys
+
+@helpers.filtered_test
+@pytest.mark.parametrize('kem_name', helpers.available_kems_by_name())
+def test_kem_leak(kem_name):
+    if not(helpers.is_kem_enabled_by_name(kem_name)): pytest.skip('Not enabled')
+    if kem_name == 'Classic-McEliece-8192128' : pytest.skip("Classic-McEliece-8192128 known to have memory leaks")
+    helpers.run_subprocess(
+        ["valgrind", "-s", "--error-exitcode=1", "--leak-check=full", "--show-leak-kinds=all", helpers.path_to_executable('test_kem'), kem_name],
+    )
+
+@helpers.filtered_test
+@pytest.mark.parametrize('sig_name', helpers.available_sigs_by_name())
+def test_sig_leak(sig_name):
+    if not(helpers.is_sig_enabled_by_name(sig_name)): pytest.skip('Not enabled')
+    if sys.platform.startswith("win") and 'APPVEYOR' in os.environ:
+        if 'SPHINCS' in sig_name and ('192f' in sig_name or '192s' in sig_name or '256f' in sig_name or '256s' in sig_name):
+            pytest.skip('Skipping SPHINCS+ 192s and 256s tests on Windows AppVeyor builds')
+    helpers.run_subprocess(
+        ["valgrind", "-s", "--error-exitcode=1", "--leak-check=full", "--show-leak-kinds=all", helpers.path_to_executable('test_sig'), sig_name],
+    )
+
+if __name__ == "__main__":
+    import sys
+    pytest.main(sys.argv)
+

--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -9,6 +9,7 @@ import sys
 @pytest.mark.parametrize('kem_name', helpers.available_kems_by_name())
 def test_kem_leak(kem_name):
     if not(helpers.is_kem_enabled_by_name(kem_name)): pytest.skip('Not enabled')
+    if sys.platform.startswith("win") or sys.platform.startswith("darwin"): pytest.skip('Leak testing not supported on this platform')
     if kem_name == 'Classic-McEliece-8192128' : pytest.skip("Classic-McEliece-8192128 known to have memory leaks")
     helpers.run_subprocess(
         ["valgrind", "-s", "--error-exitcode=1", "--leak-check=full", "--show-leak-kinds=all", helpers.path_to_executable('test_kem'), kem_name],
@@ -18,9 +19,7 @@ def test_kem_leak(kem_name):
 @pytest.mark.parametrize('sig_name', helpers.available_sigs_by_name())
 def test_sig_leak(sig_name):
     if not(helpers.is_sig_enabled_by_name(sig_name)): pytest.skip('Not enabled')
-    if sys.platform.startswith("win") and 'APPVEYOR' in os.environ:
-        if 'SPHINCS' in sig_name and ('192f' in sig_name or '192s' in sig_name or '256f' in sig_name or '256s' in sig_name):
-            pytest.skip('Skipping SPHINCS+ 192s and 256s tests on Windows AppVeyor builds')
+    if sys.platform.startswith("win") or sys.platform.startswith("darwin"): pytest.skip('Leak testing not supported on this platform')
     helpers.run_subprocess(
         ["valgrind", "-s", "--error-exitcode=1", "--leak-check=full", "--show-leak-kinds=all", helpers.path_to_executable('test_sig'), sig_name],
     )

--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -9,7 +9,7 @@ import sys
 @pytest.mark.parametrize('kem_name', helpers.available_kems_by_name())
 def test_kem_leak(kem_name):
     if not(helpers.is_kem_enabled_by_name(kem_name)): pytest.skip('Not enabled')
-    if sys.platform != "linux" or os.system("grep ubuntu /etc/os-release") != 0: pytest.skip('Leak testing not supported on this platform')
+    if sys.platform != "linux" or os.system("grep ubuntu /etc/os-release") != 0 or os.system("uname -a | grep x86_64") != 0: pytest.skip('Leak testing not supported on this platform')
     helpers.run_subprocess(
         ["valgrind", "-s", "--error-exitcode=1", "--leak-check=full", "--show-leak-kinds=all", helpers.path_to_executable('test_kem'), kem_name],
     )
@@ -18,7 +18,7 @@ def test_kem_leak(kem_name):
 @pytest.mark.parametrize('sig_name', helpers.available_sigs_by_name())
 def test_sig_leak(sig_name):
     if not(helpers.is_sig_enabled_by_name(sig_name)): pytest.skip('Not enabled')
-    if sys.platform != "linux" or os.system("grep ubuntu /etc/os-release") != 0: pytest.skip('Leak testing not supported on this platform')
+    if sys.platform != "linux" or os.system("grep ubuntu /etc/os-release") != 0 or os.system("uname -a | grep x86_64") != 0: pytest.skip('Leak testing not supported on this platform')
     helpers.run_subprocess(
         ["valgrind", "-s", "--error-exitcode=1", "--leak-check=full", "--show-leak-kinds=all", helpers.path_to_executable('test_sig'), sig_name],
     )


### PR DESCRIPTION
Fixes #1213 -- excluding "Classic-McEliece-8192128" as it fails the memory leak test. Open to suggestions how to otherwise handle / document this failure: Draft PR until then.

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

