### PR TITLE
Cover SHA3/SHAKE-implementation specific code paths in Picnic suppres…

### DIFF
--- a/tests/constant_time/sig/passes/picnic3
+++ b/tests/constant_time/sig/passes/picnic3
@@ -44,8 +44,7 @@
 {
    conditional on unitialized value (hash context init in commit)
    Memcheck:Cond
-   fun:KeccakP1600_AddLanes
-   fun:KeccakP1600_AddBytes
+   ...
    fun:keccak_inc_absorb
    fun:OQS_SHA3_shake*_inc_absorb
    fun:hash_update
@@ -55,8 +54,7 @@
 {
    use of unitialized value (hash context init in commit)
    Memcheck:Value8
-   fun:KeccakP1600_AddLanes
-   fun:KeccakP1600_AddBytes
+   ...
    fun:keccak_inc_absorb
    fun:OQS_SHA3_shake*_inc_absorb
    fun:hash_update
@@ -64,12 +62,21 @@
    fun:sign_picnic3
 }
 {
-   use of unitialized value (hash context init in commit)
-   Memcheck:Value8
-   fun:KeccakP1600_AddBytes
+   conditional on unitialized value (hash context init in commit)
+   Memcheck:Cond
+   ...
    fun:OQS_SHA3_shake*_inc_absorb
    fun:hash_update
-   src:picnic3_impl.c:106 # fun:commit
+   src:picnic3_impl.c:109 # fun:commit
+   fun:sign_picnic3
+}
+{
+   use of unitialized value (hash context init in commit)
+   Memcheck:Value8
+   ...
+   fun:OQS_SHA3_shake*_inc_absorb
+   fun:hash_update
+   src:picnic3_impl.c:109 # fun:commit
    fun:sign_picnic3
 }
 {


### PR DESCRIPTION
…sion files

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)