### PR TITLE
fix: initialize context after reset in ossl_sha3x4

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,6 +53,10 @@ jobs:
             container: openquantumsafe/ci-alpine-amd64:latest
             CMAKE_ARGS: -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON
             PYTEST_ARGS: --ignore=tests/test_alg_info.py
+          - name: alpine-openssl-all
+            container: openquantumsafe/ci-alpine-amd64:latest
+            CMAKE_ARGS: -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_USE_AES_OPENSSL=ON -DOQS_USE_SHA2_OPENSSL=ON -DOQS_USE_SHA3_OPENSSL=ON
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py
           - name: alpine-noopenssl
             container: openquantumsafe/ci-alpine-amd64:latest
             CMAKE_ARGS: -DOQS_USE_OPENSSL=OFF

--- a/src/common/sha3/ossl_sha3x4.c
+++ b/src/common/sha3/ossl_sha3x4.c
@@ -122,6 +122,10 @@ void OQS_SHA3_shake128_x4_inc_ctx_reset(OQS_SHA3_shake128_x4_inc_ctx *state) {
 	EVP_MD_CTX_reset(s->mdctx1);
 	EVP_MD_CTX_reset(s->mdctx2);
 	EVP_MD_CTX_reset(s->mdctx3);
+	EVP_DigestInit_ex(s->mdctx0, EVP_shake128(), NULL);
+	EVP_DigestInit_ex(s->mdctx1, EVP_shake128(), NULL);
+	EVP_DigestInit_ex(s->mdctx2, EVP_shake128(), NULL);
+	EVP_DigestInit_ex(s->mdctx3, EVP_shake128(), NULL);
 	s->n_out = 0;
 }
 
@@ -236,6 +240,10 @@ void OQS_SHA3_shake256_x4_inc_ctx_reset(OQS_SHA3_shake256_x4_inc_ctx *state) {
 	EVP_MD_CTX_reset(s->mdctx1);
 	EVP_MD_CTX_reset(s->mdctx2);
 	EVP_MD_CTX_reset(s->mdctx3);
+	EVP_DigestInit_ex(s->mdctx0, EVP_shake256(), NULL);
+	EVP_DigestInit_ex(s->mdctx1, EVP_shake256(), NULL);
+	EVP_DigestInit_ex(s->mdctx2, EVP_shake256(), NULL);
+	EVP_DigestInit_ex(s->mdctx3, EVP_shake256(), NULL);
 	s->n_out = 0;
 }
 


### PR DESCRIPTION
Fixes an issue in the OpenSSL sha3x4 code for context reset: `OQS_SHA3_shake128_x4_inc_ctx_reset` and `OQS_SHA3_shake256_x4_inc_ctx_reset`.

The context needs to be initialized again before use. Note the different behavior between the sha3(x4) and sha3(x1) implementations:

https://github.com/open-quantum-safe/liboqs/blob/2e42595804242d1e24e04f0f770a348c0c22313b/src/common/sha3/ossl_sha3x4.c#L119-L126

.. and

https://github.com/open-quantum-safe/liboqs/blob/2e42595804242d1e24e04f0f770a348c0c22313b/src/common/sha3/ossl_sha3.c#L222-L227

The issue can be reproduced with `-DOQS_USE_SHA3_OPENSSL=ON`, see https://github.com/open-quantum-safe/liboqs/issues/1338. It causes Kyber and Dilithium to fail.

The option seems to have never been part of a CI test, so never detected.

Fixes #1338.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
