### PR TITLE
Generate and install pkgconfig file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,10 +91,26 @@ write_basic_package_version_file(
   COMPATIBILITY AnyNewerVersion
 )
 
+if(OQS_USE_OPENSSL)
+    set(_oqs_pkgconfig_requires_private openssl)
+endif()
+
+# generate pkg-config file
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/liboqs.pc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/liboqs.pc
+  @ONLY
+)
+
 install(FILES
           "${CMAKE_CURRENT_BINARY_DIR}/liboqsConfig.cmake"
           "${CMAKE_CURRENT_BINARY_DIR}/liboqsConfigVersion.cmake"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/liboqs"
+)
+
+install(FILES
+          "${CMAKE_CURRENT_BINARY_DIR}/liboqs.pc"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
 
 install(TARGETS oqs

--- a/src/liboqs.pc.in
+++ b/src/liboqs.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: @PROJECT_NAME@
+Description: Library for quantum-safe cryptographic algorithms
+Version: @OQS_VERSION_TEXT@
+Requires.private: @_oqs_pkgconfig_requires_private@
+Cflags: -I${includedir}
+Libs: -L${libdir} -loqs


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
Adds a basic pkgconfig file generation. The main motivation for this is to enable linking a system-provided liboqs library in liboqs-rust.

I have done a simple manual test by creating a Void Linux package template for liboqs, installing it and checking that pkg-config detects its presence.

I am not proficient in pkgconfig, but I tried to follow the style found in some existing C libraries.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
Closes #1434 

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
