### PR TITLE
Stateful sigs XMSS updates

### DIFF
--- a/src/sig_stfl/lms/sig_stfl_lms_functions.c
+++ b/src/sig_stfl/lms/sig_stfl_lms_functions.c
@@ -69,7 +69,7 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_lms_sign(uint8_t *signature, size_t *signatu
 	 * Don't even attempt signing without a way to safe the updated private key
 	 */
 	if (secret_key->secure_store_scrt_key == NULL) {
-	    fprintf(stderr, "No Secure-store set for secret key.\n.");
+		fprintf(stderr, "No Secure-store set for secret key.\n.");
 		goto err;
 	}
 
@@ -243,39 +243,39 @@ int oqs_sig_stfl_lms_keypair(uint8_t *pk, OQS_SIG_STFL_SECRET_KEY *sk, const uin
 
 	oqs_key_data = malloc(sizeof(oqs_lms_key_data));
 	if (oqs_key_data == NULL) {
-	    return -1;
+		return -1;
 	}
 
 	memset(oqs_key_data, 0, sizeof(oqs_lms_key_data));
 	if (sk->length_secret_key == 0) {
-        OQS_MEM_insecure_free(oqs_key_data);
-        oqs_key_data = NULL;
-        return -1;
+		OQS_MEM_insecure_free(oqs_key_data);
+		oqs_key_data = NULL;
+		return -1;
 	}
 
 	oqs_key_data->levels = 1;
 	oqs_key_data->len_sec_key = sk->length_secret_key;
 	oqs_key_data->sec_key = (uint8_t *)malloc(sk->length_secret_key * sizeof(uint8_t));
 	if (oqs_key_data->sec_key == NULL) {
-	    OQS_MEM_insecure_free(oqs_key_data);
-	    oqs_key_data = NULL;
-	    return -1;
+		OQS_MEM_insecure_free(oqs_key_data);
+		oqs_key_data = NULL;
+		return -1;
 	}
 
-    memset(oqs_key_data->sec_key, 0, sk->length_secret_key);
+	memset(oqs_key_data->sec_key, 0, sk->length_secret_key);
 
 	//Aux Data
 	size_t len_aux_data = DEFAULT_AUX_DATA;
 	uint8_t *aux_data =  malloc(sizeof(uint8_t) * len_aux_data);
 	if (aux_data == NULL) {
-	    OQS_MEM_insecure_free( oqs_key_data->sec_key);
-	    OQS_MEM_insecure_free(oqs_key_data);
-	    return -1;
+		OQS_MEM_insecure_free( oqs_key_data->sec_key);
+		OQS_MEM_insecure_free(oqs_key_data);
+		return -1;
 	}
 
-    oqs_key_data->aux_data = aux_data;
-    oqs_key_data->len_aux_data = len_aux_data;
-    oqs_key_data->context = sk->context;
+	oqs_key_data->aux_data = aux_data;
+	oqs_key_data->len_aux_data = len_aux_data;
+	oqs_key_data->context = sk->context;
 
 	/* Set lms param set */
 	switch (oid) {
@@ -686,9 +686,9 @@ success:
 
 void oqs_lms_key_set_store_cb(OQS_SIG_STFL_SECRET_KEY *sk, secure_store_sk store_cb, void *context) {
 
-    if (sk == NULL) {
-        return;
-    }
-    sk->secure_store_scrt_key = store_cb;
-    sk->context = context;
+	if (sk == NULL) {
+		return;
+	}
+	sk->secure_store_scrt_key = store_cb;
+	sk->context = context;
 }

--- a/src/sig_stfl/lms/sig_stfl_lms_functions.c
+++ b/src/sig_stfl/lms/sig_stfl_lms_functions.c
@@ -69,6 +69,7 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_lms_sign(uint8_t *signature, size_t *signatu
 	 * Don't even attempt signing without a way to safe the updated private key
 	 */
 	if (secret_key->secure_store_scrt_key == NULL) {
+	    fprintf(stderr, "No Secure-store set for secret key.\n.");
 		goto err;
 	}
 
@@ -94,7 +95,7 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_lms_sign(uint8_t *signature, size_t *signatu
 		goto err;
 	}
 
-	context = lms_key_data->context;
+	context = secret_key->context;
 	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf, sk_key_buf_len, context);
 	if (rc_keyupdate != OQS_SUCCESS) {
 		goto err;
@@ -241,39 +242,40 @@ int oqs_sig_stfl_lms_keypair(uint8_t *pk, OQS_SIG_STFL_SECRET_KEY *sk, const uin
 	}
 
 	oqs_key_data = malloc(sizeof(oqs_lms_key_data));
-	if (oqs_key_data) {
-		oqs_key_data->levels = 1;
-		if (sk->length_secret_key) {
-			oqs_key_data->len_sec_key = sk->length_secret_key;
-			oqs_key_data->sec_key = (uint8_t *)malloc(sk->length_secret_key * sizeof(uint8_t));
-			if (oqs_key_data->sec_key) {
-				memset(oqs_key_data->sec_key, 0, sk->length_secret_key);
-			} else {
-				OQS_MEM_insecure_free(oqs_key_data);
-				oqs_key_data = NULL;
-				return -1;
-			}
-		} else {
-			OQS_MEM_insecure_free(oqs_key_data);
-			oqs_key_data = NULL;
-			return -1;
-		}
-
-		//Aux Data
-		size_t len_aux_data = DEFAULT_AUX_DATA;
-		uint8_t *aux_data =  malloc(sizeof(uint8_t) * len_aux_data);
-		if (aux_data) {
-			oqs_key_data->aux_data = aux_data;
-			oqs_key_data->len_aux_data = len_aux_data;
-		} else {
-			OQS_MEM_insecure_free( oqs_key_data->sec_key);
-			OQS_MEM_insecure_free(oqs_key_data);
-			return -1;
-		}
-	} else {
-		//TODO log error
-		return -1;
+	if (oqs_key_data == NULL) {
+	    return -1;
 	}
+
+	memset(oqs_key_data, 0, sizeof(oqs_lms_key_data));
+	if (sk->length_secret_key == 0) {
+        OQS_MEM_insecure_free(oqs_key_data);
+        oqs_key_data = NULL;
+        return -1;
+	}
+
+	oqs_key_data->levels = 1;
+	oqs_key_data->len_sec_key = sk->length_secret_key;
+	oqs_key_data->sec_key = (uint8_t *)malloc(sk->length_secret_key * sizeof(uint8_t));
+	if (oqs_key_data->sec_key == NULL) {
+	    OQS_MEM_insecure_free(oqs_key_data);
+	    oqs_key_data = NULL;
+	    return -1;
+	}
+
+    memset(oqs_key_data->sec_key, 0, sk->length_secret_key);
+
+	//Aux Data
+	size_t len_aux_data = DEFAULT_AUX_DATA;
+	uint8_t *aux_data =  malloc(sizeof(uint8_t) * len_aux_data);
+	if (aux_data == NULL) {
+	    OQS_MEM_insecure_free( oqs_key_data->sec_key);
+	    OQS_MEM_insecure_free(oqs_key_data);
+	    return -1;
+	}
+
+    oqs_key_data->aux_data = aux_data;
+    oqs_key_data->len_aux_data = len_aux_data;
+    oqs_key_data->context = sk->context;
 
 	/* Set lms param set */
 	switch (oid) {
@@ -668,6 +670,7 @@ OQS_STATUS oqs_deserialize_lms_key(OQS_SIG_STFL_SECRET_KEY *sk, const size_t sk_
 		lms_key_data->len_aux_data = aux_buf_len;
 	}
 
+	sk->context = context;
 	sk->secret_key_data = lms_key_data;
 	goto success;
 
@@ -682,9 +685,10 @@ success:
 }
 
 void oqs_lms_key_set_store_cb(OQS_SIG_STFL_SECRET_KEY *sk, secure_store_sk store_cb, void *context) {
-	oqs_lms_key_data *lms_key_data = (oqs_lms_key_data *)sk->secret_key_data;
-	if (lms_key_data) {
-		lms_key_data->context = context;
-		sk->secure_store_scrt_key = store_cb;
-	}
+
+    if (sk == NULL) {
+        return;
+    }
+    sk->secure_store_scrt_key = store_cb;
+    sk->context = context;
 }

--- a/src/sig_stfl/sig_stfl.h
+++ b/src/sig_stfl/sig_stfl.h
@@ -268,6 +268,9 @@ typedef struct OQS_SIG_STFL_SECRET_KEY {
 	/* mutual exclusion struct */
 	void *mutex;
 
+	/* file storage handle */
+	void *context;
+
 	/**
 	 * Secret Key retrieval Function
 	 *

--- a/src/sig_stfl/xmss/sig_stfl_xmss.h
+++ b/src/sig_stfl/xmss/sig_stfl_xmss.h
@@ -503,4 +503,7 @@ OQS_STATUS OQS_SECRET_KEY_XMSS_serialize_key(const OQS_SIG_STFL_SECRET_KEY *sk, 
 /* Deserialize XMSS byte string into an XMSS secret key data */
 OQS_STATUS OQS_SECRET_KEY_XMSS_deserialize_key(OQS_SIG_STFL_SECRET_KEY *sk, const size_t sk_len, const uint8_t *sk_buf, void *context);
 
+/* Set XMSS byte string into an XMSS secret key data */
+void OQS_SECRET_KEY_XMSS_set_store_cb(OQS_SIG_STFL_SECRET_KEY *sk, secure_store_sk store_cb, void *context);
+
 #endif /* OQS_SIG_STFL_XMSS_H */

--- a/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
@@ -37,8 +37,8 @@ OQS_STATUS OQS_SECRET_KEY_XMSS_deserialize_key(OQS_SIG_STFL_SECRET_KEY *sk, cons
 	}
 
 	if (sk->secret_key_data != NULL) {
-	    OQS_MEM_secure_free(sk->secret_key_data, sk->length_secret_key);
-	    sk->secret_key_data = NULL;
+		OQS_MEM_secure_free(sk->secret_key_data, sk->length_secret_key);
+		sk->secret_key_data = NULL;
 	}
 
 	// Assume key data is not present
@@ -54,10 +54,10 @@ OQS_STATUS OQS_SECRET_KEY_XMSS_deserialize_key(OQS_SIG_STFL_SECRET_KEY *sk, cons
 }
 
 void OQS_SECRET_KEY_XMSS_set_store_cb(OQS_SIG_STFL_SECRET_KEY *sk, secure_store_sk store_cb, void *context) {
-    if (!sk || !store_cb || !context) {
-        return;
-    }
+	if (!sk || !store_cb || !context) {
+		return;
+	}
 
-    sk->context = context;
-    sk->secure_store_scrt_key = store_cb;
+	sk->context = context;
+	sk->secure_store_scrt_key = store_cb;
 }

--- a/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
@@ -37,9 +37,8 @@ OQS_STATUS OQS_SECRET_KEY_XMSS_deserialize_key(OQS_SIG_STFL_SECRET_KEY *sk, cons
 	}
 
 	if (sk->secret_key_data != NULL) {
-		// Key data already present
-		// We dont want to trample over data
-		return OQS_ERROR;
+	    OQS_MEM_secure_free(sk->secret_key_data, sk->length_secret_key);
+	    sk->secret_key_data = NULL;
 	}
 
 	// Assume key data is not present
@@ -48,7 +47,17 @@ OQS_STATUS OQS_SECRET_KEY_XMSS_deserialize_key(OQS_SIG_STFL_SECRET_KEY *sk, cons
 		return OQS_ERROR;
 	}
 
+	sk->context = context;
 	memcpy(sk->secret_key_data, sk_buf, sk_len);
 
 	return OQS_SUCCESS;
+}
+
+void OQS_SECRET_KEY_XMSS_set_store_cb(OQS_SIG_STFL_SECRET_KEY *sk, secure_store_sk store_cb, void *context) {
+    if (!sk || !store_cb || !context) {
+        return;
+    }
+
+    sk->context = context;
+    sk->secure_store_scrt_key = store_cb;
 }

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h10.c
@@ -89,56 +89,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h10_keypair(XMSS_UNUSED_ATT uint
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h10_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h10_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h10.c
@@ -68,6 +68,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_SHA256_H10_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -87,17 +89,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h10_keypair(XMSS_UNUSED_ATT uint
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h10_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t)sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h10_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h16.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_SHA256_H16_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h16_keypair(XMSS_UNUSED_ATT uint
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h16_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h16_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h16.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h16_keypair(XMSS_UNUSED_ATT uint
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h16_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h16_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h20.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h20_keypair(XMSS_UNUSED_ATT uint
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h20_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h20_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h20.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_SHA256_H20_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h20_keypair(XMSS_UNUSED_ATT uint
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h20_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha256_h20_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h10.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h10_keypair(XMSS_UNUSED_ATT uint
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h10_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h10_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h10.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_SHA512_H10_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h10_keypair(XMSS_UNUSED_ATT uint
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h10_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h10_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h16.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h16_keypair(XMSS_UNUSED_ATT uint
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h16_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h16_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h16.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_SHA512_H16_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h16_keypair(XMSS_UNUSED_ATT uint
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h16_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h16_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h20.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_SHA512_H20_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h20_keypair(XMSS_UNUSED_ATT uint
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h20_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h20_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h20.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h20_keypair(XMSS_UNUSED_ATT uint
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h20_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sha512_h20_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h10.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h10_keypair(XMSS_UNUSED_ATT ui
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h10_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h10_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h10.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_SHAKE128_H10_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h10_keypair(XMSS_UNUSED_ATT ui
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h10_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h10_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h16.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h16_keypair(XMSS_UNUSED_ATT ui
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h16_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h16_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h16.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_SHAKE128_H16_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h16_keypair(XMSS_UNUSED_ATT ui
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h16_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h16_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h20.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_SHAKE128_H20_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h20_keypair(XMSS_UNUSED_ATT ui
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h20_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = oqs_serialize_lms_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h20_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h20.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h20_keypair(XMSS_UNUSED_ATT ui
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h20_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = oqs_serialize_lms_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = oqs_serialize_lms_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake128_h20_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h10.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h10_keypair(XMSS_UNUSED_ATT ui
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h10_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h10_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h10.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_SHAKE256_H10_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h10_keypair(XMSS_UNUSED_ATT ui
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h10_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h10_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h16.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_SHAKE256_H16_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h16_keypair(XMSS_UNUSED_ATT ui
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h16_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h16_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h16.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h16_keypair(XMSS_UNUSED_ATT ui
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h16_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h16_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h20.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h20_keypair(XMSS_UNUSED_ATT ui
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h20_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h20_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h20.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_SHAKE256_H20_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h20_keypair(XMSS_UNUSED_ATT ui
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h20_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_shake256_h20_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_2.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h20_2_keypair(XMSS_UNUSED_ATT 
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h20_2_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h20_2_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_2.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSSMT_SHA256_H20_2_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h20_2_keypair(XMSS_UNUSED_ATT 
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h20_2_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmssmt_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h20_2_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_4.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSSMT_SHA256_H20_4_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h20_4_keypair(XMSS_UNUSED_ATT 
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h20_4_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmssmt_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h20_4_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_4.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h20_4_keypair(XMSS_UNUSED_ATT 
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h20_4_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h20_4_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_2.c
@@ -88,57 +88,57 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_2_keypair(XMSS_UNUSED_ATT 
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_2_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        fprintf(stderr, "No secret key secure-store set.\n");
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		fprintf(stderr, "No secret key secure-store set.\n");
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_2_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_2.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSSMT_SHA256_H40_2_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,57 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_2_keypair(XMSS_UNUSED_ATT 
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_2_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmssmt_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        fprintf(stderr, "No secret key secure-store set.\n");
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_2_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_4.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSSMT_SHA256_H40_4_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_4_keypair(XMSS_UNUSED_ATT 
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_4_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmssmt_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_4_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_4.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_4_keypair(XMSS_UNUSED_ATT 
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_4_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_4_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_8.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_8.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSSMT_SHA256_H40_8_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_8_keypair(XMSS_UNUSED_ATT 
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_8_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmssmt_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_8_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_8.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_8.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_8_keypair(XMSS_UNUSED_ATT 
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_8_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h40_8_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_12.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_12.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSSMT_SHA256_H60_12_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,57 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_12_keypair(XMSS_UNUSED_ATT
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_12_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
 
-	unsigned long long sig_length = 0;
-	if (xmssmt_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	return OQS_SUCCESS;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_12_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_12.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_12.c
@@ -89,56 +89,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_12_keypair(XMSS_UNUSED_ATT
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_12_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_12_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_3.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_3.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSSMT_SHA256_H60_3_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_3_keypair(XMSS_UNUSED_ATT 
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_3_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmssmt_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_3_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_3.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_3.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_3_keypair(XMSS_UNUSED_ATT 
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_3_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_3_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_6.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_6.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_6_keypair(XMSS_UNUSED_ATT 
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_6_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_6_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_6.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_6.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSSMT_SHA256_H60_6_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_6_keypair(XMSS_UNUSED_ATT 
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_6_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmssmt_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sha256_h60_6_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_2.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h20_2_keypair(XMSS_UNUSED_AT
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h20_2_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h20_2_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_2.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSSMT_SHAKE128_H20_2_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h20_2_keypair(XMSS_UNUSED_AT
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h20_2_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmssmt_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h20_2_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_4.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSSMT_SHAKE128_H20_4_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h20_4_keypair(XMSS_UNUSED_AT
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h20_4_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmssmt_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h20_4_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_4.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h20_4_keypair(XMSS_UNUSED_AT
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h20_4_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h20_4_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_2.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSSMT_SHAKE128_H40_2_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_2_keypair(XMSS_UNUSED_AT
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_2_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmssmt_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_2_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_2.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_2_keypair(XMSS_UNUSED_AT
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_2_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_2_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_4.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSSMT_SHAKE128_H40_4_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_4_keypair(XMSS_UNUSED_AT
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_4_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmssmt_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_4_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_4.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_4_keypair(XMSS_UNUSED_AT
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_4_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_4_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_8.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_8.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSSMT_SHAKE128_H40_8_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_8_keypair(XMSS_UNUSED_AT
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_8_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmssmt_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_8_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_8.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_8.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_8_keypair(XMSS_UNUSED_AT
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_8_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h40_8_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_12.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_12.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSSMT_SHAKE128_H60_12_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h60_12_keypair(XMSS_UNUSED_A
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h60_12_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmssmt_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h60_12_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_12.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_12.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h60_12_keypair(XMSS_UNUSED_A
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h60_12_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h60_12_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_3.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_3.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSSMT_SHAKE128_H60_3_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 
@@ -86,17 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h60_3_keypair(XMSS_UNUSED_AT
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h60_3_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-		return OQS_ERROR;
-	}
+    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+    const OQS_SIG_STFL_SECRET_KEY *sk;
+    uint8_t *sk_key_buf_ptr = NULL;
+    unsigned long long sig_length = 0;
+    size_t sk_key_buf_len = 0;
 
-	unsigned long long sig_length = 0;
-	if (xmssmt_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-		return OQS_ERROR;
-	}
-	*signature_len = (size_t) sig_length;
+    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+        return OQS_ERROR;
+    }
 
-	return OQS_SUCCESS;
+    /* check for secret key update function */
+    if (secret_key->secure_store_scrt_key == NULL) {
+        return OQS_ERROR;
+    }
+
+    /* Lock secret to ensure OTS use */
+    if ((secret_key->lock_key) && (secret_key->mutex)) {
+        secret_key->lock_key(secret_key->mutex);
+    }
+
+    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+        status = OQS_ERROR;
+        goto err;
+    }
+    *signature_len = (size_t)sig_length;
+
+    /*
+     * serialize and securely store the updated private key
+     * but, delete signature and the serialized key other wise
+     */
+
+    sk = secret_key;
+    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+        goto err;
+    }
+
+    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+    if (rc_keyupdate != OQS_SUCCESS) {
+        status = OQS_ERROR;
+    }
+
+    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+    err:
+    /* Unlock secret to ensure OTS use */
+    if ((secret_key->unlock_key) && (secret_key->mutex)) {
+        secret_key->unlock_key(secret_key->mutex);
+    }
+    return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h60_3_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_3.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_3.c
@@ -88,56 +88,56 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h60_3_keypair(XMSS_UNUSED_AT
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h60_3_sign(uint8_t *signature, size_t *signature_len, XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, XMSS_UNUSED_ATT OQS_SIG_STFL_SECRET_KEY *secret_key) {
 
-    OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
-    const OQS_SIG_STFL_SECRET_KEY *sk;
-    uint8_t *sk_key_buf_ptr = NULL;
-    unsigned long long sig_length = 0;
-    size_t sk_key_buf_len = 0;
+	OQS_STATUS rc_keyupdate, status = OQS_SUCCESS;
+	const OQS_SIG_STFL_SECRET_KEY *sk;
+	uint8_t *sk_key_buf_ptr = NULL;
+	unsigned long long sig_length = 0;
+	size_t sk_key_buf_len = 0;
 
-    if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
-        return OQS_ERROR;
-    }
+	if (signature == NULL || signature_len == NULL || message == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* check for secret key update function */
-    if (secret_key->secure_store_scrt_key == NULL) {
-        return OQS_ERROR;
-    }
+	/* check for secret key update function */
+	if (secret_key->secure_store_scrt_key == NULL) {
+		return OQS_ERROR;
+	}
 
-    /* Lock secret to ensure OTS use */
-    if ((secret_key->lock_key) && (secret_key->mutex)) {
-        secret_key->lock_key(secret_key->mutex);
-    }
+	/* Lock secret to ensure OTS use */
+	if ((secret_key->lock_key) && (secret_key->mutex)) {
+		secret_key->lock_key(secret_key->mutex);
+	}
 
-    if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
-        status = OQS_ERROR;
-        goto err;
-    }
-    *signature_len = (size_t)sig_length;
+	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
+		status = OQS_ERROR;
+		goto err;
+	}
+	*signature_len = (size_t)sig_length;
 
-    /*
-     * serialize and securely store the updated private key
-     * but, delete signature and the serialized key other wise
-     */
+	/*
+	 * serialize and securely store the updated private key
+	 * but, delete signature and the serialized key other wise
+	 */
 
-    sk = secret_key;
-    rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-        goto err;
-    }
+	sk = secret_key;
+	rc_keyupdate = OQS_SECRET_KEY_XMSS_serialize_key(sk, &sk_key_buf_len, &sk_key_buf_ptr);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+		goto err;
+	}
 
-    rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
-    if (rc_keyupdate != OQS_SUCCESS) {
-        status = OQS_ERROR;
-    }
+	rc_keyupdate = secret_key->secure_store_scrt_key(sk_key_buf_ptr, sk_key_buf_len, secret_key->context);
+	if (rc_keyupdate != OQS_SUCCESS) {
+		status = OQS_ERROR;
+	}
 
-    OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
-    err:
-    /* Unlock secret to ensure OTS use */
-    if ((secret_key->unlock_key) && (secret_key->mutex)) {
-        secret_key->unlock_key(secret_key->mutex);
-    }
-    return status;
+	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
+err:
+	/* Unlock secret to ensure OTS use */
+	if ((secret_key->unlock_key) && (secret_key->mutex)) {
+		secret_key->unlock_key(secret_key->mutex);
+	}
+	return status;
 }
 
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_shake128_h60_3_verify(XMSS_UNUSED_ATT const uint8_t *message, XMSS_UNUSED_ATT size_t message_len, const uint8_t *signature, size_t signature_len, XMSS_UNUSED_ATT const uint8_t *public_key) {

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_6.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_6.c
@@ -67,6 +67,8 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSSMT_SHAKE128_H60_6_new(void) {
 
 	sk->free_key = OQS_SECRET_KEY_XMSS_free;
 
+	sk->set_scrt_key_store_cb = OQS_SECRET_KEY_XMSS_set_store_cb;
+
 	return sk;
 }
 

--- a/tests/kat_sig_stfl.c
+++ b/tests/kat_sig_stfl.c
@@ -19,9 +19,9 @@
 #define MAX_MARKER_LEN 50
 
 static OQS_STATUS do_nothing_save(uint8_t *key_buf, size_t buf_len, void *context) {
-    (void)(context);
-    (void)(buf_len);
-    return key_buf != NULL ? OQS_SUCCESS : OQS_ERROR;
+	(void)(context);
+	(void)(buf_len);
+	return key_buf != NULL ? OQS_SUCCESS : OQS_ERROR;
 }
 
 //

--- a/tests/kat_sig_stfl.c
+++ b/tests/kat_sig_stfl.c
@@ -18,6 +18,12 @@
 
 #define MAX_MARKER_LEN 50
 
+static OQS_STATUS do_nothing_save(uint8_t *key_buf, size_t buf_len, void *context) {
+    (void)(context);
+    (void)(buf_len);
+    return key_buf != NULL ? OQS_SUCCESS : OQS_ERROR;
+}
+
 //
 // ALLOW TO READ HEXADECIMAL ENTRY (KEYS, DATA, TEXT, etc.)
 //
@@ -159,6 +165,8 @@ OQS_STATUS sig_stfl_kat(const char *method_name, const char *katfile) {
 	// Grab the pk and sk from KAT file
 	public_key = malloc(sig->length_public_key);
 	secret_key = OQS_SIG_STFL_SECRET_KEY_new(sig->method_name);
+	OQS_SIG_STFL_SECRET_KEY_SET_store_cb(secret_key, do_nothing_save, NULL);
+
 	signature = calloc(sig->length_signature, sizeof(uint8_t));
 	signature_kat = calloc(sig->length_signature, sizeof(uint8_t));
 

--- a/tests/test_sig_stfl.c
+++ b/tests/test_sig_stfl.c
@@ -322,6 +322,52 @@ typedef struct magic_s {
 	uint8_t val[31];
 } magic_t;
 
+static const char *convert_method_name_to_file_name(const char *method_name) {
+
+    const char *file_store = NULL;
+    char *name = NULL;
+    if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h20_2) == 0) {
+        file_store = "XMSSMT-SHA2_20-2_256";
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h20_4) == 0) {
+        file_store = "XMSSMT-SHA2_20-4_256";
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2) == 0) {
+        file_store = "XMSSMT-SHA2_40-2_256";
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_4) == 0) {
+        file_store = "XMSSMT-SHA2_40-4_256";
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_8) == 0) {
+        file_store = "XMSSMT-SHA2_40-8_256";
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3) == 0) {
+        file_store = "XMSSMT-SHA2_60-3_256";
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_6) == 0) {
+        file_store = "XMSSMT-SHA2_60-6_256";
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_12) == 0) {
+        file_store = "XMSSMT-SHA2_60-12_256";
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h20_2) == 0) {
+        file_store = "XMSSMT-SHAKE_20-2_256";
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h20_4) == 0) {
+        file_store = "XMSSMT-SHAKE_20-4_256";
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2) == 0) {
+        file_store = "XMSSMT-SHAKE_40-2_256";
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_4) == 0) {
+        file_store = "XMSSMT-SHAKE_40-4_256";
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_8) == 0) {
+        file_store = "XMSSMT-SHAKE_40-8_256";
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3) == 0) {
+        file_store = "XMSSMT-SHAKE_60-3_256";
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_6) == 0) {
+        file_store = "XMSSMT-SHAKE_60-6_256";
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_12) == 0) {
+        file_store = "XMSSMT-SHAKE_60-12_256";
+    } else {
+        file_store = method_name;
+    }
+
+    if (file_store) {
+        name = strdup(file_store);
+    }
+    return name;
+}
+
 static OQS_STATUS sig_stfl_test_correctness(const char *method_name, const char *katfile) {
 
 	OQS_SIG_STFL *sig = NULL;
@@ -367,6 +413,16 @@ static OQS_STATUS sig_stfl_test_correctness(const char *method_name, const char 
 
 	OQS_SIG_STFL_SECRET_KEY_SET_lock(secret_key, lock_sk_key);
 	OQS_SIG_STFL_SECRET_KEY_SET_unlock(secret_key, unlock_sk_key);
+
+    file_store = convert_method_name_to_file_name(sig->method_name);
+    if (file_store == NULL) {
+        fprintf(stderr, "%s: file_store is null\n", __FUNCTION__);
+        goto err;
+    }
+
+    /* set context and secure store callback */
+    context = strdup(((file_store)));
+    OQS_SIG_STFL_SECRET_KEY_SET_store_cb(secret_key, test_save_secret_key, (void *)context);
 
 #if OQS_USE_PTHREADS_IN_TESTS
 	sk_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
@@ -421,42 +477,6 @@ static OQS_STATUS sig_stfl_test_correctness(const char *method_name, const char 
 		goto err;
 	}
 
-	if (strcmp(sig->method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h20_2) == 0) {
-		file_store = "XMSSMT-SHA2_20-2_256";
-	} else if (strcmp(sig->method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h20_4) == 0) {
-		file_store = "XMSSMT-SHA2_20-4_256";
-	} else if (strcmp(sig->method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2) == 0) {
-		file_store = "XMSSMT-SHA2_40-2_256";
-	} else if (strcmp(sig->method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_4) == 0) {
-		file_store = "XMSSMT-SHA2_40-4_256";
-	} else if (strcmp(sig->method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_8) == 0) {
-		file_store = "XMSSMT-SHA2_40-8_256";
-	} else if (strcmp(sig->method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3) == 0) {
-		file_store = "XMSSMT-SHA2_60-3_256";
-	} else if (strcmp(sig->method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_6) == 0) {
-		file_store = "XMSSMT-SHA2_60-6_256";
-	} else if (strcmp(sig->method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_12) == 0) {
-		file_store = "XMSSMT-SHA2_60-12_256";
-	} else if (strcmp(sig->method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h20_2) == 0) {
-		file_store = "XMSSMT-SHAKE_20-2_256";
-	} else if (strcmp(sig->method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h20_4) == 0) {
-		file_store = "XMSSMT-SHAKE_20-4_256";
-	} else if (strcmp(sig->method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2) == 0) {
-		file_store = "XMSSMT-SHAKE_40-2_256";
-	} else if (strcmp(sig->method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_4) == 0) {
-		file_store = "XMSSMT-SHAKE_40-4_256";
-	} else if (strcmp(sig->method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_8) == 0) {
-		file_store = "XMSSMT-SHAKE_40-8_256";
-	} else if (strcmp(sig->method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3) == 0) {
-		file_store = "XMSSMT-SHAKE_60-3_256";
-	} else if (strcmp(sig->method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_6) == 0) {
-		file_store = "XMSSMT-SHAKE_60-6_256";
-	} else if (strcmp(sig->method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_12) == 0) {
-		file_store = "XMSSMT-SHAKE_60-12_256";
-	} else {
-		file_store = sig->method_name;
-	}
-
 	/* write key pair to disk */
 	if (oqs_fstore("sk", file_store, sk_buf, sk_buf_len) != OQS_SUCCESS) {
 		goto err;
@@ -465,10 +485,6 @@ static OQS_STATUS sig_stfl_test_correctness(const char *method_name, const char 
 	if (oqs_fstore("pk", file_store, public_key, sig->length_public_key) != OQS_SUCCESS) {
 		goto err;
 	}
-
-	/* set context and secure store callback */
-	context = strdup(((file_store)));
-	OQS_SIG_STFL_SECRET_KEY_SET_store_cb(secret_key, test_save_secret_key, (void *)context);
 
 	rc = OQS_SIG_STFL_sign(sig, signature, &signature_len, message, message_len, secret_key);
 	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
@@ -568,81 +584,70 @@ static OQS_STATUS sig_stfl_test_secret_key(const char *method_name) {
 	size_t to_file_sk_len = 0;
 	char *context = NULL;
 	char *context_2 = NULL;
+	const char *file_store_name = NULL;
 
 	/*
 	 * Temporarily skip algs with long key generation times.
 	 */
 
-	if (strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w1) == 0
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w2) == 0
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w4) == 0
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w8) == 0
+	if (0) {
 
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h10_w1) == 0
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h15_w1) == 0) {
-		goto keep_going;
-	} else {
+#ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h16
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h16) == 0) {
 		goto skip_test;
-	}
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h20
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h20) == 0) {
+		goto skip_test;
+#endif
 
-//	if (0) {
-//
-//#ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h16
-//	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h16) == 0) {
-//		goto skip_test;
-//#endif
-//#ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h20
-//	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h20) == 0) {
-//		goto skip_test;
-//#endif
-//
-//#ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h16
-//	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h16)) {
-//		goto skip_test;
-//#endif
-//#ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h20
-//	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h20)) {
-//		goto skip_test;
-//#endif
-//
-//#ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h16
-//	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h16)) {
-//		goto skip_test;
-//#endif
-//#ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h20
-//	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h20)) {
-//		goto skip_test;
-//#endif
-//
-//#ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h16
-//	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h16)) {
-//		goto skip_test;
-//#endif
-//#ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h20
-//	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h20)) {
-//		goto skip_test;
-//#endif
-//
-//#ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h40_2
-//	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2)) {
-//		goto skip_test;
-//#endif
-//#ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h60_3
-//	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3)) {
-//		goto skip_test;
-//#endif
-//
-//#ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h40_2
-//	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2)) {
-//		goto skip_test;
-//#endif
-//#ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h60_3
-//	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3)) {
-//		goto skip_test;
-//#endif
-//	} else {
-//		goto keep_going;
-//	}
+#ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h16
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h16)) {
+		goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h20
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h20)) {
+		goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h16
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h16)) {
+		goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h20
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h20)) {
+		goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h16
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h16)) {
+		goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h20
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h20)) {
+		goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h40_2
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2)) {
+		goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h60_3
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3)) {
+		goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h40_2
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2)) {
+		goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h60_3
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3)) {
+		goto skip_test;
+#endif
+	} else {
+		goto keep_going;
+	}
 
 skip_test:
 	printf("Skip slow test %s.\n", method_name);
@@ -706,7 +711,8 @@ keep_going:
 		goto err;
 	}
 
-	if (oqs_fstore("sk", sig_obj->method_name, to_file_sk_buf, to_file_sk_len) != OQS_SUCCESS) {
+	file_store_name  = convert_method_name_to_file_name(sig_obj->method_name);
+	if (oqs_fstore("sk", file_store_name, to_file_sk_buf, to_file_sk_len) != OQS_SUCCESS) {
 		goto err;
 	}
 
@@ -723,7 +729,7 @@ keep_going:
 
 	/* read secret key from disk */
 	frm_file_sk_buf = malloc(to_file_sk_len);
-	if (oqs_fload("sk", method_name, frm_file_sk_buf, to_file_sk_len, &frm_file_sk_len) != OQS_SUCCESS) {
+	if (oqs_fload("sk", file_store_name, frm_file_sk_buf, to_file_sk_len, &frm_file_sk_len) != OQS_SUCCESS) {
 		goto err;
 	}
 	if (to_file_sk_len != frm_file_sk_len) {
@@ -769,28 +775,6 @@ static OQS_STATUS sig_stfl_test_query_key(const char *method_name) {
 
 	size_t message_len_1 = sizeof(message_1);
 	size_t message_len_2 = sizeof(message_2);
-
-	/*
-	 * Temporarily skip algs with long key generation times.
-	 */
-
-	if (strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w1) == 0
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w2) == 0
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w4) == 0
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w8) == 0
-
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h10_w1) == 0
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h15_w1) == 0) {
-		goto keep_going;
-	} else {
-		goto skip_test;
-	}
-
-skip_test:
-	printf("Skip slow alg %s.\n", method_name);
-	return rc;
-
-keep_going:
 
 	printf("================================================================================\n");
 	printf("Testing stateful Signature Verification %s\n", method_name);
@@ -839,27 +823,8 @@ static OQS_STATUS sig_stfl_test_sig_gen(const char *method_name) {
 	size_t message_len_1 = sizeof(message_1);
 	size_t message_len_2 = sizeof(message_2);
 
-	/*
-	 * Temporarily skip algs with long key generation times.
-	 */
-
-	if (strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w1) == 0
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w2) == 0
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w4) == 0
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w8) == 0
-
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h10_w1) == 0
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h15_w1) == 0) {
-		goto  keep_going;
-	} else {
-		goto skip_test;
-	}
-
-skip_test:
-	printf("Skip slow alg %s.\n", method_name);
-	return rc;
-
-keep_going:
+	char *context = NULL;
+	const char *key_store_name = convert_method_name_to_file_name(method_name);
 
 	printf("================================================================================\n");
 	printf("Testing stateful Signature Generation %s\n", method_name);
@@ -868,6 +833,10 @@ keep_going:
 	if ( lock_test_sk == NULL || lock_test_sig_obj == NULL) {
 		return OQS_ERROR;
 	}
+
+    /* set context and secure store callback */
+    context = strdup(((key_store_name)));
+    OQS_SIG_STFL_SECRET_KEY_SET_store_cb(lock_test_sk, test_save_secret_key, (void *)context);
 
 	/*
 	 * Get max num signature and the amount remaining
@@ -957,34 +926,13 @@ keep_going:
 err:
 	rc = OQS_ERROR;
 end_it:
+    OQS_MEM_insecure_free(context);
 
 	return rc;
 }
 
 static OQS_STATUS sig_stfl_test_secret_key_lock(const char *method_name) {
 	OQS_STATUS rc = OQS_SUCCESS;
-
-	/*
-	 * Temporarily skip algs with long key generation times.
-	 */
-
-	if (strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w1) == 0
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w2) == 0
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w4) == 0
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h5_w8) == 0
-
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h10_w1) == 0
-	        || strcmp(method_name, OQS_SIG_STFL_alg_lms_sha256_n32_h15_w1) == 0) {
-		goto keep_going;
-	} else {
-		goto skip_test;
-	}
-
-skip_test:
-	printf("Skip slow test %s.\n", method_name);
-	return rc;
-
-keep_going:
 
 	printf("================================================================================\n");
 	printf("Testing stateful Signature locks %s\n", method_name);

--- a/tests/test_sig_stfl.c
+++ b/tests/test_sig_stfl.c
@@ -324,48 +324,48 @@ typedef struct magic_s {
 
 static const char *convert_method_name_to_file_name(const char *method_name) {
 
-    const char *file_store = NULL;
-    char *name = NULL;
-    if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h20_2) == 0) {
-        file_store = "XMSSMT-SHA2_20-2_256";
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h20_4) == 0) {
-        file_store = "XMSSMT-SHA2_20-4_256";
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2) == 0) {
-        file_store = "XMSSMT-SHA2_40-2_256";
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_4) == 0) {
-        file_store = "XMSSMT-SHA2_40-4_256";
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_8) == 0) {
-        file_store = "XMSSMT-SHA2_40-8_256";
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3) == 0) {
-        file_store = "XMSSMT-SHA2_60-3_256";
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_6) == 0) {
-        file_store = "XMSSMT-SHA2_60-6_256";
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_12) == 0) {
-        file_store = "XMSSMT-SHA2_60-12_256";
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h20_2) == 0) {
-        file_store = "XMSSMT-SHAKE_20-2_256";
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h20_4) == 0) {
-        file_store = "XMSSMT-SHAKE_20-4_256";
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2) == 0) {
-        file_store = "XMSSMT-SHAKE_40-2_256";
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_4) == 0) {
-        file_store = "XMSSMT-SHAKE_40-4_256";
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_8) == 0) {
-        file_store = "XMSSMT-SHAKE_40-8_256";
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3) == 0) {
-        file_store = "XMSSMT-SHAKE_60-3_256";
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_6) == 0) {
-        file_store = "XMSSMT-SHAKE_60-6_256";
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_12) == 0) {
-        file_store = "XMSSMT-SHAKE_60-12_256";
-    } else {
-        file_store = method_name;
-    }
+	const char *file_store = NULL;
+	char *name = NULL;
+	if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h20_2) == 0) {
+		file_store = "XMSSMT-SHA2_20-2_256";
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h20_4) == 0) {
+		file_store = "XMSSMT-SHA2_20-4_256";
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2) == 0) {
+		file_store = "XMSSMT-SHA2_40-2_256";
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_4) == 0) {
+		file_store = "XMSSMT-SHA2_40-4_256";
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_8) == 0) {
+		file_store = "XMSSMT-SHA2_40-8_256";
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3) == 0) {
+		file_store = "XMSSMT-SHA2_60-3_256";
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_6) == 0) {
+		file_store = "XMSSMT-SHA2_60-6_256";
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_12) == 0) {
+		file_store = "XMSSMT-SHA2_60-12_256";
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h20_2) == 0) {
+		file_store = "XMSSMT-SHAKE_20-2_256";
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h20_4) == 0) {
+		file_store = "XMSSMT-SHAKE_20-4_256";
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2) == 0) {
+		file_store = "XMSSMT-SHAKE_40-2_256";
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_4) == 0) {
+		file_store = "XMSSMT-SHAKE_40-4_256";
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_8) == 0) {
+		file_store = "XMSSMT-SHAKE_40-8_256";
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3) == 0) {
+		file_store = "XMSSMT-SHAKE_60-3_256";
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_6) == 0) {
+		file_store = "XMSSMT-SHAKE_60-6_256";
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_12) == 0) {
+		file_store = "XMSSMT-SHAKE_60-12_256";
+	} else {
+		file_store = method_name;
+	}
 
