### PR TITLE
fix kat_kem linkage to make HQC PR pass CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -117,47 +117,46 @@ jobs:
           name: liboqs-openssl3-shared-x64
           path: build/*.deb
 
-# Does anyone care if we delete support for this platform?
-#  linux_arm_emulated:
-#    needs: [stylecheck, buildcheck]
-#    runs-on: ubuntu-latest
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        include:
-#          - name: armhf
-#            ARCH: armhf
-#            CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
-#            PYTEST_ARGS: --ignore=tests/test_alg_info.py
-#          # no longer supporting armel
-#          # - name: armel
-#          #   ARCH: armel
-#          #   CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v2
-#      - name: Install the emulation handlers
-#        run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
-#      - name: Build in an x86_64 container
-#        run: |
-#          docker run --rm \
-#                     -v `pwd`:`pwd` \
-#                     -w `pwd` \
-#                     openquantumsafe/ci-debian-buster-amd64:latest /bin/bash \
-#                     -c "mkdir build && \
-#                         (cd build && \
-#                          cmake .. -GNinja ${{ matrix.CMAKE_ARGS }} \
-#                                   -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_${{ matrix.ARCH }}.cmake && \
-#                          cmake -LA .. && \
-#                          ninja)"
-#      - name: Run the tests in an ${{ matrix.ARCH }} container
-#        timeout-minutes: 60
-#        run: |
-#          docker run --rm -e SKIP_TESTS=style,mem_kem,mem_sig \
-#                          -v `pwd`:`pwd` \
-#                          -w `pwd` \
-#                          openquantumsafe/ci-debian-buster-${{ matrix.ARCH }}:latest /bin/bash \
-#                          -c "mkdir -p tmp && \
-#                              python3 -m pytest --verbose \
-#                                                --numprocesses=auto \
-#                                                --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}"
+  linux_arm_emulated:
+    needs: [stylecheck, buildcheck]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: armhf
+            ARCH: armhf
+            CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py
+          # no longer supporting armel
+          # - name: armel
+          #   ARCH: armel
+          #   CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install the emulation handlers
+        run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      - name: Build in an x86_64 container
+        run: |
+          docker run --rm \
+                     -v `pwd`:`pwd` \
+                     -w `pwd` \
+                     openquantumsafe/ci-debian-buster-amd64:latest /bin/bash \
+                     -c "mkdir build && \
+                         (cd build && \
+                          cmake .. -GNinja ${{ matrix.CMAKE_ARGS }} \
+                                   -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_${{ matrix.ARCH }}.cmake && \
+                          cmake -LA .. && \
+                          ninja)"
+      - name: Run the tests in an ${{ matrix.ARCH }} container
+        timeout-minutes: 60
+        run: |
+          docker run --rm -e SKIP_TESTS=style,mem_kem,mem_sig \
+                          -v `pwd`:`pwd` \
+                          -w `pwd` \
+                          openquantumsafe/ci-debian-buster-${{ matrix.ARCH }}:latest /bin/bash \
+                          -c "mkdir -p tmp && \
+                              python3 -m pytest --verbose \
+                                                --numprocesses=auto \
+                                                --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -117,46 +117,47 @@ jobs:
           name: liboqs-openssl3-shared-x64
           path: build/*.deb
 
-  linux_arm_emulated:
-    needs: [stylecheck, buildcheck]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: armhf
-            ARCH: armhf
-            CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
-            PYTEST_ARGS: --ignore=tests/test_alg_info.py
-          # no longer supporting armel
-          # - name: armel
-          #   ARCH: armel
-          #   CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Install the emulation handlers
-        run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
-      - name: Build in an x86_64 container
-        run: |
-          docker run --rm \
-                     -v `pwd`:`pwd` \
-                     -w `pwd` \
-                     openquantumsafe/ci-debian-buster-amd64:latest /bin/bash \
-                     -c "mkdir build && \
-                         (cd build && \
-                          cmake .. -GNinja ${{ matrix.CMAKE_ARGS }} \
-                                   -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_${{ matrix.ARCH }}.cmake && \
-                          cmake -LA .. && \
-                          ninja)"
-      - name: Run the tests in an ${{ matrix.ARCH }} container
-        timeout-minutes: 60
-        run: |
-          docker run --rm -e SKIP_TESTS=style,mem_kem,mem_sig \
-                          -v `pwd`:`pwd` \
-                          -w `pwd` \
-                          openquantumsafe/ci-debian-buster-${{ matrix.ARCH }}:latest /bin/bash \
-                          -c "mkdir -p tmp && \
-                              python3 -m pytest --verbose \
-                                                --numprocesses=auto \
-                                                --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}"
+# Does anyone care if we delete support for this platform?
+#  linux_arm_emulated:
+#    needs: [stylecheck, buildcheck]
+#    runs-on: ubuntu-latest
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        include:
+#          - name: armhf
+#            ARCH: armhf
+#            CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
+#            PYTEST_ARGS: --ignore=tests/test_alg_info.py
+#          # no longer supporting armel
+#          # - name: armel
+#          #   ARCH: armel
+#          #   CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v2
+#      - name: Install the emulation handlers
+#        run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
+#      - name: Build in an x86_64 container
+#        run: |
+#          docker run --rm \
+#                     -v `pwd`:`pwd` \
+#                     -w `pwd` \
+#                     openquantumsafe/ci-debian-buster-amd64:latest /bin/bash \
+#                     -c "mkdir build && \
+#                         (cd build && \
+#                          cmake .. -GNinja ${{ matrix.CMAKE_ARGS }} \
+#                                   -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_${{ matrix.ARCH }}.cmake && \
+#                          cmake -LA .. && \
+#                          ninja)"
+#      - name: Run the tests in an ${{ matrix.ARCH }} container
+#        timeout-minutes: 60
+#        run: |
+#          docker run --rm -e SKIP_TESTS=style,mem_kem,mem_sig \
+#                          -v `pwd`:`pwd` \
+#                          -w `pwd` \
+#                          openquantumsafe/ci-debian-buster-${{ matrix.ARCH }}:latest /bin/bash \
+#                          -c "mkdir -p tmp && \
+#                              python3 -m pytest --verbose \
+#                                                --numprocesses=auto \
+#                                                --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,6 +54,8 @@ add_library(oqs kem/kem.c
                 ${SIG_OBJS}
                 ${COMMON_OBJS})
 set(COMMON_OBJS ${COMMON_OBJS} PARENT_SCOPE)
+set(_ALL_OBJS ${KEM_OBJS} ${SIG_OBJS} ${COMMON_OBJS} $<TARGET_OBJECTS:oqs>)
+set(ALL_OBJS ${_ALL_OBJS} PARENT_SCOPE)
 if(DEFINED SANITIZER_LD_FLAGS)
     target_link_libraries(oqs PUBLIC ${SANITIZER_LD_FLAGS})
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,7 +65,7 @@ add_executable(example_kem example_kem.c)
 target_link_libraries(example_kem PRIVATE ${API_TEST_DEPS})
 
 # KAT KEM needs to call the internal SHA3 functions directly, hence the extra dependencies
-add_executable(kat_kem kat_kem.c ${COMMON_OBJS})
+add_executable(kat_kem kat_kem.c ${ALL_OBJS})
 target_link_libraries(kat_kem PRIVATE ${API_TEST_DEPS} ${INTERNAL_TEST_DEPS})
 
 add_executable(test_kem test_kem.c)


### PR DESCRIPTION
This fixes the ["strange MacOS" CI problem](https://github.com/open-quantum-safe/liboqs/pull/1585#issuecomment-1792422996): Conceptually it isn't quite unlogical that the object file of "kem.c" should be made available to the link command of `kat_kem` (even though it should be part of the library). Let's see what CI says about the other platforms now....

