### PR TITLE
Fallback code for `aligned_alloc` and use of `explicit_bzero`

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -72,6 +72,23 @@ else()
     endif()
 endif()
 
+# check available functions to perform aligned mallocs
+check_symbol_exists(aligned_alloc stdlib.h CMAKE_HAVE_ALIGNED_ALLOC)
+check_symbol_exists(posix_memalign stdlib.h CMAKE_HAVE_POSIX_MEMALIGN)
+check_symbol_exists(memalign malloc.h CMAKE_HAVE_MEMALIGN)
+
+if(CMAKE_HAVE_ALIGNED_ALLOC)
+    target_compile_definitions(common PRIVATE OQS_HAVE_ALIGNED_ALLOC)
+endif()
+
+if(CMAKE_HAVE_POSIX_MEMALIGN)
+    target_compile_definitions(common PRIVATE OQS_HAVE_POSIX_MEMALIGN)
+endif()
+
+if(CMAKE_HAVE_MEMALIGN)
+    target_compile_definitions(common PRIVATE OQS_HAVE_MEMALIGN)
+endif()
+
 if(NOT ${OQS_USE_SHA3_OPENSSL}) # using XKCP
     set(_COMMON_OBJS ${_COMMON_OBJS} ${XKCP_LOW_OBJS})
 endif()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -89,6 +89,13 @@ if(CMAKE_HAVE_MEMALIGN)
     target_compile_definitions(common PRIVATE OQS_HAVE_MEMALIGN)
 endif()
 
+# check if explicit_bzero exists
+check_symbol_exists(explicit_bzero string.h CMAKE_HAVE_EXPLICIT_BZERO)
+
+if(CMAKE_HAVE_EXPLICIT_BZERO)
+    target_compile_definitions(common PRIVATE OQS_HAVE_EXPLICIT_BZERO)
+endif()
+
 if(NOT ${OQS_USE_SHA3_OPENSSL}) # using XKCP
     set(_COMMON_OBJS ${_COMMON_OBJS} ${XKCP_LOW_OBJS})
 endif()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -89,11 +89,16 @@ if(CMAKE_HAVE_MEMALIGN)
     target_compile_definitions(common PRIVATE OQS_HAVE_MEMALIGN)
 endif()
 
-# check if explicit_bzero exists
+# check if explicit_bzero exists or memset_s
 check_symbol_exists(explicit_bzero string.h CMAKE_HAVE_EXPLICIT_BZERO)
+check_symbol_exists(memset_s string.h CMAKE_HAVE_MEMSET_S)
 
 if(CMAKE_HAVE_EXPLICIT_BZERO)
     target_compile_definitions(common PRIVATE OQS_HAVE_EXPLICIT_BZERO)
+endif()
+
+if(CMAKE_HAVE_MEMSET_S)
+    target_compile_definitions(common PRIVATE OQS_HAVE_MEMSET_S)
 endif()
 
 if(NOT ${OQS_USE_SHA3_OPENSSL}) # using XKCP

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -5,7 +5,12 @@
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
+#if !defined(OQS_HAVE_POSIX_MEMALIGN) || defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
+#include <malloc.h>
+#endif
 
 #if defined(_WIN32)
 #include <windows.h>
