### PR TITLE
docs: Add valgrind as test dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ We realize some parties may want to deploy quantum-safe cryptography prior to th
 
 	On Ubuntu:
 
-		 sudo apt install astyle cmake gcc ninja-build libssl-dev python3-pytest python3-pytest-xdist unzip xsltproc doxygen graphviz python3-yaml
+		 sudo apt install astyle cmake gcc ninja-build libssl-dev python3-pytest python3-pytest-xdist unzip xsltproc doxygen graphviz python3-yaml valgrind
 
 	On macOS, using a package manager of your choice (we've picked Homebrew):
 
-		brew install cmake ninja openssl@1.1 wget doxygen graphviz astyle
+		brew install cmake ninja openssl@1.1 wget doxygen graphviz astyle valgrind
 		pip3 install pytest pytest-xdist pyyaml
 
 	Note that, if you want liboqs to use OpenSSL for various symmetric crypto algorithms (AES, SHA-2, etc.) then you must have OpenSSL version 1.1.1 or higher.
@@ -120,10 +120,6 @@ The following instructions assume we are in `build`.
 	- `example_sig`: Minimal runnable example showing the usage of the signature API
 	- `test_aes`, `test_sha3`: Simple test harnesses for crypto sub-components
 	- `test_portability`: Simple test harnesses for checking cross-CPU code portability; requires presence of `qemu`; proper operation validated only on Ubuntu
-
-	Install test suite dependencies:
-
-		sudo apt install valgrind
 
 	The complete test suite can be run using
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ The following instructions assume we are in `build`.
 	- `test_aes`, `test_sha3`: Simple test harnesses for crypto sub-components
 	- `test_portability`: Simple test harnesses for checking cross-CPU code portability; requires presence of `qemu`; proper operation validated only on Ubuntu
 
+	Install test suite dependencies:
+
+		sudo apt install valgrind
+
 	The complete test suite can be run using
 
 		ninja run_tests


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

Please kindly add valgrind as test dependencies in README.md. I am getting error when running the complete test suite without valgrind: 

> FileNotFoundError: [Errno 2] No such file or directory: 'valgrind'
>
> /usr/lib/python3.8/subprocess.py:1704: FileNotFoundError
> ----------------------------- Captured stdout call -----------------------------
> ID=ubuntu
> HOME_URL="https://www.ubuntu.com/"
> SUPPORT_URL="https://help.ubuntu.com/"
> BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
> PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
> Linux bb-ubuntu-68 5.13.0-51-generic #58~20.04.1-Ubuntu SMP Tue Jun 14 11:29:12 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
> . > valgrind -s --error-exitcode=1 --leak-check=full --show-leak-kinds=all /home/user/OpenQuantumSafe/liboqs/build/tests/test_kem Classic-McEliece-6960119f
> ============= 124 failed, 637 passed, 260 skipped in 39.41 seconds =============
> FAILED: tests/CMakeFiles/run_tests
> cd /home/user/OpenQuantumSafe/liboqs && /usr/bin/cmake -E env OQS_BUILD_DIR=/home/user/OpenQuantumSafe/liboqs/build python3 -m pytest --verbose --numprocesses=auto --ignore=scripts/copy_from_upstream/repos
> ninja: build stopped: subcommand failed.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
