### PR TITLE
Prefer arc4random on Apple platforms

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,10 +60,6 @@ endif()
 if(${OQS_USE_OPENSSL})
     target_link_libraries(oqs PRIVATE ${OPENSSL_CRYPTO_LIBRARY})
 endif()
-if(IOS)
-    find_library(IOS_SECURITY Security)
-    target_link_libraries(oqs PUBLIC ${IOS_SECURITY})
-endif()
 
 target_include_directories(oqs
                            PUBLIC

--- a/src/common/rand/rand.c
+++ b/src/common/rand/rand.c
@@ -8,14 +8,7 @@
 #else
 #include <unistd.h>
 #include <strings.h>
-#if defined(__APPLE__)
-#include <TargetConditionals.h>
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
-#include <Security/SecRandom.h>
-#else
-#include <sys/random.h>
-#endif
-#else
+#if !defined(__APPLE__)
 #include <unistd.h>
 #endif
 #endif
@@ -65,6 +58,11 @@ OQS_API void OQS_randombytes(uint8_t *random_array, size_t bytes_to_read) {
 }
 
 #if !defined(_WIN32)
+#if defined(__APPLE__)
+void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
+	arc4random_buf(random_array, bytes_to_read);
+}
+#else
 #if defined(OQS_HAVE_GETENTROPY)
 void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
 	while (bytes_to_read > 256) {
@@ -75,17 +73,6 @@ void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
 		bytes_to_read -= 256;
 	}
 	if (getentropy(random_array, bytes_to_read)) {
-		exit(EXIT_FAILURE);
-	}
-}
-#else
-#if defined(__APPLE__) && (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
-void OQS_randombytes_system(uint8_t *random_array, size_t bytes_to_read) {
-	int status =
-	    SecRandomCopyBytes(kSecRandomDefault, bytes_to_read, random_array);
-
-	if (status == errSecSuccess) {
-		perror("OQS_randombytes");
 		exit(EXIT_FAILURE);
 	}
 }


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

On Apple platforms arc4random is always available and it never fails. This removes a possible failure mode of liboqs on Apple platforms with `getentropy()`.

The man page for `getentropy()` on MacOSX also discourages its use

```
However, it should be noted that getentropy() is primarily intended for use in the construction and seeding of userspace PRNGs like
     arc4random(3) or CC_crypto(3).  Clients who simply require random data should use arc4random(3), CCRandomGenerateBytes() from
     CC_crypto(3), or SecRandomCopyBytes() from the Security framework instead of getentropy() or random(4)
```

On iOS we currently use SecRandomCopyBytes() this requires linking to the Security framework and the call can fail. We have run into issues with this call failing so we propose using `arc4random_buf()` as it can never fail.


* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
