### PR TITLE
Apply patch to Kyber aarch64 code from PQClean for variable-time division issue.

### DIFF
--- a/scripts/copy_from_upstream/copy_from_upstream.yml
+++ b/scripts/copy_from_upstream/copy_from_upstream.yml
@@ -8,7 +8,7 @@ upstreams:
     sig_meta_path: 'crypto_sign/{pqclean_scheme}/META.yml'
     kem_scheme_path: 'crypto_kem/{pqclean_scheme}'
     sig_scheme_path: 'crypto_sign/{pqclean_scheme}'
-    patches: [pqclean-dilithium-arm-randomized-signing.patch, pqclean-kyber-armneon-shake-fixes.patch, pqclean-kyber-armneon-768-1024-fixes.patch]
+    patches: [pqclean-dilithium-arm-randomized-signing.patch, pqclean-kyber-armneon-shake-fixes.patch, pqclean-kyber-armneon-768-1024-fixes.patch, pqclean-kyber-armneon-variable-timing-fix.patch]
     ignore: pqclean_sphincs-shake-256s-simple_aarch64, pqclean_sphincs-shake-256s-simple_aarch64, pqclean_sphincs-shake-256f-simple_aarch64, pqclean_sphincs-shake-192s-simple_aarch64, pqclean_sphincs-shake-192f-simple_aarch64, pqclean_sphincs-shake-128s-simple_aarch64, pqclean_sphincs-shake-128f-simple_aarch64
   -
     name: pqclean

