### PR TITLE
adding OpenSSL3 test; activating sanitizer test

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -74,7 +74,7 @@ jobs:
           - name: address-sanitizer
             container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
             CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address
-            PYTEST_ARGS: --ignore=tests/test_portability.py --numprocesses=auto --maxprocesses=10
+            PYTEST_ARGS: --ignore=tests/test_distbuild.py --ignore=tests/test_leaks.py --numprocesses=auto --maxprocesses=10
     container:
       image: ${{ matrix.container }}
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -67,11 +67,14 @@ jobs:
             container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
             CMAKE_ARGS: -DOQS_ALGS_ENABLED=STD
             PYTEST_ARGS: --ignore=tests/test_leaks.py
-          # disabled until #1067 lands
-          # - name: address-sanitizer
-          #   container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-          #   CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address
-          #   PYTEST_ARGS: --ignore=tests/test_portability.py --numprocesses=auto --maxprocesses=10
+          - name: jammy-nistr4-openssl3
+            container: openquantumsafe/ci-ubuntu-jammy:latest
+            CMAKE_ARGS: -DOQS_ALGS_ENABLED=NIST_R4
+            PYTEST_ARGS: --ignore=tests/test_leaks.py
+          - name: address-sanitizer
+            container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+            CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address
+            PYTEST_ARGS: --ignore=tests/test_portability.py --numprocesses=auto --maxprocesses=10
     container:
       image: ${{ matrix.container }}
     steps:


### PR DESCRIPTION
Fixes #1340

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

@dstebila @xvzcf This PR also re-activated a test that was commented to be inactive until #1067 lands: https://github.com/open-quantum-safe/liboqs/blob/924ea88cb045b053af143bd139acde5194eab47c/.github/workflows/linux.yml#L70-L74 This did land, but the test (still) fails. ~Do you remember what's going on here?~ It'd surely be easy to re-comment this change unrelated to the purpose of the PR -- but it might be nice to understand the reason.

Edi/Add: Reason understood: Outdated test name & overlapping asan test that needed exclusion
