### PR TITLE
Fixing OpenSSL SHA2 incremental API integration

### DIFF
--- a/.CMake/alg_support.cmake
+++ b/.CMake/alg_support.cmake
@@ -66,6 +66,9 @@ cmake_dependent_option(OQS_USE_SHA2_OPENSSL "" ON "OQS_USE_OPENSSL" OFF)
 # enough to support our incremental API.
 cmake_dependent_option(OQS_USE_SHA3_OPENSSL "" OFF "OQS_USE_OPENSSL" OFF)
 
+# sanity check: Disable OpenSSL if not a single OpenSSL component define is on
+cmake_dependent_option(OQS_USE_OPENSSL "" ON "OQS_USE_AES_OPENSSL OR OQS_USE_SHA2_OPENSSL OR OQS_USE_SHA3_OPENSSL" OFF)
+
 if(CMAKE_SYSTEM_NAME MATCHES "Linux|Darwin")
 if(OQS_DIST_X86_64_BUILD OR OQS_USE_AVX2_INSTRUCTIONS)
     cmake_dependent_option(OQS_ENABLE_SHA3_xkcp_low_avx2 "" ON "NOT OQS_USE_SHA3_OPENSSL" OFF)

--- a/src/common/aes/aes256_ni.c
+++ b/src/common/aes/aes256_ni.c
@@ -77,7 +77,7 @@ static inline void aes256ni_setkey_encrypt(const unsigned char *key, __m128i rke
 
 void oqs_aes256_load_schedule_ni(const uint8_t *key, void **_schedule) {
 	*_schedule = malloc(sizeof(aes256ctx));
-	OQS_EXIT_IF_NULLPTR(*_schedule);
+	OQS_EXIT_IF_NULLPTR(*_schedule, "AES");
 	assert(*_schedule != NULL);
 	__m128i *schedule = ((aes256ctx *) *_schedule)->sk_exp;
 	aes256ni_setkey_encrypt(key, schedule);

--- a/src/common/aes/aes_c.c
+++ b/src/common/aes/aes_c.c
@@ -644,7 +644,7 @@ static void aes_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, 
 
 void oqs_aes128_load_schedule_c(const uint8_t *key, void **_schedule) {
 	*_schedule = malloc(sizeof(aes128ctx));
-	OQS_EXIT_IF_NULLPTR(*_schedule);
+	OQS_EXIT_IF_NULLPTR(*_schedule, "AES");
 	aes128ctx *ctx = (aes128ctx *) *_schedule;
 	uint64_t skey[22];
 	br_aes_ct64_keysched(skey, key, 16);
@@ -653,7 +653,7 @@ void oqs_aes128_load_schedule_c(const uint8_t *key, void **_schedule) {
 
 void oqs_aes256_load_schedule_c(const uint8_t *key, void **_schedule) {
 	*_schedule = malloc(sizeof(aes256ctx));
-	OQS_EXIT_IF_NULLPTR(*_schedule);
+	OQS_EXIT_IF_NULLPTR(*_schedule, "AES");
 	aes256ctx *ctx = (aes256ctx *) *_schedule;
 	uint64_t skey[30];
 	br_aes_ct64_keysched(skey, key, 32);
@@ -705,7 +705,7 @@ void oqs_aes256_load_iv_c(const uint8_t *iv, size_t iv_len, void *_schedule) {
 }
 
 void oqs_aes256_load_iv_u64_c(uint64_t iv, void *schedule) {
-	OQS_EXIT_IF_NULLPTR(schedule);
+	OQS_EXIT_IF_NULLPTR(schedule, "AES");
 	aes256ctx *ctx = (aes256ctx *) schedule;
 	ctx->iv[7] = (unsigned char)(iv >> 56);
 	ctx->iv[6] = (unsigned char)(iv >> 48);

--- a/src/common/aes/aes_ossl.c
+++ b/src/common/aes/aes_ossl.c
@@ -30,11 +30,11 @@ static inline void br_enc64be(unsigned char *dst, uint64_t x) {
 
 void OQS_AES128_ECB_load_schedule(const uint8_t *key, void **schedule) {
 	*schedule = malloc(sizeof(struct key_schedule));
-	OQS_EXIT_IF_NULLPTR(*schedule);
+	OQS_EXIT_IF_NULLPTR(*schedule, "OpenSSL");
 	struct key_schedule *ks = (struct key_schedule *) *schedule;
 	ks->for_ECB = 1;
 	ks->ctx = EVP_CIPHER_CTX_new();
-	OQS_EXIT_IF_NULLPTR(ks->ctx);
+	OQS_EXIT_IF_NULLPTR(ks->ctx, "OpenSSL");
 	OQS_OPENSSL_GUARD(EVP_EncryptInit_ex(ks->ctx, oqs_aes_128_ecb(), NULL, key, NULL));
 	EVP_CIPHER_CTX_set_padding(ks->ctx, 0);
 }
@@ -69,11 +69,11 @@ void OQS_AES128_ECB_enc_sch(const uint8_t *plaintext, const size_t plaintext_len
 
 void OQS_AES256_ECB_load_schedule(const uint8_t *key, void **schedule) {
 	*schedule = malloc(sizeof(struct key_schedule));
-	OQS_EXIT_IF_NULLPTR(*schedule);
+	OQS_EXIT_IF_NULLPTR(*schedule, "OpenSSL");
 	struct key_schedule *ks = (struct key_schedule *) *schedule;
 	ks->for_ECB = 1;
 	ks->ctx = EVP_CIPHER_CTX_new();
-	OQS_EXIT_IF_NULLPTR(ks->ctx);
+	OQS_EXIT_IF_NULLPTR(ks->ctx, "OpenSSL");
 	OQS_OPENSSL_GUARD(EVP_EncryptInit_ex(ks->ctx, oqs_aes_256_ecb(), NULL, key, NULL));
 	EVP_CIPHER_CTX_set_padding(ks->ctx, 0);
 }
@@ -84,14 +84,14 @@ void OQS_AES256_CTR_inc_init(const uint8_t *key, void **schedule) {
 	EVP_CIPHER_CTX *ctr_ctx = EVP_CIPHER_CTX_new();
 	assert(ctr_ctx != NULL);
 
-	OQS_EXIT_IF_NULLPTR(*schedule);
+	OQS_EXIT_IF_NULLPTR(*schedule, "OpenSSL");
 	ks->for_ECB = 0;
 	ks->ctx = ctr_ctx;
 	memcpy(ks->key, key, 32);
 }
 
 void OQS_AES256_CTR_inc_iv(const uint8_t *iv, size_t iv_len, void *schedule) {
-	OQS_EXIT_IF_NULLPTR(schedule);
+	OQS_EXIT_IF_NULLPTR(schedule, "OpenSSL");
 	struct key_schedule *ks = (struct key_schedule *) schedule;
 	if (iv_len == 12) {
 		memcpy(ks->iv, iv, 12);
@@ -105,7 +105,7 @@ void OQS_AES256_CTR_inc_iv(const uint8_t *iv, size_t iv_len, void *schedule) {
 }
 
 void OQS_AES256_CTR_inc_ivu64(uint64_t iv, void *schedule) {
-	OQS_EXIT_IF_NULLPTR(schedule);
+	OQS_EXIT_IF_NULLPTR(schedule, "OpenSSL");
 	struct key_schedule *ks = (struct key_schedule *) schedule;
 	br_enc64be(ks->iv, iv);
 	memset(&ks->iv[8], 0, 8);

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -24,10 +24,10 @@ extern "C" {
  * Macro for terminating the program if x is
  * a null pointer.
  */
-#define OQS_EXIT_IF_NULLPTR(x)    \
+#define OQS_EXIT_IF_NULLPTR(x, loc)    \
     do {                          \
         if ( (x) == (void*)0 ) {  \
-            fprintf(stderr, "Unexpected NULL returned from OpenSSL API. Exiting.\n"); \
+            fprintf(stderr, "Unexpected NULL returned from %s API. Exiting.\n", loc); \
             exit(EXIT_FAILURE); \
         }  \
     } while (0)

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -12,6 +12,7 @@
 #include <limits.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 #include <oqs/oqsconfig.h>
 
@@ -23,10 +24,12 @@ extern "C" {
  * Macro for terminating the program if x is
  * a null pointer.
  */
-#define OQS_EXIT_IF_NULLPTR(x)  \
-    do {                        \
-        if ( (x) == (void*)0 )  \
+#define OQS_EXIT_IF_NULLPTR(x)    \
+    do {                          \
+        if ( (x) == (void*)0 ) {  \
+            fprintf(stderr, "Unexpected NULL returned from OpenSSL API. Exiting.\n"); \
             exit(EXIT_FAILURE); \
+        }  \
     } while (0)
 
 /**
@@ -43,6 +46,7 @@ extern "C" {
 #define OQS_OPENSSL_GUARD(x)    \
     do {                        \
         if( 1 != (x) ) {        \
+            fprintf(stderr, "Error return value from OpenSSL API: %d. Exiting.\n", x); \
             exit(EXIT_FAILURE); \
         }                       \
     } while (0)

--- a/src/common/ossl_helpers.c
+++ b/src/common/ossl_helpers.c
@@ -14,29 +14,29 @@ static EVP_CIPHER *aes128_ecb_ptr, *aes256_ecb_ptr, *aes256_ctr_ptr;
 void oqs_fetch_ossl_objects(void) {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 	sha256_ptr = EVP_MD_fetch(NULL, "SHA256", NULL);
-	OQS_EXIT_IF_NULLPTR(sha256_ptr);
+	OQS_EXIT_IF_NULLPTR(sha256_ptr, "OpenSSL");
 	sha384_ptr = EVP_MD_fetch(NULL, "SHA384", NULL);
-	OQS_EXIT_IF_NULLPTR(sha384_ptr);
+	OQS_EXIT_IF_NULLPTR(sha384_ptr, "OpenSSL");
 	sha512_ptr = EVP_MD_fetch(NULL, "SHA512", NULL);
-	OQS_EXIT_IF_NULLPTR(sha512_ptr);
+	OQS_EXIT_IF_NULLPTR(sha512_ptr, "OpenSSL");
 
 	sha3_256_ptr = EVP_MD_fetch(NULL, "SHA3-256", NULL);
-	OQS_EXIT_IF_NULLPTR(sha3_256_ptr);
+	OQS_EXIT_IF_NULLPTR(sha3_256_ptr, "OpenSSL");
 	sha3_384_ptr = EVP_MD_fetch(NULL, "SHA3-384", NULL);
-	OQS_EXIT_IF_NULLPTR(sha3_384_ptr);
+	OQS_EXIT_IF_NULLPTR(sha3_384_ptr, "OpenSSL");
 	sha3_512_ptr = EVP_MD_fetch(NULL, "SHA3-512", NULL);
-	OQS_EXIT_IF_NULLPTR(sha3_512_ptr);
+	OQS_EXIT_IF_NULLPTR(sha3_512_ptr, "OpenSSL");
 	shake128_ptr = EVP_MD_fetch(NULL, "SHAKE128", NULL);
-	OQS_EXIT_IF_NULLPTR(shake128_ptr);
+	OQS_EXIT_IF_NULLPTR(shake128_ptr, "OpenSSL");
 	shake256_ptr = EVP_MD_fetch(NULL, "SHAKE256", NULL);
-	OQS_EXIT_IF_NULLPTR(shake256_ptr);
+	OQS_EXIT_IF_NULLPTR(shake256_ptr, "OpenSSL");
 
 	aes128_ecb_ptr = EVP_CIPHER_fetch(NULL, "AES-128-ECB", NULL);
-	OQS_EXIT_IF_NULLPTR(aes128_ecb_ptr);
+	OQS_EXIT_IF_NULLPTR(aes128_ecb_ptr, "OpenSSL");
 	aes256_ecb_ptr = EVP_CIPHER_fetch(NULL, "AES-256-ECB", NULL);
-	OQS_EXIT_IF_NULLPTR(aes256_ecb_ptr);
+	OQS_EXIT_IF_NULLPTR(aes256_ecb_ptr, "OpenSSL");
 	aes256_ctr_ptr = EVP_CIPHER_fetch(NULL, "AES-256-CTR", NULL);
-	OQS_EXIT_IF_NULLPTR(aes256_ctr_ptr);
+	OQS_EXIT_IF_NULLPTR(aes256_ctr_ptr, "OpenSSL");
 #endif
 }
 

--- a/src/common/ossl_helpers.c
+++ b/src/common/ossl_helpers.c
@@ -13,35 +13,59 @@ static EVP_CIPHER *aes128_ecb_ptr, *aes256_ecb_ptr, *aes256_ctr_ptr;
 
 void oqs_fetch_ossl_objects(void) {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#ifdef OQS_USE_SHA2_OPENSSL
 	sha256_ptr = EVP_MD_fetch(NULL, "SHA256", NULL);
+	OQS_EXIT_IF_NULLPTR(sha256_ptr);
 	sha384_ptr = EVP_MD_fetch(NULL, "SHA384", NULL);
+	OQS_EXIT_IF_NULLPTR(sha384_ptr);
 	sha512_ptr = EVP_MD_fetch(NULL, "SHA512", NULL);
-	sha3_256_ptr = EVP_MD_fetch(NULL, "SHA3-256", NULL);
-	sha3_384_ptr = EVP_MD_fetch(NULL, "SHA3-384", NULL);
-	sha3_512_ptr = EVP_MD_fetch(NULL, "SHA3-512", NULL);
-	shake128_ptr = EVP_MD_fetch(NULL, "SHAKE128", NULL);
-	shake256_ptr = EVP_MD_fetch(NULL, "SHAKE256", NULL);
+	OQS_EXIT_IF_NULLPTR(sha512_ptr);
+#endif /* OQS_USE_SHA2_OPENSSL */
 
+#ifdef OQS_USE_SHA3_OPENSSL
+	sha3_256_ptr = EVP_MD_fetch(NULL, "SHA3-256", NULL);
+	OQS_EXIT_IF_NULLPTR(sha3_256_ptr);
+	sha3_384_ptr = EVP_MD_fetch(NULL, "SHA3-384", NULL);
+	OQS_EXIT_IF_NULLPTR(sha3_384_ptr);
+	sha3_512_ptr = EVP_MD_fetch(NULL, "SHA3-512", NULL);
+	OQS_EXIT_IF_NULLPTR(sha3_512_ptr);
+	shake128_ptr = EVP_MD_fetch(NULL, "SHAKE128", NULL);
+	OQS_EXIT_IF_NULLPTR(shake128_ptr);
+	shake256_ptr = EVP_MD_fetch(NULL, "SHAKE256", NULL);
+	OQS_EXIT_IF_NULLPTR(shake256_ptr);
+#endif /* OQS_USE_SHA3_OPENSSL */
+
+#ifdef OQS_USE_AES_OPENSSL
 	aes128_ecb_ptr = EVP_CIPHER_fetch(NULL, "AES-128-ECB", NULL);
+	OQS_EXIT_IF_NULLPTR(aes128_ecb_ptr);
 	aes256_ecb_ptr = EVP_CIPHER_fetch(NULL, "AES-256-ECB", NULL);
+	OQS_EXIT_IF_NULLPTR(aes256_ecb_ptr);
 	aes256_ctr_ptr = EVP_CIPHER_fetch(NULL, "AES-256-CTR", NULL);
+	OQS_EXIT_IF_NULLPTR(aes256_ctr_ptr);
+#endif /* OQS_USE_AES_OPENSSL */
 #endif
 }
 
 void oqs_free_ossl_objects(void) {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#ifdef OQS_USE_SHA2_OPENSSL
 	EVP_MD_free(sha256_ptr);
 	EVP_MD_free(sha384_ptr);
 	EVP_MD_free(sha512_ptr);
+#endif
+#ifdef OQS_USE_SHA3_OPENSSL
 	EVP_MD_free(sha3_256_ptr);
 	EVP_MD_free(sha3_384_ptr);
 	EVP_MD_free(sha3_512_ptr);
 	EVP_MD_free(shake128_ptr);
 	EVP_MD_free(shake256_ptr);
+#endif
 
+#ifdef OQS_USE_AES_OPENSSL
 	EVP_CIPHER_free(aes128_ecb_ptr);
 	EVP_CIPHER_free(aes256_ecb_ptr);
 	EVP_CIPHER_free(aes256_ctr_ptr);
+#endif /* OQS_USE_AES_OPENSSL */
 #endif
 }
 

--- a/src/common/ossl_helpers.c
+++ b/src/common/ossl_helpers.c
@@ -13,16 +13,13 @@ static EVP_CIPHER *aes128_ecb_ptr, *aes256_ecb_ptr, *aes256_ctr_ptr;
 
 void oqs_fetch_ossl_objects(void) {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-#ifdef OQS_USE_SHA2_OPENSSL
 	sha256_ptr = EVP_MD_fetch(NULL, "SHA256", NULL);
 	OQS_EXIT_IF_NULLPTR(sha256_ptr);
 	sha384_ptr = EVP_MD_fetch(NULL, "SHA384", NULL);
 	OQS_EXIT_IF_NULLPTR(sha384_ptr);
 	sha512_ptr = EVP_MD_fetch(NULL, "SHA512", NULL);
 	OQS_EXIT_IF_NULLPTR(sha512_ptr);
-#endif /* OQS_USE_SHA2_OPENSSL */
 
-#ifdef OQS_USE_SHA3_OPENSSL
 	sha3_256_ptr = EVP_MD_fetch(NULL, "SHA3-256", NULL);
 	OQS_EXIT_IF_NULLPTR(sha3_256_ptr);
 	sha3_384_ptr = EVP_MD_fetch(NULL, "SHA3-384", NULL);
@@ -33,39 +30,29 @@ void oqs_fetch_ossl_objects(void) {
 	OQS_EXIT_IF_NULLPTR(shake128_ptr);
 	shake256_ptr = EVP_MD_fetch(NULL, "SHAKE256", NULL);
 	OQS_EXIT_IF_NULLPTR(shake256_ptr);
-#endif /* OQS_USE_SHA3_OPENSSL */
 
-#ifdef OQS_USE_AES_OPENSSL
 	aes128_ecb_ptr = EVP_CIPHER_fetch(NULL, "AES-128-ECB", NULL);
 	OQS_EXIT_IF_NULLPTR(aes128_ecb_ptr);
 	aes256_ecb_ptr = EVP_CIPHER_fetch(NULL, "AES-256-ECB", NULL);
 	OQS_EXIT_IF_NULLPTR(aes256_ecb_ptr);
 	aes256_ctr_ptr = EVP_CIPHER_fetch(NULL, "AES-256-CTR", NULL);
 	OQS_EXIT_IF_NULLPTR(aes256_ctr_ptr);
-#endif /* OQS_USE_AES_OPENSSL */
 #endif
 }
 
 void oqs_free_ossl_objects(void) {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-#ifdef OQS_USE_SHA2_OPENSSL
 	EVP_MD_free(sha256_ptr);
 	EVP_MD_free(sha384_ptr);
 	EVP_MD_free(sha512_ptr);
-#endif
-#ifdef OQS_USE_SHA3_OPENSSL
 	EVP_MD_free(sha3_256_ptr);
 	EVP_MD_free(sha3_384_ptr);
 	EVP_MD_free(sha3_512_ptr);
 	EVP_MD_free(shake128_ptr);
 	EVP_MD_free(shake256_ptr);
-#endif
-
-#ifdef OQS_USE_AES_OPENSSL
 	EVP_CIPHER_free(aes128_ecb_ptr);
 	EVP_CIPHER_free(aes256_ecb_ptr);
 	EVP_CIPHER_free(aes256_ctr_ptr);
-#endif /* OQS_USE_AES_OPENSSL */
 #endif
 }
 

--- a/src/common/sha2/sha2.h
+++ b/src/common/sha2/sha2.h
@@ -59,8 +59,8 @@ void OQS_SHA2_sha256_inc_init(OQS_SHA2_sha256_ctx *state);
  * \brief Duplicate state for the SHA-256 incremental hashing API.
  *
  * \warning dest must be allocated by the caller. Caller is responsible
- * for releasing dest by calling either OQS_SHA3_sha3_256_inc_finalize or
- * OQS_SHA3_sha3_256_inc_ctx_release.
+ * for releasing dest by calling either OQS_SHA2_sha256_inc_finalize or
+ * OQS_SHA2_sha256_inc_ctx_release.
  *
  * \param dest The function state to copy into; must be initialized
  * \param src The function state to copy; must be initialized
@@ -74,7 +74,7 @@ void OQS_SHA2_sha256_inc_ctx_clone(OQS_SHA2_sha256_ctx *dest, const OQS_SHA2_sha
  *
  * \param state The state to update
  * \param in Message input byte array
- * \param inblocks The number of blocks of message bytes to process
+ * \param inblocks The number of 64-byte blocks of message bytes to process
  */
 void OQS_SHA2_sha256_inc_blocks(OQS_SHA2_sha256_ctx *state, const uint8_t *in, size_t inblocks);
 
@@ -133,8 +133,8 @@ void OQS_SHA2_sha384_inc_init(OQS_SHA2_sha384_ctx *state);
  * \brief Duplicate state for the SHA-384 incremental hashing API.
  *
  * \warning dest must be allocated by the caller. Caller is responsible
- * for releasing dest by calling either OQS_SHA3_sha3_384_inc_finalize or
- * OQS_SHA3_sha3_384_inc_ctx_release.
+ * for releasing dest by calling either OQS_SHA2_sha384_inc_finalize or
+ * OQS_SHA2_sha384_inc_ctx_release.
  *
  * \param dest The function state to copy into; must be initialized
  * \param src The function state to copy; must be initialized
@@ -148,7 +148,7 @@ void OQS_SHA2_sha384_inc_ctx_clone(OQS_SHA2_sha384_ctx *dest, const OQS_SHA2_sha
  *
  * \param state The state to update
  * \param in Message input byte array
- * \param inblocks The number of blocks of message bytes to process
+ * \param inblocks The number of 128-byte blocks of message bytes to process
  */
 void OQS_SHA2_sha384_inc_blocks(OQS_SHA2_sha384_ctx *state, const uint8_t *in, size_t inblocks);
 
@@ -207,8 +207,8 @@ void OQS_SHA2_sha512_inc_init(OQS_SHA2_sha512_ctx *state);
  * \brief Duplicate state for the SHA-512 incremental hashing API.
  *
  * \warning dest must be allocated by the caller. Caller is responsible
- * for releasing dest by calling either OQS_SHA3_sha3_512_inc_finalize or
- * OQS_SHA3_sha3_512_inc_ctx_release.
+ * for releasing dest by calling either OQS_SHA2_sha512_inc_finalize or
+ * OQS_SHA2_sha512_inc_ctx_release.
  *
  * \param dest The function state to copy into; must be initialized
  * \param src The function state to copy; must be initialized
@@ -222,7 +222,7 @@ void OQS_SHA2_sha512_inc_ctx_clone(OQS_SHA2_sha512_ctx *dest, const OQS_SHA2_sha
  *
  * \param state The state to update
  * \param in Message input byte array
- * \param inblocks The number of blocks of message bytes to process
+ * \param inblocks The number of 128-byte blocks of message bytes to process
  */
 void OQS_SHA2_sha512_inc_blocks(OQS_SHA2_sha512_ctx *state, const uint8_t *in, size_t inblocks);
 

--- a/src/common/sha2/sha2_ossl.c
+++ b/src/common/sha2/sha2_ossl.c
@@ -18,27 +18,31 @@ static void do_hash(uint8_t *output, const uint8_t *input, size_t inplen, const 
 	EVP_MD_CTX *mdctx;
 	unsigned int outlen;
 	mdctx = EVP_MD_CTX_new();
-	EVP_DigestInit_ex(mdctx, md, NULL);
-	EVP_DigestUpdate(mdctx, input, inplen);
-	EVP_DigestFinal_ex(mdctx, output, &outlen);
+	OQS_EXIT_IF_NULLPTR(mdctx);
+	OQS_OPENSSL_GUARD(EVP_DigestInit_ex(mdctx, md, NULL));
+	OQS_OPENSSL_GUARD(EVP_DigestUpdate(mdctx, input, inplen));
+	OQS_OPENSSL_GUARD(EVP_DigestFinal_ex(mdctx, output, &outlen));
 	EVP_MD_CTX_free(mdctx);
 }
 
 void OQS_SHA2_sha256(uint8_t *output, const uint8_t *input, size_t inplen) {
 	const EVP_MD *md;
 	md = oqs_sha256();
+	OQS_EXIT_IF_NULLPTR(md);
 	do_hash(output, input, inplen, md);
 }
 
 void OQS_SHA2_sha384(uint8_t *output, const uint8_t *input, size_t inplen) {
 	const EVP_MD *md;
 	md = oqs_sha384();
+	OQS_EXIT_IF_NULLPTR(md);
 	do_hash(output, input, inplen, md);
 }
 
 void OQS_SHA2_sha512(uint8_t *output, const uint8_t *input, size_t inplen) {
 	const EVP_MD *md;
 	md = oqs_sha512();
+	OQS_EXIT_IF_NULLPTR(md);
 	do_hash(output, input, inplen, md);
 }
 
@@ -50,20 +54,21 @@ void OQS_SHA2_sha256_inc_init(OQS_SHA2_sha256_ctx *state) {
 	md = oqs_sha256();
 	OQS_EXIT_IF_NULLPTR(md);
 	mdctx = EVP_MD_CTX_new();
-	EVP_DigestInit_ex(mdctx, md, NULL);
+	OQS_EXIT_IF_NULLPTR(mdctx);
+	OQS_OPENSSL_GUARD(EVP_DigestInit_ex(mdctx, md, NULL));
 	state->ctx = mdctx;
 }
 
 void OQS_SHA2_sha256_inc_blocks(OQS_SHA2_sha256_ctx *state, const uint8_t *in, size_t inblocks) {
-	EVP_DigestUpdate((EVP_MD_CTX *) state->ctx, in, inblocks * SHA2_BLOCK_SIZE);
+	OQS_OPENSSL_GUARD(EVP_DigestUpdate((EVP_MD_CTX *) state->ctx, in, inblocks * SHA2_BLOCK_SIZE));
 }
 
 void OQS_SHA2_sha256_inc_finalize(uint8_t *out, OQS_SHA2_sha256_ctx *state, const uint8_t *in, size_t inlen) {
 	unsigned int md_len;
 	if (inlen > 0) {
-		EVP_DigestUpdate((EVP_MD_CTX *) state->ctx, in, inlen);
+		OQS_OPENSSL_GUARD(EVP_DigestUpdate((EVP_MD_CTX *) state->ctx, in, inlen));
 	}
-	EVP_DigestFinal_ex((EVP_MD_CTX *) state->ctx, out, &md_len);
+	OQS_OPENSSL_GUARD(EVP_DigestFinal_ex((EVP_MD_CTX *) state->ctx, out, &md_len));
 	EVP_MD_CTX_free((EVP_MD_CTX *) state->ctx);
 }
 
@@ -73,7 +78,7 @@ void OQS_SHA2_sha256_inc_ctx_release(OQS_SHA2_sha256_ctx *state) {
 
 void OQS_SHA2_sha256_inc_ctx_clone(OQS_SHA2_sha256_ctx *dest, const OQS_SHA2_sha256_ctx *src) {
 	OQS_SHA2_sha256_inc_init(dest);
-	EVP_MD_CTX_copy_ex((EVP_MD_CTX *) dest->ctx, (EVP_MD_CTX *) src->ctx);
+	OQS_OPENSSL_GUARD(EVP_MD_CTX_copy_ex((EVP_MD_CTX *) dest->ctx, (EVP_MD_CTX *) src->ctx));
 }
 
 void OQS_SHA2_sha384_inc_init(OQS_SHA2_sha384_ctx *state) {
@@ -82,20 +87,21 @@ void OQS_SHA2_sha384_inc_init(OQS_SHA2_sha384_ctx *state) {
 	md = oqs_sha384();
 	OQS_EXIT_IF_NULLPTR(md);
 	mdctx = EVP_MD_CTX_new();
-	EVP_DigestInit_ex(mdctx, md, NULL);
+	OQS_EXIT_IF_NULLPTR(mdctx);
+	OQS_OPENSSL_GUARD(EVP_DigestInit_ex(mdctx, md, NULL));
 	state->ctx = mdctx;
 }
 
 void OQS_SHA2_sha384_inc_blocks(OQS_SHA2_sha384_ctx *state, const uint8_t *in, size_t inblocks) {
-	EVP_DigestUpdate((EVP_MD_CTX *) state->ctx, in, inblocks * SHA2_BLOCK_SIZE);
+	OQS_OPENSSL_GUARD(EVP_DigestUpdate((EVP_MD_CTX *) state->ctx, in, inblocks * 2* SHA2_BLOCK_SIZE));
 }
 
 void OQS_SHA2_sha384_inc_finalize(uint8_t *out, OQS_SHA2_sha384_ctx *state, const uint8_t *in, size_t inlen) {
 	unsigned int md_len;
 	if (inlen > 0) {
-		EVP_DigestUpdate((EVP_MD_CTX *) state->ctx, in, inlen);
+		OQS_OPENSSL_GUARD(EVP_DigestUpdate((EVP_MD_CTX *) state->ctx, in, inlen));
 	}
-	EVP_DigestFinal_ex((EVP_MD_CTX *) state->ctx, out, &md_len);
+	OQS_OPENSSL_GUARD(EVP_DigestFinal_ex((EVP_MD_CTX *) state->ctx, out, &md_len));
 	EVP_MD_CTX_free((EVP_MD_CTX *) state->ctx);
 }
 
@@ -105,7 +111,7 @@ void OQS_SHA2_sha384_inc_ctx_release(OQS_SHA2_sha384_ctx *state) {
 
 void OQS_SHA2_sha384_inc_ctx_clone(OQS_SHA2_sha384_ctx *dest, const OQS_SHA2_sha384_ctx *src) {
 	OQS_SHA2_sha384_inc_init(dest);
-	EVP_MD_CTX_copy_ex((EVP_MD_CTX *) dest->ctx, (EVP_MD_CTX *) src->ctx);
+	OQS_OPENSSL_GUARD(EVP_MD_CTX_copy_ex((EVP_MD_CTX *) dest->ctx, (EVP_MD_CTX *) src->ctx));
 }
 
 void OQS_SHA2_sha512_inc_init(OQS_SHA2_sha512_ctx *state) {
@@ -114,20 +120,21 @@ void OQS_SHA2_sha512_inc_init(OQS_SHA2_sha512_ctx *state) {
 	md = oqs_sha512();
 	OQS_EXIT_IF_NULLPTR(md);
 	mdctx = EVP_MD_CTX_new();
-	EVP_DigestInit_ex(mdctx, md, NULL);
+	OQS_EXIT_IF_NULLPTR(mdctx);
+	OQS_OPENSSL_GUARD(EVP_DigestInit_ex(mdctx, md, NULL));
 	state->ctx = mdctx;
 }
 
 void OQS_SHA2_sha512_inc_blocks(OQS_SHA2_sha512_ctx *state, const uint8_t *in, size_t inblocks) {
-	EVP_DigestUpdate((EVP_MD_CTX *) state->ctx, in, inblocks * SHA2_BLOCK_SIZE);
+	OQS_OPENSSL_GUARD(EVP_DigestUpdate((EVP_MD_CTX *) state->ctx, in, inblocks * 2 * SHA2_BLOCK_SIZE));
 }
 
 void OQS_SHA2_sha512_inc_finalize(uint8_t *out, OQS_SHA2_sha512_ctx *state, const uint8_t *in, size_t inlen) {
 	unsigned int md_len;
 	if (inlen > 0) {
-		EVP_DigestUpdate((EVP_MD_CTX *) state->ctx, in, inlen);
+		OQS_OPENSSL_GUARD(EVP_DigestUpdate((EVP_MD_CTX *) state->ctx, in, inlen));
 	}
-	EVP_DigestFinal_ex((EVP_MD_CTX *) state->ctx, out, &md_len);
+	OQS_OPENSSL_GUARD(EVP_DigestFinal_ex((EVP_MD_CTX *) state->ctx, out, &md_len));
 	EVP_MD_CTX_free((EVP_MD_CTX *) state->ctx);
 }
 
@@ -137,7 +144,7 @@ void OQS_SHA2_sha512_inc_ctx_release(OQS_SHA2_sha512_ctx *state) {
 
 void OQS_SHA2_sha512_inc_ctx_clone(OQS_SHA2_sha512_ctx *dest, const OQS_SHA2_sha512_ctx *src) {
 	OQS_SHA2_sha512_inc_init(dest);
-	EVP_MD_CTX_copy_ex((EVP_MD_CTX *) dest->ctx, (EVP_MD_CTX *) src->ctx);
+	OQS_OPENSSL_GUARD(EVP_MD_CTX_copy_ex((EVP_MD_CTX *) dest->ctx, (EVP_MD_CTX *) src->ctx));
 }
 
 #endif

--- a/src/common/sha2/sha2_ossl.c
+++ b/src/common/sha2/sha2_ossl.c
@@ -18,7 +18,7 @@ static void do_hash(uint8_t *output, const uint8_t *input, size_t inplen, const 
 	EVP_MD_CTX *mdctx;
 	unsigned int outlen;
 	mdctx = EVP_MD_CTX_new();
-	OQS_EXIT_IF_NULLPTR(mdctx);
+	OQS_EXIT_IF_NULLPTR(mdctx, "OpenSSL");
 	OQS_OPENSSL_GUARD(EVP_DigestInit_ex(mdctx, md, NULL));
 	OQS_OPENSSL_GUARD(EVP_DigestUpdate(mdctx, input, inplen));
 	OQS_OPENSSL_GUARD(EVP_DigestFinal_ex(mdctx, output, &outlen));
@@ -28,21 +28,21 @@ static void do_hash(uint8_t *output, const uint8_t *input, size_t inplen, const 
 void OQS_SHA2_sha256(uint8_t *output, const uint8_t *input, size_t inplen) {
 	const EVP_MD *md;
 	md = oqs_sha256();
-	OQS_EXIT_IF_NULLPTR(md);
+	OQS_EXIT_IF_NULLPTR(md, "OpenSSL");
 	do_hash(output, input, inplen, md);
 }
 
 void OQS_SHA2_sha384(uint8_t *output, const uint8_t *input, size_t inplen) {
 	const EVP_MD *md;
 	md = oqs_sha384();
-	OQS_EXIT_IF_NULLPTR(md);
+	OQS_EXIT_IF_NULLPTR(md, "OpenSSL");
 	do_hash(output, input, inplen, md);
 }
 
 void OQS_SHA2_sha512(uint8_t *output, const uint8_t *input, size_t inplen) {
 	const EVP_MD *md;
 	md = oqs_sha512();
-	OQS_EXIT_IF_NULLPTR(md);
+	OQS_EXIT_IF_NULLPTR(md, "OpenSSL");
 	do_hash(output, input, inplen, md);
 }
 
@@ -52,9 +52,9 @@ void OQS_SHA2_sha256_inc_init(OQS_SHA2_sha256_ctx *state) {
 	EVP_MD_CTX *mdctx;
 	const EVP_MD *md = NULL;
 	md = oqs_sha256();
-	OQS_EXIT_IF_NULLPTR(md);
+	OQS_EXIT_IF_NULLPTR(md, "OpenSSL");
 	mdctx = EVP_MD_CTX_new();
-	OQS_EXIT_IF_NULLPTR(mdctx);
+	OQS_EXIT_IF_NULLPTR(mdctx, "OpenSSL");
 	OQS_OPENSSL_GUARD(EVP_DigestInit_ex(mdctx, md, NULL));
 	state->ctx = mdctx;
 }
@@ -70,10 +70,12 @@ void OQS_SHA2_sha256_inc_finalize(uint8_t *out, OQS_SHA2_sha256_ctx *state, cons
 	}
 	OQS_OPENSSL_GUARD(EVP_DigestFinal_ex((EVP_MD_CTX *) state->ctx, out, &md_len));
 	EVP_MD_CTX_free((EVP_MD_CTX *) state->ctx);
+	state->ctx = NULL;
 }
 
 void OQS_SHA2_sha256_inc_ctx_release(OQS_SHA2_sha256_ctx *state) {
 	EVP_MD_CTX_destroy((EVP_MD_CTX *) state->ctx);
+	state->ctx = NULL;
 }
 
 void OQS_SHA2_sha256_inc_ctx_clone(OQS_SHA2_sha256_ctx *dest, const OQS_SHA2_sha256_ctx *src) {
@@ -85,9 +87,9 @@ void OQS_SHA2_sha384_inc_init(OQS_SHA2_sha384_ctx *state) {
 	EVP_MD_CTX *mdctx;
 	const EVP_MD *md = NULL;
 	md = oqs_sha384();
-	OQS_EXIT_IF_NULLPTR(md);
+	OQS_EXIT_IF_NULLPTR(md, "OpenSSL");
 	mdctx = EVP_MD_CTX_new();
-	OQS_EXIT_IF_NULLPTR(mdctx);
+	OQS_EXIT_IF_NULLPTR(mdctx, "OpenSSL");
 	OQS_OPENSSL_GUARD(EVP_DigestInit_ex(mdctx, md, NULL));
 	state->ctx = mdctx;
 }
@@ -103,10 +105,12 @@ void OQS_SHA2_sha384_inc_finalize(uint8_t *out, OQS_SHA2_sha384_ctx *state, cons
 	}
 	OQS_OPENSSL_GUARD(EVP_DigestFinal_ex((EVP_MD_CTX *) state->ctx, out, &md_len));
 	EVP_MD_CTX_free((EVP_MD_CTX *) state->ctx);
+	state->ctx = NULL;
 }
 
 void OQS_SHA2_sha384_inc_ctx_release(OQS_SHA2_sha384_ctx *state) {
 	EVP_MD_CTX_destroy((EVP_MD_CTX *) state->ctx);
+	state->ctx = NULL;
 }
 
 void OQS_SHA2_sha384_inc_ctx_clone(OQS_SHA2_sha384_ctx *dest, const OQS_SHA2_sha384_ctx *src) {
@@ -118,9 +122,9 @@ void OQS_SHA2_sha512_inc_init(OQS_SHA2_sha512_ctx *state) {
 	EVP_MD_CTX *mdctx;
 	const EVP_MD *md = NULL;
 	md = oqs_sha512();
-	OQS_EXIT_IF_NULLPTR(md);
+	OQS_EXIT_IF_NULLPTR(md, "OpenSSL");
 	mdctx = EVP_MD_CTX_new();
-	OQS_EXIT_IF_NULLPTR(mdctx);
+	OQS_EXIT_IF_NULLPTR(mdctx, "OpenSSL");
 	OQS_OPENSSL_GUARD(EVP_DigestInit_ex(mdctx, md, NULL));
 	state->ctx = mdctx;
 }
@@ -136,10 +140,12 @@ void OQS_SHA2_sha512_inc_finalize(uint8_t *out, OQS_SHA2_sha512_ctx *state, cons
 	}
 	OQS_OPENSSL_GUARD(EVP_DigestFinal_ex((EVP_MD_CTX *) state->ctx, out, &md_len));
 	EVP_MD_CTX_free((EVP_MD_CTX *) state->ctx);
+	state->ctx = NULL;
 }
 
 void OQS_SHA2_sha512_inc_ctx_release(OQS_SHA2_sha512_ctx *state) {
 	EVP_MD_CTX_destroy((EVP_MD_CTX *) state->ctx);
+	state->ctx = NULL;
 }
 
 void OQS_SHA2_sha512_inc_ctx_clone(OQS_SHA2_sha512_ctx *dest, const OQS_SHA2_sha512_ctx *src) {

--- a/src/common/sha2/sha2_ossl.c
+++ b/src/common/sha2/sha2_ossl.c
@@ -93,7 +93,7 @@ void OQS_SHA2_sha384_inc_init(OQS_SHA2_sha384_ctx *state) {
 }
 
 void OQS_SHA2_sha384_inc_blocks(OQS_SHA2_sha384_ctx *state, const uint8_t *in, size_t inblocks) {
-	OQS_OPENSSL_GUARD(EVP_DigestUpdate((EVP_MD_CTX *) state->ctx, in, inblocks * 2* SHA2_BLOCK_SIZE));
+	OQS_OPENSSL_GUARD(EVP_DigestUpdate((EVP_MD_CTX *) state->ctx, in, inblocks * 2 * SHA2_BLOCK_SIZE));
 }
 
 void OQS_SHA2_sha384_inc_finalize(uint8_t *out, OQS_SHA2_sha384_ctx *state, const uint8_t *in, size_t inlen) {

--- a/tests/test_hash.c
+++ b/tests/test_hash.c
@@ -117,9 +117,9 @@ static int do_sha384(void) {
 	OQS_SHA2_sha384_ctx state2;
 	OQS_SHA2_sha384_inc_ctx_clone(&state2, &state);
 	// hash with first state
-	if (msg_len > 64) {
+	if (msg_len > 128) {
 		OQS_SHA2_sha384_inc_blocks(&state, msg, 1);
-		OQS_SHA2_sha384_inc_finalize(output_inc, &state, &msg[64], msg_len - 64);
+		OQS_SHA2_sha384_inc_finalize(output_inc, &state, &msg[128], msg_len - 128);
 	} else {
 		OQS_SHA2_sha384_inc_finalize(output_inc, &state, msg, msg_len);
 	}
@@ -129,9 +129,9 @@ static int do_sha384(void) {
 		return -2;
 	}
 	// hash with second state
-	if (msg_len > 64) {
+	if (msg_len > 128) {
 		OQS_SHA2_sha384_inc_blocks(&state2, msg, 1);
-		OQS_SHA2_sha384_inc_finalize(output_inc, &state2, &msg[64], msg_len - 64);
+		OQS_SHA2_sha384_inc_finalize(output_inc, &state2, &msg[128], msg_len - 128);
 	} else {
 		OQS_SHA2_sha384_inc_finalize(output_inc, &state2, msg, msg_len);
 	}
@@ -164,9 +164,9 @@ static int do_sha512(void) {
 	OQS_SHA2_sha512_ctx state2;
 	OQS_SHA2_sha512_inc_ctx_clone(&state2, &state);
 	// hash with first state
-	if (msg_len > 64) {
+	if (msg_len > 128) {
 		OQS_SHA2_sha512_inc_blocks(&state, msg, 1);
-		OQS_SHA2_sha512_inc_finalize(output_inc, &state, &msg[64], msg_len - 64);
+		OQS_SHA2_sha512_inc_finalize(output_inc, &state, &msg[128], msg_len - 128);
 	} else {
 		OQS_SHA2_sha512_inc_finalize(output_inc, &state, msg, msg_len);
 	}
@@ -176,9 +176,9 @@ static int do_sha512(void) {
 		return -2;
 	}
 	// hash with second state
-	if (msg_len > 64) {
+	if (msg_len > 128) {
 		OQS_SHA2_sha512_inc_blocks(&state2, msg, 1);
-		OQS_SHA2_sha512_inc_finalize(output_inc, &state2, &msg[64], msg_len - 64);
+		OQS_SHA2_sha512_inc_finalize(output_inc, &state2, &msg[128], msg_len - 128);
 	} else {
 		OQS_SHA2_sha512_inc_finalize(output_inc, &state2, msg, msg_len);
 	}

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -20,7 +20,7 @@ def test_sha3():
     )
 
 @helpers.filtered_test
-@pytest.mark.parametrize('msg', ['', 'a', 'abc', '1234567890123456789012345678901678901567890'])
+@pytest.mark.parametrize('msg', ['', 'a', 'abc', '1234567890123456789012345678901678901567890', '1234567890123456789012345678901678901567890andthensometohavemorethan64bytes', '1234567890123456789012345678901678901567890andlotsmoretexttosurelyandwithoutdoubtgobeyondthe128bytesrequiredtotriggerallincrementalblocklogiccases'])
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Not supported on Windows")
 def test_sha256(msg):
     output = helpers.run_subprocess(
@@ -35,7 +35,7 @@ def test_sha256(msg):
     assert(output.rstrip() == hashlib.sha256(msg.encode()).hexdigest())
 
 @helpers.filtered_test
-@pytest.mark.parametrize('msg', ['', 'a', 'abc', '1234567890123456789012345678901678901567890'])
+@pytest.mark.parametrize('msg', ['', 'a', 'abc', '1234567890123456789012345678901678901567890', '1234567890123456789012345678901678901567890andthensometohavemorethan64bytes', '1234567890123456789012345678901678901567890andlotsmoretexttosurelyandwithoutdoubtgobeyondthe128bytesrequiredtotriggerallincrementalblocklogiccases'])
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Not supported on Windows")
 def test_sha384(msg):
     output = helpers.run_subprocess(
@@ -50,7 +50,7 @@ def test_sha384(msg):
     assert(output.rstrip() == hashlib.sha384(msg.encode()).hexdigest())
 
 @helpers.filtered_test
-@pytest.mark.parametrize('msg', ['', 'a', 'abc', '1234567890123456789012345678901678901567890'])
+@pytest.mark.parametrize('msg', ['', 'a', 'abc', '1234567890123456789012345678901678901567890', '1234567890123456789012345678901678901567890andthensometohavemorethan64bytes', '1234567890123456789012345678901678901567890andlotsmoretexttosurelyandwithoutdoubtgobeyondthe128bytesrequiredtotriggerallincrementalblocklogiccases'])
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Not supported on Windows")
 def test_sha512(msg):
     output = helpers.run_subprocess(


### PR DESCRIPTION
Possibly fixes #1452. Fixes issues in #1420.

- Corrects SHA2 API documentation
- Checks all SHA2 OpenSSL API return values
- Fixes SHA384 and SHA512 incremental API implementations
- Corrects testing for these APIs
- Enhances test vectors to avoid re-occurrence of problem

* [yes] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

