### PR TITLE
re-enabling msys2 testing after picnic is gone

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,11 +31,10 @@ environment:
       OQS_ALGS_ENABLED: All
     - BUILD_SHARED: ON
       COMPILER: msvc2019
-      #    Disabled until https://github.com/open-quantum-safe/liboqs/issues/1218#issuecomment-1170067669 resolved
-      #    - BUILD_SHARED: OFF
-      #      COMPILER: msys2
-      #    - BUILD_SHARED: ON
-      #      COMPILER: msys2
+    - BUILD_SHARED: OFF
+      COMPILER: msys2
+    - BUILD_SHARED: ON
+      COMPILER: msys2
 
 for:
   - matrix:


### PR DESCRIPTION
Reverts #1243, enhancing Windows testing again.

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

