### PR TITLE
build: Align VS test folder with all other Generators

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,18 @@ endif()
 get_property(OQS_COMPILE_OPTIONS TARGET speed_kem PROPERTY COMPILE_OPTIONS)
 add_definitions(-DOQS_COMPILE_OPTIONS="[${OQS_COMPILE_OPTIONS}]")
 
+if (CMAKE_GENERATOR MATCHES "Visual Studio")
+    # With Visual studio the output of tests go into a folder with the configuration option. Force it to the same folder as if
+    # generating with Ninja
+    set_target_properties(
+        dump_alg_info example_kem kat_kem test_kem example_sig kat_sig test_sig test_sig_mem test_kem_mem speed_kem speed_sig
+        PROPERTIES 
+        RUNTIME_OUTPUT_DIRECTORY_DEBUG          "${CMAKE_BINARY_DIR}/tests"
+        RUNTIME_OUTPUT_DIRECTORY_RELEASE        "${CMAKE_BINARY_DIR}/tests"
+        RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}/tests"
+        RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL     "${CMAKE_BINARY_DIR}/tests")
+endif()
+
 # TODO: Get CMake to find python.
 # and set PATH variable in Windows
 # for DLL builds.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -141,9 +141,6 @@ def path_to_executable(program_name):
         if 'APPVEYOR_BUILD_FOLDER' not in os.environ: os.environ['APPVEYOR_BUILD_FOLDER'] = "."
         path = os.path.join(path, os.environ['APPVEYOR_BUILD_FOLDER'])
     path = os.path.join(path, get_current_build_dir_name(), "tests")
-    if sys.platform.startswith("win"):
-        if 'GITHUB_ACTIONS' in os.environ:
-            path = os.path.join(path, "Debug")
     for executable in [
         os.path.join(path, program_name),
         os.path.join(path, program_name + ".EXE"),


### PR DESCRIPTION
This aligns the output folder for tests much like other platforms.

Fixes #1555

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
