### PR TITLE
Fix typo in Picnic's NEON detection

### DIFF
--- a/src/sig/picnic/external/cpu.h
+++ b/src/sig/picnic/external/cpu.h
@@ -95,7 +95,7 @@ bool cpu_supports(unsigned int caps);
 #if defined(__aarch64__)
 #define CPU_SUPPORTS_NEON 1
 #elif defined(__arm__)
-#define CPU_SUPPRTS_NEON OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)
+#define CPU_SUPPORTS_NEON OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)
 #else
 #define CPU_SUPPORTS_NEON 0
 #endif


### PR DESCRIPTION
This change addresses the Picnic part of #1296.

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)