-    if (file_store) {
-        name = strdup(file_store);
-    }
-    return name;
+	if (file_store) {
+		name = strdup(file_store);
+	}
+	return name;
 }
 
 static OQS_STATUS sig_stfl_test_correctness(const char *method_name, const char *katfile) {
@@ -414,15 +414,15 @@ static OQS_STATUS sig_stfl_test_correctness(const char *method_name, const char 
 	OQS_SIG_STFL_SECRET_KEY_SET_lock(secret_key, lock_sk_key);
 	OQS_SIG_STFL_SECRET_KEY_SET_unlock(secret_key, unlock_sk_key);
 
-    file_store = convert_method_name_to_file_name(sig->method_name);
-    if (file_store == NULL) {
-        fprintf(stderr, "%s: file_store is null\n", __FUNCTION__);
-        goto err;
-    }
+	file_store = convert_method_name_to_file_name(sig->method_name);
+	if (file_store == NULL) {
+		fprintf(stderr, "%s: file_store is null\n", __FUNCTION__);
+		goto err;
+	}
 
-    /* set context and secure store callback */
-    context = strdup(((file_store)));
-    OQS_SIG_STFL_SECRET_KEY_SET_store_cb(secret_key, test_save_secret_key, (void *)context);
+	/* set context and secure store callback */
+	context = strdup(((file_store)));
+	OQS_SIG_STFL_SECRET_KEY_SET_store_cb(secret_key, test_save_secret_key, (void *)context);
 
 #if OQS_USE_PTHREADS_IN_TESTS
 	sk_lock = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
@@ -834,9 +834,9 @@ static OQS_STATUS sig_stfl_test_sig_gen(const char *method_name) {
 		return OQS_ERROR;
 	}
 
-    /* set context and secure store callback */
-    context = strdup(((key_store_name)));
-    OQS_SIG_STFL_SECRET_KEY_SET_store_cb(lock_test_sk, test_save_secret_key, (void *)context);
+	/* set context and secure store callback */
+	context = strdup(((key_store_name)));
+	OQS_SIG_STFL_SECRET_KEY_SET_store_cb(lock_test_sk, test_save_secret_key, (void *)context);
 
 	/*
 	 * Get max num signature and the amount remaining
@@ -926,7 +926,7 @@ static OQS_STATUS sig_stfl_test_sig_gen(const char *method_name) {
 err:
 	rc = OQS_ERROR;
 end_it:
-    OQS_MEM_insecure_free(context);
+	OQS_MEM_insecure_free(context);
 
 	return rc;
 }

--- a/tests/test_sig_stfl.c
+++ b/tests/test_sig_stfl.c
@@ -893,7 +893,7 @@ static OQS_STATUS sig_stfl_test_sig_gen(const char *method_name) {
 	size_t message_len_2 = sizeof(message_2);
 
 	char *context = NULL;
-	char *key_store_name = convert_method_name_to_file_name(method_name);
+	char *key_store_name = NULL;
 
 	printf("================================================================================\n");
 	printf("Testing stateful Signature Generation %s\n", method_name);
@@ -903,6 +903,7 @@ static OQS_STATUS sig_stfl_test_sig_gen(const char *method_name) {
 		return OQS_ERROR;
 	}
 
+	key_store_name = convert_method_name_to_file_name(method_name);
 	/* set context and secure store callback */
 	context = strdup(((key_store_name)));
 	OQS_SIG_STFL_SECRET_KEY_SET_store_cb(lock_test_sk, test_save_secret_key, (void *)context);

--- a/tests/test_sig_stfl.c
+++ b/tests/test_sig_stfl.c
@@ -844,72 +844,72 @@ static OQS_STATUS sig_stfl_test_query_key(const char *method_name) {
 	size_t message_len_1 = sizeof(message_1);
 	size_t message_len_2 = sizeof(message_2);
 
-    /*
-     * Temporarily skip algs with long key generation times.
-     */
+	/*
+	 * Temporarily skip algs with long key generation times.
+	 */
 
-    if (0) {
+	if (0) {
 
 #ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h16
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h16) == 0) {
-        goto skip_test;
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h16) == 0) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h20
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h20) == 0) {
-        goto skip_test;
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h20) == 0) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h16
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h16)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h16)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h20
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h20)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h20)) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h16
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h16)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h16)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h20
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h20)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h20)) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h16
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h16)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h16)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h20
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h20)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h20)) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h40_2
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h60_3
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3)) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h40_2
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h60_3
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3)) {
+		goto skip_test;
 #endif
-    } else {
-        goto keep_going;
-    }
+	} else {
+		goto keep_going;
+	}
 
 skip_test:
