### PR TITLE
Copy from upstream (Kyber), add pqcrystals-* licenses to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ liboqs includes some third party libraries or modules that are licensed differen
 - `src/common/rand/rand_nist.c`: See file
 - `src/kem/bike/additional`: Apache License v2.0
 - `src/kem/classic_mceliece/pqclean_*`: public domain
+- `src/kem/kyber/pqcrystals-*`: public domain (CC0) or Apache License v2.0
 - `src/kem/kyber/pqclean_*`: public domain
+- `src/sig/dilithium/pqcrystals-*`: public domain (CC0) or Apache License v2.0
 - `src/sig/dilithium/pqclean_*`: public domain
 - `src/sig/sphincs/pqclean_*`: CC0 (public domain)
 

--- a/docs/algorithms/kem/kyber.md
+++ b/docs/algorithms/kem/kyber.md
@@ -7,9 +7,9 @@
 - **Authors' website**: https://pq-crystals.org/
 - **Specification version**: NIST Round 3 submission.
 - **Primary Source**<a name="primary-source"></a>:
-  - **Source**: https://github.com/pq-crystals/kyber/commit/1ee0baa2100a545ac852edea2e4441b8f742814d with copy_from_upstream patches
+  - **Source**: https://github.com/pq-crystals/kyber/commit/518de2414a85052bb91349bcbcc347f391292d5b with copy_from_upstream patches
   - **Implementation license (SPDX-Identifier)**: CC0-1.0
-- **Optimized Implementation sources**: https://github.com/pq-crystals/kyber/commit/1ee0baa2100a545ac852edea2e4441b8f742814d with copy_from_upstream patches
+- **Optimized Implementation sources**: https://github.com/pq-crystals/kyber/commit/518de2414a85052bb91349bcbcc347f391292d5b with copy_from_upstream patches
   - **pqclean-aarch64**:<a name="pqclean-aarch64"></a>
       - **Source**: https://github.com/PQClean/PQClean/commit/33bceb17eb06a40fbdc72251f533734e8d869615 with copy_from_upstream patches
       - **Implementation license (SPDX-Identifier)**: CC0-1.0

--- a/docs/algorithms/kem/kyber.md
+++ b/docs/algorithms/kem/kyber.md
@@ -8,7 +8,7 @@
 - **Specification version**: NIST Round 3 submission.
 - **Primary Source**<a name="primary-source"></a>:
   - **Source**: https://github.com/pq-crystals/kyber/commit/518de2414a85052bb91349bcbcc347f391292d5b with copy_from_upstream patches
-  - **Implementation license (SPDX-Identifier)**: CC0-1.0
+  - **Implementation license (SPDX-Identifier)**: CC0-1.0 or Apache-2.0
 - **Optimized Implementation sources**: https://github.com/pq-crystals/kyber/commit/518de2414a85052bb91349bcbcc347f391292d5b with copy_from_upstream patches
   - **pqclean-aarch64**:<a name="pqclean-aarch64"></a>
       - **Source**: https://github.com/PQClean/PQClean/commit/33bceb17eb06a40fbdc72251f533734e8d869615 with copy_from_upstream patches

--- a/docs/algorithms/kem/kyber.yml
+++ b/docs/algorithms/kem/kyber.yml
@@ -19,7 +19,7 @@ spec-version: NIST Round 3 submission
 primary-upstream:
   source: https://github.com/pq-crystals/kyber/commit/518de2414a85052bb91349bcbcc347f391292d5b
     with copy_from_upstream patches
-  spdx-license-identifier: CC0-1.0
+  spdx-license-identifier: CC0-1.0 or Apache-2.0
 optimized-upstreams:
   pqclean-aarch64:
     source: https://github.com/PQClean/PQClean/commit/33bceb17eb06a40fbdc72251f533734e8d869615

--- a/docs/algorithms/kem/kyber.yml
+++ b/docs/algorithms/kem/kyber.yml
@@ -17,7 +17,7 @@ website: https://pq-crystals.org/
 nist-round: 3
 spec-version: NIST Round 3 submission
 primary-upstream:
-  source: https://github.com/pq-crystals/kyber/commit/1ee0baa2100a545ac852edea2e4441b8f742814d
+  source: https://github.com/pq-crystals/kyber/commit/518de2414a85052bb91349bcbcc347f391292d5b
     with copy_from_upstream patches
   spdx-license-identifier: CC0-1.0
 optimized-upstreams:

--- a/docs/algorithms/sig/dilithium.md
+++ b/docs/algorithms/sig/dilithium.md
@@ -8,7 +8,7 @@
 - **Specification version**: 3.1.
 - **Primary Source**<a name="primary-source"></a>:
   - **Source**: https://github.com/pq-crystals/dilithium/commit/3e9b9f1412f6c7435dbeb4e10692ea58f181ee51 with copy_from_upstream patches
