### PR TITLE
llvm15 update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,10 +138,10 @@ jobs:
       - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
       - run:
           name: Configure
-          command: mkdir build && cd build && pwd && source ~/.bashrc && scan-build-14 cmake -GNinja ..
+          command: mkdir build && cd build && pwd && source ~/.bashrc && scan-build-15 cmake -GNinja ..
       - run:
           name: Build
-          command: scan-build-14 --status-bugs ninja
+          command: scan-build-15 --status-bugs ninja
           working_directory: build
 
   arm_machine:
@@ -360,10 +360,10 @@ workflows:
           PYTEST_ARGS: --ignore=tests/test_namespace.py --ignore=tests/test_leaks.py --numprocesses=auto
       - linux_oqs:
           <<: *require_buildcheck
-          name: ubuntu-focal-clang14
+          name: ubuntu-focal-clang15
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-          CMAKE_ARGS: -DOQS_ALGS_ENABLED=All -DCMAKE_C_COMPILER=clang-14 -DOQS_OPT_TARGET=skylake
+          CMAKE_ARGS: -DOQS_ALGS_ENABLED=All -DCMAKE_C_COMPILER=clang-15 -DOQS_OPT_TARGET=skylake
       - linux_oqs:
           <<: *require_buildcheck
           name: ubuntu-bionic-i386


### PR DESCRIPTION
This follows https://github.com/open-quantum-safe/ci-containers/pull/65 and unblocks CI failures.

Suggested to merge after #1351 

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

