### PR TITLE
Add option to all pytests to skip particular algorithms

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Run tests
         timeout-minutes: 60
         env:
-          SKIP_ALGS: "SPHINCS+-Haraka-256s-*"
+          SKIP_ALGS: "SPHINCS\\+-Haraka-256s-*"
         run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}
 
   linux_arm_emulated:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -74,6 +74,8 @@ jobs:
         working-directory: build
       - name: Run tests
         timeout-minutes: 60
+        env:
+          SKIP_ALGS: "SPHINCS+-Haraka-256s-*"
         run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}
 
   linux_arm_emulated:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,6 +4,7 @@ import functools
 import os
 import os.path
 import pytest
+import re
 import subprocess
 import sys
 import json
@@ -112,6 +113,14 @@ def filtered_test(func):
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
+        if ('SKIP_ALGS' in os.environ) and len(os.environ['SKIP_ALGS'])>0:
+            for algexp in os.environ['SKIP_ALGS'].split(','):
+                for arg in args:
+                    if len(re.findall(algexp, arg))>0:
+                        pytest.skip("Test disabled by alg filter")
+                for arg in kwargs:
+                    if len(re.findall(algexp, kwargs[arg]))>0:
+                        pytest.skip("Test disabled by alg filter")
         if ('SKIP_TESTS' in os.environ) and (funcname in os.environ['SKIP_TESTS'].lower().split(',')):
             pytest.skip("Test disabled by filter")
         else:


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
We have `SKIP_ALGS` available on `test_constant_time.py` but nowhere else.  This adds it to the general test filter alongside `SKIP_TESTS`.  (The method I've used to add it is somewhat brutish, but seems to do the job.)
