### PR TITLE
document BIKE lacks constant time protection

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -16,12 +16,12 @@ jobs:
             container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
             CMAKE_ARGS: -DOQS_OPT_TARGET=generic -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
             PYTEST_ARGS: --numprocesses=auto -k 'test_constant_time'
-            SKIP_ALGS: 'SPHINCS\+-SHA*,Classic-McEliece-6(.)*'
+            SKIP_ALGS: 'SPHINCS\+-SHA*,Classic-McEliece-6(.)*,BIKE*'
           - name: extensions
             container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
             CMAKE_ARGS: -DOQS_OPT_TARGET=haswell -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
             PYTEST_ARGS: --numprocesses=auto -k 'test_constant_time'
-            SKIP_ALGS: 'SPHINCS\+-SHA*,Classic-McEliece-6(.)*'
+            SKIP_ALGS: 'SPHINCS\+-SHA*,Classic-McEliece-6(.)*,BIKE*'
     container:
       image: ${{ matrix.container }}
     steps:

--- a/docs/algorithms/kem/bike.md
+++ b/docs/algorithms/kem/bike.md
@@ -11,6 +11,10 @@
 - **Ancestors of primary source**:
   - https://bikesuite.org/files/v5.0/Reference_Implementation.2022.10.04.1.zip
 
+## Advisories
+
+- The implementations for all parameter sets DO NOT provide constant time execution properties.
+
 ## Parameter set summary
 
 |  Parameter set  | Security model   |   Claimed NIST Level |   Public key size (bytes) |   Secret key size (bytes) |   Ciphertext size (bytes) |   Shared secret size (bytes) |

--- a/docs/algorithms/kem/bike.yml
+++ b/docs/algorithms/kem/bike.yml
@@ -27,6 +27,9 @@ primary-upstream:
   spdx-license-identifier: Apache-2.0
 upstream-ancestors:
 - https://bikesuite.org/files/v5.0/Reference_Implementation.2022.10.04.1.zip
+advisories:
+- 'The implementations for all parameter sets DO NOT provide constant time execution
+  properties.'
 parameter-sets:
 - name: BIKE-L1
   claimed-nist-level: 1

--- a/tests/constant_time/kem/issues.json
+++ b/tests/constant_time/kem/issues.json
@@ -1,6 +1,7 @@
 {
   "BIKE-L1": ["bike_has_no_timing_protections"],
   "BIKE-L3": ["bike_has_no_timing_protections"],
+  "BIKE-L5": ["bike_has_no_timing_protections"],
   "Classic-McEliece-348864": [],
   "Classic-McEliece-348864f": [],
   "Classic-McEliece-460896": [],


### PR DESCRIPTION
Fixes #1396 . Tagging @dkostic @crockeea for fact check.

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ no Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)
