### PR TITLE
[NFCI] Move Keccak rhotates tables to rodata

### DIFF
--- a/src/common/sha3/xkcp_low/KeccakP-1600/avx2/KeccakP-1600-AVX2.S
+++ b/src/common/sha3/xkcp_low/KeccakP-1600/avx2/KeccakP-1600-AVX2.S
@@ -1042,6 +1042,7 @@ KeccakP1600_12rounds_FastLoop_Absorb_LanesAddLoop:
 .size   KeccakP1600_12rounds_FastLoop_Absorb,.-KeccakP1600_12rounds_FastLoop_Absorb
 #endif
 
+.section .rodata
 .equ    ALLON,        0xFFFFFFFFFFFFFFFF
 
 .balign 64


### PR DESCRIPTION
rhotates tables are placed to .text section which confuses tools such as BOLT. Move them to rodata to unbreak and avoid polluting icache/iTLB with data.

Sync with OpenSSL https://github.com/openssl/openssl/pull/21440
