### PR TITLE
Fix constant time failure for Falcon AVX2

### DIFF
--- a/tests/constant_time/sig/passes/falcon_keygen
+++ b/tests/constant_time/sig/passes/falcon_keygen
@@ -26,6 +26,12 @@
 {
    Rejection sampling for small (f,g) norm
    Memcheck:Cond
+   src:keygen.c:4175 # fun:PQCLEAN_FALCON*_*_keygen
+   fun:PQCLEAN_FALCON*_*_crypto_sign_keypair
+}
+{
+   Rejection sampling for small (f,g) norm
+   Memcheck:Cond
    src:keygen.c:4176 # fun:PQCLEAN_FALCON*_*_keygen
    fun:PQCLEAN_FALCON*_*_crypto_sign_keypair
 }


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
Constant-time tests for Falcon on AVX2 are failing as per https://github.com/open-quantum-safe/liboqs/actions/runs/4333882416/jobs/7567377140

This is due to line numbers changing slightly since the last revision.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [No] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [No] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