--- a/scripts/copy_from_upstream/patches/pqclean-kyber-armneon-variable-timing-fix.patch
+++ b/scripts/copy_from_upstream/patches/pqclean-kyber-armneon-variable-timing-fix.patch
@@ -1,0 +1,81 @@
+diff --git a/crypto_kem/kyber1024/aarch64/poly.c b/crypto_kem/kyber1024/aarch64/poly.c
+index 1dfa52c..02e010b 100644
+--- a/crypto_kem/kyber1024/aarch64/poly.c
++++ b/crypto_kem/kyber1024/aarch64/poly.c
+@@ -207,14 +207,19 @@ void poly_frommsg(int16_t r[KYBER_N], const uint8_t msg[KYBER_INDCPA_MSGBYTES])
+ **************************************************/
+ void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const int16_t a[KYBER_N]) {
+     unsigned int i, j;
+-    uint16_t t;
++    uint32_t t;
+ 
+     for (i = 0; i < KYBER_N / 8; i++) {
+         msg[i] = 0;
+         for (j = 0; j < 8; j++) {
+             t  = a[8 * i + j];
+-            t += ((int16_t)t >> 15) & KYBER_Q;
+-            t  = (((t << 1) + KYBER_Q / 2) / KYBER_Q) & 1;
++            // t += ((int16_t)t >> 15) & KYBER_Q;
++            // t  = (((t << 1) + KYBER_Q/2)/KYBER_Q) & 1;
++            t <<= 1;
++            t += 1665;
++            t *= 80635;
++            t >>= 28;
++            t &= 1;
+             msg[i] |= t << j;
+         }
+     }
+diff --git a/crypto_kem/kyber512/aarch64/poly.c b/crypto_kem/kyber512/aarch64/poly.c
+index dffc655..fcfcedd 100644
+--- a/crypto_kem/kyber512/aarch64/poly.c
++++ b/crypto_kem/kyber512/aarch64/poly.c
+@@ -194,14 +194,19 @@ void poly_frommsg(int16_t r[KYBER_N], const uint8_t msg[KYBER_INDCPA_MSGBYTES])
+ **************************************************/
+ void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const int16_t a[KYBER_N]) {
+     unsigned int i, j;
+-    uint16_t t;
++    uint32_t t;
+ 
+     for (i = 0; i < KYBER_N / 8; i++) {
+         msg[i] = 0;
+         for (j = 0; j < 8; j++) {
+             t  = a[8 * i + j];
+-            t += ((int16_t)t >> 15) & KYBER_Q;
+-            t  = (((t << 1) + KYBER_Q / 2) / KYBER_Q) & 1;
++            // t += ((int16_t)t >> 15) & KYBER_Q;
++            // t  = (((t << 1) + KYBER_Q/2)/KYBER_Q) & 1;
++            t <<= 1;
++            t += 1665;
++            t *= 80635;
++            t >>= 28;
++            t &= 1;
+             msg[i] |= t << j;
+         }
+     }
+diff --git a/crypto_kem/kyber768/aarch64/poly.c b/crypto_kem/kyber768/aarch64/poly.c
+index dffc655..fcfcedd 100644
+--- a/crypto_kem/kyber768/aarch64/poly.c
++++ b/crypto_kem/kyber768/aarch64/poly.c
+@@ -194,14 +194,19 @@ void poly_frommsg(int16_t r[KYBER_N], const uint8_t msg[KYBER_INDCPA_MSGBYTES])
+ **************************************************/
+ void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const int16_t a[KYBER_N]) {
+     unsigned int i, j;
+-    uint16_t t;
++    uint32_t t;
+ 
+     for (i = 0; i < KYBER_N / 8; i++) {
+         msg[i] = 0;
+         for (j = 0; j < 8; j++) {
+             t  = a[8 * i + j];
+-            t += ((int16_t)t >> 15) & KYBER_Q;
+-            t  = (((t << 1) + KYBER_Q / 2) / KYBER_Q) & 1;
++            // t += ((int16_t)t >> 15) & KYBER_Q;
++            // t  = (((t << 1) + KYBER_Q/2)/KYBER_Q) & 1;
++            t <<= 1;
++            t += 1665;
++            t *= 80635;
++            t >>= 28;
++            t &= 1;
+             msg[i] |= t << j;
+         }
+     }

--- a/src/kem/kyber/oldpqclean_kyber1024_aarch64/poly.c
+++ b/src/kem/kyber/oldpqclean_kyber1024_aarch64/poly.c
@@ -207,14 +207,19 @@ void poly_frommsg(int16_t r[KYBER_N], const uint8_t msg[KYBER_INDCPA_MSGBYTES]) 
 **************************************************/
 void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const int16_t a[KYBER_N]) {
     unsigned int i, j;
-    uint16_t t;
+    uint32_t t;
 
     for (i = 0; i < KYBER_N / 8; i++) {
         msg[i] = 0;
         for (j = 0; j < 8; j++) {
             t  = a[8 * i + j];
-            t += ((int16_t)t >> 15) & KYBER_Q;
-            t  = (((t << 1) + KYBER_Q / 2) / KYBER_Q) & 1;
+            // t += ((int16_t)t >> 15) & KYBER_Q;
+            // t  = (((t << 1) + KYBER_Q/2)/KYBER_Q) & 1;
+            t <<= 1;
+            t += 1665;
+            t *= 80635;
+            t >>= 28;
+            t &= 1;
             msg[i] |= t << j;
         }
     }

--- a/src/kem/kyber/oldpqclean_kyber512_aarch64/poly.c
+++ b/src/kem/kyber/oldpqclean_kyber512_aarch64/poly.c
@@ -194,14 +194,19 @@ void poly_frommsg(int16_t r[KYBER_N], const uint8_t msg[KYBER_INDCPA_MSGBYTES]) 
 **************************************************/
 void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const int16_t a[KYBER_N]) {
     unsigned int i, j;
-    uint16_t t;
+    uint32_t t;
 
     for (i = 0; i < KYBER_N / 8; i++) {
         msg[i] = 0;
         for (j = 0; j < 8; j++) {
             t  = a[8 * i + j];
-            t += ((int16_t)t >> 15) & KYBER_Q;
-            t  = (((t << 1) + KYBER_Q / 2) / KYBER_Q) & 1;
+            // t += ((int16_t)t >> 15) & KYBER_Q;
+            // t  = (((t << 1) + KYBER_Q/2)/KYBER_Q) & 1;
+            t <<= 1;
+            t += 1665;
+            t *= 80635;
+            t >>= 28;
+            t &= 1;
             msg[i] |= t << j;
         }
     }

--- a/src/kem/kyber/oldpqclean_kyber768_aarch64/poly.c
+++ b/src/kem/kyber/oldpqclean_kyber768_aarch64/poly.c
@@ -194,14 +194,19 @@ void poly_frommsg(int16_t r[KYBER_N], const uint8_t msg[KYBER_INDCPA_MSGBYTES]) 
 **************************************************/
 void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const int16_t a[KYBER_N]) {
     unsigned int i, j;
-    uint16_t t;
+    uint32_t t;
 
     for (i = 0; i < KYBER_N / 8; i++) {
         msg[i] = 0;
         for (j = 0; j < 8; j++) {
             t  = a[8 * i + j];
-            t += ((int16_t)t >> 15) & KYBER_Q;
-            t  = (((t << 1) + KYBER_Q / 2) / KYBER_Q) & 1;
+            // t += ((int16_t)t >> 15) & KYBER_Q;
+            // t  = (((t << 1) + KYBER_Q/2)/KYBER_Q) & 1;
+            t <<= 1;
+            t += 1665;
+            t *= 80635;
+            t >>= 28;
+            t &= 1;
             msg[i] |= t << j;
         }
     }


### PR DESCRIPTION
This is a follow-up to PR #1631.

Adds patch to aarch64 Kyber pulled from PQClean for issue with variable-time division in poly_tomsg.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

