### PR TITLE
Adds AES context release in Dilithium-AES / fix memory leak

### DIFF
--- a/scripts/copy_from_upstream/patches/pqcrystals-dilithium-avx2-shake-aes.patch
+++ b/scripts/copy_from_upstream/patches/pqcrystals-dilithium-avx2-shake-aes.patch
@@ -294,7 +294,21 @@ index 3dee7a62..8c254f07 100644
        poly_uniform_preinit(&row->vec[j], &aesctx);
        poly_nttunpack(&row->vec[j]);
      }
-@@ -449,16 +460,21 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size
+@@ -434,8 +445,12 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size
+ 
+     /* Get hint polynomial and reconstruct w1 */
+     memset(h.vec, 0, sizeof(poly));
+-    if(hint[OMEGA + i] < pos || hint[OMEGA + i] > OMEGA)
++    if(hint[OMEGA + i] < pos || hint[OMEGA + i] > OMEGA) {
++#ifdef DILITHIUM_USE_AES
++      aes256_ctx_release(&aesctx);
++#endif
+       return -1;
++    }
+ 
+     for(j = pos; j < hint[OMEGA + i]; ++j) {
+       /* Coefficients are ordered for strong unforgeability */
+@@ -449,16 +464,21 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size
      polyw1_pack(buf.coeffs + i*POLYW1_PACKEDBYTES, &w1);
    }
  

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/sign.c
@@ -445,8 +445,12 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size
 
     /* Get hint polynomial and reconstruct w1 */
     memset(h.vec, 0, sizeof(poly));
-    if(hint[OMEGA + i] < pos || hint[OMEGA + i] > OMEGA)
+    if(hint[OMEGA + i] < pos || hint[OMEGA + i] > OMEGA) {
+#ifdef DILITHIUM_USE_AES
+      aes256_ctx_release(&aesctx);
+#endif
       return -1;
+    }
 
     for(j = pos; j < hint[OMEGA + i]; ++j) {
       /* Coefficients are ordered for strong unforgeability */

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2aes_avx2/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2aes_avx2/sign.c
@@ -445,8 +445,12 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size
 
     /* Get hint polynomial and reconstruct w1 */
     memset(h.vec, 0, sizeof(poly));
-    if(hint[OMEGA + i] < pos || hint[OMEGA + i] > OMEGA)
+    if(hint[OMEGA + i] < pos || hint[OMEGA + i] > OMEGA) {
+#ifdef DILITHIUM_USE_AES
+      aes256_ctx_release(&aesctx);
+#endif
       return -1;
+    }
 
     for(j = pos; j < hint[OMEGA + i]; ++j) {
       /* Coefficients are ordered for strong unforgeability */

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/sign.c
@@ -445,8 +445,12 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size
 
     /* Get hint polynomial and reconstruct w1 */
     memset(h.vec, 0, sizeof(poly));
-    if(hint[OMEGA + i] < pos || hint[OMEGA + i] > OMEGA)
+    if(hint[OMEGA + i] < pos || hint[OMEGA + i] > OMEGA) {
+#ifdef DILITHIUM_USE_AES
+      aes256_ctx_release(&aesctx);
+#endif
       return -1;
+    }
 
     for(j = pos; j < hint[OMEGA + i]; ++j) {
       /* Coefficients are ordered for strong unforgeability */

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3aes_avx2/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3aes_avx2/sign.c
@@ -445,8 +445,12 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size
 
     /* Get hint polynomial and reconstruct w1 */
     memset(h.vec, 0, sizeof(poly));
-    if(hint[OMEGA + i] < pos || hint[OMEGA + i] > OMEGA)
+    if(hint[OMEGA + i] < pos || hint[OMEGA + i] > OMEGA) {
+#ifdef DILITHIUM_USE_AES
+      aes256_ctx_release(&aesctx);
+#endif
       return -1;
+    }
 
     for(j = pos; j < hint[OMEGA + i]; ++j) {
       /* Coefficients are ordered for strong unforgeability */

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/sign.c
@@ -445,8 +445,12 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size
 
     /* Get hint polynomial and reconstruct w1 */
     memset(h.vec, 0, sizeof(poly));
-    if(hint[OMEGA + i] < pos || hint[OMEGA + i] > OMEGA)
+    if(hint[OMEGA + i] < pos || hint[OMEGA + i] > OMEGA) {
+#ifdef DILITHIUM_USE_AES
+      aes256_ctx_release(&aesctx);
+#endif
       return -1;
+    }
 
     for(j = pos; j < hint[OMEGA + i]; ++j) {
       /* Coefficients are ordered for strong unforgeability */

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5aes_avx2/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5aes_avx2/sign.c
@@ -445,8 +445,12 @@ int crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size
 
     /* Get hint polynomial and reconstruct w1 */
     memset(h.vec, 0, sizeof(poly));
-    if(hint[OMEGA + i] < pos || hint[OMEGA + i] > OMEGA)
+    if(hint[OMEGA + i] < pos || hint[OMEGA + i] > OMEGA) {
+#ifdef DILITHIUM_USE_AES
+      aes256_ctx_release(&aesctx);
+#endif
       return -1;
+    }
 
     for(j = pos; j < hint[OMEGA + i]; ++j) {
       /* Coefficients are ordered for strong unforgeability */


### PR DESCRIPTION
Adds a `aes256_ctx_release` in Dilithium-AES. Fixes a memory leak detected in #1234.
Updates sign.c patch and does copy_from_upstream.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
