### PR TITLE
update BIKE documentation

### DIFF
--- a/docs/algorithms/kem/bike.md
+++ b/docs/algorithms/kem/bike.md
@@ -23,7 +23,7 @@
 
 |       Implementation source       | Identifier in upstream   | Supported architecture(s)   | Supported operating system(s)   | CPU extension(s) used   | No branching-on-secrets claimed?   | No branching-on-secrets checked by valgrind?   | Large stack usage?‡   |
 |:---------------------------------:|:-------------------------|:----------------------------|:--------------------------------|:------------------------|:-----------------------------------|:-----------------------------------------------|:----------------------|
-| [Primary Source](#primary-source) | master                   | little endian               | All                             | None                    | True                               | True                                           | False                 |
+| [Primary Source](#primary-source) | master                   | little endian               | Linux,Darwin                    | None                    | True                               | True                                           | False                 |
 | [Primary Source](#primary-source) | master                   | x86\_64                     | Linux,Darwin                    | AVX2,AVX512,PCLMUL,SSE2 | True                               | True                                           | False                 |
 
 Are implementations chosen based on runtime CPU feature detection? **Yes**.
@@ -34,7 +34,7 @@ Are implementations chosen based on runtime CPU feature detection? **Yes**.
 
 |       Implementation source       | Identifier in upstream   | Supported architecture(s)   | Supported operating system(s)   | CPU extension(s) used   | No branching-on-secrets claimed?   | No branching-on-secrets checked by valgrind?   | Large stack usage?   |
 |:---------------------------------:|:-------------------------|:----------------------------|:--------------------------------|:------------------------|:-----------------------------------|:-----------------------------------------------|:---------------------|
-| [Primary Source](#primary-source) | master                   | little endian               | All                             | None                    | True                               | True                                           | False                |
+| [Primary Source](#primary-source) | master                   | little endian               | Linux,Darwin                    | None                    | True                               | True                                           | False                |
 | [Primary Source](#primary-source) | master                   | x86\_64                     | Linux,Darwin                    | AVX2,AVX512,PCLMUL,SSE2 | True                               | True                                           | False                |
 
 Are implementations chosen based on runtime CPU feature detection? **Yes**.
@@ -43,7 +43,7 @@ Are implementations chosen based on runtime CPU feature detection? **Yes**.
 
 |       Implementation source       | Identifier in upstream   | Supported architecture(s)   | Supported operating system(s)   | CPU extension(s) used   | No branching-on-secrets claimed?   | No branching-on-secrets checked by valgrind?   | Large stack usage?   |
 |:---------------------------------:|:-------------------------|:----------------------------|:--------------------------------|:------------------------|:-----------------------------------|:-----------------------------------------------|:---------------------|
-| [Primary Source](#primary-source) | master                   | little endian               | All                             | None                    | True                               | True                                           | False                |
+| [Primary Source](#primary-source) | master                   | little endian               | Linux,Darwin                    | None                    | True                               | True                                           | False                |
 | [Primary Source](#primary-source) | master                   | x86\_64                     | Linux,Darwin                    | AVX2,AVX512,PCLMUL,SSE2 | True                               | True                                           | False                |
 
 Are implementations chosen based on runtime CPU feature detection? **Yes**.

--- a/docs/algorithms/kem/bike.yml
+++ b/docs/algorithms/kem/bike.yml
@@ -42,7 +42,8 @@ parameter-sets:
     supported-platforms:
     - architecture: little endian
       operating_systems:
-      - All
+      - Linux
+      - Darwin
     no-secret-dependent-branching-claimed: true
     no-secret-dependent-branching-checked-by-valgrind: true
     large-stack-usage: false
@@ -77,7 +78,8 @@ parameter-sets:
     supported-platforms:
     - architecture: little endian
       operating_systems:
-      - All
+      - Linux
+      - Darwin
     no-secret-dependent-branching-claimed: true
     no-secret-dependent-branching-checked-by-valgrind: true
     large-stack-usage: false
@@ -112,7 +114,8 @@ parameter-sets:
     supported-platforms:
     - architecture: little endian
       operating_systems:
-      - All
+      - Linux
+      - Darwin
     no-secret-dependent-branching-claimed: true
     no-secret-dependent-branching-checked-by-valgrind: true
     large-stack-usage: false


### PR DESCRIPTION
Fixes #1504 

BIKE is not working on Windows. OQS doesn't test BIKE on Windows. This fixes the incorrect documentation. @dkostic FYI/comment before merge.

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

