### PR TITLE
re-enable armhf speed testing

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -126,7 +126,7 @@ jobs:
           - name: armhf
             ARCH: armhf
             CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
-            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_speed.py
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py
           # no longer supporting armel
           # - name: armel
           #   ARCH: armel


### PR DESCRIPTION
Pursuing https://github.com/open-quantum-safe/liboqs/issues/1393#issuecomment-1693720285

~Not intended for merge.~

This PR's CI seems to show that #1393 is resolved. Now suggesting to merge this to keep "speed" testing for armhf activated to avoid regression.
