### PR TITLE
src/kem/kyber/.../*.S, src/sig/dilithium/.../*.S: Return using `ret'

### DIFF
--- a/src/kem/kyber/pqclean_kyber1024_aarch64/__asm_NTT.S
+++ b/src/kem/kyber/pqclean_kyber1024_aarch64/__asm_NTT.S
@@ -167,7 +167,7 @@ _PQCLEAN_KYBER1024_AARCH64_asm_ntt_SIMD_top:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 .align 2
@@ -297,7 +297,7 @@ _PQCLEAN_KYBER1024_AARCH64_asm_ntt_SIMD_bot:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/kem/kyber/pqclean_kyber1024_aarch64/__asm_base_mul.S
+++ b/src/kem/kyber/pqclean_kyber1024_aarch64/__asm_base_mul.S
@@ -67,7 +67,7 @@ _PQCLEAN_KYBER1024_AARCH64_asm_point_mul_extended:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 .align 2
@@ -222,7 +222,7 @@ _PQCLEAN_KYBER1024_AARCH64_asm_asymmetric_mul:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 .align 2
@@ -396,7 +396,7 @@ _PQCLEAN_KYBER1024_AARCH64_asm_asymmetric_mul_montgomery:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/kem/kyber/pqclean_kyber1024_aarch64/__asm_iNTT.S
+++ b/src/kem/kyber/pqclean_kyber1024_aarch64/__asm_iNTT.S
@@ -85,7 +85,7 @@ _PQCLEAN_KYBER1024_AARCH64_asm_intt_SIMD_bot:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_KYBER1024_AARCH64_asm_intt_SIMD_top
@@ -335,7 +335,7 @@ _PQCLEAN_KYBER1024_AARCH64_asm_intt_SIMD_top:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/kem/kyber/pqclean_kyber1024_aarch64/__asm_poly.S
+++ b/src/kem/kyber/pqclean_kyber1024_aarch64/__asm_poly.S
@@ -63,7 +63,7 @@ _PQCLEAN_KYBER1024_AARCH64_asm_add_reduce:
     st1 { v4.8H,  v5.8H,  v6.8H,  v7.8H}, [x0], #64
     st1 {v16.8H, v17.8H, v18.8H, v19.8H}, [x0], #64
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_KYBER1024_AARCH64_asm_sub_reduce
@@ -127,7 +127,7 @@ _PQCLEAN_KYBER1024_AARCH64_asm_sub_reduce:
     st1 { v4.8H,  v5.8H,  v6.8H,  v7.8H}, [x0], #64
     st1 {v16.8H, v17.8H, v18.8H, v19.8H}, [x0], #64
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_KYBER1024_AARCH64_asm_add_add_reduce
@@ -215,7 +215,7 @@ _PQCLEAN_KYBER1024_AARCH64_asm_add_add_reduce:
     st1 { v4.8H,  v5.8H,  v6.8H,  v7.8H}, [x0], #64
     st1 {v20.8H, v21.8H, v22.8H, v23.8H}, [x0], #64
 
-    br lr
+    ret
 
 
 

--- a/src/kem/kyber/pqclean_kyber512_aarch64/__asm_NTT.S
+++ b/src/kem/kyber/pqclean_kyber512_aarch64/__asm_NTT.S
@@ -167,7 +167,7 @@ _PQCLEAN_KYBER512_AARCH64_asm_ntt_SIMD_top:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 .align 2
@@ -297,7 +297,7 @@ _PQCLEAN_KYBER512_AARCH64_asm_ntt_SIMD_bot:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/kem/kyber/pqclean_kyber512_aarch64/__asm_base_mul.S
+++ b/src/kem/kyber/pqclean_kyber512_aarch64/__asm_base_mul.S
@@ -67,7 +67,7 @@ _PQCLEAN_KYBER512_AARCH64_asm_point_mul_extended:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 .align 2
@@ -222,7 +222,7 @@ _PQCLEAN_KYBER512_AARCH64_asm_asymmetric_mul:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 .align 2
@@ -396,7 +396,7 @@ _PQCLEAN_KYBER512_AARCH64_asm_asymmetric_mul_montgomery:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/kem/kyber/pqclean_kyber512_aarch64/__asm_iNTT.S
+++ b/src/kem/kyber/pqclean_kyber512_aarch64/__asm_iNTT.S
@@ -85,7 +85,7 @@ _PQCLEAN_KYBER512_AARCH64_asm_intt_SIMD_bot:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_KYBER512_AARCH64_asm_intt_SIMD_top
@@ -335,7 +335,7 @@ _PQCLEAN_KYBER512_AARCH64_asm_intt_SIMD_top:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/kem/kyber/pqclean_kyber512_aarch64/__asm_poly.S
+++ b/src/kem/kyber/pqclean_kyber512_aarch64/__asm_poly.S
@@ -63,7 +63,7 @@ _PQCLEAN_KYBER512_AARCH64_asm_add_reduce:
     st1 { v4.8H,  v5.8H,  v6.8H,  v7.8H}, [x0], #64
     st1 {v16.8H, v17.8H, v18.8H, v19.8H}, [x0], #64
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_KYBER512_AARCH64_asm_sub_reduce
@@ -127,7 +127,7 @@ _PQCLEAN_KYBER512_AARCH64_asm_sub_reduce:
     st1 { v4.8H,  v5.8H,  v6.8H,  v7.8H}, [x0], #64
     st1 {v16.8H, v17.8H, v18.8H, v19.8H}, [x0], #64
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_KYBER512_AARCH64_asm_add_add_reduce
@@ -215,7 +215,7 @@ _PQCLEAN_KYBER512_AARCH64_asm_add_add_reduce:
     st1 { v4.8H,  v5.8H,  v6.8H,  v7.8H}, [x0], #64
     st1 {v20.8H, v21.8H, v22.8H, v23.8H}, [x0], #64
 
-    br lr
+    ret
 
 
 

--- a/src/kem/kyber/pqclean_kyber768_aarch64/__asm_NTT.S
+++ b/src/kem/kyber/pqclean_kyber768_aarch64/__asm_NTT.S
@@ -167,7 +167,7 @@ _PQCLEAN_KYBER768_AARCH64_asm_ntt_SIMD_top:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 .align 2
@@ -297,7 +297,7 @@ _PQCLEAN_KYBER768_AARCH64_asm_ntt_SIMD_bot:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/kem/kyber/pqclean_kyber768_aarch64/__asm_base_mul.S
+++ b/src/kem/kyber/pqclean_kyber768_aarch64/__asm_base_mul.S
@@ -67,7 +67,7 @@ _PQCLEAN_KYBER768_AARCH64_asm_point_mul_extended:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 .align 2
@@ -222,7 +222,7 @@ _PQCLEAN_KYBER768_AARCH64_asm_asymmetric_mul:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 .align 2
@@ -396,7 +396,7 @@ _PQCLEAN_KYBER768_AARCH64_asm_asymmetric_mul_montgomery:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/kem/kyber/pqclean_kyber768_aarch64/__asm_iNTT.S
+++ b/src/kem/kyber/pqclean_kyber768_aarch64/__asm_iNTT.S
@@ -85,7 +85,7 @@ _PQCLEAN_KYBER768_AARCH64_asm_intt_SIMD_bot:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_KYBER768_AARCH64_asm_intt_SIMD_top
@@ -335,7 +335,7 @@ _PQCLEAN_KYBER768_AARCH64_asm_intt_SIMD_top:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/kem/kyber/pqclean_kyber768_aarch64/__asm_poly.S
+++ b/src/kem/kyber/pqclean_kyber768_aarch64/__asm_poly.S
@@ -63,7 +63,7 @@ _PQCLEAN_KYBER768_AARCH64_asm_add_reduce:
     st1 { v4.8H,  v5.8H,  v6.8H,  v7.8H}, [x0], #64
     st1 {v16.8H, v17.8H, v18.8H, v19.8H}, [x0], #64
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_KYBER768_AARCH64_asm_sub_reduce
@@ -127,7 +127,7 @@ _PQCLEAN_KYBER768_AARCH64_asm_sub_reduce:
     st1 { v4.8H,  v5.8H,  v6.8H,  v7.8H}, [x0], #64
     st1 {v16.8H, v17.8H, v18.8H, v19.8H}, [x0], #64
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_KYBER768_AARCH64_asm_add_add_reduce
@@ -215,7 +215,7 @@ _PQCLEAN_KYBER768_AARCH64_asm_add_add_reduce:
     st1 { v4.8H,  v5.8H,  v6.8H,  v7.8H}, [x0], #64
     st1 {v20.8H, v21.8H, v22.8H, v23.8H}, [x0], #64
 
-    br lr
+    ret
 
 
 

--- a/src/sig/dilithium/pqclean_dilithium2_aarch64/__asm_NTT.S
+++ b/src/sig/dilithium/pqclean_dilithium2_aarch64/__asm_NTT.S
@@ -180,7 +180,7 @@ _PQCLEAN_DILITHIUM2_AARCH64_asm_ntt_SIMD_top:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM2_AARCH64_asm_ntt_SIMD_bot
@@ -257,7 +257,7 @@ _PQCLEAN_DILITHIUM2_AARCH64_asm_ntt_SIMD_bot:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/sig/dilithium/pqclean_dilithium2_aarch64/__asm_iNTT.S
+++ b/src/sig/dilithium/pqclean_dilithium2_aarch64/__asm_iNTT.S
@@ -409,7 +409,7 @@ _PQCLEAN_DILITHIUM2_AARCH64_asm_intt_SIMD_top:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM2_AARCH64_asm_intt_SIMD_bot
@@ -500,7 +500,7 @@ _PQCLEAN_DILITHIUM2_AARCH64_asm_intt_SIMD_bot:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/sig/dilithium/pqclean_dilithium2_aarch64/__asm_poly.S
+++ b/src/sig/dilithium/pqclean_dilithium2_aarch64/__asm_poly.S
@@ -76,7 +76,7 @@ _PQCLEAN_DILITHIUM2_AARCH64_asm_10_to_32:
     sub x7, x7, #1
     cbnz x7, _10_to_32_loop
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM2_AARCH64_asm_poly_reduce
@@ -172,7 +172,7 @@ _PQCLEAN_DILITHIUM2_AARCH64_asm_poly_reduce:
     st1 { v6.4S}, [x0], #16
     st1 { v7.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM2_AARCH64_asm_poly_caddq
@@ -268,7 +268,7 @@ _PQCLEAN_DILITHIUM2_AARCH64_asm_poly_caddq:
     st1 { v6.4S}, [x0], #16
     st1 { v7.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM2_AARCH64_asm_poly_freeze
@@ -400,7 +400,7 @@ _PQCLEAN_DILITHIUM2_AARCH64_asm_poly_freeze:
     st1 { v6.4S}, [x0], #16
     st1 { v7.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM2_AARCH64_asm_poly_power2round
@@ -549,7 +549,7 @@ _PQCLEAN_DILITHIUM2_AARCH64_asm_poly_power2round:
     st1 {v30.4S}, [x1], #16
     st1 {v31.4S}, [x1], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM2_AARCH64_asm_poly_add
@@ -601,7 +601,7 @@ _PQCLEAN_DILITHIUM2_AARCH64_asm_poly_add:
     st1 {v18.4S}, [x0], #16
     st1 {v19.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM2_AARCH64_asm_poly_sub
@@ -653,7 +653,7 @@ _PQCLEAN_DILITHIUM2_AARCH64_asm_poly_sub:
     st1 {v18.4S}, [x0], #16
     st1 {v19.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM2_AARCH64_asm_poly_shiftl
@@ -723,7 +723,7 @@ _PQCLEAN_DILITHIUM2_AARCH64_asm_poly_shiftl:
     st1 {v22.4S}, [x0], #16
     st1 {v23.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM2_AARCH64_asm_poly_pointwise_montgomery
@@ -844,7 +844,7 @@ _PQCLEAN_DILITHIUM2_AARCH64_asm_poly_pointwise_montgomery:
 
     pop_all
 
-    br lr
+    ret
 
 
 .align 2
@@ -1198,7 +1198,7 @@ _PQCLEAN_DILITHIUM2_AARCH64_asm_polyvecl_pointwise_acc_montgomery:
 
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/sig/dilithium/pqclean_dilithium3_aarch64/__asm_NTT.S
+++ b/src/sig/dilithium/pqclean_dilithium3_aarch64/__asm_NTT.S
@@ -180,7 +180,7 @@ _PQCLEAN_DILITHIUM3_AARCH64_asm_ntt_SIMD_top:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM3_AARCH64_asm_ntt_SIMD_bot
@@ -257,7 +257,7 @@ _PQCLEAN_DILITHIUM3_AARCH64_asm_ntt_SIMD_bot:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/sig/dilithium/pqclean_dilithium3_aarch64/__asm_iNTT.S
+++ b/src/sig/dilithium/pqclean_dilithium3_aarch64/__asm_iNTT.S
@@ -409,7 +409,7 @@ _PQCLEAN_DILITHIUM3_AARCH64_asm_intt_SIMD_top:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM3_AARCH64_asm_intt_SIMD_bot
@@ -500,7 +500,7 @@ _PQCLEAN_DILITHIUM3_AARCH64_asm_intt_SIMD_bot:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/sig/dilithium/pqclean_dilithium3_aarch64/__asm_poly.S
+++ b/src/sig/dilithium/pqclean_dilithium3_aarch64/__asm_poly.S
@@ -76,7 +76,7 @@ _PQCLEAN_DILITHIUM3_AARCH64_asm_10_to_32:
     sub x7, x7, #1
     cbnz x7, _10_to_32_loop
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM3_AARCH64_asm_poly_reduce
@@ -172,7 +172,7 @@ _PQCLEAN_DILITHIUM3_AARCH64_asm_poly_reduce:
     st1 { v6.4S}, [x0], #16
     st1 { v7.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM3_AARCH64_asm_poly_caddq
@@ -268,7 +268,7 @@ _PQCLEAN_DILITHIUM3_AARCH64_asm_poly_caddq:
     st1 { v6.4S}, [x0], #16
     st1 { v7.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM3_AARCH64_asm_poly_freeze
@@ -400,7 +400,7 @@ _PQCLEAN_DILITHIUM3_AARCH64_asm_poly_freeze:
     st1 { v6.4S}, [x0], #16
     st1 { v7.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM3_AARCH64_asm_poly_power2round
@@ -549,7 +549,7 @@ _PQCLEAN_DILITHIUM3_AARCH64_asm_poly_power2round:
     st1 {v30.4S}, [x1], #16
     st1 {v31.4S}, [x1], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM3_AARCH64_asm_poly_add
@@ -601,7 +601,7 @@ _PQCLEAN_DILITHIUM3_AARCH64_asm_poly_add:
     st1 {v18.4S}, [x0], #16
     st1 {v19.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM3_AARCH64_asm_poly_sub
@@ -653,7 +653,7 @@ _PQCLEAN_DILITHIUM3_AARCH64_asm_poly_sub:
     st1 {v18.4S}, [x0], #16
     st1 {v19.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM3_AARCH64_asm_poly_shiftl
@@ -723,7 +723,7 @@ _PQCLEAN_DILITHIUM3_AARCH64_asm_poly_shiftl:
     st1 {v22.4S}, [x0], #16
     st1 {v23.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM3_AARCH64_asm_poly_pointwise_montgomery
@@ -844,7 +844,7 @@ _PQCLEAN_DILITHIUM3_AARCH64_asm_poly_pointwise_montgomery:
 
     pop_all
 
-    br lr
+    ret
 
 
 .align 2
@@ -1198,7 +1198,7 @@ _PQCLEAN_DILITHIUM3_AARCH64_asm_polyvecl_pointwise_acc_montgomery:
 
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/sig/dilithium/pqclean_dilithium5_aarch64/__asm_NTT.S
+++ b/src/sig/dilithium/pqclean_dilithium5_aarch64/__asm_NTT.S
@@ -180,7 +180,7 @@ _PQCLEAN_DILITHIUM5_AARCH64_asm_ntt_SIMD_top:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM5_AARCH64_asm_ntt_SIMD_bot
@@ -257,7 +257,7 @@ _PQCLEAN_DILITHIUM5_AARCH64_asm_ntt_SIMD_bot:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/sig/dilithium/pqclean_dilithium5_aarch64/__asm_iNTT.S
+++ b/src/sig/dilithium/pqclean_dilithium5_aarch64/__asm_iNTT.S
@@ -409,7 +409,7 @@ _PQCLEAN_DILITHIUM5_AARCH64_asm_intt_SIMD_top:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM5_AARCH64_asm_intt_SIMD_bot
@@ -500,7 +500,7 @@ _PQCLEAN_DILITHIUM5_AARCH64_asm_intt_SIMD_bot:
     .unreq    counter
     pop_all
 
-    br lr
+    ret
 
 
 

--- a/src/sig/dilithium/pqclean_dilithium5_aarch64/__asm_poly.S
+++ b/src/sig/dilithium/pqclean_dilithium5_aarch64/__asm_poly.S
@@ -76,7 +76,7 @@ _PQCLEAN_DILITHIUM5_AARCH64_asm_10_to_32:
     sub x7, x7, #1
     cbnz x7, _10_to_32_loop
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM5_AARCH64_asm_poly_reduce
@@ -172,7 +172,7 @@ _PQCLEAN_DILITHIUM5_AARCH64_asm_poly_reduce:
     st1 { v6.4S}, [x0], #16
     st1 { v7.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM5_AARCH64_asm_poly_caddq
@@ -268,7 +268,7 @@ _PQCLEAN_DILITHIUM5_AARCH64_asm_poly_caddq:
     st1 { v6.4S}, [x0], #16
     st1 { v7.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM5_AARCH64_asm_poly_freeze
@@ -400,7 +400,7 @@ _PQCLEAN_DILITHIUM5_AARCH64_asm_poly_freeze:
     st1 { v6.4S}, [x0], #16
     st1 { v7.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM5_AARCH64_asm_poly_power2round
@@ -549,7 +549,7 @@ _PQCLEAN_DILITHIUM5_AARCH64_asm_poly_power2round:
     st1 {v30.4S}, [x1], #16
     st1 {v31.4S}, [x1], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM5_AARCH64_asm_poly_add
@@ -601,7 +601,7 @@ _PQCLEAN_DILITHIUM5_AARCH64_asm_poly_add:
     st1 {v18.4S}, [x0], #16
     st1 {v19.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM5_AARCH64_asm_poly_sub
@@ -653,7 +653,7 @@ _PQCLEAN_DILITHIUM5_AARCH64_asm_poly_sub:
     st1 {v18.4S}, [x0], #16
     st1 {v19.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM5_AARCH64_asm_poly_shiftl
@@ -723,7 +723,7 @@ _PQCLEAN_DILITHIUM5_AARCH64_asm_poly_shiftl:
     st1 {v22.4S}, [x0], #16
     st1 {v23.4S}, [x0], #16
 
-    br lr
+    ret
 
 .align 2
 .global PQCLEAN_DILITHIUM5_AARCH64_asm_poly_pointwise_montgomery
@@ -844,7 +844,7 @@ _PQCLEAN_DILITHIUM5_AARCH64_asm_poly_pointwise_montgomery:
 
     pop_all
 
-    br lr
+    ret
 
 
 .align 2
@@ -1198,7 +1198,7 @@ _PQCLEAN_DILITHIUM5_AARCH64_asm_polyvecl_pointwise_acc_montgomery:
 
     pop_all
 
-    br lr
+    ret
 
 
 


### PR DESCRIPTION
Partly, `lr` isn't a register alias under older versions of GNU `as`. But, mostly, `br` doesn't mean the same thing to the branch predictor, so it will cause unnecessary misprediction stalls.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
