### PR TITLE
add valgrind option

### DIFF
--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -12,7 +12,7 @@ def test_kem_leak(kem_name):
     if sys.platform != "linux" or os.system("grep ubuntu /etc/os-release") != 0 or os.system("uname -a | grep x86_64") != 0: pytest.skip('Leak testing not supported on this platform')
     if kem_name == "Classic-McEliece-8192128": pytest.skip("Classic-McEliece-8192128 known to fail memory leak testing")
     helpers.run_subprocess(
-        ["valgrind", "-s", "--error-exitcode=1", "--leak-check=full", "--show-leak-kinds=all", helpers.path_to_executable('test_kem'), kem_name],
+        ["valgrind", "-s", "--error-exitcode=1", "--leak-check=full", "--show-leak-kinds=all", "--vex-guest-max-insns=25", helpers.path_to_executable('test_kem'), kem_name],
     )
 
 @helpers.filtered_test


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
valgrind reported errors on several unit tests.  A search suggested adding the option:
    --vex-guest-max-insns=25
to the valgrind command.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
Resolves valgrind errors in unit test.

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
