### PR TITLE
adding scan-build test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ localCheckout: &localCheckout
   run: |-
     PROJECT_PATH=$(cd ${CIRCLE_WORKING_DIRECTORY}; pwd)
     mkdir -p ${PROJECT_PATH}
+    git config --global --add safe.directory /tmp/_circleci_local_build_repo
     cd /tmp/_circleci_local_build_repo
     git ls-files -z | xargs -0 -s 2090860 tar -c | tar -x -C ${PROJECT_PATH}
     cp -a /tmp/_circleci_local_build_repo/.git ${PROJECT_PATH}
@@ -123,6 +124,25 @@ jobs:
           path: build/test-results
       - store_artifacts:
           path: build/test-results
+
+
+  scan_build:
+    description: Executing scan-build test
+    parameters:
+      CONTAINER:
+        description: "The docker container to use."
+        type: string
+    docker:
+      - image: << parameters.CONTAINER >>
+    steps:
+      - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
+      - run:
+          name: Configure
+          command: mkdir build && cd build && pwd && source ~/.bashrc && scan-build cmake -GNinja ..
+      - run:
+          name: Build
+          command: scan-build --status-bugs ninja
+          working_directory: build
 
   arm_machine:
     description: A template for running liboqs tests on ARM(presently only 64) machines
@@ -319,6 +339,11 @@ workflows:
       #    name: debian-buster
       #    context: openquantumsafe
       #    CONTAINER: openquantumsafe/ci-debian-buster-amd64:latest
+      - scan_build:
+          <<: *require_buildcheck
+          name: scan_build
+          context: openquantumsafe
+          CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
       - linux_oqs:
           <<: *require_buildcheck
           name: ubuntu-focal-noopenssl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,10 +138,10 @@ jobs:
       - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
       - run:
           name: Configure
-          command: mkdir build && cd build && pwd && source ~/.bashrc && scan-build cmake -GNinja ..
+          command: mkdir build && cd build && pwd && source ~/.bashrc && scan-build-14 cmake -GNinja ..
       - run:
           name: Build
-          command: scan-build --status-bugs ninja
+          command: scan-build-14 --status-bugs ninja
           working_directory: build
 
   arm_machine:
@@ -359,10 +359,10 @@ workflows:
           PYTEST_ARGS: --ignore=tests/test_namespace.py --numprocesses=auto
       - linux_oqs:
           <<: *require_buildcheck
-          name: ubuntu-focal-clang9
+          name: ubuntu-focal-clang14
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-          CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9
+          CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-14
       - linux_oqs:
           <<: *require_buildcheck
           name: ubuntu-bionic-i386

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,8 +137,8 @@ jobs:
     steps:
       - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
       - run:
-          name: Configure
-          command: mkdir build && cd build && pwd && source ~/.bashrc && scan-build-14 cmake -GNinja ..
+          name: Configure (excluding Kyber because of known issue)
+          command: mkdir build && cd build && pwd && source ~/.bashrc && scan-build-14 cmake -GNinja -DOQS_ENABLE_KEM_KYBER=OFF ..
       - run:
           name: Build
           command: scan-build-14 --status-bugs ninja

--- a/docs/algorithms/kem/kyber.md
+++ b/docs/algorithms/kem/kyber.md
@@ -47,6 +47,8 @@ Are implementations chosen based on runtime CPU feature detection? **Yes**.
 
 Are implementations chosen based on runtime CPU feature detection? **Yes**.
 
+Implementation known to fail [scan-build](https://clang-analyzer.llvm.org/scan-build.html).
+
 ## Kyber768 implementation characteristics
 
 |        Implementation source        | Identifier in upstream   | Supported architecture(s)   | Supported operating system(s)   | CPU extension(s) used   | No branching-on-secrets claimed?   | No branching-on-secrets checked by valgrind?   | Large stack usage?   |
@@ -66,6 +68,8 @@ Are implementations chosen based on runtime CPU feature detection? **Yes**.
 
 Are implementations chosen based on runtime CPU feature detection? **Yes**.
 
+Implementation known to fail [scan-build](https://clang-analyzer.llvm.org/scan-build.html).
+
 ## Kyber1024 implementation characteristics
 
 |        Implementation source        | Identifier in upstream   | Supported architecture(s)   | Supported operating system(s)   | CPU extension(s) used   | No branching-on-secrets claimed?   | No branching-on-secrets checked by valgrind?   | Large stack usage?   |
@@ -84,6 +88,8 @@ Are implementations chosen based on runtime CPU feature detection? **Yes**.
 | [Primary Source](#primary-source) | avx2                     | x86\_64                     | Linux,Darwin                    | AES,AVX2,BMI2,POPCNT,SSE2,SSSE3 | True                               | True                                           | False                |
 
 Are implementations chosen based on runtime CPU feature detection? **Yes**.
+
+Implementation known to fail [scan-build](https://clang-analyzer.llvm.org/scan-build.html).
 
 ## Explanation of Terms
 


### PR DESCRIPTION
Fixes #1239. Avoid recurrence of #1212 ~(which arguably should be re-opened)~.

@dstebila : Please decide how/when to merge this. My suggestion would be after @sebastinas and @bhess had a chance to review the [run log](https://circleci.com/api/v1.1/project/github/open-quantum-safe/liboqs/17515/output/103/0?file=true&allocation-id=62bb17df947e861ada3206ce-0-build%2F54D6229E) for the picnic and kyber issues listed.

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

