### PR TITLE
correct free in test_kem/sig

### DIFF
--- a/tests/test_kem.c
+++ b/tests/test_kem.c
@@ -162,16 +162,14 @@ err:
 	ret = OQS_ERROR;
 
 cleanup:
-	if (kem != NULL) {
-		if (secret_key) {
-			OQS_MEM_secure_free(secret_key - sizeof(magic_t), kem->length_secret_key + 2 * sizeof(magic_t));
-		}
-		if (shared_secret_e) {
-			OQS_MEM_secure_free(shared_secret_e - sizeof(magic_t), kem->length_shared_secret + 2 * sizeof(magic_t));
-		}
-		if (shared_secret_d) {
-			OQS_MEM_secure_free(shared_secret_d - sizeof(magic_t), kem->length_shared_secret + 2 * sizeof(magic_t));
-		}
+	if (secret_key) {
+		OQS_MEM_secure_free(secret_key - sizeof(magic_t), kem->length_secret_key + 2 * sizeof(magic_t));
+	}
+	if (shared_secret_e) {
+		OQS_MEM_secure_free(shared_secret_e - sizeof(magic_t), kem->length_shared_secret + 2 * sizeof(magic_t));
+	}
+	if (shared_secret_d) {
+		OQS_MEM_secure_free(shared_secret_d - sizeof(magic_t), kem->length_shared_secret + 2 * sizeof(magic_t));
 	}
 	if (public_key) {
 		OQS_MEM_insecure_free(public_key - sizeof(magic_t));

--- a/tests/test_kem.c
+++ b/tests/test_kem.c
@@ -163,12 +163,22 @@ err:
 
 cleanup:
 	if (kem != NULL) {
-		OQS_MEM_secure_free(secret_key - sizeof(magic_t), kem->length_secret_key + 2 * sizeof(magic_t));
-		OQS_MEM_secure_free(shared_secret_e - sizeof(magic_t), kem->length_shared_secret + 2 * sizeof(magic_t));
-		OQS_MEM_secure_free(shared_secret_d - sizeof(magic_t), kem->length_shared_secret + 2 * sizeof(magic_t));
+		if (secret_key) {
+			OQS_MEM_secure_free(secret_key - sizeof(magic_t), kem->length_secret_key + 2 * sizeof(magic_t));
+		}
+		if (shared_secret_e) {
+			OQS_MEM_secure_free(shared_secret_e - sizeof(magic_t), kem->length_shared_secret + 2 * sizeof(magic_t));
+		}
+		if (shared_secret_d) {
+			OQS_MEM_secure_free(shared_secret_d - sizeof(magic_t), kem->length_shared_secret + 2 * sizeof(magic_t));
+		}
 	}
-	OQS_MEM_insecure_free(public_key - sizeof(magic_t));
-	OQS_MEM_insecure_free(ciphertext - sizeof(magic_t));
+	if (public_key) {
+		OQS_MEM_insecure_free(public_key - sizeof(magic_t));
+	}
+	if (ciphertext) {
+		OQS_MEM_insecure_free(ciphertext - sizeof(magic_t));
+	}
 	OQS_KEM_free(kem);
 
 	return ret;

--- a/tests/test_sig.c
+++ b/tests/test_sig.c
@@ -142,10 +142,8 @@ err:
 	ret = OQS_ERROR;
 
 cleanup:
-	if (sig != NULL) {
-		if (secret_key) {
-			OQS_MEM_secure_free(secret_key - sizeof(magic_t), sig->length_secret_key + 2 * sizeof(magic_t));
-		}
+	if (secret_key) {
+		OQS_MEM_secure_free(secret_key - sizeof(magic_t), sig->length_secret_key + 2 * sizeof(magic_t));
 	}
 	if (public_key) {
 		OQS_MEM_insecure_free(public_key - sizeof(magic_t));

--- a/tests/test_sig.c
+++ b/tests/test_sig.c
@@ -143,11 +143,19 @@ err:
 
 cleanup:
 	if (sig != NULL) {
-		OQS_MEM_secure_free(secret_key - sizeof(magic_t), sig->length_secret_key + 2 * sizeof(magic_t));
+		if (secret_key) {
+			OQS_MEM_secure_free(secret_key - sizeof(magic_t), sig->length_secret_key + 2 * sizeof(magic_t));
+		}
 	}
-	OQS_MEM_insecure_free(public_key - sizeof(magic_t));
-	OQS_MEM_insecure_free(message - sizeof(magic_t));
-	OQS_MEM_insecure_free(signature - sizeof(magic_t));
+	if (public_key) {
+		OQS_MEM_insecure_free(public_key - sizeof(magic_t));
+	}
+	if (message) {
+		OQS_MEM_insecure_free(message - sizeof(magic_t));
+	}
+	if (signature) {
+		OQS_MEM_insecure_free(signature - sizeof(magic_t));
+	}
 	OQS_SIG_free(sig);
 
 	return ret;


### PR DESCRIPTION
Fixes #1398 

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

