### PR TITLE
disable msys2 testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,11 @@ environment:
       OQS_USE_OPENSSL: ON
     - BUILD_SHARED: ON
       COMPILER: msvc2019
-    - BUILD_SHARED: OFF
-      COMPILER: msys2
-    - BUILD_SHARED: ON
-      COMPILER: msys2
+      #    Disabled until https://github.com/open-quantum-safe/liboqs/issues/1218#issuecomment-1170067669 resolved
+      #    - BUILD_SHARED: OFF
+      #      COMPILER: msys2
+      #    - BUILD_SHARED: ON
+      #      COMPILER: msys2
 
 for:
   - matrix:


### PR DESCRIPTION
Fixes #1222. Closes #1218.

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