-    printf("Skip slow test %s.\n", method_name);
-    return rc;
+	printf("Skip slow test %s.\n", method_name);
+	return rc;
 
 keep_going:
 
@@ -963,72 +963,72 @@ static OQS_STATUS sig_stfl_test_sig_gen(const char *method_name) {
 	char *context = NULL;
 	char *key_store_name = NULL;
 
-    /*
-     * Temporarily skip algs with long key generation times.
-     */
+	/*
+	 * Temporarily skip algs with long key generation times.
+	 */
 
-    if (0) {
+	if (0) {
 
 #ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h16
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h16) == 0) {
-        goto skip_test;
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h16) == 0) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h20
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h20) == 0) {
-        goto skip_test;
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h20) == 0) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h16
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h16)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h16)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h20
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h20)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h20)) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h16
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h16)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h16)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h20
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h20)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h20)) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h16
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h16)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h16)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h20
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h20)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h20)) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h40_2
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h60_3
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3)) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h40_2
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h60_3
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3)) {
+		goto skip_test;
 #endif
-    } else {
-        goto keep_going;
-    }
+	} else {
+		goto keep_going;
+	}
 
 skip_test:
-    printf("Skip slow test %s.\n", method_name);
-    return rc;
+	printf("Skip slow test %s.\n", method_name);
+	return rc;
 
 keep_going:
 
