### PR TITLE
Add missing requirements to the requirements.txt

### DIFF
--- a/scripts/copy_from_upstream/requirements.txt
+++ b/scripts/copy_from_upstream/requirements.txt
@@ -5,5 +5,6 @@ markdown-it-py==0.6.2
 MarkupSafe==1.1.1
 mdit-py-plugins==0.2.5
 PyYAML==5.4.1
+tabulate==0.8.10
 typing-extensions==3.7.4.3
 zipp==3.4.0


### PR DESCRIPTION
The script `scripts/update_docs_from_yaml.py` is using the python package
`tabulate`. It is missing from the `requirements.txt` file.

This PR adds it the the `requirements.txt` file.

~* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)~
~* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)~