-  - **Implementation license (SPDX-Identifier)**: CC0-1.0
+  - **Implementation license (SPDX-Identifier)**: CC0-1.0 or Apache-2.0
 - **Optimized Implementation sources**: https://github.com/pq-crystals/dilithium/commit/3e9b9f1412f6c7435dbeb4e10692ea58f181ee51 with copy_from_upstream patches
   - **pqclean-aarch64**:<a name="pqclean-aarch64"></a>
       - **Source**: https://github.com/PQClean/PQClean/commit/33bceb17eb06a40fbdc72251f533734e8d869615 with copy_from_upstream patches

--- a/docs/algorithms/sig/dilithium.yml
+++ b/docs/algorithms/sig/dilithium.yml
@@ -17,7 +17,7 @@ spec-version: 3.1
 primary-upstream:
   source: https://github.com/pq-crystals/dilithium/commit/3e9b9f1412f6c7435dbeb4e10692ea58f181ee51
     with copy_from_upstream patches
-  spdx-license-identifier: CC0-1.0
+  spdx-license-identifier: CC0-1.0 or Apache-2.0
 optimized-upstreams:
   pqclean-aarch64:
     source: https://github.com/PQClean/PQClean/commit/33bceb17eb06a40fbdc72251f533734e8d869615

--- a/docs/cbom.json
+++ b/docs/cbom.json
@@ -1,23 +1,23 @@
 {
   "bomFormat": "CBOM",
   "specVersion": "1.4-cbom-1.0",
-  "serialNumber": "urn:uuid:1fa1d9e9-2c4f-4cd3-862a-5fc19d2a2e85",
+  "serialNumber": "urn:uuid:4a640cdd-5ee1-4816-b261-d0fa309e1f46",
   "version": 1,
   "metadata": {
-    "timestamp": "2023-01-27T20:04:30.910014",
+    "timestamp": "2023-02-23T15:52:26.923884",
     "component": {
       "type": "library",
-      "bom-ref": "pkg:github/open-quantum-safe/liboqs@bc628c813c5a80a465ebdeb31155861e32dc6514",
+      "bom-ref": "pkg:github/open-quantum-safe/liboqs@49164467b6456a217b09c5d1a6c830abb64fc1a6",
       "name": "liboqs",
-      "version": "bc628c813c5a80a465ebdeb31155861e32dc6514"
+      "version": "49164467b6456a217b09c5d1a6c830abb64fc1a6"
     }
   },
   "components": [
     {
       "type": "library",
-      "bom-ref": "pkg:github/open-quantum-safe/liboqs@bc628c813c5a80a465ebdeb31155861e32dc6514",
+      "bom-ref": "pkg:github/open-quantum-safe/liboqs@49164467b6456a217b09c5d1a6c830abb64fc1a6",
       "name": "liboqs",
-      "version": "bc628c813c5a80a465ebdeb31155861e32dc6514"
+      "version": "49164467b6456a217b09c5d1a6c830abb64fc1a6"
     },
     {
       "type": "crypto-asset",
@@ -3028,7 +3028,7 @@
   ],
   "dependencies": [
     {
-      "ref": "pkg:github/open-quantum-safe/liboqs@bc628c813c5a80a465ebdeb31155861e32dc6514",
+      "ref": "pkg:github/open-quantum-safe/liboqs@49164467b6456a217b09c5d1a6c830abb64fc1a6",
       "dependsOn": [
         "alg:BIKE-L1:x86_64",
         "alg:BIKE-L3:x86_64",

--- a/scripts/copy_from_upstream/copy_from_upstream.yml
+++ b/scripts/copy_from_upstream/copy_from_upstream.yml
@@ -13,7 +13,7 @@ upstreams:
     name: pqcrystals-kyber
     git_url: https://github.com/pq-crystals/kyber.git
     git_branch: master
-    git_commit: 1ee0baa2100a545ac852edea2e4441b8f742814d
+    git_commit: 518de2414a85052bb91349bcbcc347f391292d5b
     kem_meta_path: '{pretty_name_full}_META.yml'
     kem_scheme_path: '.'
     patches: [pqcrystals-kyber-yml.patch, pqcrystals-kyber-ref-shake-aes.patch, pqcrystals-kyber-avx2-shake-aes.patch]

--- a/src/kem/kyber/kem_kyber_512.c
+++ b/src/kem/kyber/kem_kyber_512.c
@@ -9,7 +9,6 @@
 OQS_KEM *OQS_KEM_kyber_512_new(void) {
 
 	OQS_KEM *kem = malloc(sizeof(OQS_KEM));
-
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/kyber/pqcrystals-kyber_kyber1024-90s_avx2/LICENSE
+++ b/src/kem/kyber/pqcrystals-kyber_kyber1024-90s_avx2/LICENSE
@@ -1,4 +1,5 @@
-Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/)
+Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/);
+or Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.html).
 
 For Keccak and AES we are using public-domain
 code from sources and by authors listed in

--- a/src/kem/kyber/pqcrystals-kyber_kyber1024-90s_ref/LICENSE
+++ b/src/kem/kyber/pqcrystals-kyber_kyber1024-90s_ref/LICENSE
@@ -1,4 +1,5 @@
-Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/)
+Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/);
+or Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.html).
 
 For Keccak and AES we are using public-domain
 code from sources and by authors listed in