@@ -1146,72 +1146,72 @@ static OQS_STATUS sig_stfl_test_secret_key_lock(const char *method_name) {
 	printf("Testing stateful Signature locks %s\n", method_name);
 	printf("================================================================================\n");
 
-    /*
-     * Temporarily skip algs with long key generation times.
-     */
+	/*
+	 * Temporarily skip algs with long key generation times.
+	 */
 
-    if (0) {
+	if (0) {
 
 #ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h16
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h16) == 0) {
-        goto skip_test;
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h16) == 0) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h20
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h20) == 0) {
-        goto skip_test;
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h20) == 0) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h16
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h16)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h16)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h20
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h20)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h20)) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h16
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h16)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h16)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h20
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h20)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h20)) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h16
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h16)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h16)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h20
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h20)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h20)) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h40_2
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h60_3
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3)) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h40_2
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h60_3
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3)) {
+		goto skip_test;
 #endif
-    } else {
-        goto keep_going;
-    }
+	} else {
+		goto keep_going;
+	}
 
 skip_test:
-    printf("Skip slow test %s.\n", method_name);
-    return rc;
+	printf("Skip slow test %s.\n", method_name);
+	return rc;
 
 keep_going:
 

--- a/tests/test_sig_stfl.c
+++ b/tests/test_sig_stfl.c
@@ -387,7 +387,7 @@ static OQS_STATUS sig_stfl_test_correctness(const char *method_name, const char 
 	size_t sk_buf_len = 0;
 	size_t read_pk_len = 0;
 
-    magic_t magic;
+	magic_t magic;
 
 #if OQS_USE_PTHREADS_IN_TESTS
 	pthread_mutex_t *sk_lock = NULL;
@@ -395,67 +395,67 @@ static OQS_STATUS sig_stfl_test_correctness(const char *method_name, const char 
 
 	OQS_STATUS rc, ret = OQS_ERROR;
 
-    if (0) {
+	if (0) {
 
 #ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h16
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h16) == 0) {
-        goto skip_test;
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h16) == 0) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h20
-    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h20) == 0) {
-        goto skip_test;
+	} else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h20) == 0) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h16
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h16)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h16)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h20
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h20)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h20)) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h16
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h16)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h16)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h20
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h20)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h20)) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h16
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h16)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h16)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h20
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h20)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h20)) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h40_2
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h60_3
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3)) {
+		goto skip_test;
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h40_2
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2)) {
+		goto skip_test;
 #endif
 #ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h60_3
-    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3)) {
-        goto skip_test;
+	} else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3)) {
+		goto skip_test;
 #endif
-    } else {
-        goto test_on;
-    }
+	} else {
+		goto test_on;
+	}
 skip_test:
