### PR TITLE
Update to Picnic 3.0.17

### DIFF
--- a/docs/algorithms/sig/picnic.md
+++ b/docs/algorithms/sig/picnic.md
@@ -4,7 +4,7 @@
 - **Main cryptographic assumption**: hash function security (ROM/QROM), key recovery attacks on the lowMC block cipher.
 - **Principal submitters**: Greg Zaverucha, Melissa Chase, David Derler, Steven Goldfeder, Claudio Orlandi, Sebastian Ramacher, Christian Rechberger, Daniel Slamanig, Jonathan Katz, Xiao Wang, Vladmir Kolesnikov.
 - **Authors' website**: https://microsoft.github.io/Picnic/
-- **Specification version**: 3.0.16.
+- **Specification version**: 3.0.17.
 - **Primary Source**<a name="primary-source"></a>:
   - **Source**: https://github.com/IAIK/Picnic
   - **Implementation license (SPDX-Identifier)**: MIT

--- a/docs/algorithms/sig/picnic.yml
+++ b/docs/algorithms/sig/picnic.yml
@@ -16,7 +16,7 @@ crypto-assumption: hash function security (ROM/QROM), key recovery attacks on th
   lowMC block cipher
 website: https://microsoft.github.io/Picnic/
 nist-round: 3
-spec-version: 3.0.16
+spec-version: 3.0.17
 primary-upstream:
   source: https://github.com/IAIK/Picnic
   spdx-license-identifier: MIT

