### PR TITLE
src/common/common.c (set_available_cpu_extensions): Cope without `HWCAP_SHA3'

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -127,9 +127,11 @@ static void set_available_cpu_extensions(void) {
 	if (hwcaps & HWCAP_SHA2) {
 		cpu_ext_data[OQS_CPU_EXT_ARM_SHA2] = 1;
 	}
+#ifdef HWCAP_SHA3
 	if (hwcaps & HWCAP_SHA3) {
 		cpu_ext_data[OQS_CPU_EXT_ARM_SHA3] = 1;
 	}
+#endif
 }
 #else
 #include <sys/auxv.h>
@@ -144,9 +146,11 @@ static void set_available_cpu_extensions(void) {
 	if (hwcaps & HWCAP_SHA2) {
 		cpu_ext_data[OQS_CPU_EXT_ARM_SHA2] = 1;
 	}
+#ifdef HWCAP_SHA3
 	if (hwcaps & HWCAP_SHA3) {
 		cpu_ext_data[OQS_CPU_EXT_ARM_SHA3] = 1;
 	}
+#endif
 	if (hwcaps & HWCAP_ASIMD) {
 		cpu_ext_data[OQS_CPU_EXT_ARM_NEON] = 1;
 	}


### PR DESCRIPTION
Introduced in Linux 4.15, which, I admit, was a while ago.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
