### PR TITLE
protect ossl cleanup from multithreading errors

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -24,6 +24,7 @@
 #if defined(OQS_USE_OPENSSL)
 #include <openssl/evp.h>
 #include "ossl_helpers.h"
+CRYPTO_ONCE OQS_ONCE_STATIC_FREE;
 #endif
 
 /* Identifying the CPU is expensive so we cache the results in cpu_ext_data */
@@ -216,7 +217,7 @@ OQS_API const char *OQS_version(void) {
 
 OQS_API void OQS_destroy(void) {
 #if defined(OQS_USE_OPENSSL)
-	oqs_free_ossl_objects();
+	CRYPTO_THREAD_run_once(&OQS_ONCE_STATIC_FREE, oqs_free_ossl_objects);
 #endif
 	return;
 }


### PR DESCRIPTION
Fixes #1471 

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)


