### PR TITLE
pqclean_hqc: Fix build on GCC-12

### DIFF
--- a/src/kem/hqc/pqclean_hqc-rmrs-128_avx2/reed_muller.c
+++ b/src/kem/hqc/pqclean_hqc-rmrs-128_avx2/reed_muller.c
@@ -331,6 +331,9 @@ inline uint32_t find_peaks(__m256i *transform) {
         tmp = _mm256_or_si256(tmp, _mm256_and_si256(vect_mask, transform[i]));
     }
     result = 0;
+#if __GNUC__ == 12
+# pragma GCC unroll 16
+#endif
     for (size_t i = 0; i < 16; i++) {
         mask = ~(uint32_t) ((-(int64_t)(i ^ message % 16)) >> 63);
         result |= mask & ((uint16_t *)&tmp)[i];

--- a/src/kem/hqc/pqclean_hqc-rmrs-192_avx2/reed_muller.c
+++ b/src/kem/hqc/pqclean_hqc-rmrs-192_avx2/reed_muller.c
@@ -331,6 +331,9 @@ inline uint32_t find_peaks(__m256i *transform) {
         tmp = _mm256_or_si256(tmp, _mm256_and_si256(vect_mask, transform[i]));
     }
     result = 0;
+#if __GNUC__ == 12
+# pragma GCC unroll 16
+#endif
     for (size_t i = 0; i < 16; i++) {
         mask = ~(uint32_t) ((-(int64_t)(i ^ message % 16)) >> 63);
         result |= mask & ((uint16_t *)&tmp)[i];

--- a/src/kem/hqc/pqclean_hqc-rmrs-256_avx2/reed_muller.c
+++ b/src/kem/hqc/pqclean_hqc-rmrs-256_avx2/reed_muller.c
@@ -331,6 +331,9 @@ inline uint32_t find_peaks(__m256i *transform) {
         tmp = _mm256_or_si256(tmp, _mm256_and_si256(vect_mask, transform[i]));
     }
     result = 0;
+#if __GNUC__ == 12
+# pragma GCC unroll 16
+#endif
     for (size_t i = 0; i < 16; i++) {
         mask = ~(uint32_t) ((-(int64_t)(i ^ message % 16)) >> 63);
         result |= mask & ((uint16_t *)&tmp)[i];


### PR DESCRIPTION
Make index variable `i` immediate by unrolling the loop. This is just lucky guess that's worked, because similar in function intrinsic `_mm256_extract_epi16` requires immediate value for its index.

Workaround to the (perhaps) GCC 12 bug:
```
  In function 'find_peaks',
      inlined from 'PQCLEAN_HQCRMRS192_AVX2_reed_muller_decode' at /usr/src/RPM/BUILD/liboqs-0.7.1/src/kem/hqc/pqclean_hqc-rmrs-192_avx2/reed_muller.c:387:18:
  /usr/src/RPM/BUILD/liboqs-0.7.1/src/kem/hqc/pqclean_hqc-rmrs-192_avx2/reed_muller.c:336:44: error: 'tmp' is used uninitialized [-Werror=uninitialized]
    336 |         result |= mask & ((uint16_t *)&tmp)[i];
	|                          ~~~~~~~~~~~~~~~~~~^~~
  /usr/src/RPM/BUILD/liboqs-0.7.1/src/kem/hqc/pqclean_hqc-rmrs-192_avx2/reed_muller.c: In function 'PQCLEAN_HQCRMRS192_AVX2_reed_muller_decode':
  /usr/src/RPM/BUILD/liboqs-0.7.1/src/kem/hqc/pqclean_hqc-rmrs-192_avx2/reed_muller.c:234:13: note: 'tmp' was declared here
    234 |     __m256i tmp = _mm256_setzero_si256();
	|             ^~~
```
If LTO is enabled this error message is not shown, but HQC-128 decaps test is failed.

<!-- Please give a brief explanation of the purpose of this pull request. -->

As discussed at https://github.com/open-quantum-safe/liboqs/issues/1244

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

Fixes #1244

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming?  (If so, PRs in OQS-OpenSSL, OQS-BoringSSL, and OQS-OpenSSH will also be required by the time this is merged.)

No such changes.

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

Tested locally on `0.7.1`.
