### PR TITLE
Bump Picnic to 3.0.15

### DIFF
--- a/docs/algorithms/sig/picnic.md
+++ b/docs/algorithms/sig/picnic.md
@@ -4,7 +4,7 @@
 - **Main cryptographic assumption**: hash function security (ROM/QROM), key recovery attacks on the lowMC block cipher.
 - **Principal submitters**: Greg Zaverucha, Melissa Chase, David Derler, Steven Goldfeder, Claudio Orlandi, Sebastian Ramacher, Christian Rechberger, Daniel Slamanig, Jonathan Katz, Xiao Wang, Vladmir Kolesnikov.
 - **Authors' website**: https://microsoft.github.io/Picnic/
-- **Specification version**: 3.0.14.
+- **Specification version**: 3.0.15.
 - **Primary Source**<a name="primary-source"></a>:
   - **Source**: https://github.com/IAIK/Picnic
   - **Implementation license (SPDX-Identifier)**: MIT

--- a/docs/algorithms/sig/picnic.yml
+++ b/docs/algorithms/sig/picnic.yml
@@ -16,7 +16,7 @@ crypto-assumption: hash function security (ROM/QROM), key recovery attacks on th
   lowMC block cipher
 website: https://microsoft.github.io/Picnic/
 nist-round: 3
-spec-version: 3.0.14
+spec-version: 3.0.15
 primary-upstream:
   source: https://github.com/IAIK/Picnic
   spdx-license-identifier: MIT

--- a/src/sig/picnic/external/lowmc.c.i
+++ b/src/sig/picnic/external/lowmc.c.i
@@ -14,7 +14,7 @@
 #define SBOX(x) sbox_layer_10_uint64(&BLOCK(x, 0)->w64[(LOWMC_N / (sizeof(word) * 8)) - 1])
 #include "lowmc_impl_partial.c.i"
 #else
-#define SBOX(x) SBOX_FUNC(BLOCK(x, 0))
+#define SBOX(x) SBOX_FUNC(x)
 #include "lowmc_impl.c.i"
 #endif
 #if defined(WITH_ZKBPP)
@@ -35,7 +35,7 @@
 #undef SBOX
 #undef SBOX_FUNC
 #define SBOX_FUNC CONCAT(sbox_aux, CONCAT(IMPL, LOWMC_INSTANCE))
-#define SBOX(x, y, tapes) SBOX_FUNC(BLOCK(x, 0), BLOCK(y, 0), tapes)
+#define SBOX(x, y, tapes) SBOX_FUNC(x, y, tapes)
 #define N_LOWMC CONCAT(lowmc_aux, CONCAT(IMPL, LOWMC_INSTANCE))
 #include "lowmc_impl_aux.c.i"
 #endif

--- a/src/sig/picnic/external/picnic3_simulate.c.i
+++ b/src/sig/picnic/external/picnic3_simulate.c.i
@@ -40,23 +40,19 @@ static int SIM_ONLINE(mzd_local_t* maskedKey, randomTape_t* tapes, msgs_t* msgs,
   uint8_t output[MAX_LOWMC_BLOCK_SIZE];
   mzd_to_char_array(output, state, params->input_output_size);
 
-#if !defined(NDEBUG)
   /* timingsafe_bcmp is not strictly necessary here. The comparison does not leak any information on
-   * the secret key. In fact, this will never trigger. We still keep this check as a safe guard in
-   * case we break the computation of the signature in some way. */
-  const int ret = timingsafe_bcmp(output, pubKey, params->input_output_size);
+   * the secret key. */
+  const int ret = picnic_timingsafe_bcmp(output, pubKey, params->input_output_size);
+#if !defined(NDEBUG)
   if (ret) {
     printf("%s: output does not match pubKey\n", __func__);
     printf("pubKey: ");
-    print_hex(stdout, pubKey, params->output_size);
+    print_hex(stdout, pubKey, params->input_output_size);
     printf("\noutput: ");
-    print_hex(stdout, output, params->output_size);
+    print_hex(stdout, output, params->input_output_size);
     printf("\n");
   }
-  return ret;
-#else
-  (void)pubKey;
-  return 0;
 #endif
+  return ret;
 }
 #endif

--- a/src/sig/picnic/external/picnic3_tree.c
+++ b/src/sig/picnic/external/picnic3_tree.c
@@ -358,13 +358,12 @@ static unsigned int* getRevealedNodes(tree_t* tree, uint16_t* hideList, size_t h
 
   /* pathSets[i][0...hideListSize] ~= pathSets[i * hideListSize + ...] stores the nodes in the path
    * at depth i for each of the leaf nodes in hideListSize */
-  unsigned int* pathSets = malloc(hideListSize * pathLen * sizeof(unsigned int));
+  unsigned int* pathSets = calloc(hideListSize * pathLen, sizeof(unsigned int));
 
   /* Compute the paths back to the root */
   for (size_t i = 0; i < hideListSize; i++) {
-    unsigned int node =
-        hideList[i] +
-        (tree->numNodes - tree->numLeaves); /* input lists leaf indexes, translate to nodes */
+    /* input lists leaf indexes, translate to nodes */
+    unsigned int node                    = hideList[i] + (tree->numNodes - tree->numLeaves);
     pathSets[/* 0 * hideListSize + */ i] = node;
     unsigned int pos                     = 1;
     while ((node = getParent(node)) != 0) {

--- a/src/sig/picnic/sig_picnic.c
+++ b/src/sig/picnic/sig_picnic.c
@@ -125,7 +125,7 @@ OQS_SIG *OQS_SIG_picnic_L1_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.14";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -164,7 +164,7 @@ OQS_SIG *OQS_SIG_picnic_L1_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.14";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -203,7 +203,7 @@ OQS_SIG *OQS_SIG_picnic_L1_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.14";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -242,7 +242,7 @@ OQS_SIG *OQS_SIG_picnic_L3_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.14";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -281,7 +281,7 @@ OQS_SIG *OQS_SIG_picnic_L3_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.14";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -320,7 +320,7 @@ OQS_SIG *OQS_SIG_picnic_L3_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.14";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -359,7 +359,7 @@ OQS_SIG *OQS_SIG_picnic_L5_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.14";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -399,7 +399,7 @@ OQS_SIG *OQS_SIG_picnic_L5_UR_new() {
 	}
 
 	sig->method_name = OQS_SIG_alg_picnic_L5_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.14";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -438,7 +438,7 @@ OQS_SIG *OQS_SIG_picnic_L5_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.14";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -475,7 +475,7 @@ OQS_SIG *OQS_SIG_picnic3_L1_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L1;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.14";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -513,7 +513,7 @@ OQS_SIG *OQS_SIG_picnic3_L3_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L3;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.14";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -551,7 +551,7 @@ OQS_SIG *OQS_SIG_picnic3_L5_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L5;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.14";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;


### PR DESCRIPTION
This one should also fix the remaining scan-build warning.

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)
