### PR TITLE
update BIKE documentation

### DIFF
--- a/docs/algorithms/kem/bike.md
+++ b/docs/algorithms/kem/bike.md
@@ -4,12 +4,12 @@
 - **Main cryptographic assumption**: QC-MDPC (Quasi-Cyclic Moderate Density Parity-Check).
 - **Principal submitters**: Nicolas Aragon, Paulo Barreto, Slim Bettaieb, Loic Bidoux, Olivier Blazy, Jean-Christophe Deneuville, Phillipe Gaborit, Santosh Gosh, Shay Gueron, Tim Güneysu, Carlos Aguilar Melchor, Rafael Misoczki, Edoardo Persichetti, Nicolas Sendrier, Jean-Pierre Tillich, Valentin Vasseur, Gilles Zémor.
 - **Authors' website**: http://bikesuite.org/
-- **Specification version**: 4.1.
+- **Specification version**: 5.1.
 - **Primary Source**<a name="primary-source"></a>:
   - **Source**: https://github.com/awslabs/bike-kem
   - **Implementation license (SPDX-Identifier)**: Apache-2.0
 - **Ancestors of primary source**:
-  - https://bikesuite.org/files/v4.1/Reference_Implementation.2020.10.20.2.zip
+  - https://bikesuite.org/files/v5.0/Reference_Implementation.2022.10.04.1.zip
 
 ## Parameter set summary
 

--- a/docs/algorithms/kem/bike.yml
+++ b/docs/algorithms/kem/bike.yml
@@ -20,13 +20,13 @@ principal-submitters:
 - Gilles Zémor
 crypto-assumption: QC-MDPC (Quasi-Cyclic Moderate Density Parity-Check)
 website: http://bikesuite.org/
-nist-round: 3
-spec-version: 4.1
+nist-round: 4
+spec-version: 5.1
 primary-upstream: 
   source: https://github.com/awslabs/bike-kem
   spdx-license-identifier: Apache-2.0
 upstream-ancestors:
-- https://bikesuite.org/files/v4.1/Reference_Implementation.2020.10.20.2.zip
+- https://bikesuite.org/files/v5.0/Reference_Implementation.2022.10.04.1.zip
 parameter-sets:
 - name: BIKE-L1
   claimed-nist-level: 1


### PR DESCRIPTION
Corrects BIKE documentation (enabling proper downstream documentation).

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

