### PR TITLE
fixup dilithium-avx2 valgrind test file

### DIFF
--- a/tests/constant_time/sig/passes/dilithium-avx2
+++ b/tests/constant_time/sig/passes/dilithium-avx2
@@ -89,21 +89,21 @@
    Rejection sampling for signature distribution
    Memcheck:Cond
    ...
-   src:sign.c:285 # Call to poly_chknorm
+   src:sign.c:290 # Call to poly_chknorm
    # fun:pqcrystals_dilithium*_avx2_signature
 }
 {
    Rejection sampling for signature distribution
    Memcheck:Cond
    ...
-   src:sign.c:300 # Call to poly_chknorm
+   src:sign.c:305 # Call to poly_chknorm
    # fun:pqcrystals_dilithium*_avx2_signature
 }
 {
    Rejection sampling for signature distribution
    Memcheck:Cond
    ...
-   src:sign.c:307 # Call to poly_chknorm
+   src:sign.c:312 # Call to poly_chknorm
    # fun:pqcrystals_dilithium*_avx2_signature
 }
 {
@@ -111,34 +111,34 @@
    Memcheck:Cond
    ...
    fun:pqcrystals_dilithium*_avx2_poly_make_hint
-   src:sign.c:311 # fun:pqcrystals_dilithium*_ref_signature
+   src:sign.c:316 # fun:pqcrystals_dilithium*_ref_signature
 }
 {
    Hint does not need to be computed in constant time
    Memcheck:Value8
    ...
    fun:pqcrystals_dilithium*_avx2_poly_make_hint
-   src:sign.c:311 # fun:pqcrystals_dilithium*_ref_signature
+   src:sign.c:316 # fun:pqcrystals_dilithium*_ref_signature
 }
 {
    Rejection sampling for hint
    Memcheck:Cond
    ...
-   src:sign.c:312 # Checking number of 1 bits in hint
+   src:sign.c:317 # Checking number of 1 bits in hint
    # fun:pqcrystals_dilithium*_avx2_signature
 }
 {
    Hint positions are not secret
    Memcheck:Cond
    ...
-   src:sign.c:316 # memcpy
+   src:sign.c:321 # memcpy
    # fun:pqcrystals_dilithium*_avx2_signature
 }
 {
    Hint positions are not secret
    Memcheck:Value8
    ...
-   src:sign.c:316 # memcpy
+   src:sign.c:321 # memcpy
    # fun:pqcrystals_dilithium*_avx2_signature
 }
 {


### PR DESCRIPTION
Fixes #1279, completes #1221. 

Line numbers have been changed by manually comparing the known-good, pre-#1221 `valgrind` pass file with the pre-#1221 dilithium-avx code and manually checking where the corresponding lines are located in the current, post-#1221 dilithium-avx2 code. 

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)
