### PR TITLE
add merge group

### DIFF
--- a/.github/workflows/mergegroup.yml
+++ b/.github/workflows/mergegroup.yml
@@ -1,5 +1,6 @@
-name: Weekly constant time tests
+name: Constant time tests in merge queue
 
+# should only trigger on merge queue as per https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
 on:
   pull_request:
   merge_group:

--- a/.github/workflows/mergegroup.yml
+++ b/.github/workflows/mergegroup.yml
@@ -1,8 +1,8 @@
 name: Weekly constant time tests
 
 on:
-  schedule:
-  - cron: "5 0 * * 0"
+  pull_request:
+  merge_group:
 
 jobs:
 
@@ -12,9 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: extensions
+          - name: generic
             container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-            CMAKE_ARGS: -DOQS_OPT_TARGET=haswell -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
+            CMAKE_ARGS: -DOQS_OPT_TARGET=generic -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
             PYTEST_ARGS: --numprocesses=auto -k 'test_constant_time'
             SKIP_ALGS: 'SPHINCS\+-SHA*,Classic-McEliece-6(.)*'
     container:


### PR DESCRIPTION
Adds the use of Github action merge groups as per https://github.com/open-quantum-safe/liboqs/pull/1400#issuecomment-1453292004

May completely replace weekly testing if everyone agrees this is a good approach (and it works as advertised :).

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)
