### PR TITLE
ARM32 gcc12 build workaround

### DIFF
--- a/.CMake/compiler_opts.cmake
+++ b/.CMake/compiler_opts.cmake
@@ -169,6 +169,12 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
         endif ()
     endif()
 
+    # workaround for gcc issues on ARM32 as per https://github.com/open-quantum-safe/liboqs/issues/1288
+    if(ARCH_ARM32v7)
+        add_compile_options(-fno-ipa-modref)
+        add_compile_options(-fno-ipa-pure-const)
+    endif()
+
 elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     # Warning C4146 is raised when a unary minus operator is applied to an
     # unsigned type; this has nonetheless been standard and portable for as

--- a/.CMake/compiler_opts.cmake
+++ b/.CMake/compiler_opts.cmake
@@ -170,7 +170,7 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     endif()
 
     # workaround for gcc issues on ARM32 as per https://github.com/open-quantum-safe/liboqs/issues/1288
-    if(ARCH_ARM32v7)
+    if(ARCH_ARM32v7 AND (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0.0"))
         add_compile_options(-fno-ipa-modref)
         add_compile_options(-fno-ipa-pure-const)
     endif()


### PR DESCRIPTION
Fixes #1288

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

