### PR TITLE
Update to Picnic 3.0.16 (fixes #1253)

### DIFF
--- a/docs/algorithms/sig/picnic.md
+++ b/docs/algorithms/sig/picnic.md
@@ -4,7 +4,7 @@
 - **Main cryptographic assumption**: hash function security (ROM/QROM), key recovery attacks on the lowMC block cipher.
 - **Principal submitters**: Greg Zaverucha, Melissa Chase, David Derler, Steven Goldfeder, Claudio Orlandi, Sebastian Ramacher, Christian Rechberger, Daniel Slamanig, Jonathan Katz, Xiao Wang, Vladmir Kolesnikov.
 - **Authors' website**: https://microsoft.github.io/Picnic/
-- **Specification version**: 3.0.15.
+- **Specification version**: 3.0.16.
 - **Primary Source**<a name="primary-source"></a>:
   - **Source**: https://github.com/IAIK/Picnic
   - **Implementation license (SPDX-Identifier)**: MIT

--- a/docs/algorithms/sig/picnic.yml
+++ b/docs/algorithms/sig/picnic.yml
@@ -16,7 +16,7 @@ crypto-assumption: hash function security (ROM/QROM), key recovery attacks on th
   lowMC block cipher
 website: https://microsoft.github.io/Picnic/
 nist-round: 3
-spec-version: 3.0.15
+spec-version: 3.0.16
 primary-upstream:
   source: https://github.com/IAIK/Picnic
   spdx-license-identifier: MIT

--- a/src/sig/picnic/external/bitstream.h
+++ b/src/sig/picnic/external/bitstream.h
@@ -158,7 +158,7 @@ static inline void mzd_from_bitstream(bitstream_t* bs, mzd_local_t* v, const siz
 ATTR_TARGET_S256
 static inline void w256_to_bitstream(bitstream_t* bs, const word256 v, const size_t width,
                                      const size_t size) {
-  uint64_t buf[4] ATTR_ALIGNED(32);
+  ATTR_ALIGNED(32) uint64_t buf[4];
   mm256_store(buf, v);
 
   const uint64_t* d = &buf[width - 1];
@@ -173,7 +173,7 @@ static inline void w256_to_bitstream(bitstream_t* bs, const word256 v, const siz
 
 ATTR_TARGET_S256
 static inline word256 w256_from_bitstream(bitstream_t* bs, const size_t width, const size_t size) {
-  uint64_t buf[4] ATTR_ALIGNED(32) = {0};
+  ATTR_ALIGNED(32) uint64_t buf[4] = {0};
   uint64_t* d                      = &buf[width - 1];
   size_t bits                      = size;
   for (; bits >= sizeof(uint64_t) * 8; bits -= sizeof(uint64_t) * 8, --d) {
@@ -191,7 +191,7 @@ static inline word256 w256_from_bitstream(bitstream_t* bs, const size_t width, c
 ATTR_TARGET_S128
 static inline void w128_to_bitstream(bitstream_t* bs, const word128 v[2], const size_t width,
                                      const size_t size) {
-  uint64_t buf[4] ATTR_ALIGNED(16);
+  ATTR_ALIGNED(16) uint64_t buf[4];
   mm128_store(&buf[0], v[0]);
   mm128_store(&buf[2], v[1]);
 
@@ -208,7 +208,7 @@ static inline void w128_to_bitstream(bitstream_t* bs, const word128 v[2], const 
 ATTR_TARGET_S128
 static inline void w128_from_bitstream(bitstream_t* bs, word128 v[2], const size_t width,
                                        const size_t size) {
-  uint64_t buf[4] ATTR_ALIGNED(16) = {0};
+  ATTR_ALIGNED(16) uint64_t buf[4] = {0};
   uint64_t* d                      = &buf[width - 1];
   size_t bits                      = size;
   for (; bits >= sizeof(uint64_t) * 8; bits -= sizeof(uint64_t) * 8, --d) {

--- a/src/sig/picnic/external/lowmc_impl_partial.c.i
+++ b/src/sig/picnic/external/lowmc_impl_partial.c.i
@@ -7,7 +7,6 @@
  *  SPDX-License-Identifier: MIT
  */
 
-
 #if defined(FN_ATTR)
 FN_ATTR
 #endif

--- a/src/sig/picnic/external/macros.h
+++ b/src/sig/picnic/external/macros.h
@@ -120,12 +120,12 @@
 
 /* aligned attribute */
 /* note that C11's alignas will only do the job once DR 444 is implemented */
-#if GNUC_CHECK(4, 9) || __has_attribute(aligned)
+#if GNUC_CHECK(3, 2) || __has_attribute(aligned)
 #define ATTR_ALIGNED(i) __attribute__((aligned((i))))
 #define HAVE_USEFUL_ATTR_ALIGNED
-/* #elif defined(_MSC_VER)
-#define ATTR_ALIGNED(i) __declspec(align((i)))
-#define HAVE_USEFUL_ATTR_ALIGNED */
+#elif defined(_MSC_VER)
+#define ATTR_ALIGNED(i) __declspec(align(i))
+#define HAVE_USEFUL_ATTR_ALIGNED
 #else
 #define ATTR_ALIGNED(i)
 #endif

--- a/src/sig/picnic/external/mpc_lowmc.h
+++ b/src/sig/picnic/external/mpc_lowmc.h
@@ -26,9 +26,9 @@ typedef union {
 
 typedef view_t rvec_t;
 
-typedef struct {
+typedef ATTR_ALIGNED(32) struct {
   mzd_local_t s[SC_PROOF][(MAX_LOWMC_BLOCK_SIZE + 255) / 256];
-} in_out_shares_t ATTR_ALIGNED(32);
+} in_out_shares_t;
 
 typedef void (*zkbpp_lowmc_implementation_f)(mzd_local_t const*, view_t*, in_out_shares_t*, rvec_t*,
                                              recorded_state_t*);

--- a/src/sig/picnic/external/mzd_additional.h
+++ b/src/sig/picnic/external/mzd_additional.h
@@ -24,9 +24,7 @@ PICNIC_BEGIN_C_DECL
 typedef uint64_t word;
 #define WORD_C(v) UINT64_C(v)
 
-typedef union {
-  word w64[4];
-} block_t ATTR_ALIGNED(32);
+typedef ATTR_ALIGNED(32) struct { word w64[4]; } block_t;
 
 /**
  * Representation of matrices and vectors

--- a/src/sig/picnic/external/simd.h
+++ b/src/sig/picnic/external/simd.h
@@ -16,6 +16,10 @@
 
 #include "macros.h"
 
+#if !defined(HAVE_USEFUL_ATTR_ALIGNED)
+#error "SIMD support requires that the compiler supports some method to specify alignment."
+#endif
+
 #if defined(_MSC_VER)
 #include <immintrin.h>
 #elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))

--- a/src/sig/picnic/sig_picnic.c
+++ b/src/sig/picnic/sig_picnic.c
@@ -125,7 +125,7 @@ OQS_SIG *OQS_SIG_picnic_L1_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -164,7 +164,7 @@ OQS_SIG *OQS_SIG_picnic_L1_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -203,7 +203,7 @@ OQS_SIG *OQS_SIG_picnic_L1_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -242,7 +242,7 @@ OQS_SIG *OQS_SIG_picnic_L3_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -281,7 +281,7 @@ OQS_SIG *OQS_SIG_picnic_L3_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -320,7 +320,7 @@ OQS_SIG *OQS_SIG_picnic_L3_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -359,7 +359,7 @@ OQS_SIG *OQS_SIG_picnic_L5_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -399,7 +399,7 @@ OQS_SIG *OQS_SIG_picnic_L5_UR_new() {
 	}
 
 	sig->method_name = OQS_SIG_alg_picnic_L5_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -438,7 +438,7 @@ OQS_SIG *OQS_SIG_picnic_L5_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -475,7 +475,7 @@ OQS_SIG *OQS_SIG_picnic3_L1_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L1;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -513,7 +513,7 @@ OQS_SIG *OQS_SIG_picnic3_L3_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L3;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -551,7 +551,7 @@ OQS_SIG *OQS_SIG_picnic3_L5_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L5;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.15";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;


### PR DESCRIPTION
This update fixes alignment issues when built with MSVC.

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)