### PR TITLE
Extend test_hash to cover more input lengths

### DIFF
--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -3,6 +3,7 @@
 import hashlib
 import helpers
 import pytest
+import random
 import sys
 
 @helpers.filtered_test
@@ -20,49 +21,31 @@ def test_sha3():
     )
 
 @helpers.filtered_test
-@pytest.mark.parametrize('msg', ['', 'a', 'abc', '1234567890123456789012345678901678901567890', '1234567890123456789012345678901678901567890andthensometohavemorethan64bytes', '1234567890123456789012345678901678901567890andlotsmoretexttosurelyandwithoutdoubtgobeyondthe128bytesrequiredtotriggerallincrementalblocklogiccases'])
+@pytest.mark.parametrize('algname', ['sha256', 'sha384', 'sha512', 'sha3_256', 'sha3_384', 'sha3_512'])
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Not supported on Windows")
-def test_sha256(msg):
-    output = helpers.run_subprocess(
-        [helpers.path_to_executable('test_hash'), 'sha256'],
-        input = msg.encode(),
-    )
-    assert(output.rstrip() == hashlib.sha256(msg.encode()).hexdigest())
-    output = helpers.run_subprocess(
-        [helpers.path_to_executable('test_hash'), 'sha256inc'],
-        input = msg.encode(),
-    )
-    assert(output.rstrip() == hashlib.sha256(msg.encode()).hexdigest())
-
-@helpers.filtered_test
-@pytest.mark.parametrize('msg', ['', 'a', 'abc', '1234567890123456789012345678901678901567890', '1234567890123456789012345678901678901567890andthensometohavemorethan64bytes', '1234567890123456789012345678901678901567890andlotsmoretexttosurelyandwithoutdoubtgobeyondthe128bytesrequiredtotriggerallincrementalblocklogiccases'])
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="Not supported on Windows")
-def test_sha384(msg):
-    output = helpers.run_subprocess(
-        [helpers.path_to_executable('test_hash'), 'sha384'],
-        input = msg.encode(),
-    )
-    assert(output.rstrip() == hashlib.sha384(msg.encode()).hexdigest())
-    output = helpers.run_subprocess(
-        [helpers.path_to_executable('test_hash'), 'sha384inc'],
-        input = msg.encode(),
-    )
-    assert(output.rstrip() == hashlib.sha384(msg.encode()).hexdigest())
-
-@helpers.filtered_test
-@pytest.mark.parametrize('msg', ['', 'a', 'abc', '1234567890123456789012345678901678901567890', '1234567890123456789012345678901678901567890andthensometohavemorethan64bytes', '1234567890123456789012345678901678901567890andlotsmoretexttosurelyandwithoutdoubtgobeyondthe128bytesrequiredtotriggerallincrementalblocklogiccases'])
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="Not supported on Windows")
-def test_sha512(msg):
-    output = helpers.run_subprocess(
-        [helpers.path_to_executable('test_hash'), 'sha512'],
-        input = msg.encode(),
-    )
-    assert(output.rstrip() == hashlib.sha512(msg.encode()).hexdigest())
-    output = helpers.run_subprocess(
-        [helpers.path_to_executable('test_hash'), 'sha512inc'],
-        input = msg.encode(),
-    )
-    assert(output.rstrip() == hashlib.sha512(msg.encode()).hexdigest())
+def test_hash_sha2_random(algname):
+    # hash every size from 0 to 1024, then every 11th size after that 
+    # (why 11? it's coprime with powers of 2, so we should land in a 
+    #  bunch of random-ish spots relative to block boundaries)
+    for i in list(range(0, 1024)) + list(range(1025, 20000, 11)):
+        msg = "".join("1" for j in range(i)).encode()
+        hasher = hashlib.new(algname)
+        hasher.update(msg)
+        output = helpers.run_subprocess(
+            [helpers.path_to_executable('test_hash'), algname],
+            input = msg,
+        )
+        if output.rstrip() != hasher.hexdigest():
+            print(msg.hex())
+            assert False, algname + " hashes don't match for the above " + str(i) + "-byte hex string; liboqs output = " + output.rstrip() + "; Python output = " + hasher.hexdigest()
+        if algname[0:4] == "sha3": continue
+        output = helpers.run_subprocess(
+            [helpers.path_to_executable('test_hash'), algname + 'inc'],
+            input = msg,
+        )
+        if output.rstrip() != hasher.hexdigest():
+            print(msg.hex())
+            assert False, algname + " hashes (using liboqs incremental API) don't match for the above " + str(i) + "-byte hex string; liboqs output = " + output.rstrip() + "; Python output = " + hasher.hexdigest()
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
Add more test cases to the test_hash in hopes of catching the type of bugs that arose in #1420.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [No] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [No] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
