### PR TITLE
compiler future-proofing Release builds

### DIFF
--- a/.CMake/compiler_opts.cmake
+++ b/.CMake/compiler_opts.cmake
@@ -12,6 +12,10 @@
 # If OQS_OPT_TARGET=generic we target a generic CPU.
 # Otherwise we target the specified CPU.
 
+# Pedantic checks (-Wall, ...) are not enabled by default for Release
+# builds such as to avoid future build errors introduced by currently
+# unknown compiler warnings
+
 include(CheckCCompilerFlag)
 check_c_compiler_flag("-Wa,--noexecstack" CC_SUPPORTS_WA_NOEXECSTACK)
 
@@ -82,11 +86,13 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
 endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+  if(${OQS_STRICT_WARNINGS})
     add_compile_options(-Werror)
     add_compile_options(-Wall)
     add_compile_options(-Wextra)
     add_compile_options(-Wpedantic)
     add_compile_options(-Wno-unused-command-line-argument)
+  endif()
     if(CC_SUPPORTS_WA_NOEXECSTACK)
         add_compile_options("-Wa,--noexecstack")
     endif()
@@ -134,6 +140,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang")
     endif()
 
 elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+  if(${OQS_STRICT_WARNINGS})
     add_compile_options(-Werror)
     add_compile_options(-Wall)
     add_compile_options(-Wextra)
@@ -143,6 +150,7 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wformat=2)
     add_compile_options(-Wfloat-equal)
     add_compile_options(-Wwrite-strings)
+  endif()
     if (NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         if(CC_SUPPORTS_WA_NOEXECSTACK)
             add_compile_options("-Wa,--noexecstack")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
                            -c "cd /root/project && \
                                uname -a && \
                                mkdir build && cd build && source ~/.bashrc && \
-                               cmake -GNinja $CMAKE_ARGS .. && cmake -LA .. && ninja && \
+                               cmake -GNinja -DOQS_STRICT_WARNINGS=ON $CMAKE_ARGS .. && cmake -LA .. && ninja && \
                                cd .. && mkdir -p tmp && \
                                python3 -m pytest --verbose \
                                                  --ignore=tests/test_code_conventions.py \
@@ -364,7 +364,7 @@ workflows:
           name: ubuntu-focal-clang15
           context: openquantumsafe
           CONTAINER: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-          CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-15 -DOQS_OPT_TARGET=skylake
+          CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DCMAKE_C_COMPILER=clang-15 -DOQS_OPT_TARGET=skylake
       - linux_oqs:
           <<: *require_buildcheck
           name: ubuntu-bionic-i386
@@ -383,7 +383,7 @@ workflows:
       - macOS:
           <<: *require_buildcheck
           name: macOS-noopenssl
-          CMAKE_ARGS: -DOQS_USE_OPENSSL=OFF
+          CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=OFF
       - macOS:
           <<: *require_buildcheck
           name: macOS-shared

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,23 +53,23 @@ jobs:
         include:
           - name: alpine
             container: openquantumsafe/ci-alpine-amd64:latest
-            CMAKE_ARGS: -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON
             PYTEST_ARGS: --ignore=tests/test_alg_info.py
           - name: alpine-openssl-all
             container: openquantumsafe/ci-alpine-amd64:latest
-            CMAKE_ARGS: -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_USE_AES_OPENSSL=ON -DOQS_USE_SHA2_OPENSSL=ON -DOQS_USE_SHA3_OPENSSL=ON
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_USE_AES_OPENSSL=ON -DOQS_USE_SHA2_OPENSSL=ON -DOQS_USE_SHA3_OPENSSL=ON
             PYTEST_ARGS: --ignore=tests/test_alg_info.py
           - name: alpine-noopenssl
             container: openquantumsafe/ci-alpine-amd64:latest
-            CMAKE_ARGS: -DOQS_USE_OPENSSL=OFF
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=OFF
             PYTEST_ARGS: --ignore=tests/test_alg_info.py
           - name: focal-std-openssl
             container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-            CMAKE_ARGS: -DOQS_ALGS_ENABLED=STD
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=STD
             PYTEST_ARGS: --ignore=tests/test_leaks.py
           - name: jammy-nistr4-openssl3
             container: openquantumsafe/ci-ubuntu-jammy:latest
-            CMAKE_ARGS: -DOQS_ALGS_ENABLED=NIST_R4
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=NIST_R4
             PYTEST_ARGS: --ignore=tests/test_leaks.py
           - name: address-sanitizer
             container: openquantumsafe/ci-ubuntu-focal-x86_64:latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(OQS_DIST_BUILD "Build distributable library with optimized code for sever
 option(OQS_BUILD_ONLY_LIB "Build only liboqs and do not expose build targets for tests, documentation, and pretty-printing available." OFF)
 set(OQS_MINIMAL_BUILD "" CACHE STRING "Only build specifically listed algorithms.")
 option(OQS_PERMIT_UNSUPPORTED_ARCHITECTURE "Permit compilation on an an unsupported architecture." OFF)
+option(OQS_STRICT_WARNINGS "Enable all compiler warnings." OFF)
 
 set(OQS_OPT_TARGET auto CACHE STRING "The target microarchitecture for optimization.")
 

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -17,6 +17,7 @@ The following options can be passed to CMake before the build file generation pr
 - [OQS_SPEED_USE_ARM_PMU](#OQS_SPEED_USE_ARM_PMU)
 - [USE_SANITIZER](#USE_SANITIZER)
 - [OQS_ENABLE_TEST_CONSTANT_TIME](#OQS_ENABLE_TEST_CONSTANT_TIME)
+- [OQS_STRICT_WARNINGS](#OQS_STRICT_WARNINGS)
 
 ## BUILD_SHARED_LIBS
 
@@ -138,3 +139,11 @@ This is used in conjunction with `tests/test_constant_time.py` to use Valgrind t
 See the documentation in [`tests/test_constant_time.py`](https://github.com/open-quantum-safe/liboqs/blob/main/tests/test_constant_time.py) for more information on usage.
 
 **Default**: `OFF`.
+
+## OQS_STRICT_WARNINGS
+
+Can be `ON` or `OFF`. When `ON`, all compiler warnings are enabled and treated as errors. This setting is recommended to be enabled prior to submission of a Pull Request as CI runs with this setting active. When `OFF`, significantly fewer compiler warnings are enabled such as to avoid undue build errors triggered by (future) compiler warning features/unknown at development time of this library.
+
+**Default**: `OFF`.
+
+

--- a/src/kem/kyber/kem_kyber_512.c
+++ b/src/kem/kyber/kem_kyber_512.c
@@ -9,7 +9,7 @@
 OQS_KEM *OQS_KEM_kyber_512_new(void) {
 
 	OQS_KEM *kem = malloc(sizeof(OQS_KEM));
-	int unusedvar;
+
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/kyber/kem_kyber_512.c
+++ b/src/kem/kyber/kem_kyber_512.c
@@ -9,6 +9,7 @@
 OQS_KEM *OQS_KEM_kyber_512_new(void) {
 
 	OQS_KEM *kem = malloc(sizeof(OQS_KEM));
+	int unusedvar;
 	if (kem == NULL) {
 		return NULL;
 	}


### PR DESCRIPTION
As discussed in https://github.com/open-quantum-safe/liboqs/issues/1375#issuecomment-1412379440.

An initial CI error is intentional to test the feature. Will follow up with a correction (removal of unused variable).

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)
