### PR TITLE
Enable extensions in constant-time tests

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -19,7 +19,7 @@ jobs:
             SKIP_ALGS: 'SPHINCS\+-SHA*,Classic-McEliece-(.)*'
           - name: extensions
             container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-            CMAKE_ARGS: -DOQS_OPT_TARGET=haswell -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
+            CMAKE_ARGS: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=haswell -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
             PYTEST_ARGS: --numprocesses=auto -k 'test_constant_time'
             SKIP_ALGS: 'SPHINCS\+-SHA*,Classic-McEliece-(.)*'
     container:


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

Due to a configuration error, our weekly constant-time tests only run with `OQS_OPT_TARGET=generic`. This PR enables the intended configuration of `OQS_OPT_TARGET=haswell` by setting `OQS_DIST_BUILD=OFF`.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
Fixes #1566.

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in [oqs-provider](https://github.com/open-quantum-safe/oqs-provider), [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl), [OQS-BoringSSL](https://github.com/open-quantum-safe/boringssl), and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