--- a/src/sig/picnic/external/lowmc.c
+++ b/src/sig/picnic/external/lowmc.c
@@ -732,7 +732,7 @@ static void sbox_aux_s256_lowmc_255_255_4(mzd_local_t* statein, mzd_local_t* sta
 
 void lowmc_compute(const lowmc_parameters_t* lowmc, const lowmc_key_t* key, const mzd_local_t* x,
                    mzd_local_t* y) {
-  const uint32_t lowmc_id = LOWMC_GET_ID(lowmc);
+  const uint32_t lowmc_id = lowmc_get_id(lowmc);
 #if defined(WITH_OPT)
 #if defined(WITH_AVX2)
   /* AVX2 enabled instances */
@@ -865,7 +865,7 @@ void lowmc_compute(const lowmc_parameters_t* lowmc, const lowmc_key_t* key, cons
 #if defined(PICNIC_STATIC)
 // This function is only used by the LowMC benchmark.
 lowmc_implementation_f lowmc_get_implementation(const lowmc_parameters_t* lowmc) {
-  const uint32_t lowmc_id = LOWMC_GET_ID(lowmc);
+  const uint32_t lowmc_id = lowmc_get_id(lowmc);
 #if defined(WITH_OPT)
 #if defined(WITH_AVX2)
   /* AVX2 enabled instances */
@@ -982,7 +982,7 @@ lowmc_implementation_f lowmc_get_implementation(const lowmc_parameters_t* lowmc)
 #if defined(WITH_ZKBPP)
 void lowmc_record_state(const lowmc_parameters_t* lowmc, const lowmc_key_t* key,
                         const mzd_local_t* x, recorded_state_t* state) {
-  const uint32_t lowmc_id = LOWMC_GET_ID(lowmc);
+  const uint32_t lowmc_id = lowmc_get_id(lowmc);
 #if defined(WITH_OPT)
 #if defined(WITH_AVX2)
   /* AVX2 enabled instances */
@@ -1109,7 +1109,7 @@ void lowmc_record_state(const lowmc_parameters_t* lowmc, const lowmc_key_t* key,
 
 #if defined(WITH_KKW)
 void lowmc_compute_aux(const lowmc_parameters_t* lowmc, lowmc_key_t* key, randomTape_t* tapes) {
-  const uint32_t lowmc_id = LOWMC_GET_ID(lowmc);
+  const uint32_t lowmc_id = lowmc_get_id(lowmc);
 #if defined(WITH_OPT)
 #if defined(WITH_AVX2)
   /* AVX2 enabled instances */

--- a/src/sig/picnic/external/lowmc_pars.h
+++ b/src/sig/picnic/external/lowmc_pars.h
@@ -80,7 +80,16 @@ typedef struct {
   const mzd_local_t* precomputed_constant_non_linear;
 } lowmc_partial_t;
 
+/**
+ * Unique identifier for a LowMC instance
+ */
 #define LOWMC_ID(n, m) ((((uint32_t)n) << 16) | (uint32_t)m)
-#define LOWMC_GET_ID(lowmc) LOWMC_ID(lowmc->n, lowmc->m)
+
+/**
+ * Obtain unique LowMC instance identifier
+ */
+static inline ATTR_PURE uint32_t lowmc_get_id(const lowmc_parameters_t* lowmc) {
+  return LOWMC_ID(lowmc->n, lowmc->m);
+}
 
 #endif

--- a/src/sig/picnic/external/mpc_lowmc.c
+++ b/src/sig/picnic/external/mpc_lowmc.c
@@ -484,20 +484,14 @@ static void mpc_sbox_verify_uint64_lowmc_255_255_4(mzd_local_t* out, const mzd_l
   do {                                                                                             \
     for (unsigned int m = 0; m < (sc); ++m) {                                                      \
       word256 tmp = mm256_load(IN(m));                                                             \
-      x0s[m]      = mm256_and(tmp, MASK_A);                                                        \
-      x1s[m]      = mm256_and(tmp, MASK_B);                                                        \
+      x0s[m]      = mm256_rotate_left(mm256_and(tmp, MASK_A), 2);                                  \
+      x1s[m]      = mm256_rotate_left(mm256_and(tmp, MASK_B), 1);                                  \
       x2m[m]      = mm256_and(tmp, MASK_C);                                                        \
                                                                                                    \
-      x0s[m] = mm256_rotate_left(x0s[m], 2);                                                       \
-      x1s[m] = mm256_rotate_left(x1s[m], 1);                                                       \
-                                                                                                   \
       tmp    = mm256_load(RVEC(m));                                                                \
-      r0m[m] = mm256_and(tmp, MASK_A);                                                             \
-      r1m[m] = mm256_and(tmp, MASK_B);                                                             \
+      r0s[m] = mm256_rotate_left(mm256_and(tmp, MASK_A), 2);                                       \
+      r1s[m] = mm256_rotate_left(mm256_and(tmp, MASK_B), 1);                                       \
       r2m[m] = mm256_and(tmp, MASK_C);                                                             \
-                                                                                                   \
-      r0s[m] = mm256_rotate_left(r0m[m], 2);                                                       \
-      r1s[m] = mm256_rotate_left(r1m[m], 1);                                                       \
     }                                                                                              \
   } while (0)
 
@@ -508,12 +502,11 @@ static void mpc_sbox_verify_uint64_lowmc_255_255_4(mzd_local_t* out, const mzd_l
       x0s[m] = mm256_xor(x0s[m], x1s[m]);                                                          \
       r1m[m] = mm256_xor(x0s[m], r1m[m]);                                                          \
       r0m[m] = mm256_xor(x0s[m], r0m[m]);                                                          \
-      r0m[m] = mm256_xor(r0m[m], x2m[m]);                                                          \
                                                                                                    \
       x0s[m] = mm256_rotate_right(r2m[m], 2);                                                      \
       x1s[m] = mm256_rotate_right(r1m[m], 1);                                                      \
                                                                                                    \
-      mm256_store(OUT(m), mm256_xor(r0m[m], mm256_xor(x0s[m], x1s[m])));                           \
+      mm256_store(OUT(m), mm256_xor(mm256_xor(r0m[m], x2m[m]), mm256_xor(x0s[m], x1s[m])));        \
     }                                                                                              \
   } while (0)
 
@@ -1007,7 +1000,7 @@ static void mpc_sbox_verify_s256_lowmc_255_255_4(mzd_local_t* out, const mzd_loc
 #endif
 
 zkbpp_lowmc_implementation_f get_zkbpp_lowmc_implementation(const lowmc_parameters_t* lowmc) {
-  const uint32_t lowmc_id = LOWMC_GET_ID(lowmc);
+  const uint32_t lowmc_id = lowmc_get_id(lowmc);
 #if defined(WITH_OPT)
 #if defined(WITH_AVX2)
   /* AVX2 enabled instances */
@@ -1122,7 +1115,7 @@ zkbpp_lowmc_implementation_f get_zkbpp_lowmc_implementation(const lowmc_paramete
 
 zkbpp_lowmc_verify_implementation_f
 get_zkbpp_lowmc_verify_implementation(const lowmc_parameters_t* lowmc) {
-  const uint32_t lowmc_id = LOWMC_GET_ID(lowmc);
+  const uint32_t lowmc_id = lowmc_get_id(lowmc);
 #if defined(WITH_OPT)
 #if defined(WITH_AVX2)
   /* AVX2 enabled instances */

--- a/src/sig/picnic/external/picnic3_impl.c
+++ b/src/sig/picnic/external/picnic3_impl.c
@@ -72,7 +72,7 @@ static void createRandomTapes(randomTape_t* tapes, uint8_t* seeds, uint8_t* salt
  */
 static void computeAuxTape(randomTape_t* tapes, uint8_t* input_masks,
                            const picnic_instance_t* params) {
-  mzd_local_t lowmc_key[1];
+  mzd_local_t lowmc_key[1] = {0};
 
   size_t tapeSizeBytes = 2 * params->view_size;
 
@@ -642,9 +642,7 @@ static int sign_picnic3(const uint8_t* privateKey, const uint8_t* pubKey, const 
   commitments_t Cv;
   allocateCommitments2(&Cv, params, params->num_rounds);
 
-  mzd_local_t m_plaintext[1];
-  mzd_local_t m_maskedKey[1];
-
+  mzd_local_t m_plaintext[1] = {0};
   mzd_from_char_array(m_plaintext, plaintext, params->input_output_size);
 
   lowmc_simulate_online_f simulateOnline = lowmc_simulate_online_get_implementation(&params->lowmc);
@@ -677,6 +675,7 @@ static int sign_picnic3(const uint8_t* privateKey, const uint8_t* pubKey, const 
     for (size_t i = params->lowmc.n; i < params->input_output_size * 8; i++) {
       setBit(maskedKey, i, 0);
     }
+    mzd_local_t m_maskedKey[1] = {0};
     mzd_from_char_array(m_maskedKey, maskedKey, params->input_output_size);
 
     int rv = simulateOnline(m_maskedKey, &tapes[t], &msgs[t], m_plaintext, pubKey, params);

--- a/src/sig/picnic/external/picnic3_simulate.c
+++ b/src/sig/picnic/external/picnic3_simulate.c
@@ -574,59 +574,65 @@ static void picnic3_mpc_sbox_s256_lowmc_255_255_4(mzd_local_t* statein, randomTa
 #endif // WITH_OPT
 
 lowmc_simulate_online_f lowmc_simulate_online_get_implementation(const lowmc_parameters_t* lowmc) {
-  assert((lowmc->m == 43 && lowmc->n == 129) || (lowmc->m == 64 && lowmc->n == 192) ||
-         (lowmc->m == 85 && lowmc->n == 255));
+  const uint32_t lowmc_id = lowmc_get_id(lowmc);
 
 #if defined(WITH_OPT)
 #if defined(WITH_AVX2)
   if (CPU_SUPPORTS_AVX2) {
+    switch (lowmc_id) {
 #if defined(WITH_LOWMC_129_129_4)
-    if (lowmc->n == 129 && lowmc->m == 43)
+    case LOWMC_ID(129, 43):
       return lowmc_simulate_online_s256_129_43;
 #endif
 #if defined(WITH_LOWMC_192_192_4)
-    if (lowmc->n == 192 && lowmc->m == 64)
+    case LOWMC_ID(192, 64):
       return lowmc_simulate_online_s256_192_64;
 #endif
 #if defined(WITH_LOWMC_255_255_4)
-    if (lowmc->n == 255 && lowmc->m == 85)
+    case LOWMC_ID(255, 85):
       return lowmc_simulate_online_s256_255_85;
 #endif
+    }
   }
 #endif
 
 #if defined(WITH_SSE2) || defined(WITH_NEON)
   if (CPU_SUPPORTS_SSE2 || CPU_SUPPORTS_NEON) {
+    switch (lowmc_id) {
 #if defined(WITH_LOWMC_129_129_4)
-    if (lowmc->n == 129 && lowmc->m == 43)
+    case LOWMC_ID(129, 43):
       return lowmc_simulate_online_s128_129_43;
 #endif
 #if defined(WITH_LOWMC_192_192_4)
-    if (lowmc->n == 192 && lowmc->m == 64)
+    case LOWMC_ID(192, 64):
       return lowmc_simulate_online_s128_192_64;
 #endif
 #if defined(WITH_LOWMC_255_255_4)
-    if (lowmc->n == 255 && lowmc->m == 85)
+    case LOWMC_ID(255, 85):
       return lowmc_simulate_online_s128_255_85;
 #endif
+    }
   }
 #endif
 #endif
 
 #if !defined(NO_UINT64_FALLBACK)
+  switch (lowmc_id) {
 #if defined(WITH_LOWMC_129_129_4)
-  if (lowmc->n == 129 && lowmc->m == 43)
+  case LOWMC_ID(129, 43):
     return lowmc_simulate_online_uint64_129_43;
 #endif
 #if defined(WITH_LOWMC_192_192_4)
-  if (lowmc->n == 192 && lowmc->m == 64)
+  case LOWMC_ID(192, 64):
     return lowmc_simulate_online_uint64_192_64;
 #endif
 #if defined(WITH_LOWMC_255_255_4)
-  if (lowmc->n == 255 && lowmc->m == 85)
+  case LOWMC_ID(255, 85):
     return lowmc_simulate_online_uint64_255_85;
 #endif
+  }
 #endif
 
+  UNREACHABLE;
   return NULL;
 }

--- a/src/sig/picnic/external/picnic3_simulate.c.i
+++ b/src/sig/picnic/external/picnic3_simulate.c.i
@@ -37,12 +37,15 @@ static int SIM_ONLINE(mzd_local_t* maskedKey, randomTape_t* tapes, msgs_t* msgs,
   }
 
   /* check that the output is correct */
-  uint8_t output[MAX_LOWMC_BLOCK_SIZE];
+  uint8_t output[MAX_LOWMC_BLOCK_SIZE] = {0};
   mzd_to_char_array(output, state, params->input_output_size);
 
-  /* timingsafe_bcmp is not strictly necessary here. The comparison does not leak any information on
-   * the secret key. */
+  /* timingsafe_bcmp is not strictly necessary here. The comparison does not leak
+   * any information on the secret key. Also, the result is fine to be leaked as
+   * it essentially only conveys the information whether the public key stored in
+   * the secret key is consistent. */
   const int ret = picnic_timingsafe_bcmp(output, pubKey, params->input_output_size);
+  picnic_declassify(&ret, sizeof(ret));
 #if !defined(NDEBUG)
   if (ret) {
     printf("%s: output does not match pubKey\n", __func__);

--- a/src/sig/picnic/external/picnic3_types.c
+++ b/src/sig/picnic/external/picnic3_types.c
@@ -52,11 +52,13 @@ void allocateProof2(proof2_t* proof, const picnic_instance_t* params) {
 }
 
 static void freeProof2(proof2_t* proof) {
-  free(proof->seedInfo);
-  free(proof->C);
-  free(proof->input);
-  free(proof->aux);
-  free(proof->msgs);
+  if (proof) {
+    free(proof->seedInfo);
+    free(proof->C);
+    free(proof->input);
+    free(proof->aux);
+    free(proof->msgs);
+  }
 }
 
 bool allocateSignature2(signature2_t* sig, const picnic_instance_t* params) {

--- a/src/sig/picnic/external/picnic3_types.h
+++ b/src/sig/picnic/external/picnic3_types.h
@@ -38,13 +38,13 @@ typedef struct msgs_t {
 } msgs_t;
 
 typedef struct proof2_t {
-  uint16_t unOpenedIndex; // P[t], index of the party that is not opened.
   uint8_t* seedInfo; // Information required to compute the tree with seeds of of all opened parties
-  size_t seedInfoLen; // Length of seedInfo buffer
-  uint8_t* aux;       // Last party's correction bits; NULL if P[t] == N-1
-  uint8_t* C;         // Commitment to preprocessing step of unopened party
-  uint8_t* input;     // Masked input used in online execution
-  uint8_t* msgs;      // Broadcast messages of unopened party P[t]
+  size_t seedInfoLen;     // Length of seedInfo buffer
+  uint8_t* aux;           // Last party's correction bits; NULL if P[t] == N-1
+  uint8_t* C;             // Commitment to preprocessing step of unopened party
+  uint8_t* input;         // Masked input used in online execution
+  uint8_t* msgs;          // Broadcast messages of unopened party P[t]
+  uint16_t unOpenedIndex; // P[t], index of the party that is not opened.
 } proof2_t;
 
 typedef struct signature2_t {
@@ -58,8 +58,6 @@ typedef struct signature2_t {
   uint16_t* challengeP;
   proof2_t* proofs; // One proof for each online execution the verifier checks
 } signature2_t;
-
-#define UNUSED_PARAMETER(x) (void)(x)
 
 void allocateRandomTape(randomTape_t* tape, const picnic_instance_t* params);
 void freeRandomTape(randomTape_t* tape);

--- a/src/sig/picnic/sig_picnic.c
+++ b/src/sig/picnic/sig_picnic.c
@@ -125,7 +125,7 @@ OQS_SIG *OQS_SIG_picnic_L1_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.17";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -164,7 +164,7 @@ OQS_SIG *OQS_SIG_picnic_L1_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.17";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -203,7 +203,7 @@ OQS_SIG *OQS_SIG_picnic_L1_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L1_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.17";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -242,7 +242,7 @@ OQS_SIG *OQS_SIG_picnic_L3_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.17";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -281,7 +281,7 @@ OQS_SIG *OQS_SIG_picnic_L3_UR_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.17";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -320,7 +320,7 @@ OQS_SIG *OQS_SIG_picnic_L3_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L3_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.17";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -359,7 +359,7 @@ OQS_SIG *OQS_SIG_picnic_L5_FS_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_FS;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.17";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -399,7 +399,7 @@ OQS_SIG *OQS_SIG_picnic_L5_UR_new() {
 	}
 
 	sig->method_name = OQS_SIG_alg_picnic_L5_UR;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.17";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -438,7 +438,7 @@ OQS_SIG *OQS_SIG_picnic_L5_full_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic_L5_full;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.17";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;
@@ -475,7 +475,7 @@ OQS_SIG *OQS_SIG_picnic3_L1_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L1;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.17";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;
@@ -513,7 +513,7 @@ OQS_SIG *OQS_SIG_picnic3_L3_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L3;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.17";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;
@@ -551,7 +551,7 @@ OQS_SIG *OQS_SIG_picnic3_L5_new() {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_picnic3_L5;
-	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.16";
+	sig->alg_version = "https://github.com/IAIK/Picnic/tree/v3.0.17";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;

--- a/tests/constant_time/sig/passes/picnic
+++ b/tests/constant_time/sig/passes/picnic
@@ -20,3 +20,10 @@
    fun:oqs_sig_picnic_picnic_impl_sign
    fun:oqs_sig_picnic_sign
 }
+{
+   "Check" variable is initialized
+   Memcheck:Cond
+   fun:oqs_sig_picnic_picnic_impl_sign
+   fun:oqs_sig_picnic_sign
+   fun:common_picnic_sign
+}

--- a/tests/constant_time/sig/passes/picnic3
+++ b/tests/constant_time/sig/passes/picnic3
@@ -157,3 +157,102 @@
    fun:oqs_sig_picnic_impl_sign_picnic3
    fun:oqs_sig_picnic_sign
 }
+{
+   Variable is initialized
+   Memcheck:Cond
+   fun:oqs_sig_picnic_getLeaf
+   fun:sign_picnic3
+   fun:oqs_sig_picnic_impl_sign_picnic3
+   fun:oqs_sig_picnic_sign
+   fun:common_picnic_sign
+ }
+ {
+   Variable is initialized
+   Memcheck:Value8
+   fun:KeccakP1600_AddLanes
+   fun:KeccakP1600_AddBytes
+   fun:keccak_inc_absorb
+   fun:OQS_SHA3_shake256_inc_absorb
+   fun:hash_update
+   fun:commit
+   fun:sign_picnic3
+   fun:oqs_sig_picnic_impl_sign_picnic3
+   fun:oqs_sig_picnic_sign
+   fun:common_picnic_sign
+}
+{
+   Variable is initialized
+   Memcheck:Cond
+   fun:KeccakP1600_AddLanes
+   fun:KeccakP1600_AddBytes
+   fun:keccak_inc_absorb
+   fun:OQS_SHA3_shake256_inc_absorb
+   fun:hash_update
+   fun:commit
+   fun:sign_picnic3
+   fun:oqs_sig_picnic_impl_sign_picnic3
+   fun:oqs_sig_picnic_sign
+   fun:common_picnic_sign
+}
+{
+   Variable is initialized
+   Memcheck:Cond
+   fun:sign_picnic3
+   fun:oqs_sig_picnic_impl_sign_picnic3
+   fun:oqs_sig_picnic_sign
+   fun:common_picnic_sign
+}
+{
+   Variable is initialized
+   Memcheck:Value8
+   fun:sign_picnic3
+   fun:oqs_sig_picnic_impl_sign_picnic3
+   fun:oqs_sig_picnic_sign
+   fun:common_picnic_sign
+}
+{
+   Variable is initialized
+   Memcheck:Cond
+   fun:indexOf
+   fun:sign_picnic3
+   fun:oqs_sig_picnic_impl_sign_picnic3
+   fun:oqs_sig_picnic_sign
+   fun:common_picnic_sign
+}
+{
+   Variable is initialized
+   Memcheck:Cond
+   fun:contains
+   fun:sign_picnic3
+   fun:oqs_sig_picnic_impl_sign_picnic3
+   fun:oqs_sig_picnic_sign
+   fun:common_picnic_sign
+}
+{
+   Variable is initialized
+   Memcheck:Value8
+   fun:KeccakP1600_AddLanes
+   fun:KeccakP1600_AddBytes
+   fun:keccak_inc_absorb
+   fun:OQS_SHA3_shake128_inc_absorb
+   fun:hash_update
+   fun:commit
+   fun:sign_picnic3
+   fun:oqs_sig_picnic_impl_sign_picnic3
+   fun:oqs_sig_picnic_sign
+   fun:common_picnic_sign
+}
+{
+   Variable is initialized
+   Memcheck:Cond
+   fun:KeccakP1600_AddLanes
+   fun:KeccakP1600_AddBytes
+   fun:keccak_inc_absorb
+   fun:OQS_SHA3_shake128_inc_absorb
+   fun:hash_update
+   fun:commit
+   fun:sign_picnic3
+   fun:oqs_sig_picnic_impl_sign_picnic3
+   fun:oqs_sig_picnic_sign
+   fun:common_picnic_sign
+}


### PR DESCRIPTION
This is the Picnic update for #1278.

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)
