### PR TITLE
adding library version retrieval function

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -191,6 +191,10 @@ OQS_API void OQS_init(void) {
 	return;
 }
 
+OQS_API const char *OQS_version(void) {
+	return OQS_VERSION_TEXT;
+}
+
 OQS_API int OQS_MEM_secure_bcmp(const void *a, const void *b, size_t len) {
 	/* Assume CHAR_BIT = 8 */
 	uint8_t r = 0;

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -144,6 +144,11 @@ OQS_API int OQS_CPU_has_extension(OQS_CPU_EXT ext);
 OQS_API void OQS_init(void);
 
 /**
+ * Return library version string.
+ */
+OQS_API const char *OQS_version(void);
+
+/**
  * Constant time comparison of byte sequences `a` and `b` of length `len`.
  * Returns 0 if the byte sequences are equal or if `len`=0.
  * Returns 1 otherwise.

--- a/tests/test_kem.c
+++ b/tests/test_kem.c
@@ -204,6 +204,8 @@ void *test_wrapper(void *arg) {
 
 int main(int argc, char **argv) {
 
+	printf("Testing KEM algorithms using liboqs version %s\n", OQS_version());
+
 	if (argc != 2) {
 		fprintf(stderr, "Usage: test_kem algname\n");
 		fprintf(stderr, "  algname: ");

--- a/tests/test_sig.c
+++ b/tests/test_sig.c
@@ -183,6 +183,8 @@ void *test_wrapper(void *arg) {
 
 int main(int argc, char **argv) {
 
+	printf("Testing signature algorithms using liboqs version %s\n", OQS_version());
+
 	if (argc != 2) {
 		fprintf(stderr, "Usage: test_sig algname\n");
 		fprintf(stderr, "  algname: ");


### PR DESCRIPTION
Provide a mechanism to retrieve at runtime, e.g., in a shared library, the current library version string. For use e.g. in language wrappers to display the true library version wrapped.

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

A common API is added, though. Downstream project's CI should be observed.
