### PR TITLE
Pull latest Kyber version from upstream

### DIFF
--- a/docs/algorithms/kem/kyber.md
+++ b/docs/algorithms/kem/kyber.md
@@ -7,9 +7,9 @@
 - **Authors' website**: https://pq-crystals.org/
 - **Specification version**: NIST Round 3 submission.
 - **Primary Source**<a name="primary-source"></a>:
-  - **Source**: https://github.com/pq-crystals/kyber/commit/518de2414a85052bb91349bcbcc347f391292d5b with copy_from_upstream patches
+  - **Source**: https://github.com/pq-crystals/kyber/commit/dda29cc63af721981ee2c831cf00822e69be3220 with copy_from_upstream patches
   - **Implementation license (SPDX-Identifier)**: CC0-1.0 or Apache-2.0
-- **Optimized Implementation sources**: https://github.com/pq-crystals/kyber/commit/518de2414a85052bb91349bcbcc347f391292d5b with copy_from_upstream patches
+- **Optimized Implementation sources**: https://github.com/pq-crystals/kyber/commit/dda29cc63af721981ee2c831cf00822e69be3220 with copy_from_upstream patches
   - **oldpqclean-aarch64**:<a name="oldpqclean-aarch64"></a>
       - **Source**: https://github.com/PQClean/PQClean/commit/8e220a87308154d48fdfac40abbb191ac7fce06a with copy_from_upstream patches
       - **Implementation license (SPDX-Identifier)**: CC0-1.0 and (CC0-1.0 or Apache-2.0) and (CC0-1.0 or MIT) and MIT

--- a/docs/algorithms/kem/kyber.yml
+++ b/docs/algorithms/kem/kyber.yml
@@ -17,7 +17,7 @@ website: https://pq-crystals.org/
 nist-round: 3
 spec-version: NIST Round 3 submission
 primary-upstream:
-  source: https://github.com/pq-crystals/kyber/commit/518de2414a85052bb91349bcbcc347f391292d5b
+  source: https://github.com/pq-crystals/kyber/commit/dda29cc63af721981ee2c831cf00822e69be3220
     with copy_from_upstream patches
   spdx-license-identifier: CC0-1.0 or Apache-2.0
 optimized-upstreams:

--- a/scripts/copy_from_upstream/copy_from_upstream.yml
+++ b/scripts/copy_from_upstream/copy_from_upstream.yml
@@ -25,7 +25,7 @@ upstreams:
     name: pqcrystals-kyber
     git_url: https://github.com/pq-crystals/kyber.git
     git_branch: master
-    git_commit: 518de2414a85052bb91349bcbcc347f391292d5b
+    git_commit: dda29cc63af721981ee2c831cf00822e69be3220
     kem_meta_path: '{pretty_name_full}_META.yml'
     kem_scheme_path: '.'
     patches: [pqcrystals-kyber-yml.patch, pqcrystals-kyber-ref-shake-aes.patch, pqcrystals-kyber-avx2-shake-aes.patch]

--- a/src/kem/kyber/pqcrystals-kyber_kyber1024_avx2/verify.c
+++ b/src/kem/kyber/pqcrystals-kyber_kyber1024_avx2/verify.c
@@ -57,6 +57,16 @@ void cmov(uint8_t * restrict r, const uint8_t *x, size_t len, uint8_t b)
   size_t i;
   __m256i xvec, rvec, bvec;
 
