### PR TITLE
Na statful sig lock

### DIFF
--- a/src/sig_stfl/lms/sig_stfl_lms.c
+++ b/src/sig_stfl/lms/sig_stfl_lms.c
@@ -114,7 +114,17 @@ void OQS_SECRET_KEY_LMS_free(OQS_SIG_STFL_SECRET_KEY *sk) {
 
 /* Convert LMS secret key object to byte string */
 static OQS_STATUS OQS_SECRET_KEY_LMS_serialize_key(const OQS_SIG_STFL_SECRET_KEY *sk, size_t *sk_len, uint8_t **sk_buf_ptr) {
-	return oqs_serialize_lms_key(sk, sk_len, sk_buf_ptr);
+    OQS_STATUS status;
+    if (sk->lock_key && sk->mutex) {
+        sk->lock_key(sk->mutex);
+    }
+
+    status = oqs_serialize_lms_key(sk, sk_len, sk_buf_ptr);
+
+    if (sk->unlock_key && sk->mutex) {
+        sk->unlock_key(sk->mutex);
+    }
+    return status;
 }
 
 /* Insert lms byte string in an LMS secret key object */

--- a/src/sig_stfl/lms/sig_stfl_lms.c
+++ b/src/sig_stfl/lms/sig_stfl_lms.c
@@ -114,17 +114,17 @@ void OQS_SECRET_KEY_LMS_free(OQS_SIG_STFL_SECRET_KEY *sk) {
 
 /* Convert LMS secret key object to byte string */
 static OQS_STATUS OQS_SECRET_KEY_LMS_serialize_key(const OQS_SIG_STFL_SECRET_KEY *sk, size_t *sk_len, uint8_t **sk_buf_ptr) {
-    OQS_STATUS status;
-    if (sk->lock_key && sk->mutex) {
-        sk->lock_key(sk->mutex);
-    }
+	OQS_STATUS status;
+	if (sk->lock_key && sk->mutex) {
+		sk->lock_key(sk->mutex);
+	}
 
-    status = oqs_serialize_lms_key(sk, sk_len, sk_buf_ptr);
+	status = oqs_serialize_lms_key(sk, sk_len, sk_buf_ptr);
 
-    if (sk->unlock_key && sk->mutex) {
-        sk->unlock_key(sk->mutex);
-    }
-    return status;
+	if (sk->unlock_key && sk->mutex) {
+		sk->unlock_key(sk->mutex);
+	}
+	return status;
 }
 
 /* Insert lms byte string in an LMS secret key object */

--- a/src/sig_stfl/lms/sig_stfl_lms_functions.c
+++ b/src/sig_stfl/lms/sig_stfl_lms_functions.c
@@ -47,7 +47,7 @@ typedef struct OQS_LMS_KEY_DATA {
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_lms_sign(uint8_t *signature, size_t *signature_length, const uint8_t *message,
         size_t message_len, OQS_SIG_STFL_SECRET_KEY *secret_key) {
-    OQS_STATUS status = OQS_ERROR;
+	OQS_STATUS status = OQS_ERROR;
 	OQS_STATUS rc_keyupdate = OQS_ERROR;
 	oqs_lms_key_data *lms_key_data = NULL;
 	const OQS_SIG_STFL_SECRET_KEY *sk;
@@ -61,7 +61,7 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_lms_sign(uint8_t *signature, size_t *signatu
 
 	/* Lock secret to ensure OTS use */
 	if ((secret_key->lock_key) && (secret_key->mutex)) {
-	    secret_key->lock_key(secret_key->mutex);
+		secret_key->lock_key(secret_key->mutex);
 	}
 
 	/*
@@ -109,12 +109,12 @@ err:
 	*signature_length = 0;
 
 passed:
-    OQS_MEM_secure_free(sk_key_buf, sk_key_buf_len);
+	OQS_MEM_secure_free(sk_key_buf, sk_key_buf_len);
 
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
 	return status;
 }
 
@@ -140,17 +140,17 @@ OQS_API OQS_STATUS OQS_SIG_STFL_lms_sigs_left(unsigned long long *remain, const 
 	if (remain == NULL  || secret_key == NULL) {
 		return OQS_ERROR;
 	}
-    /* Lock secret key to ensure data integrity use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret key to ensure data integrity use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
 	remain = 0;
 
-    /* Unlock secret key */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
+	/* Unlock secret key */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
 	return OQS_SUCCESS;
 }
 

--- a/src/sig_stfl/sig_stfl.c
+++ b/src/sig_stfl/sig_stfl.c
@@ -716,3 +716,52 @@ OQS_API OQS_STATUS OQS_SECRET_KEY_STFL_deserialize_key(OQS_SIG_STFL_SECRET_KEY *
 
 	return sk->deserialize_key(sk, key_len, sk_buf, context);
 }
+
+
+
+/*  OQS_SIG_STFL_SECRET_KEY_SET_lock callback function*/
+OQS_API void OQS_SIG_STFL_SECRET_KEY_SET_lock(OQS_SIG_STFL_SECRET_KEY *sk, lock_key lock) {
+    if (sk == NULL) {
+        return;
+    }
+    sk->lock_key = lock;
+}
+
+/*  OQS_SIG_STFL_SECRET_KEY_SET_unlock callback function */
+OQS_API void OQS_SIG_STFL_SECRET_KEY_SET_unlock(OQS_SIG_STFL_SECRET_KEY *sk, unlock_key unlock) {
+    if (sk == NULL) {
+        return;
+    }
+    sk->unlock_key = unlock;
+}
+
+/*  OQS_SIG_STFL_SECRET_KEY_SET_mutex */
+OQS_API void OQS_SIG_STFL_SECRET_KEY_SET_mutex(OQS_SIG_STFL_SECRET_KEY *sk, void *mutex) {
+    if (sk == NULL) {
+        return;
+    }
+    sk->mutex = mutex;
+}
+
+/* OQS_SIG_STFL_SECRET_KEY_lock  */
+OQS_API OQS_STATUS OQS_SIG_STFL_SECRET_KEY_lock(OQS_SIG_STFL_SECRET_KEY *sk) {
+    if (sk == NULL) {
+        return OQS_ERROR;
+    }
+    if (sk->lock_key == NULL) {
+        return OQS_SUCCESS;
+    }
+
+    return (sk->lock_key(sk->mutex));
+}
+
+/* OQS_SIG_STFL_SECRET_KEY_unlock */
+OQS_API OQS_STATUS OQS_SIG_STFL_SECRET_KEY_unlock(OQS_SIG_STFL_SECRET_KEY *sk) {
+    if (sk == NULL) {
+        return OQS_ERROR;
+    }
+    if(sk->unlock_key == NULL) {
+        return OQS_SUCCESS;
+    }
+    return (sk->unlock_key(sk->mutex));
+}

--- a/src/sig_stfl/sig_stfl.c
+++ b/src/sig_stfl/sig_stfl.c
@@ -721,47 +721,47 @@ OQS_API OQS_STATUS OQS_SECRET_KEY_STFL_deserialize_key(OQS_SIG_STFL_SECRET_KEY *
 
 /*  OQS_SIG_STFL_SECRET_KEY_SET_lock callback function*/
 OQS_API void OQS_SIG_STFL_SECRET_KEY_SET_lock(OQS_SIG_STFL_SECRET_KEY *sk, lock_key lock) {
-    if (sk == NULL) {
-        return;
-    }
-    sk->lock_key = lock;
+	if (sk == NULL) {
+		return;
+	}
+	sk->lock_key = lock;
 }
 
 /*  OQS_SIG_STFL_SECRET_KEY_SET_unlock callback function */
 OQS_API void OQS_SIG_STFL_SECRET_KEY_SET_unlock(OQS_SIG_STFL_SECRET_KEY *sk, unlock_key unlock) {
-    if (sk == NULL) {
-        return;
-    }
-    sk->unlock_key = unlock;
+	if (sk == NULL) {
+		return;
+	}
+	sk->unlock_key = unlock;
 }
 
 /*  OQS_SIG_STFL_SECRET_KEY_SET_mutex */
 OQS_API void OQS_SIG_STFL_SECRET_KEY_SET_mutex(OQS_SIG_STFL_SECRET_KEY *sk, void *mutex) {
-    if (sk == NULL) {
-        return;
-    }
-    sk->mutex = mutex;
+	if (sk == NULL) {
+		return;
+	}
+	sk->mutex = mutex;
 }
 
 /* OQS_SIG_STFL_SECRET_KEY_lock  */
 OQS_API OQS_STATUS OQS_SIG_STFL_SECRET_KEY_lock(OQS_SIG_STFL_SECRET_KEY *sk) {
-    if (sk == NULL) {
-        return OQS_ERROR;
-    }
-    if (sk->lock_key == NULL) {
-        return OQS_SUCCESS;
-    }
+	if (sk == NULL) {
+		return OQS_ERROR;
+	}
+	if (sk->lock_key == NULL) {
+		return OQS_SUCCESS;
+	}
 
-    return (sk->lock_key(sk->mutex));
+	return (sk->lock_key(sk->mutex));
 }
 
 /* OQS_SIG_STFL_SECRET_KEY_unlock */
 OQS_API OQS_STATUS OQS_SIG_STFL_SECRET_KEY_unlock(OQS_SIG_STFL_SECRET_KEY *sk) {
-    if (sk == NULL) {
-        return OQS_ERROR;
-    }
-    if(sk->unlock_key == NULL) {
-        return OQS_SUCCESS;
-    }
-    return (sk->unlock_key(sk->mutex));
+	if (sk == NULL) {
+		return OQS_ERROR;
+	}
+	if (sk->unlock_key == NULL) {
+		return OQS_SUCCESS;
+	}
+	return (sk->unlock_key(sk->mutex));
 }

--- a/src/sig_stfl/sig_stfl.h
+++ b/src/sig_stfl/sig_stfl.h
@@ -16,6 +16,29 @@
 
 #include <oqs/oqs.h>
 
+/*
+ * Developer's Notes:
+ * Stateful signatures are based on one-time use of a secret key. A pool of secret keys are created for this purpose.
+ * The state of these keys are tracked to ensure that they are used only once to generate a signature.
+ *
+ * As such, product specific environments do play a role in ensuring the safety of the keys.
+ * Secret keys must be store securely.
+ * The key index/counter must be updated after each signature generation.
+ * Secret key must be protected in a thread-save manner.
+ *
+ * Application therefore are required to provide environment specific callback functions to
+ *  - store private key
+ *  - lock/unlock private key
+ *
+ *  See below for details
+ *  OQS_SIG_STFL_SECRET_KEY_SET_lock
+ *  OQS_SIG_STFL_SECRET_KEY_SET_unlock
+ *  OQS_SIG_STFL_SECRET_KEY_SET_mutex
+ *  OQS_SIG_STFL_SECRET_KEY_SET_store_cb
+ *
+ */
+
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -279,7 +302,7 @@ typedef struct OQS_SIG_STFL_SECRET_KEY {
 	 * @return OQS_SUCCESS or OQS_ERROR
 	 * Idealy written to secure device
 	 */
-	OQS_STATUS (*secure_store_scrt_key)(/*const*/ uint8_t *sk_buf, size_t buf_len, void *context);
+	OQS_STATUS (*secure_store_scrt_key)(uint8_t *sk_buf, size_t buf_len, void *context);
 
 	/**
 	 * Secret Key free internal variant specific data

--- a/tests/test_sig_stfl.c
+++ b/tests/test_sig_stfl.c
@@ -341,6 +341,10 @@ static OQS_STATUS sig_stfl_test_correctness(const char *method_name, const char 
 	size_t sk_buf_len = 0;
 	size_t read_pk_len = 0;
 
+#if OQS_USE_PTHREADS_IN_TESTS
+	pthread_mutex_t *sk_lock = NULL;
+#endif
+
 	OQS_STATUS rc, ret = OQS_ERROR;
 
 	//The magic numbers are random values.
@@ -365,7 +369,6 @@ static OQS_STATUS sig_stfl_test_correctness(const char *method_name, const char 
 	OQS_SIG_STFL_SECRET_KEY_SET_unlock(secret_key, unlock_sk_key);
 
 #if OQS_USE_PTHREADS_IN_TESTS
-	pthread_mutex_t *sk_lock = NULL;
 	sk_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
 	if (sk_lock == NULL) {
 		goto err;
@@ -742,10 +745,29 @@ end_it:
 static OQS_STATUS sig_stfl_test_query_key(const char *method_name) {
 	OQS_STATUS rc = OQS_SUCCESS;
 
-	uint8_t message_1[] = "The quick brown fox ...";
-	uint8_t message_2[] = "The quick brown fox jumped from the tree.";
 	size_t message_len_1 = sizeof(message_1);
 	size_t message_len_2 = sizeof(message_2);
+
+	/*
+	 * Temporarily skip algs with long key generation times.
+	 */
+
+	if (strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w1) != 0) {
+		goto skip_test;
+	} else {
+		goto keep_going;
+	}
+
+skip_test:
+	printf("Skip slow alg %s.\n", method_name);
+	return rc;
+
+keep_going:
+
+//	uint8_t message_1[] = "The quick brown fox ...";
+//	uint8_t message_2[] = "The quick brown fox jumped from the tree.";
+//	size_t message_len_1 = sizeof(message_1);
+//	size_t message_len_2 = sizeof(message_2);
 
 	printf("================================================================================\n");
 	printf("Testing stateful Signature Verification %s\n", method_name);
@@ -795,6 +817,21 @@ static OQS_STATUS sig_stfl_test_sig_gen(const char *method_name) {
 	size_t message_len_1 = sizeof(message_1);
 	size_t message_len_2 = sizeof(message_2);
 
+	/*
+	 * Temporarily skip algs with long key generation times.
+	 */
+
+	if (strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w1) != 0) {
+		goto skip_test;
+	} else {
+		goto keep_going;
+	}
+
+skip_test:
+	printf("Skip slow alg %s.\n", method_name);
+	return rc;
+
+keep_going:
 
 	printf("================================================================================\n");
 	printf("Testing stateful Signature Generation %s\n", method_name);

--- a/tests/test_sig_stfl.c
+++ b/tests/test_sig_stfl.c
@@ -764,11 +764,6 @@ skip_test:
 
 keep_going:
 
-//	uint8_t message_1[] = "The quick brown fox ...";
-//	uint8_t message_2[] = "The quick brown fox jumped from the tree.";
-//	size_t message_len_1 = sizeof(message_1);
-//	size_t message_len_2 = sizeof(message_2);
-
 	printf("================================================================================\n");
 	printf("Testing stateful Signature Verification %s\n", method_name);
 	printf("================================================================================\n");

--- a/tests/test_sig_stfl.c
+++ b/tests/test_sig_stfl.c
@@ -69,33 +69,33 @@ static OQS_STATUS test_save_secret_key(uint8_t *key_buf, size_t buf_len, void *c
 
 #if OQS_USE_PTHREADS_IN_TESTS
 static OQS_STATUS lock_sk_key(void *mutex) {
-    if (mutex == NULL) {
-        return OQS_ERROR;
-    }
+	if (mutex == NULL) {
+		return OQS_ERROR;
+	}
 
-    if (!(pthread_mutex_lock((pthread_mutex_t*)mutex))) {
-        return OQS_SUCCESS;
-    }
-    return  OQS_ERROR;
+	if (!(pthread_mutex_lock((pthread_mutex_t *)mutex))) {
+		return OQS_SUCCESS;
+	}
+	return  OQS_ERROR;
 }
 
 static OQS_STATUS unlock_sk_key(void *mutex) {
-    if (mutex == NULL) {
-        return OQS_ERROR;
-    }
+	if (mutex == NULL) {
+		return OQS_ERROR;
+	}
 
-    if (!(pthread_mutex_unlock((pthread_mutex_t*)mutex))) {
-        return OQS_SUCCESS;
-    }
-    return  OQS_ERROR;
+	if (!(pthread_mutex_unlock((pthread_mutex_t *)mutex))) {
+		return OQS_SUCCESS;
+	}
+	return  OQS_ERROR;
 }
 #else
 static OQS_STATUS lock_sk_key(void *mutex) {
-    return sk != NULL ? OQS_SUCCESS : OQS_ERROR;
+	return sk != NULL ? OQS_SUCCESS : OQS_ERROR;
 }
 
 static OQS_STATUS unlock_sk_key(void *mutex) {
-    return sk != NULL ? OQS_SUCCESS : OQS_ERROR;
+	return sk != NULL ? OQS_SUCCESS : OQS_ERROR;
 }
 #endif
 
@@ -366,15 +366,15 @@ static OQS_STATUS sig_stfl_test_correctness(const char *method_name, const char 
 
 #if OQS_USE_PTHREADS_IN_TESTS
 	pthread_mutex_t *sk_lock;
-	sk_lock=(pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
+	sk_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
 	if (sk_lock == NULL) {
-	    goto err;
+		goto err;
 	}
 
-    if (0 != pthread_mutex_init(sk_lock, 0)) {
-        goto err;
-    }
-    OQS_SIG_STFL_SECRET_KEY_SET_mutex(secret_key, sk_lock);
+	if (0 != pthread_mutex_init(sk_lock, 0)) {
+		goto err;
+	}
+	OQS_SIG_STFL_SECRET_KEY_SET_mutex(secret_key, sk_lock);
 #endif
 	public_key = malloc(sig->length_public_key + 2 * sizeof(magic_t));
 	message = malloc(message_len + 2 * sizeof(magic_t));
@@ -544,10 +544,10 @@ cleanup:
 	OQS_MEM_insecure_free(context);
 
 #if OQS_USE_PTHREADS_IN_TESTS
-    if(sk_lock) {
-        pthread_mutex_destroy(sk_lock);
-        OQS_MEM_insecure_free(sk_lock);
-    }
+	if (sk_lock) {
+		pthread_mutex_destroy(sk_lock);
+		OQS_MEM_insecure_free(sk_lock);
+	}
 #endif
 	return ret;
 }
@@ -740,203 +740,203 @@ end_it:
 }
 
 static OQS_STATUS sig_stfl_test_query_key(const char *method_name) {
-    OQS_STATUS rc = OQS_SUCCESS;
+	OQS_STATUS rc = OQS_SUCCESS;
 
-    uint8_t message_1[] = "The quick brown fox ...";
-    uint8_t message_2[] = "The quick brown fox jumped from the tree.";
-    size_t message_len_1 = sizeof(message_1);
-    size_t message_len_2 = sizeof(message_2);
+	uint8_t message_1[] = "The quick brown fox ...";
+	uint8_t message_2[] = "The quick brown fox jumped from the tree.";
+	size_t message_len_1 = sizeof(message_1);
+	size_t message_len_2 = sizeof(message_2);
 
-    printf("================================================================================\n");
-    printf("Testing stateful Signature Verification %s\n", method_name);
-    printf("================================================================================\n");
+	printf("================================================================================\n");
+	printf("Testing stateful Signature Verification %s\n", method_name);
+	printf("================================================================================\n");
 
-    if( lock_test_sk == NULL || lock_test_sig_obj == NULL || signature_1 == NULL
-                             || signature_2 == NULL || lock_test_public_key == NULL) {
-        return OQS_ERROR;
-    }
+	if ( lock_test_sk == NULL || lock_test_sig_obj == NULL || signature_1 == NULL
+	        || signature_2 == NULL || lock_test_public_key == NULL) {
+		return OQS_ERROR;
+	}
 
 
-    printf("================================================================================\n");
-    printf("Sig Verify 1  %s\n", method_name);
-    printf("================================================================================\n");
+	printf("================================================================================\n");
+	printf("Sig Verify 1  %s\n", method_name);
+	printf("================================================================================\n");
 
-    rc = OQS_SIG_STFL_verify(lock_test_sig_obj, message_1, message_len_1, signature_1, signature_len_1, lock_test_public_key);
-    OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
-    if (rc != OQS_SUCCESS) {
-        fprintf(stderr, "ERROR: lock thread test OQS_SIG_STFL_verify failed\n");
-        goto err;
-    }
+	rc = OQS_SIG_STFL_verify(lock_test_sig_obj, message_1, message_len_1, signature_1, signature_len_1, lock_test_public_key);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	if (rc != OQS_SUCCESS) {
+		fprintf(stderr, "ERROR: lock thread test OQS_SIG_STFL_verify failed\n");
+		goto err;
+	}
 
-    printf("================================================================================\n");
-    printf("Sig Verify 2 %s\n", method_name);
-    printf("================================================================================\n");
+	printf("================================================================================\n");
+	printf("Sig Verify 2 %s\n", method_name);
+	printf("================================================================================\n");
 
-    rc = OQS_SIG_STFL_verify(lock_test_sig_obj, message_2, message_len_2, signature_2, signature_len_2, lock_test_public_key);
-    OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
-    if (rc != OQS_SUCCESS) {
-        fprintf(stderr, "ERROR: lock thread test OQS_SIG_STFL_verify failed\n");
-        goto err;
-    }
-    rc = OQS_SUCCESS;
-    printf("================================================================================\n");
-    printf("Stateful Signature Verification %s Passed.\n", method_name);
-    printf("================================================================================\n");
-    goto end_it;
+	rc = OQS_SIG_STFL_verify(lock_test_sig_obj, message_2, message_len_2, signature_2, signature_len_2, lock_test_public_key);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	if (rc != OQS_SUCCESS) {
+		fprintf(stderr, "ERROR: lock thread test OQS_SIG_STFL_verify failed\n");
+		goto err;
+	}
+	rc = OQS_SUCCESS;
+	printf("================================================================================\n");
+	printf("Stateful Signature Verification %s Passed.\n", method_name);
+	printf("================================================================================\n");
+	goto end_it;
 err:
-    rc = OQS_ERROR;
+	rc = OQS_ERROR;
 end_it:
 
-    return rc;
+	return rc;
 }
 
 static OQS_STATUS sig_stfl_test_sig_gen(const char *method_name) {
-    OQS_STATUS rc = OQS_SUCCESS;
-    size_t message_len_1 = sizeof(message_1);
-    size_t message_len_2 = sizeof(message_2);
+	OQS_STATUS rc = OQS_SUCCESS;
+	size_t message_len_1 = sizeof(message_1);
+	size_t message_len_2 = sizeof(message_2);
 
 
-    printf("================================================================================\n");
-    printf("Testing stateful Signature Generation %s\n", method_name);
-    printf("================================================================================\n");
+	printf("================================================================================\n");
+	printf("Testing stateful Signature Generation %s\n", method_name);
+	printf("================================================================================\n");
 
-    if( lock_test_sk == NULL || lock_test_sig_obj == NULL) {
-        return OQS_ERROR;
-    }
+	if ( lock_test_sk == NULL || lock_test_sig_obj == NULL) {
+		return OQS_ERROR;
+	}
 
 
-    printf("================================================================================\n");
-    printf("Sig Gen 1  %s\n", method_name);
-    printf("================================================================================\n");
+	printf("================================================================================\n");
+	printf("Sig Gen 1  %s\n", method_name);
+	printf("================================================================================\n");
 
-    signature_1 = malloc(lock_test_sig_obj->length_signature);
+	signature_1 = malloc(lock_test_sig_obj->length_signature);
 
-    rc = OQS_SIG_STFL_sign(lock_test_sig_obj, signature_1, &signature_len_1, message_1, message_len_1, lock_test_sk);
-    OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
-    if (rc != OQS_SUCCESS) {
-        fprintf(stderr, "ERROR: lock thread test OQS_SIG_STFL_sign failed\n");
-        goto err;
-    }
+	rc = OQS_SIG_STFL_sign(lock_test_sig_obj, signature_1, &signature_len_1, message_1, message_len_1, lock_test_sk);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	if (rc != OQS_SUCCESS) {
+		fprintf(stderr, "ERROR: lock thread test OQS_SIG_STFL_sign failed\n");
+		goto err;
+	}
 
 //    sleep(3);
 
-    printf("================================================================================\n");
-    printf("Sig Gen 2 %s\n", method_name);
-    printf("================================================================================\n");
+	printf("================================================================================\n");
+	printf("Sig Gen 2 %s\n", method_name);
+	printf("================================================================================\n");
 
-    signature_2 = malloc(lock_test_sig_obj->length_signature);
+	signature_2 = malloc(lock_test_sig_obj->length_signature);
 
-    rc = OQS_SIG_STFL_sign(lock_test_sig_obj, signature_2, &signature_len_2, message_2, message_len_2, lock_test_sk);
-    OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
-    if (rc != OQS_SUCCESS) {
-        fprintf(stderr, "ERROR: lock thread test OQS_SIG_STFL_sign failed\n");
-        goto err;
-    }
-    rc = OQS_SUCCESS;
-    printf("================================================================================\n");
-    printf("Stateful Key Gen %s Passed.\n", method_name);
-    printf("================================================================================\n");
-    goto end_it;
+	rc = OQS_SIG_STFL_sign(lock_test_sig_obj, signature_2, &signature_len_2, message_2, message_len_2, lock_test_sk);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	if (rc != OQS_SUCCESS) {
+		fprintf(stderr, "ERROR: lock thread test OQS_SIG_STFL_sign failed\n");
+		goto err;
+	}
+	rc = OQS_SUCCESS;
+	printf("================================================================================\n");
+	printf("Stateful Key Gen %s Passed.\n", method_name);
+	printf("================================================================================\n");
+	goto end_it;
 err:
-    rc = OQS_ERROR;
+	rc = OQS_ERROR;
 end_it:
 
-    return rc;
+	return rc;
 }
 
 
 static OQS_STATUS sig_stfl_test_secret_key_lock(const char *method_name) {
-    OQS_STATUS rc = OQS_SUCCESS;
+	OQS_STATUS rc = OQS_SUCCESS;
 
-    /*
-     * Temporarily skip algs with long key generation times.
-     */
+	/*
+	 * Temporarily skip algs with long key generation times.
+	 */
 
-    if (strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w1) != 0) {
-        goto skip_test;
-    } else {
-        goto keep_going;
-    }
+	if (strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w1) != 0) {
+		goto skip_test;
+	} else {
+		goto keep_going;
+	}
 
 skip_test:
-    printf("Skip slow test %s.\n", method_name);
-    return rc;
+	printf("Skip slow test %s.\n", method_name);
+	return rc;
 
 keep_going:
 
-    printf("================================================================================\n");
-    printf("Testing stateful Signature locks %s\n", method_name);
-    printf("================================================================================\n");
+	printf("================================================================================\n");
+	printf("Testing stateful Signature locks %s\n", method_name);
+	printf("================================================================================\n");
 
-    printf("================================================================================\n");
-    printf("Create stateful Signature  %s\n", method_name);
-    printf("================================================================================\n");
+	printf("================================================================================\n");
+	printf("Create stateful Signature  %s\n", method_name);
+	printf("================================================================================\n");
 
-    lock_test_sig_obj = OQS_SIG_STFL_new(method_name);
-    if (lock_test_sig_obj == NULL) {
-        fprintf(stderr, "ERROR: OQS_SIG_STFL_new failed\n");
-        goto err;
-    }
+	lock_test_sig_obj = OQS_SIG_STFL_new(method_name);
+	if (lock_test_sig_obj == NULL) {
+		fprintf(stderr, "ERROR: OQS_SIG_STFL_new failed\n");
+		goto err;
+	}
 
-    lock_test_public_key = malloc(lock_test_sig_obj->length_public_key * sizeof(uint8_t));
+	lock_test_public_key = malloc(lock_test_sig_obj->length_public_key * sizeof(uint8_t));
 
-    printf("================================================================================\n");
-    printf("Create stateful Secret Key  %s\n", method_name);
-    printf("================================================================================\n");
+	printf("================================================================================\n");
+	printf("Create stateful Secret Key  %s\n", method_name);
+	printf("================================================================================\n");
 
-    lock_test_sk = OQS_SIG_STFL_SECRET_KEY_new(method_name);
-    if (lock_test_sk == NULL) {
-        fprintf(stderr, "ERROR: OQS_SECRET_KEY_new failed\n");
-        goto err;
-    }
+	lock_test_sk = OQS_SIG_STFL_SECRET_KEY_new(method_name);
+	if (lock_test_sk == NULL) {
+		fprintf(stderr, "ERROR: OQS_SECRET_KEY_new failed\n");
+		goto err;
+	}
 
-    OQS_SIG_STFL_SECRET_KEY_SET_lock(lock_test_sk, lock_sk_key);
-    OQS_SIG_STFL_SECRET_KEY_SET_unlock(lock_test_sk, unlock_sk_key);
+	OQS_SIG_STFL_SECRET_KEY_SET_lock(lock_test_sk, lock_sk_key);
+	OQS_SIG_STFL_SECRET_KEY_SET_unlock(lock_test_sk, unlock_sk_key);
 
 #if OQS_USE_PTHREADS_IN_TESTS
 
-    test_sk_lock=(pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
-    if (test_sk_lock == NULL) {
-        goto err;
-    }
+	test_sk_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
+	if (test_sk_lock == NULL) {
+		goto err;
+	}
 
-    if (0 != pthread_mutex_init(test_sk_lock, 0)) {
-        goto err;
-    }
-    OQS_SIG_STFL_SECRET_KEY_SET_mutex(lock_test_sk, test_sk_lock);
+	if (0 != pthread_mutex_init(test_sk_lock, 0)) {
+		goto err;
+	}
+	OQS_SIG_STFL_SECRET_KEY_SET_mutex(lock_test_sk, test_sk_lock);
 #endif
 
-    printf("================================================================================\n");
-    printf("Generate keypair  %s\n", method_name);
-    printf("================================================================================\n");
+	printf("================================================================================\n");
+	printf("Generate keypair  %s\n", method_name);
+	printf("================================================================================\n");
 
-    rc = OQS_SIG_STFL_keypair(lock_test_sig_obj, lock_test_public_key, lock_test_sk);
+	rc = OQS_SIG_STFL_keypair(lock_test_sig_obj, lock_test_public_key, lock_test_sk);
 
-    if (rc != OQS_SUCCESS) {
-        fprintf(stderr, "OQS STFL key gen failed.\n");
-        goto err;
-    }
+	if (rc != OQS_SUCCESS) {
+		fprintf(stderr, "OQS STFL key gen failed.\n");
+		goto err;
+	}
 
 
 
-    if (!lock_test_sk->secret_key_data) {
-        fprintf(stderr, "ERROR: OQS_SECRET_KEY_new incomplete.\n");
-        goto err;
-    }
+	if (!lock_test_sk->secret_key_data) {
+		fprintf(stderr, "ERROR: OQS_SECRET_KEY_new incomplete.\n");
+		goto err;
+	}
 
-    /* set context and secure store callback */
-    if (lock_test_sk->set_scrt_key_store_cb) {
-        lock_test_context = strdup(((method_name)));
-        lock_test_sk->set_scrt_key_store_cb(lock_test_sk, test_save_secret_key, (void *)lock_test_context);
-    }
+	/* set context and secure store callback */
+	if (lock_test_sk->set_scrt_key_store_cb) {
+		lock_test_context = strdup(((method_name)));
+		lock_test_sk->set_scrt_key_store_cb(lock_test_sk, test_save_secret_key, (void *)lock_test_context);
+	}
 
-    printf("Test Secret Key Creator Thread created Stateful Signature and Secret Key objects.\n");
-    goto end_it;
+	printf("Test Secret Key Creator Thread created Stateful Signature and Secret Key objects.\n");
+	goto end_it;
 
 err:
-    rc = OQS_ERROR;
+	rc = OQS_ERROR;
 end_it:
-    return rc;
+	return rc;
 }
 
 #ifdef OQS_ENABLE_TEST_CONSTANT_TIME
@@ -964,29 +964,29 @@ struct thread_data {
 };
 
 struct lock_test_data {
-    const char *alg_name;
-    OQS_STATUS rc;
+	const char *alg_name;
+	OQS_STATUS rc;
 };
 
 struct lock_sign_data {
-    const char *alg_name;
-    OQS_STATUS rc;
+	const char *alg_name;
+	OQS_STATUS rc;
 };
 
 void *test_query_key(void *arg) {
-    struct lock_test_data *td = arg;
-    printf("%s: Start Query Stateful Key info\n", __FUNCTION__);
-    td->rc = sig_stfl_test_query_key(td->alg_name);
-    printf("%s: End Query Stateful Key info\n", __FUNCTION__);
-    return NULL;
+	struct lock_test_data *td = arg;
+	printf("%s: Start Query Stateful Key info\n", __FUNCTION__);
+	td->rc = sig_stfl_test_query_key(td->alg_name);
+	printf("%s: End Query Stateful Key info\n", __FUNCTION__);
+	return NULL;
 }
 
 void *test_sig_gen(void *arg) {
-    struct lock_test_data *td = arg;
-    printf("%s: Start Generate Stateful Signature\n", __FUNCTION__);
-    td->rc = sig_stfl_test_sig_gen(td->alg_name);
-    printf("%s: End Generate Stateful Signature\n", __FUNCTION__);
-    return NULL;
+	struct lock_test_data *td = arg;
+	printf("%s: Start Generate Stateful Signature\n", __FUNCTION__);
+	td->rc = sig_stfl_test_sig_gen(td->alg_name);
+	printf("%s: End Generate Stateful Signature\n", __FUNCTION__);
+	return NULL;
 }
 
 void *test_locks(void *arg) {
@@ -998,10 +998,10 @@ void *test_locks(void *arg) {
 }
 
 void *test_wrapper(void *arg) {
-    struct thread_data *td = arg;
-    td->rc = sig_stfl_test_correctness(td->alg_name, td->katfile);
-    td->rc1 = sig_stfl_test_secret_key(td->alg_name);
-    return NULL;
+	struct thread_data *td = arg;
+	td->rc = sig_stfl_test_correctness(td->alg_name, td->katfile);
+	td->rc1 = sig_stfl_test_secret_key(td->alg_name);
+	return NULL;
 }
 #endif
 
@@ -1046,14 +1046,14 @@ int main(int argc, char **argv) {
 #define MAX_LEN_SIG_NAME_ 64
 
 	pthread_t thread;
-    pthread_t tst_lck_thread;
+	pthread_t tst_lck_thread;
 	pthread_mutex_t *lock;
 	struct thread_data td;
 	td.alg_name = alg_name;
 	td.katfile = katfile;
 
-    struct lock_test_data td_lock;
-    td_lock.alg_name = alg_name;
+	struct lock_test_data td_lock;
+	td_lock.alg_name = alg_name;
 
 
 	int trc = pthread_create(&thread, NULL, test_wrapper, &td);
@@ -1066,43 +1066,43 @@ int main(int argc, char **argv) {
 	rc = td.rc;
 	rc1 = td.rc1;
 
-    int trc_2 = pthread_create(&thread, NULL, test_locks, &td_lock);
-    if (trc_2) {
-        fprintf(stderr, "ERROR: Creating pthread for stateful key gen test\n");
-        OQS_destroy();
-        return EXIT_FAILURE;
-    }
-    pthread_join(thread, NULL);
-    rc_lck = td_lock.rc;
+	int trc_2 = pthread_create(&thread, NULL, test_locks, &td_lock);
+	if (trc_2) {
+		fprintf(stderr, "ERROR: Creating pthread for stateful key gen test\n");
+		OQS_destroy();
+		return EXIT_FAILURE;
+	}
+	pthread_join(thread, NULL);
+	rc_lck = td_lock.rc;
 
-    int trc_3 = pthread_create(&thread, NULL, test_sig_gen, &td_lock);
-    if (trc_3) {
-        fprintf(stderr, "ERROR: Creating pthread for sig gen test\n");
-        OQS_destroy();
-        return EXIT_FAILURE;
-    }
-    pthread_join(thread, NULL);
-    rc_sig = td_lock.rc;
+	int trc_3 = pthread_create(&thread, NULL, test_sig_gen, &td_lock);
+	if (trc_3) {
+		fprintf(stderr, "ERROR: Creating pthread for sig gen test\n");
+		OQS_destroy();
+		return EXIT_FAILURE;
+	}
+	pthread_join(thread, NULL);
+	rc_sig = td_lock.rc;
 
-    int trc_4 = pthread_create(&thread, NULL, test_query_key, &td_lock);
-    if (trc_4) {
-        fprintf(stderr, "ERROR: Creating pthread for query key test.\n");
-        OQS_destroy();
-        return EXIT_FAILURE;
-    }
-    pthread_join(thread, NULL);
-    rc_qry = td_lock.rc;
+	int trc_4 = pthread_create(&thread, NULL, test_query_key, &td_lock);
+	if (trc_4) {
+		fprintf(stderr, "ERROR: Creating pthread for query key test.\n");
+		OQS_destroy();
+		return EXIT_FAILURE;
+	}
+	pthread_join(thread, NULL);
+	rc_qry = td_lock.rc;
 #else
 	rc = sig_stfl_test_correctness(alg_name, katfile);
 	rc1 = sig_stfl_test_secret_key(alg_name);
 #endif
 
-    OQS_SIG_STFL_SECRET_KEY_free(lock_test_sk);
-    OQS_MEM_insecure_free(lock_test_public_key);
-    OQS_SIG_STFL_free(lock_test_sig_obj);
-    OQS_MEM_insecure_free(lock_test_context);
-    OQS_MEM_insecure_free(signature_1);
-    OQS_MEM_insecure_free(signature_2);
+	OQS_SIG_STFL_SECRET_KEY_free(lock_test_sk);
+	OQS_MEM_insecure_free(lock_test_public_key);
+	OQS_SIG_STFL_free(lock_test_sig_obj);
+	OQS_MEM_insecure_free(lock_test_context);
+	OQS_MEM_insecure_free(signature_1);
+	OQS_MEM_insecure_free(signature_2);
 
 	if ((rc != OQS_SUCCESS) || (rc1 != OQS_SUCCESS) || (rc_lck != OQS_SUCCESS) || (rc_sig != OQS_SUCCESS)
 	        || (rc_qry != OQS_SUCCESS)) {


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
This PR enables a way to apply a lock(mutex) to secret key objects thereby giving protection from simultaneous access.
Stateful Sig API now include functions to set locking/unlocking callbacks and an associated mutex.
The library can then lock/unlock the secret key during signature generation and other queries (signing and queries for the number of signing operations remaining).

These supplied callbacks are application/OS specific.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
