### PR TITLE
create deb package and retain as artifact

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,13 +80,13 @@ jobs:
             container: openquantumsafe/ci-alpine-amd64:latest
             CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=OFF
             PYTEST_ARGS: --ignore=tests/test_alg_info.py
-          - name: focal-std-openssl
+          - name: focal-nistr4-openssl
             container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=STD
-            PYTEST_ARGS: --ignore=tests/test_leaks.py
-          - name: jammy-nistr4-openssl3
-            container: openquantumsafe/ci-ubuntu-jammy:latest
             CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=NIST_R4
+            PYTEST_ARGS: --ignore=tests/test_leaks.py
+          - name: jammy-std-openssl3
+            container: openquantumsafe/ci-ubuntu-jammy:latest
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=STD -DBUILD_SHARED_LIBS=ON
             PYTEST_ARGS: --ignore=tests/test_leaks.py
           - name: address-sanitizer
             container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
@@ -105,6 +105,16 @@ jobs:
       - name: Run tests
         timeout-minutes: 60
         run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}
+      - name: Package .deb
+        if: ${{ matrix.name }} == 'jammy-std-openssl3'
+        run: cpack
+        working-directory: build
+      - name: Retain .deb file
+        if: ${{ matrix.name }} == 'jammy-std-openssl3'
+        uses: actions/upload-artifact@v3
+        with:
+          name: liboqs-openssl3-shared-x64
+          path: build/*.deb
 
   linux_arm_emulated:
     needs: [stylecheck, buildcheck]


### PR DESCRIPTION
In pursuit of https://github.com/open-quantum-safe/oqs-provider/issues/94 this PR prepares (for) binary releases (to be added to release packages, for example).

The binary is intentionally created to
- only contain the standardized algorithms ("STD")
- only use OpenSSL3 APIs (so it can seamlessly be integrated to ´oqsprovider´)
- be built shared (such as to permit independent `dpkg -i`(installs))

Suggestions for other setups welcome. Suggestions where (else) to store the artifact also welcome (www.openquantumsafe.org?)

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
