### PR TITLE
Trigger liboqs-python CI via GitHub API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,7 +390,6 @@ workflows:
           <<: *require_buildcheck
           name: macOS-shared
           CMAKE_ARGS: -DBUILD_SHARED_LIBS=ON -DOQS_DIST_BUILD=OFF -DOQS_ENABLE_KEM_CLASSIC_MCELIECE=OFF
-      - trigger-downstream-ci
 
   commit-to-main:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,6 +390,7 @@ workflows:
           <<: *require_buildcheck
           name: macOS-shared
           CMAKE_ARGS: -DBUILD_SHARED_LIBS=ON -DOQS_DIST_BUILD=OFF -DOQS_ENABLE_KEM_CLASSIC_MCELIECE=OFF
+      - trigger-downstream-ci
 
   commit-to-main:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,27 +308,6 @@ jobs:
                  https://api.github.com/repos/open-quantum-safe/liboqs-python/dispatches | tee curl_out \
             && grep -q "204" curl_out
 
-  temporary-liboqs-python:
-    docker:
-      - image: cimg/base:2020.01
-# Re-enable iff docker enforces rate limitations without auth:
-#        auth:
-#          username: $DOCKER_LOGIN
-#          password: $DOCKER_PASSWORD
-    steps:
-      - run:
-          name: Trigger liboqs-python CI
-          command: |2
-            curl --silent \
-                 --write-out "\n%{response_code}\n" \
-                 --request POST \
-                 --header "Accept: application/vnd.github+json" \
-                 --header "Authorization: Bearer $OQSBOT_GITHUB_ACTIONS" \
-                 --header "X-GitHub-Api-Version: 2022-11-28" \
-                 --data '{"event_type":"liboqs-upstream-trigger"}' \
-                 https://api.github.com/repos/open-quantum-safe/liboqs-python/dispatches | tee curl_out \
-            && grep -q "204" curl_out
-
 workflows:
   version: 2.1
   build:
@@ -411,7 +390,7 @@ workflows:
           <<: *require_buildcheck
           name: macOS-shared
           CMAKE_ARGS: -DBUILD_SHARED_LIBS=ON -DOQS_DIST_BUILD=OFF -DOQS_ENABLE_KEM_CLASSIC_MCELIECE=OFF
-      - temporary-liboqs-python
+      - trigger-downstream-ci
 
   commit-to-main:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,6 +308,27 @@ jobs:
                  https://api.github.com/repos/open-quantum-safe/liboqs-python/dispatches | tee curl_out \
             && grep -q "204" curl_out
 
+  temporary-liboqs-python:
+    docker:
+      - image: cimg/base:2020.01
+# Re-enable iff docker enforces rate limitations without auth:
+#        auth:
+#          username: $DOCKER_LOGIN
+#          password: $DOCKER_PASSWORD
+    steps:
+      - run:
+          name: Trigger liboqs-python CI
+          command: |2
+            curl --silent \
+                 --write-out "\n%{response_code}\n" \
+                 --request POST \
+                 --header "Accept: application/vnd.github+json" \
+                 --header "Authorization: Bearer $OQSBOT_GITHUB_ACTIONS" \
+                 --header "X-GitHub-Api-Version: 2022-11-28" \
+                 --data '{"event_type":"liboqs-upstream-trigger"}' \
+                 https://api.github.com/repos/open-quantum-safe/liboqs-python/dispatches | tee curl_out \
+            && grep -q "204" curl_out
+
 workflows:
   version: 2.1
   build:
@@ -390,7 +411,7 @@ workflows:
           <<: *require_buildcheck
           name: macOS-shared
           CMAKE_ARGS: -DBUILD_SHARED_LIBS=ON -DOQS_DIST_BUILD=OFF -DOQS_ENABLE_KEM_CLASSIC_MCELIECE=OFF
-      - trigger-downstream-ci
+      - temporary-liboqs-python
 
   commit-to-main:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,6 +295,18 @@ jobs:
                  --data '{ "branch": "master" }' \
                  https://circleci.com/api/v2/project/gh/open-quantum-safe/liboqs-java/pipeline | tee curl_out \
             && grep -q "201" curl_out
+      - run:
+          name: Trigger liboqs-python CI
+          command: |2
+            curl --silent \
+                 --write-out "\n%{response_code}\n" \
+                 --request POST \
+                 --header "Accept: application/vnd.github+json" \
+                 --header "Authorization: Bearer $OQSBOT_GITHUB_ACTIONS" \
+                 --header "X-GitHub-Api-Version: 2022-11-28" \
+                 --data '{"event_type":"liboqs-upstream-trigger"}' \
+                 https://api.github.com/repos/open-quantum-safe/liboqs-python/dispatches | tee curl_out \
+            && grep -q "204" curl_out
 
 workflows:
   version: 2.1


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
The liboqs-python repository recently adopted GitHub Actions for CI/CD instead of CircleCI (https://github.com/open-quantum-safe/liboqs-python/commit/f52b2650897b5b918b58d3c3d11cad79b6a2f219), breaking the existing code in liboqs to trigger the downstream project's pipelines. The trigger was removed entirely in https://github.com/open-quantum-safe/liboqs/pull/1498.

This PR adds a new trigger for the liboqs-python CI, in which the liboqs-python pipelines are started via a call to the GitHub API. Doing this requires a personal access token; this was issued to the oqs-bot machine user and stored in the $OQSBOT_GITHUB_ACTIONS variable in the [liboqs CircleCI environment](https://app.circleci.com/settings/project/github/open-quantum-safe/liboqs/environment-variables?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2Fopen-quantum-safe%2Fliboqs).

Since the downstream pipelines are only triggered on a commit to the main branch, I temporarily added the liboqs-python trigger to the `build` workflow in an earlier (now reverted) commit for testing purposes. The liboqs pipeline run can be found [here](https://app.circleci.com/pipelines/github/open-quantum-safe/liboqs/2662/workflows/f05d9fb2-6e56-4801-b8b1-2d93649a1b66/jobs/21219) and the corresponding liboqs-python run [here](https://github.com/open-quantum-safe/liboqs-python/actions/runs/5521878243).

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
Fixes #1499.

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