-    printf("skipping slow test %s\n", method_name);
-    return OQS_SUCCESS;
+	printf("skipping slow test %s\n", method_name);
+	return OQS_SUCCESS;
 
 test_on:
 
@@ -1064,7 +1064,7 @@ static OQS_STATUS sig_stfl_test_secret_key_lock(const char *method_name) {
 
 	/* set context and secure store callback */
 	if (lock_test_sk->set_scrt_key_store_cb) {
-	    lock_test_context = convert_method_name_to_file_name(method_name);
+		lock_test_context = convert_method_name_to_file_name(method_name);
 		lock_test_sk->set_scrt_key_store_cb(lock_test_sk, test_save_secret_key, (void *)lock_test_context);
 	}
 

--- a/tests/test_sig_stfl.c
+++ b/tests/test_sig_stfl.c
@@ -841,9 +841,77 @@ end_it:
 
 static OQS_STATUS sig_stfl_test_query_key(const char *method_name) {
 	OQS_STATUS rc = OQS_SUCCESS;
-
 	size_t message_len_1 = sizeof(message_1);
 	size_t message_len_2 = sizeof(message_2);
+
+    /*
+     * Temporarily skip algs with long key generation times.
+     */
+
+    if (0) {
+
+#ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h16
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h16) == 0) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h20
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h20) == 0) {
+        goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h16
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h16)) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h20
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h20)) {
+        goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h16
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h16)) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h20
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h20)) {
+        goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h16
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h16)) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h20
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h20)) {
+        goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h40_2
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2)) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h60_3
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3)) {
+        goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h40_2
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2)) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h60_3
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3)) {
+        goto skip_test;
+#endif
+    } else {
+        goto keep_going;
+    }
+
+skip_test:
+    printf("Skip slow test %s.\n", method_name);
+    return rc;
+
+keep_going:
 
 	printf("================================================================================\n");
 	printf("Testing stateful Signature Verification %s\n", method_name);
