### PR TITLE
Use CMAKE_USE_PTHREADS_INIT

### DIFF
--- a/.CMake/compiler_opts.cmake
+++ b/.CMake/compiler_opts.cmake
@@ -106,8 +106,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang")
 
     if(NOT ${OQS_BUILD_ONLY_LIB})
         set(THREADS_PREFER_PTHREAD_FLAG ON)
-        find_package(Threads REQUIRED)
-        set(OQS_USE_PTHREADS_IN_TESTS 1)
+        find_package(Threads)
     endif()
 
     if(${OQS_DEBUG_BUILD})
@@ -168,8 +167,7 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
 
     if(NOT ${OQS_BUILD_ONLY_LIB})
         set(THREADS_PREFER_PTHREAD_FLAG ON)
-        find_package(Threads REQUIRED)
-        set(OQS_USE_PTHREADS_IN_TESTS 1)
+        find_package(Threads)
     endif()
 
     if(${OQS_DEBUG_BUILD})

--- a/src/oqsconfig.h.cmake
+++ b/src/oqsconfig.h.cmake
@@ -18,12 +18,12 @@
 #cmakedefine USE_SANITIZER "@USE_SANITIZER@"
 #cmakedefine CMAKE_BUILD_TYPE "@CMAKE_BUILD_TYPE@"
 
+#cmakedefine CMAKE_USE_PTHREADS_INIT 1
+
 #cmakedefine OQS_USE_OPENSSL 1
 #cmakedefine OQS_USE_AES_OPENSSL 1
 #cmakedefine OQS_USE_SHA2_OPENSSL 1
 #cmakedefine OQS_USE_SHA3_OPENSSL 1
-
-#cmakedefine OQS_USE_PTHREADS_IN_TESTS 1
 
 #cmakedefine OQS_USE_ADX_INSTRUCTIONS 1
 #cmakedefine OQS_USE_AES_INSTRUCTIONS 1

--- a/tests/test_kem.c
+++ b/tests/test_kem.c
@@ -7,7 +7,7 @@
 
 #include <oqs/oqs.h>
 
-#if OQS_USE_PTHREADS_IN_TESTS
+#if CMAKE_USE_PTHREADS_INIT
 #include <pthread.h>
 #endif
 
@@ -197,7 +197,7 @@ static void TEST_KEM_randombytes(uint8_t *random_array, size_t bytes_to_read) {
 }
 #endif
 
-#if OQS_USE_PTHREADS_IN_TESTS
+#if CMAKE_USE_PTHREADS_INIT
 struct thread_data {
 	char *alg_name;
 	OQS_STATUS rc;
@@ -245,7 +245,7 @@ int main(int argc, char **argv) {
 #endif
 
 	OQS_STATUS rc;
-#if OQS_USE_PTHREADS_IN_TESTS
+#if CMAKE_USE_PTHREADS_INIT
 #define MAX_LEN_KEM_NAME_ 64
 	// don't run Classic McEliece in threads because of large stack usage
 	char no_thread_kem_patterns[][MAX_LEN_KEM_NAME_]  = {"Classic-McEliece", "HQC-256-"};

--- a/tests/test_sig.c
+++ b/tests/test_sig.c
@@ -10,7 +10,7 @@
 
 #include <oqs/oqs.h>
 
-#if OQS_USE_PTHREADS_IN_TESTS
+#if CMAKE_USE_PTHREADS_INIT
 #include <pthread.h>
 #endif
 
@@ -174,7 +174,7 @@ static void TEST_SIG_randombytes(uint8_t *random_array, size_t bytes_to_read) {
 }
 #endif
 
-#if OQS_USE_PTHREADS_IN_TESTS
+#if CMAKE_USE_PTHREADS_INIT
 struct thread_data {
 	char *alg_name;
 	OQS_STATUS rc;
@@ -222,7 +222,7 @@ int main(int argc, char **argv) {
 #endif
 
 	OQS_STATUS rc;
-#if OQS_USE_PTHREADS_IN_TESTS
+#if CMAKE_USE_PTHREADS_INIT
 #define MAX_LEN_SIG_NAME_ 64
 	pthread_t thread;
 	struct thread_data td;


### PR DESCRIPTION
Precursor to #1549. Replace `OQS_USE_PTHREADS_IN_TESTS` with `CMAKE_USE_PTHREADS_INIT` to clean up the Threads inclusion and linking story.

* [x] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)? NO
* [x] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? NO