### PR TITLE
Bump GitPython 3.1.34 -> 3.1.35 as per Dependabot

### DIFF
--- a/scripts/copy_from_upstream/requirements.txt
+++ b/scripts/copy_from_upstream/requirements.txt
@@ -1,5 +1,5 @@
 attrs==20.3.0
-GitPython==3.1.34
+GitPython==3.1.35
 importlib-metadata==3.7.0
 Jinja2==2.11.3
 markdown-it-py==2.2.0


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

See the security alert here: https://github.com/open-quantum-safe/liboqs/security/dependabot/7

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