--- a/src/kem/kyber/pqcrystals-kyber_kyber1024_avx2/LICENSE
+++ b/src/kem/kyber/pqcrystals-kyber_kyber1024_avx2/LICENSE
@@ -1,4 +1,5 @@
-Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/)
+Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/);
+or Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.html).
 
 For Keccak and AES we are using public-domain
 code from sources and by authors listed in

--- a/src/kem/kyber/pqcrystals-kyber_kyber1024_ref/LICENSE
+++ b/src/kem/kyber/pqcrystals-kyber_kyber1024_ref/LICENSE
@@ -1,4 +1,5 @@
-Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/)
+Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/);
+or Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.html).
 
 For Keccak and AES we are using public-domain
 code from sources and by authors listed in

--- a/src/kem/kyber/pqcrystals-kyber_kyber512-90s_avx2/LICENSE
+++ b/src/kem/kyber/pqcrystals-kyber_kyber512-90s_avx2/LICENSE
@@ -1,4 +1,5 @@
-Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/)
+Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/);
+or Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.html).
 
 For Keccak and AES we are using public-domain
 code from sources and by authors listed in

--- a/src/kem/kyber/pqcrystals-kyber_kyber512-90s_ref/LICENSE
+++ b/src/kem/kyber/pqcrystals-kyber_kyber512-90s_ref/LICENSE
@@ -1,4 +1,5 @@
-Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/)
+Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/);
+or Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.html).
 
 For Keccak and AES we are using public-domain
 code from sources and by authors listed in

--- a/src/kem/kyber/pqcrystals-kyber_kyber512_avx2/LICENSE
+++ b/src/kem/kyber/pqcrystals-kyber_kyber512_avx2/LICENSE
@@ -1,4 +1,5 @@
-Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/)
+Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/);
+or Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.html).
 
 For Keccak and AES we are using public-domain
 code from sources and by authors listed in

--- a/src/kem/kyber/pqcrystals-kyber_kyber512_ref/LICENSE
+++ b/src/kem/kyber/pqcrystals-kyber_kyber512_ref/LICENSE
@@ -1,4 +1,5 @@
-Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/)
+Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/);
+or Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.html).
 
 For Keccak and AES we are using public-domain
 code from sources and by authors listed in

--- a/src/kem/kyber/pqcrystals-kyber_kyber768-90s_avx2/LICENSE
+++ b/src/kem/kyber/pqcrystals-kyber_kyber768-90s_avx2/LICENSE
@@ -1,4 +1,5 @@
-Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/)
+Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/);
+or Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.html).
 
 For Keccak and AES we are using public-domain
 code from sources and by authors listed in

--- a/src/kem/kyber/pqcrystals-kyber_kyber768-90s_ref/LICENSE
+++ b/src/kem/kyber/pqcrystals-kyber_kyber768-90s_ref/LICENSE
@@ -1,4 +1,5 @@
-Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/)
+Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/);
+or Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.html).
 
 For Keccak and AES we are using public-domain
 code from sources and by authors listed in

--- a/src/kem/kyber/pqcrystals-kyber_kyber768_avx2/LICENSE
+++ b/src/kem/kyber/pqcrystals-kyber_kyber768_avx2/LICENSE
@@ -1,4 +1,5 @@
-Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/)
+Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/);
+or Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.html).
 
 For Keccak and AES we are using public-domain
 code from sources and by authors listed in

--- a/src/kem/kyber/pqcrystals-kyber_kyber768_ref/LICENSE
+++ b/src/kem/kyber/pqcrystals-kyber_kyber768_ref/LICENSE
@@ -1,4 +1,5 @@
-Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/)
+Public Domain (https://creativecommons.org/share-your-work/public-domain/cc0/);
+or Apache 2.0 License (https://www.apache.org/licenses/LICENSE-2.0.html).
 
 For Keccak and AES we are using public-domain
 code from sources and by authors listed in


### PR DESCRIPTION
- Pulls latest Kyber commit from upstream (pqcrystals)
- Updates readme with pqcrystals license information (CC0 or Apache-2.0)

Fixes #1402 

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
