### PR TITLE
src/common/pqclean_shims/compat.h: Fix polyfill version check sense

### DIFF
--- a/src/common/pqclean_shims/compat.h
+++ b/src/common/pqclean_shims/compat.h
@@ -22,10 +22,10 @@
 
 #if defined(__GNUC__) && !defined(__clang__)
 
-#if ((__GNUC__ << 16) + __GNUC_MINOR__ >= ((7) << 16) + (1)) // at least GCC 7.1
+#if ((__GNUC__ << 16) + __GNUC_MINOR__ < ((7) << 16) + (1)) // at least GCC 7.1
 /* Versions of the GCC pre-7.1 don't have __m256*_u types */
 UNALIGNED_VECTOR_POLYFILL_GCC
-#  endif // GCC >= 7.1
+#  endif // GCC < 7.1
 
 #elif defined(__GNUC__) && defined(__clang__)
 


### PR DESCRIPTION
We need to define the types if GCC is too /old/.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
