### PR TITLE
Strawman version of one-time fetching MD objects from OpenSSL

### DIFF
--- a/src/common/aes/aes_ossl.c
+++ b/src/common/aes/aes_ossl.c
@@ -9,6 +9,36 @@
 
 #include <openssl/evp.h>
 
+EVP_CIPHER *_aes_128_ecb() {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	static EVP_CIPHER *ptr;
+	ptr = ptr ? ptr : EVP_CIPHER_fetch(NULL, "AES-128-ECB", NULL);
+	return ptr;
+#else
+	return EVP_aes_128_ecb();
+#endif
+}
+
+EVP_CIPHER *_aes_256_ecb() {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	static EVP_CIPHER *ptr;
+	ptr = ptr ? ptr : EVP_CIPHER_fetch(NULL, "AES-256-ECB", NULL);
+	return ptr;
+#else
+	return EVP_aes_256_ecb();
+#endif
+}
+
+EVP_CIPHER *_aes_256_ctr() {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	static EVP_CIPHER *ptr;
+	ptr = ptr ? ptr : EVP_CIPHER_fetch(NULL, "AES-256-CTR", NULL);
+	return ptr;
+#else
+	return EVP_aes_256_ctr();
+#endif
+}
+
 struct key_schedule {
 	int for_ECB;
 	EVP_CIPHER_CTX *ctx;
@@ -34,7 +64,7 @@ void OQS_AES128_ECB_load_schedule(const uint8_t *key, void **schedule) {
 	ks->for_ECB = 1;
 	ks->ctx = EVP_CIPHER_CTX_new();
 	OQS_EXIT_IF_NULLPTR(ks->ctx);
-	OQS_OPENSSL_GUARD(EVP_EncryptInit_ex(ks->ctx, EVP_aes_128_ecb(), NULL, key, NULL));
+	OQS_OPENSSL_GUARD(EVP_EncryptInit_ex(ks->ctx, _aes_128_ecb(), NULL, key, NULL));
 	EVP_CIPHER_CTX_set_padding(ks->ctx, 0);
 }
 
@@ -73,7 +103,7 @@ void OQS_AES256_ECB_load_schedule(const uint8_t *key, void **schedule) {
 	ks->for_ECB = 1;
 	ks->ctx = EVP_CIPHER_CTX_new();
 	OQS_EXIT_IF_NULLPTR(ks->ctx);
-	OQS_OPENSSL_GUARD(EVP_EncryptInit_ex(ks->ctx, EVP_aes_256_ecb(), NULL, key, NULL));
+	OQS_OPENSSL_GUARD(EVP_EncryptInit_ex(ks->ctx, _aes_256_ecb(), NULL, key, NULL));
 	EVP_CIPHER_CTX_set_padding(ks->ctx, 0);
 }
 
@@ -100,7 +130,7 @@ void OQS_AES256_CTR_inc_iv(const uint8_t *iv, size_t iv_len, void *schedule) {
 	} else {
 		exit(EXIT_FAILURE);
 	}
-	OQS_OPENSSL_GUARD(EVP_EncryptInit_ex(ks->ctx, EVP_aes_256_ctr(), NULL, ks->key, ks->iv));
+	OQS_OPENSSL_GUARD(EVP_EncryptInit_ex(ks->ctx, _aes_256_ctr(), NULL, ks->key, ks->iv));
 }
 
 void OQS_AES256_CTR_inc_ivu64(uint64_t iv, void *schedule) {
@@ -108,7 +138,7 @@ void OQS_AES256_CTR_inc_ivu64(uint64_t iv, void *schedule) {
 	struct key_schedule *ks = (struct key_schedule *) schedule;
 	br_enc64be(ks->iv, iv);
 	memset(&ks->iv[8], 0, 8);
-	OQS_OPENSSL_GUARD(EVP_EncryptInit_ex(ks->ctx, EVP_aes_256_ctr(), NULL, ks->key, ks->iv));
+	OQS_OPENSSL_GUARD(EVP_EncryptInit_ex(ks->ctx, _aes_256_ctr(), NULL, ks->key, ks->iv));
 }
 
 void OQS_AES256_free_schedule(void *schedule) {
@@ -144,7 +174,7 @@ void OQS_AES256_CTR_inc_stream_iv(const uint8_t *iv, size_t iv_len, const void *
 		exit(EXIT_FAILURE);
 	}
 	const struct key_schedule *ks = (const struct key_schedule *) schedule;
-	OQS_OPENSSL_GUARD(EVP_EncryptInit_ex(ctr_ctx, EVP_aes_256_ctr(), NULL, ks->key, iv_ctr));
+	OQS_OPENSSL_GUARD(EVP_EncryptInit_ex(ctr_ctx, _aes_256_ctr(), NULL, ks->key, iv_ctr));
 
 	SIZE_T_TO_INT_OR_EXIT(out_len, out_len_input_int)
 	memset(out, 0, (size_t)out_len_input_int);

--- a/src/common/sha2/sha2_ossl.c
+++ b/src/common/sha2/sha2_ossl.c
@@ -13,6 +13,36 @@
 
 #include <openssl/evp.h>
 
+EVP_MD *_sha256() {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	static EVP_MD *ptr;
+	ptr = ptr ? ptr : EVP_MD_fetch(NULL, "SHA256", NULL);
+	return ptr;
+#else
+	return EVP_sha256();
+#endif
+}
+
+EVP_MD *_sha384() {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	static EVP_MD *ptr;
+	ptr = ptr ? ptr : EVP_MD_fetch(NULL, "SHA384", NULL);
+	return ptr;
+#else
+	return EVP_sha384();
+#endif
+}
+
+EVP_MD *_sha512() {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	static EVP_MD *ptr;
+	ptr = ptr ? ptr : EVP_MD_fetch(NULL, "SHA512", NULL);
+	return ptr;
+#else
+	return EVP_sha512();
+#endif
+}
+
 static void do_hash(uint8_t *output, const uint8_t *input, size_t inplen, const EVP_MD *md) {
 	EVP_MD_CTX *mdctx;
 	unsigned int outlen;
@@ -25,19 +55,19 @@ static void do_hash(uint8_t *output, const uint8_t *input, size_t inplen, const 
 
 void OQS_SHA2_sha256(uint8_t *output, const uint8_t *input, size_t inplen) {
 	const EVP_MD *md;
-	md = EVP_sha256();
+	md = _sha256();
 	do_hash(output, input, inplen, md);
 }
 
 void OQS_SHA2_sha384(uint8_t *output, const uint8_t *input, size_t inplen) {
 	const EVP_MD *md;
-	md = EVP_sha384();
+	md = _sha384();
 	do_hash(output, input, inplen, md);
 }
 
 void OQS_SHA2_sha512(uint8_t *output, const uint8_t *input, size_t inplen) {
 	const EVP_MD *md;
-	md = EVP_sha512();
+	md = _sha512();
 	do_hash(output, input, inplen, md);
 }
 
@@ -46,7 +76,7 @@ void OQS_SHA2_sha512(uint8_t *output, const uint8_t *input, size_t inplen) {
 void OQS_SHA2_sha256_inc_init(OQS_SHA2_sha256_ctx *state) {
 	EVP_MD_CTX *mdctx;
 	const EVP_MD *md = NULL;
-	md = EVP_sha256();
+	md = _sha256();
 	OQS_EXIT_IF_NULLPTR(md);
 	mdctx = EVP_MD_CTX_new();
 	EVP_DigestInit_ex(mdctx, md, NULL);
@@ -78,7 +108,7 @@ void OQS_SHA2_sha256_inc_ctx_clone(OQS_SHA2_sha256_ctx *dest, const OQS_SHA2_sha
 void OQS_SHA2_sha384_inc_init(OQS_SHA2_sha384_ctx *state) {
 	EVP_MD_CTX *mdctx;
 	const EVP_MD *md = NULL;
-	md = EVP_sha384();
+	md = _sha384();
 	OQS_EXIT_IF_NULLPTR(md);
 	mdctx = EVP_MD_CTX_new();
 	EVP_DigestInit_ex(mdctx, md, NULL);
@@ -110,7 +140,7 @@ void OQS_SHA2_sha384_inc_ctx_clone(OQS_SHA2_sha384_ctx *dest, const OQS_SHA2_sha
 void OQS_SHA2_sha512_inc_init(OQS_SHA2_sha512_ctx *state) {
 	EVP_MD_CTX *mdctx;
 	const EVP_MD *md = NULL;
-	md = EVP_sha512();
+	md = _sha512();
 	OQS_EXIT_IF_NULLPTR(md);
 	mdctx = EVP_MD_CTX_new();
 	EVP_DigestInit_ex(mdctx, md, NULL);

--- a/src/common/sha3/ossl_sha3.c
+++ b/src/common/sha3/ossl_sha3.c
@@ -14,6 +14,56 @@
 #include <openssl/evp.h>
 #include <string.h>
 
+EVP_MD *_sha3_256() {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	static EVP_MD *ptr;
+	ptr = ptr ? ptr : EVP_MD_fetch(NULL, "SHA3-256", NULL);
+	return ptr;
+#else
+	return EVP_sha3_256();
+#endif
+}
+
+EVP_MD *_sha3_384() {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	static EVP_MD *ptr;
+	ptr = ptr ? ptr : EVP_MD_fetch(NULL, "SHA3-384", NULL);
+	return ptr;
+#else
+	return EVP_sha3_384();
+#endif
+}
+
+EVP_MD *_sha3_512() {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	static EVP_MD *ptr;
+	ptr = ptr ? ptr : EVP_MD_fetch(NULL, "SHA3-512", NULL);
+	return ptr;
+#else
+	return EVP_sha3_512();
+#endif
+}
+
+static EVP_MD *_shake128() {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	static EVP_MD *ptr;
+	ptr = ptr ? ptr : EVP_MD_fetch(NULL, "SHAKE128", NULL);
+	return ptr;
+#else
+	return EVP_shake128();
+#endif
+}
+
+static EVP_MD *_shake256() {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	static EVP_MD *ptr;
+	ptr = ptr ? ptr : EVP_MD_fetch(NULL, "SHAKE256", NULL);
+	return ptr;
+#else
+	return EVP_shake256();
+#endif
+}
+
 static void do_hash(uint8_t *output, const uint8_t *input, size_t inplen, const EVP_MD *md) {
 	EVP_MD_CTX *mdctx;
 	mdctx = EVP_MD_CTX_new();
@@ -35,7 +85,7 @@ static void do_xof(uint8_t *output, size_t outlen, const uint8_t *input, size_t 
 /* SHA3-256 */
 
 void OQS_SHA3_sha3_256(uint8_t *output, const uint8_t *input, size_t inplen) {
-	do_hash(output, input, inplen, EVP_sha3_256());
+	do_hash(output, input, inplen, _sha3_256());
 }
 
 /* SHA3-256 incremental */
@@ -43,7 +93,7 @@ void OQS_SHA3_sha3_256(uint8_t *output, const uint8_t *input, size_t inplen) {
 void OQS_SHA3_sha3_256_inc_init(OQS_SHA3_sha3_256_inc_ctx *state) {
 	state->ctx = EVP_MD_CTX_new();
 	EVP_MD_CTX *s = (EVP_MD_CTX *)state->ctx;
-	EVP_DigestInit_ex(s, EVP_sha3_256(), NULL);
+	EVP_DigestInit_ex(s, _sha3_256(), NULL);
 }
 
 void OQS_SHA3_sha3_256_inc_absorb(OQS_SHA3_sha3_256_inc_ctx *state, const uint8_t *input, size_t inplen) {
@@ -65,19 +115,19 @@ void OQS_SHA3_sha3_256_inc_ctx_clone(OQS_SHA3_sha3_256_inc_ctx *dest, const OQS_
 void OQS_SHA3_sha3_256_inc_ctx_reset(OQS_SHA3_sha3_256_inc_ctx *state) {
 	EVP_MD_CTX *s = state->ctx;
 	EVP_MD_CTX_reset(s);
-	EVP_DigestInit_ex(s, EVP_sha3_256(), NULL);
+	EVP_DigestInit_ex(s, _sha3_256(), NULL);
 }
 
 /* SHA3-384 */
 
 void OQS_SHA3_sha3_384(uint8_t *output, const uint8_t *input, size_t inplen) {
-	do_hash(output, input, inplen, EVP_sha3_384());
+	do_hash(output, input, inplen, _sha3_384());
 }
 
 /* SHA3-384 incremental */
 void OQS_SHA3_sha3_384_inc_init(OQS_SHA3_sha3_384_inc_ctx *state) {
 	state->ctx = EVP_MD_CTX_new();
-	EVP_DigestInit_ex((EVP_MD_CTX *)state->ctx, EVP_sha3_384(), NULL);
+	EVP_DigestInit_ex((EVP_MD_CTX *)state->ctx, _sha3_384(), NULL);
 }
 
 void OQS_SHA3_sha3_384_inc_absorb(OQS_SHA3_sha3_384_inc_ctx *state, const uint8_t *input, size_t inplen) {
@@ -99,20 +149,20 @@ void OQS_SHA3_sha3_384_inc_ctx_clone(OQS_SHA3_sha3_384_inc_ctx *dest, const OQS_
 void OQS_SHA3_sha3_384_inc_ctx_reset(OQS_SHA3_sha3_384_inc_ctx *state) {
 	EVP_MD_CTX *s = state->ctx;
 	EVP_MD_CTX_reset(s);
-	EVP_DigestInit_ex(s, EVP_sha3_384(), NULL);
+	EVP_DigestInit_ex(s, _sha3_384(), NULL);
 }
 
 /* SHA3-512 */
 
 void OQS_SHA3_sha3_512(uint8_t *output, const uint8_t *input, size_t inplen) {
-	do_hash(output, input, inplen, EVP_sha3_512());
+	do_hash(output, input, inplen, _sha3_512());
 }
 
 /* SHA3-512 incremental */
 
 void OQS_SHA3_sha3_512_inc_init(OQS_SHA3_sha3_512_inc_ctx *state) {
 	state->ctx = EVP_MD_CTX_new();
-	EVP_DigestInit_ex((EVP_MD_CTX *)state->ctx, EVP_sha3_512(), NULL);
+	EVP_DigestInit_ex((EVP_MD_CTX *)state->ctx, _sha3_512(), NULL);
 }
 
 void OQS_SHA3_sha3_512_inc_absorb(OQS_SHA3_sha3_512_inc_ctx *state, const uint8_t *input, size_t inplen) {
@@ -134,13 +184,13 @@ void OQS_SHA3_sha3_512_inc_ctx_clone(OQS_SHA3_sha3_512_inc_ctx *dest, const OQS_
 void OQS_SHA3_sha3_512_inc_ctx_reset(OQS_SHA3_sha3_512_inc_ctx *state) {
 	EVP_MD_CTX *s = state->ctx;
 	EVP_MD_CTX_reset(s);
-	EVP_DigestInit_ex(s, EVP_sha3_512(), NULL);
+	EVP_DigestInit_ex(s, _sha3_512(), NULL);
 }
 
 /* SHAKE-128 */
 
 void OQS_SHA3_shake128(uint8_t *output, size_t outlen, const uint8_t *input, size_t inplen) {
-	do_xof(output, outlen, input, inplen, EVP_shake128());
+	do_xof(output, outlen, input, inplen, _shake128());
 }
 
 /* SHAKE-128 incremental
@@ -171,7 +221,7 @@ void OQS_SHA3_shake128_inc_init(OQS_SHA3_shake128_inc_ctx *state) {
 	intrn_shake128_inc_ctx *s = (intrn_shake128_inc_ctx *)state->ctx;
 	s->mdctx = EVP_MD_CTX_new();
 	s->n_out = 0;
-	EVP_DigestInit_ex(s->mdctx, EVP_shake128(), NULL);
+	EVP_DigestInit_ex(s->mdctx, _shake128(), NULL);
 }
 
 void OQS_SHA3_shake128_inc_absorb(OQS_SHA3_shake128_inc_ctx *state, const uint8_t *input, size_t inplen) {
@@ -188,7 +238,7 @@ void OQS_SHA3_shake128_inc_squeeze(uint8_t *output, size_t outlen, OQS_SHA3_shak
 	EVP_MD_CTX *clone;
 
 	clone = EVP_MD_CTX_new();
-	EVP_DigestInit_ex(clone, EVP_shake128(), NULL);
+	EVP_DigestInit_ex(clone, _shake128(), NULL);
 	EVP_MD_CTX_copy_ex(clone, s->mdctx);
 	if (s->n_out == 0) {
 		EVP_DigestFinalXOF(clone, output, outlen);
@@ -222,14 +272,14 @@ void OQS_SHA3_shake128_inc_ctx_clone(OQS_SHA3_shake128_inc_ctx *dest, const OQS_
 void OQS_SHA3_shake128_inc_ctx_reset(OQS_SHA3_shake128_inc_ctx *state) {
 	intrn_shake128_inc_ctx *s = (intrn_shake128_inc_ctx *)state->ctx;
 	EVP_MD_CTX_reset(s->mdctx);
-	EVP_DigestInit_ex(s->mdctx, EVP_shake128(), NULL);
+	EVP_DigestInit_ex(s->mdctx, _shake128(), NULL);
 	s->n_out = 0;
 }
 
 /* SHAKE-256 */
 
 void OQS_SHA3_shake256(uint8_t *output, size_t outlen, const uint8_t *input, size_t inplen) {
-	do_xof(output, outlen, input, inplen, EVP_shake256());
+	do_xof(output, outlen, input, inplen, _shake256());
 }
 
 /* SHAKE-256 incremental
@@ -248,7 +298,7 @@ void OQS_SHA3_shake256_inc_init(OQS_SHA3_shake256_inc_ctx *state) {
 	intrn_shake256_inc_ctx *s = (intrn_shake256_inc_ctx *)state->ctx;
 	s->mdctx = EVP_MD_CTX_new();
 	s->n_out = 0;
-	EVP_DigestInit_ex(s->mdctx, EVP_shake256(), NULL);
+	EVP_DigestInit_ex(s->mdctx, _shake256(), NULL);
 }
 
 void OQS_SHA3_shake256_inc_absorb(OQS_SHA3_shake256_inc_ctx *state, const uint8_t *input, size_t inplen) {
@@ -265,7 +315,7 @@ void OQS_SHA3_shake256_inc_squeeze(uint8_t *output, size_t outlen, OQS_SHA3_shak
 	EVP_MD_CTX *clone;
 
 	clone = EVP_MD_CTX_new();
-	EVP_DigestInit_ex(clone, EVP_shake256(), NULL);
+	EVP_DigestInit_ex(clone, _shake256(), NULL);
 	EVP_MD_CTX_copy_ex(clone, s->mdctx);
 	if (s->n_out == 0) {
 		EVP_DigestFinalXOF(clone, output, outlen);
@@ -299,7 +349,7 @@ void OQS_SHA3_shake256_inc_ctx_clone(OQS_SHA3_shake256_inc_ctx *dest, const OQS_
 void OQS_SHA3_shake256_inc_ctx_reset(OQS_SHA3_shake256_inc_ctx *state) {
 	intrn_shake256_inc_ctx *s = (intrn_shake256_inc_ctx *)state->ctx;
 	EVP_MD_CTX_reset(s->mdctx);
-	EVP_DigestInit_ex(s->mdctx, EVP_shake256(), NULL);
+	EVP_DigestInit_ex(s->mdctx, _shake256(), NULL);
 	s->n_out = 0;
 }
 

--- a/src/common/sha3/ossl_sha3x4.c
+++ b/src/common/sha3/ossl_sha3x4.c
@@ -11,6 +11,26 @@
 
 #include <string.h>
 
+static EVP_MD *_shake128() {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	static EVP_MD *ptr;
+	ptr = ptr ? ptr : EVP_MD_fetch(NULL, "SHAKE128", NULL);
+	return ptr;
+#else
+	return EVP_shake128();
+#endif
+}
+
+static EVP_MD *_shake256() {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	static EVP_MD *ptr;
+	ptr = ptr ? ptr : EVP_MD_fetch(NULL, "SHAKE256", NULL);
+	return ptr;
+#else
+	return EVP_shake256();
+#endif
+}
+
 /* SHAKE-128 */
 
 void OQS_SHA3_shake128_x4(uint8_t *output0, uint8_t *output1, uint8_t *output2, uint8_t *output3, size_t outlen,
@@ -39,10 +59,10 @@ void OQS_SHA3_shake128_x4_inc_init(OQS_SHA3_shake128_x4_inc_ctx *state) {
 	s->mdctx1 = EVP_MD_CTX_new();
 	s->mdctx2 = EVP_MD_CTX_new();
 	s->mdctx3 = EVP_MD_CTX_new();
-	EVP_DigestInit_ex(s->mdctx0, EVP_shake128(), NULL);
-	EVP_DigestInit_ex(s->mdctx1, EVP_shake128(), NULL);
-	EVP_DigestInit_ex(s->mdctx2, EVP_shake128(), NULL);
-	EVP_DigestInit_ex(s->mdctx3, EVP_shake128(), NULL);
+	EVP_DigestInit_ex(s->mdctx0, _shake128(), NULL);
+	EVP_DigestInit_ex(s->mdctx1, _shake128(), NULL);
+	EVP_DigestInit_ex(s->mdctx2, _shake128(), NULL);
+	EVP_DigestInit_ex(s->mdctx3, _shake128(), NULL);
 	s->n_out = 0;
 }
 
@@ -63,7 +83,7 @@ void OQS_SHA3_shake128_x4_inc_squeeze(uint8_t *out0, uint8_t *out1, uint8_t *out
 	EVP_MD_CTX *clone;
 
 	clone = EVP_MD_CTX_new();
-	EVP_DigestInit_ex(clone, EVP_shake128(), NULL);
+	EVP_DigestInit_ex(clone, _shake128(), NULL);
 	if (s->n_out == 0) {
 		EVP_MD_CTX_copy_ex(clone, s->mdctx0);
 		EVP_DigestFinalXOF(clone, out0, outlen);
@@ -122,10 +142,10 @@ void OQS_SHA3_shake128_x4_inc_ctx_reset(OQS_SHA3_shake128_x4_inc_ctx *state) {
 	EVP_MD_CTX_reset(s->mdctx1);
 	EVP_MD_CTX_reset(s->mdctx2);
 	EVP_MD_CTX_reset(s->mdctx3);
-	EVP_DigestInit_ex(s->mdctx0, EVP_shake128(), NULL);
-	EVP_DigestInit_ex(s->mdctx1, EVP_shake128(), NULL);
-	EVP_DigestInit_ex(s->mdctx2, EVP_shake128(), NULL);
-	EVP_DigestInit_ex(s->mdctx3, EVP_shake128(), NULL);
+	EVP_DigestInit_ex(s->mdctx0, _shake128(), NULL);
+	EVP_DigestInit_ex(s->mdctx1, _shake128(), NULL);
+	EVP_DigestInit_ex(s->mdctx2, _shake128(), NULL);
+	EVP_DigestInit_ex(s->mdctx3, _shake128(), NULL);
 	s->n_out = 0;
 }
 
@@ -157,10 +177,10 @@ void OQS_SHA3_shake256_x4_inc_init(OQS_SHA3_shake256_x4_inc_ctx *state) {
 	s->mdctx1 = EVP_MD_CTX_new();
 	s->mdctx2 = EVP_MD_CTX_new();
 	s->mdctx3 = EVP_MD_CTX_new();
-	EVP_DigestInit_ex(s->mdctx0, EVP_shake256(), NULL);
-	EVP_DigestInit_ex(s->mdctx1, EVP_shake256(), NULL);
-	EVP_DigestInit_ex(s->mdctx2, EVP_shake256(), NULL);
-	EVP_DigestInit_ex(s->mdctx3, EVP_shake256(), NULL);
+	EVP_DigestInit_ex(s->mdctx0, _shake256(), NULL);
+	EVP_DigestInit_ex(s->mdctx1, _shake256(), NULL);
+	EVP_DigestInit_ex(s->mdctx2, _shake256(), NULL);
+	EVP_DigestInit_ex(s->mdctx3, _shake256(), NULL);
 	s->n_out = 0;
 }
 
@@ -181,7 +201,7 @@ void OQS_SHA3_shake256_x4_inc_squeeze(uint8_t *out0, uint8_t *out1, uint8_t *out
 	EVP_MD_CTX *clone;
 
 	clone = EVP_MD_CTX_new();
-	EVP_DigestInit_ex(clone, EVP_shake256(), NULL);
+	EVP_DigestInit_ex(clone, _shake256(), NULL);
 	if (s->n_out == 0) {
 		EVP_MD_CTX_copy_ex(clone, s->mdctx0);
 		EVP_DigestFinalXOF(clone, out0, outlen);
@@ -240,10 +260,10 @@ void OQS_SHA3_shake256_x4_inc_ctx_reset(OQS_SHA3_shake256_x4_inc_ctx *state) {
 	EVP_MD_CTX_reset(s->mdctx1);
 	EVP_MD_CTX_reset(s->mdctx2);
 	EVP_MD_CTX_reset(s->mdctx3);
-	EVP_DigestInit_ex(s->mdctx0, EVP_shake256(), NULL);
-	EVP_DigestInit_ex(s->mdctx1, EVP_shake256(), NULL);
-	EVP_DigestInit_ex(s->mdctx2, EVP_shake256(), NULL);
-	EVP_DigestInit_ex(s->mdctx3, EVP_shake256(), NULL);
+	EVP_DigestInit_ex(s->mdctx0, _shake256(), NULL);
+	EVP_DigestInit_ex(s->mdctx1, _shake256(), NULL);
+	EVP_DigestInit_ex(s->mdctx2, _shake256(), NULL);
+	EVP_DigestInit_ex(s->mdctx3, _shake256(), NULL);
 	s->n_out = 0;
 }
 


### PR DESCRIPTION
We need init them and free them in one place to avoid threading issues.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