@@ -233,13 +238,16 @@ OQS_API void OQS_MEM_insecure_free(void *ptr) {
 }
 
 void *OQS_MEM_aligned_alloc(size_t alignment, size_t size) {
-#if defined(__MINGW32__) || defined(__MINGW64__)
-	return __mingw_aligned_malloc(size, alignment);
-#elif defined(_MSC_VER)
-	return _aligned_malloc(size, alignment);
-#elif defined(_ISOC11_SOURCE) // glibc
+#if defined(OQS_HAVE_ALIGNED_ALLOC) // glibc and other implementations providing aligned_alloc
 	return aligned_alloc(alignment, size);
-#elif (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L) || defined(__APPLE__)
+#else
+	// Check alignment (power of 2, and >= sizeof(void*)) and size (multiple of alignment)
+	if (alignment & (alignment - 1) || size & (alignment - 1) || alignment < sizeof(void *)) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+#if defined(OQS_HAVE_POSIX_MEMALIGN)
 	void *ptr = NULL;
 	const int err = posix_memalign(&ptr, alignment, size);
 	if (err) {
@@ -247,17 +255,63 @@ void *OQS_MEM_aligned_alloc(size_t alignment, size_t size) {
 		ptr = NULL;
 	}
 	return ptr;
-#else // musl, maybe others.
-	return aligned_alloc(alignment, size);
+#elif defined(OQS_HAVE_MEMALIGN)
+	return memalign(alignment, size);
+#elif defined(__MINGW32__) || defined(__MINGW64__)
+	return __mingw_aligned_malloc(size, alignment);
+#elif defined(_MSC_VER)
+	return _aligned_malloc(size, alignment);
+#else
+	if (!size) {
+		return NULL;
+	}
+	// Overallocate to be able to align the pointer (alignment -1) and to store
+	// the difference between the pointer returned to the user (ptr) and the
+	// pointer returned by malloc (buffer). The difference is caped to 255 and
+	// can be made larger if necessary, but this should be enough for all users
+	// in liboqs.
+	//
+	// buffer      ptr
+	// ↓           ↓
+	// ...........|...................
+	//            |
+	//       diff = ptr - buffer
+	const size_t offset = alignment - 1 + sizeof(uint8_t);
+	uint8_t *buffer = malloc(size + offset);
+	if (!buffer) {
+		return NULL;
+	}
+
+	// Align the pointer returned to the user.
+	uint8_t *ptr = (uint8_t *)(((uintptr_t)(buffer) + offset) & ~(alignment - 1));
+	ptrdiff_t diff = ptr - buffer;
+	if (diff > UINT8_MAX) {
+		// This should never happen in our code, but just to be safe
+		free(buffer); // IGNORE free-check
+		errno = EINVAL;
+		return NULL;
+	}
+	// Store the difference one byte ahead the returned poitner so that free
+	// can reconstruct buffer.
+	ptr[-1] = diff;
+	return ptr;
+#endif
 #endif
 }
 
 void OQS_MEM_aligned_free(void *ptr) {
-#if defined(__MINGW32__) || defined(__MINGW64__)
+#if defined(OQS_HAVE_ALIGNED_ALLOC) || defined(OQS_HAVE_POSIX_MEMALIGN) || defined(OQS_HAVE_MEMALIGN)
+	free(ptr); // IGNORE free-check
+#elif defined(__MINGW32__) || defined(__MINGW64__)
 	__mingw_aligned_free(ptr);
 #elif defined(_MSC_VER)
 	_aligned_free(ptr);
 #else
-	free(ptr); // IGNORE free-check
+	if (ptr) {
+		// Reconstruct the pointer returned from malloc using the difference
+		// stored one byte ahead of ptr.
+		uint8_t *u8ptr = ptr;
+		free(u8ptr - u8ptr[-1]); // IGNORE free-check
+	}
 #endif
 }

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -215,6 +215,8 @@ OQS_API int OQS_MEM_secure_bcmp(const void *a, const void *b, size_t len) {
 OQS_API void OQS_MEM_cleanse(void *ptr, size_t len) {
 #if defined(_WIN32)
 	SecureZeroMemory(ptr, len);
+#elif defined(OQS_HAVE_EXPLICIT_BZERO)
+	explicit_bzero(ptr, len);
 #elif defined(HAVE_MEMSET_S)
 	if (0U < len && memset_s(ptr, (rsize_t)len, 0, (rsize_t)len) != 0) {
 		abort();

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0 AND MIT
 
+#if !defined(_WIN32) && !defined(OQS_HAVE_EXPLICIT_BZERO)
+// Request memset_s
+#define __STDC_WANT_LIB_EXT1__ 1
+#endif
+
 #include <oqs/common.h>
 
 #include <errno.h>
@@ -217,7 +222,7 @@ OQS_API void OQS_MEM_cleanse(void *ptr, size_t len) {
 	SecureZeroMemory(ptr, len);
 #elif defined(OQS_HAVE_EXPLICIT_BZERO)
 	explicit_bzero(ptr, len);
-#elif defined(HAVE_MEMSET_S)
+#elif defined(__STDC_LIB_EXT1__) || defined(OQS_HAVE_MEMSET_S)
 	if (0U < len && memset_s(ptr, (rsize_t)len, 0, (rsize_t)len) != 0) {
 		abort();
 	}


### PR DESCRIPTION
There are two parts to this PR. The first one adds checks for `aligned_alloc` and friends and uses whatever is available. The second part fixes the check for `memset_s` (via cmake and Annex K support) and also uses `explicit_bzero` if available. 

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)