+#if defined(__GNUC__) || defined(__clang__)
+  // Prevent the compiler from
+  //    1) inferring that b is 0/1-valued, and
+  //    2) handling the two cases with a branch.
+  // This is not necessary when verify.c and kem.c are separate translation
+  // units, but we expect that downstream consumers will copy this code and/or
+  // change how it is built.
+  __asm__("" : "+r"(b) : /* no inputs */);
+#endif
+
   bvec = _mm256_set1_epi64x(-(uint64_t)b);
   for(i=0;i<len/32;i++) {
     rvec = _mm256_loadu_si256((__m256i *)&r[32*i]);

--- a/src/kem/kyber/pqcrystals-kyber_kyber1024_ref/poly.c
+++ b/src/kem/kyber/pqcrystals-kyber_kyber1024_ref/poly.c
@@ -180,14 +180,19 @@ void poly_frommsg(poly *r, const uint8_t msg[KYBER_INDCPA_MSGBYTES])
 void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const poly *a)
 {
   unsigned int i,j;
-  uint16_t t;
+  uint32_t t;
 
   for(i=0;i<KYBER_N/8;i++) {
     msg[i] = 0;
     for(j=0;j<8;j++) {
       t  = a->coeffs[8*i+j];
-      t += ((int16_t)t >> 15) & KYBER_Q;
-      t  = (((t << 1) + KYBER_Q/2)/KYBER_Q) & 1;
+      // t += ((int16_t)t >> 15) & KYBER_Q;
+      // t  = (((t << 1) + KYBER_Q/2)/KYBER_Q) & 1;
+      t <<= 1;
+      t += 1665;
+      t *= 80635;
+      t >>= 28;
+      t &= 1;
       msg[i] |= t << j;
     }
   }

--- a/src/kem/kyber/pqcrystals-kyber_kyber1024_ref/verify.c
+++ b/src/kem/kyber/pqcrystals-kyber_kyber1024_ref/verify.c
@@ -41,6 +41,16 @@ void cmov(uint8_t *r, const uint8_t *x, size_t len, uint8_t b)
 {
   size_t i;
 
+#if defined(__GNUC__) || defined(__clang__)
+  // Prevent the compiler from
+  //    1) inferring that b is 0/1-valued, and
+  //    2) handling the two cases with a branch.
+  // This is not necessary when verify.c and kem.c are separate translation
+  // units, but we expect that downstream consumers will copy this code and/or
+  // change how it is built.
+  __asm__("" : "+r"(b) : /* no inputs */);
+#endif
+
   b = -b;
   for(i=0;i<len;i++)
     r[i] ^= b & (r[i] ^ x[i]);

--- a/src/kem/kyber/pqcrystals-kyber_kyber512_avx2/verify.c
+++ b/src/kem/kyber/pqcrystals-kyber_kyber512_avx2/verify.c
@@ -57,6 +57,16 @@ void cmov(uint8_t * restrict r, const uint8_t *x, size_t len, uint8_t b)
   size_t i;
   __m256i xvec, rvec, bvec;
 
+#if defined(__GNUC__) || defined(__clang__)
+  // Prevent the compiler from
+  //    1) inferring that b is 0/1-valued, and
+  //    2) handling the two cases with a branch.
+  // This is not necessary when verify.c and kem.c are separate translation
+  // units, but we expect that downstream consumers will copy this code and/or
+  // change how it is built.
+  __asm__("" : "+r"(b) : /* no inputs */);
+#endif
+
   bvec = _mm256_set1_epi64x(-(uint64_t)b);
   for(i=0;i<len/32;i++) {
     rvec = _mm256_loadu_si256((__m256i *)&r[32*i]);

--- a/src/kem/kyber/pqcrystals-kyber_kyber512_ref/poly.c
+++ b/src/kem/kyber/pqcrystals-kyber_kyber512_ref/poly.c
@@ -180,14 +180,19 @@ void poly_frommsg(poly *r, const uint8_t msg[KYBER_INDCPA_MSGBYTES])
 void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const poly *a)
 {
   unsigned int i,j;
-  uint16_t t;
+  uint32_t t;
 
   for(i=0;i<KYBER_N/8;i++) {
     msg[i] = 0;
     for(j=0;j<8;j++) {
       t  = a->coeffs[8*i+j];
-      t += ((int16_t)t >> 15) & KYBER_Q;
-      t  = (((t << 1) + KYBER_Q/2)/KYBER_Q) & 1;
+      // t += ((int16_t)t >> 15) & KYBER_Q;
+      // t  = (((t << 1) + KYBER_Q/2)/KYBER_Q) & 1;
+      t <<= 1;
+      t += 1665;
+      t *= 80635;
+      t >>= 28;
+      t &= 1;
       msg[i] |= t << j;
     }
   }

--- a/src/kem/kyber/pqcrystals-kyber_kyber512_ref/verify.c
+++ b/src/kem/kyber/pqcrystals-kyber_kyber512_ref/verify.c
@@ -41,6 +41,16 @@ void cmov(uint8_t *r, const uint8_t *x, size_t len, uint8_t b)
 {
   size_t i;
 
+#if defined(__GNUC__) || defined(__clang__)
+  // Prevent the compiler from
+  //    1) inferring that b is 0/1-valued, and
+  //    2) handling the two cases with a branch.
+  // This is not necessary when verify.c and kem.c are separate translation
+  // units, but we expect that downstream consumers will copy this code and/or
+  // change how it is built.
+  __asm__("" : "+r"(b) : /* no inputs */);
+#endif
+
   b = -b;
   for(i=0;i<len;i++)
     r[i] ^= b & (r[i] ^ x[i]);

--- a/src/kem/kyber/pqcrystals-kyber_kyber768_avx2/verify.c
+++ b/src/kem/kyber/pqcrystals-kyber_kyber768_avx2/verify.c
@@ -57,6 +57,16 @@ void cmov(uint8_t * restrict r, const uint8_t *x, size_t len, uint8_t b)
   size_t i;
   __m256i xvec, rvec, bvec;
 
+#if defined(__GNUC__) || defined(__clang__)
+  // Prevent the compiler from
+  //    1) inferring that b is 0/1-valued, and
+  //    2) handling the two cases with a branch.
+  // This is not necessary when verify.c and kem.c are separate translation
+  // units, but we expect that downstream consumers will copy this code and/or
+  // change how it is built.
+  __asm__("" : "+r"(b) : /* no inputs */);
+#endif
+
   bvec = _mm256_set1_epi64x(-(uint64_t)b);
   for(i=0;i<len/32;i++) {
     rvec = _mm256_loadu_si256((__m256i *)&r[32*i]);

--- a/src/kem/kyber/pqcrystals-kyber_kyber768_ref/poly.c
+++ b/src/kem/kyber/pqcrystals-kyber_kyber768_ref/poly.c
@@ -180,14 +180,19 @@ void poly_frommsg(poly *r, const uint8_t msg[KYBER_INDCPA_MSGBYTES])
 void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const poly *a)
 {
   unsigned int i,j;
-  uint16_t t;
+  uint32_t t;
 
   for(i=0;i<KYBER_N/8;i++) {
     msg[i] = 0;
     for(j=0;j<8;j++) {
       t  = a->coeffs[8*i+j];
-      t += ((int16_t)t >> 15) & KYBER_Q;
-      t  = (((t << 1) + KYBER_Q/2)/KYBER_Q) & 1;
+      // t += ((int16_t)t >> 15) & KYBER_Q;
+      // t  = (((t << 1) + KYBER_Q/2)/KYBER_Q) & 1;
+      t <<= 1;
+      t += 1665;
+      t *= 80635;
+      t >>= 28;
+      t &= 1;
       msg[i] |= t << j;
     }
   }

--- a/src/kem/kyber/pqcrystals-kyber_kyber768_ref/verify.c
+++ b/src/kem/kyber/pqcrystals-kyber_kyber768_ref/verify.c
@@ -41,6 +41,16 @@ void cmov(uint8_t *r, const uint8_t *x, size_t len, uint8_t b)
 {
   size_t i;
 
+#if defined(__GNUC__) || defined(__clang__)
+  // Prevent the compiler from
+  //    1) inferring that b is 0/1-valued, and
+  //    2) handling the two cases with a branch.
+  // This is not necessary when verify.c and kem.c are separate translation
+  // units, but we expect that downstream consumers will copy this code and/or
+  // change how it is built.
+  __asm__("" : "+r"(b) : /* no inputs */);
+#endif
+
   b = -b;
   for(i=0;i<len;i++)
     r[i] ^= b & (r[i] ^ x[i]);


### PR DESCRIPTION
Pull latest Kyber version from upstream, which fixes a potential constant-time issue in the "ref" version as reported here:
https://groups.google.com/a/list.nist.gov/d/msgid/pqc-forum/ZXxUpck1501jEcRq%40localhost

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