@@ -894,6 +962,75 @@ static OQS_STATUS sig_stfl_test_sig_gen(const char *method_name) {
 
 	char *context = NULL;
 	char *key_store_name = NULL;
+
+    /*
+     * Temporarily skip algs with long key generation times.
+     */
+
+    if (0) {
+
+#ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h16
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h16) == 0) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h20
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h20) == 0) {
+        goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h16
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h16)) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h20
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h20)) {
+        goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h16
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h16)) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h20
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h20)) {
+        goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h16
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h16)) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h20
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h20)) {
+        goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h40_2
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2)) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h60_3
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3)) {
+        goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h40_2
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2)) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h60_3
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3)) {
+        goto skip_test;
+#endif
+    } else {
+        goto keep_going;
+    }
+
+skip_test:
+    printf("Skip slow test %s.\n", method_name);
+    return rc;
+
+keep_going:
 
 	printf("================================================================================\n");
 	printf("Testing stateful Signature Generation %s\n", method_name);
@@ -1008,6 +1145,75 @@ static OQS_STATUS sig_stfl_test_secret_key_lock(const char *method_name) {
 	printf("================================================================================\n");
 	printf("Testing stateful Signature locks %s\n", method_name);
 	printf("================================================================================\n");
+
+    /*
+     * Temporarily skip algs with long key generation times.
+     */
+
+    if (0) {
+
+#ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h16
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h16) == 0) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmss_sha256_h20
+    } else if (strcmp(method_name, OQS_SIG_STFL_alg_xmss_sha256_h20) == 0) {
+        goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h16
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h16)) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmss_shake128_h20
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake128_h20)) {
+        goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h16
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h16)) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmss_sha512_h20
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_sha512_h20)) {
+        goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h16
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h16)) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmss_shake256_h20
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmss_shake256_h20)) {
+        goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h40_2
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h40_2)) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmssmt_sha256_h60_3
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_sha256_h60_3)) {
+        goto skip_test;
+#endif
+
+#ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h40_2
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h40_2)) {
+        goto skip_test;
+#endif
+#ifdef OQS_ENABLE_SIG_STFL_xmssmt_shake128_h60_3
+    } else if (0 == strcasecmp(method_name, OQS_SIG_STFL_alg_xmssmt_shake128_h60_3)) {
+        goto skip_test;
+#endif
+    } else {
+        goto keep_going;
+    }
+
+skip_test:
+    printf("Skip slow test %s.\n", method_name);
+    return rc;
+
+keep_going:
 
 	printf("================================================================================\n");
 	printf("Create stateful Signature  %s\n", method_name);


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

Updated XMSS code to use callbacks for "secure store/update" of secret key after each signature generation.
Reflect these changes in the test app.
Some XMSS tests takes too long and hit the time-out limit.
 
<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

