### PR TITLE
CI test copy_from_upstream

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,7 +19,7 @@ jobs:
         run: scripts/validate_cbom.sh
 
   upstreamcheck:
-    name: Check upstream code is properly integrated (work around CBOM issue 1406)
+    name: Check upstream code is properly integrated
     container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
     runs-on: ubuntu-latest
     steps:
@@ -33,7 +33,7 @@ jobs:
           cd scripts/copy_from_upstream && \
           ! pip3 install -r requirements.txt 2>&1 | grep ERROR && \
           python3 copy_from_upstream.py copy && \
-          ! git status | grep -v cbom | grep modified
+          ! git status | grep modified
 
   buildcheck:
     name: Check that code passes a basic build before starting heavier tests

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,7 +19,7 @@ jobs:
         run: scripts/validate_cbom.sh
 
   upstreamcheck:
-    name: Check upstream code is properly integrated
+    name: Check upstream code is properly integrated (work around CBOM issue 1406)
     container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
     runs-on: ubuntu-latest
     steps:
@@ -32,7 +32,8 @@ jobs:
           export LIBOQS_DIR=`pwd` && \
           cd scripts/copy_from_upstream && \
           ! pip3 install -r requirements.txt 2>&1 | grep ERROR && \
-          python3 copy_from_upstream.py verify
+          python3 copy_from_upstream.py copy && \
+          ! git status | grep -v cbom | grep modified
 
   buildcheck:
     name: Check that code passes a basic build before starting heavier tests

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,6 +18,22 @@ jobs:
       - name: Validate CBOM
         run: scripts/validate_cbom.sh
 
+  upstreamcheck:
+    name: Check upstream code is properly integrated
+    container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Verify copy_from_upstream state
+        run: |
+          git config --global user.name "ciuser" && \
+          git config --global user.email "ci@openquantumsafe.org" && \
+          export LIBOQS_DIR=`pwd` && \
+          cd scripts/copy_from_upstream && \
+          pip3 install -r requirements.txt && \
+          python3 copy_from_upstream.py verify
+
   buildcheck:
     name: Check that code passes a basic build before starting heavier tests
     container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
@@ -45,7 +61,7 @@ jobs:
         working-directory: build
 
   linux_intel:
-    needs: [stylecheck, buildcheck]
+    needs: [stylecheck, upstreamcheck, buildcheck]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,7 +31,7 @@ jobs:
           git config --global user.email "ci@openquantumsafe.org" && \
           export LIBOQS_DIR=`pwd` && \
           cd scripts/copy_from_upstream && \
-          pip3 install -r requirements.txt && \
+          ! pip3 install -r requirements.txt 2>&1 | grep ERROR && \
           python3 copy_from_upstream.py verify
 
   buildcheck:

--- a/docs/cbom.json
+++ b/docs/cbom.json
@@ -1,23 +1,23 @@
 {
   "bomFormat": "CBOM",
   "specVersion": "1.4-cbom-1.0",
-  "serialNumber": "urn:uuid:4a640cdd-5ee1-4816-b261-d0fa309e1f46",
+  "serialNumber": "urn:uuid:ac72fb7e-1016-4cd9-925b-72df28c22f74",
   "version": 1,
   "metadata": {
-    "timestamp": "2023-02-23T15:52:26.923884",
+    "timestamp": "2023-03-06T16:07:06.998705",
     "component": {
       "type": "library",
-      "bom-ref": "pkg:github/open-quantum-safe/liboqs@49164467b6456a217b09c5d1a6c830abb64fc1a6",
+      "bom-ref": "pkg:github/open-quantum-safe/liboqs@f49e57f71cf550b7ba7ed3ec94cb4f99e41a6d8c",
       "name": "liboqs",
-      "version": "49164467b6456a217b09c5d1a6c830abb64fc1a6"
+      "version": "f49e57f71cf550b7ba7ed3ec94cb4f99e41a6d8c"
     }
   },
   "components": [
     {
       "type": "library",
-      "bom-ref": "pkg:github/open-quantum-safe/liboqs@49164467b6456a217b09c5d1a6c830abb64fc1a6",
+      "bom-ref": "pkg:github/open-quantum-safe/liboqs@f49e57f71cf550b7ba7ed3ec94cb4f99e41a6d8c",
       "name": "liboqs",
-      "version": "49164467b6456a217b09c5d1a6c830abb64fc1a6"
+      "version": "f49e57f71cf550b7ba7ed3ec94cb4f99e41a6d8c"
     },
     {
       "type": "crypto-asset",
@@ -3028,7 +3028,7 @@
   ],
   "dependencies": [
     {
-      "ref": "pkg:github/open-quantum-safe/liboqs@49164467b6456a217b09c5d1a6c830abb64fc1a6",
+      "ref": "pkg:github/open-quantum-safe/liboqs@f49e57f71cf550b7ba7ed3ec94cb4f99e41a6d8c",
       "dependsOn": [
         "alg:BIKE-L1:x86_64",
         "alg:BIKE-L3:x86_64",

--- a/scripts/copy_from_upstream/requirements.txt
+++ b/scripts/copy_from_upstream/requirements.txt
@@ -4,7 +4,7 @@ importlib-metadata==3.7.0
 Jinja2==2.11.3
 markdown-it-py==2.2.0
 MarkupSafe==1.1.1
-mdit-py-plugins==0.2.5
+mdit-py-plugins==0.3.4
 PyYAML==5.4.1
 tabulate==0.8.10
 typing-extensions==3.7.4.3

--- a/scripts/copy_from_upstream/requirements.txt
+++ b/scripts/copy_from_upstream/requirements.txt
@@ -2,7 +2,7 @@ attrs==20.3.0
 GitPython==3.1.30
 importlib-metadata==3.7.0
 Jinja2==2.11.3
-markdown-it-py==0.6.2
+markdown-it-py==2.2.0
 MarkupSafe==1.1.1
 mdit-py-plugins==0.2.5
 PyYAML==5.4.1


### PR DESCRIPTION
Replaces #1404, adding testing for correct use of `copy_from_upstream`. Depends on https://github.com/open-quantum-safe/ci-containers/pull/66 landing.

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

