### PR TITLE
Add Apache 2.0 and MIT License to XMSS

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -34,6 +34,6 @@ Karolin Varner
 Sebastian Verschoor (University of Waterloo)
 Thom Wiggers (Radboud University)
 Dindyal Jeevesh Rishi (University of Mauritius / cyberstorm.mu)
-Duc Tri Nguyen (SandboxAQ)
+Duc Tri Nguyen
 
 See additional contributors at https://github.com/open-quantum-safe/liboqs/graphs/contributors

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -34,5 +34,6 @@ Karolin Varner
 Sebastian Verschoor (University of Waterloo)
 Thom Wiggers (Radboud University)
 Dindyal Jeevesh Rishi (University of Mauritius / cyberstorm.mu)
+Duc Tri Nguyen (SandboxAQ)
 
 See additional contributors at https://github.com/open-quantum-safe/liboqs/graphs/contributors

--- a/src/sig_stfl/xmss/CMakeLists.txt
+++ b/src/sig_stfl/xmss/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Apache-2.0 AND MIT
 
 set(_XMSS_OBJS "")
 

--- a/src/sig_stfl/xmss/LICENSE
+++ b/src/sig_stfl/xmss/LICENSE
@@ -1,0 +1,12 @@
+## License
+
+This XMSS reference implementation is Copyright (c) 2024 SandboxAQ and licensed under both the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) and [MIT License](LICENSE-MIT).
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+This XMSS reference implementation is based on the [XMSS reference implementation written by Andreas Hülsing and Joost Rijneveld](https://github.com/XMSS/xmss-reference#license) provided under the CC0 1.0 Universal Public Domain Dedication.
+
+
+## Disclaimer
+
+The software and documentation are provided "as is" and SandboxAQ hereby disclaims all warranties, whether express, implied, statutory, or otherwise. SandboxAQ specifically disclaims, without limitation, all implied warranties of merchantability, fitness for a particular purpose, title, and non-infringement, and all warranties arising from course of dealing, usage, or trade practice. SandboxAQ makes no warranty of any kind that the software and documentation, or any products or results of the use thereof, will meet any person's requirements, operate without interruption, achieve any intended result, be compatible or work with any software, system or other services, or be secure, accurate, complete, free of harmful code, or error-free.

--- a/src/sig_stfl/xmss/LICENSE-MIT
+++ b/src/sig_stfl/xmss/LICENSE-MIT
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright © 2024 SandboxAQ
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/sig_stfl/xmss/external/core_hash.c
+++ b/src/sig_stfl/xmss/external/core_hash.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #include <oqs/sha2.h>
 #include <oqs/sha3.h>
 #include "core_hash.h"

--- a/src/sig_stfl/xmss/external/core_hash.h
+++ b/src/sig_stfl/xmss/external/core_hash.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #ifndef CORE_HASH
 #define CORE_HASH
 

--- a/src/sig_stfl/xmss/external/hash.c
+++ b/src/sig_stfl/xmss/external/hash.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #include <stdint.h>
 #include <string.h>
 

--- a/src/sig_stfl/xmss/external/hash.h
+++ b/src/sig_stfl/xmss/external/hash.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #ifndef XMSS_HASH_H
 #define XMSS_HASH_H
 

--- a/src/sig_stfl/xmss/external/hash_address.c
+++ b/src/sig_stfl/xmss/external/hash_address.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #include <stdint.h>
 #include "hash_address.h"
 

--- a/src/sig_stfl/xmss/external/hash_address.h
+++ b/src/sig_stfl/xmss/external/hash_address.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #ifndef XMSS_HASH_ADDRESS_H
 #define XMSS_HASH_ADDRESS_H
 

--- a/src/sig_stfl/xmss/external/namespace.h
+++ b/src/sig_stfl/xmss/external/namespace.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #ifndef XMSS_NAMESPACE_H
 #define XMSS_NAMESPACE_H
 

--- a/src/sig_stfl/xmss/external/params.c
+++ b/src/sig_stfl/xmss/external/params.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #include <stdint.h>
 #include <string.h>
 

--- a/src/sig_stfl/xmss/external/params.h
+++ b/src/sig_stfl/xmss/external/params.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #ifndef XMSS_PARAMS_H
 #define XMSS_PARAMS_H
 

--- a/src/sig_stfl/xmss/external/utils.c
+++ b/src/sig_stfl/xmss/external/utils.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #include "utils.h"
 
 /**

--- a/src/sig_stfl/xmss/external/utils.h
+++ b/src/sig_stfl/xmss/external/utils.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #ifndef XMSS_UTILS_H
 #define XMSS_UTILS_H
 

--- a/src/sig_stfl/xmss/external/wots.c
+++ b/src/sig_stfl/xmss/external/wots.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #include <stdint.h>
 #include <string.h>
 

--- a/src/sig_stfl/xmss/external/wots.h
+++ b/src/sig_stfl/xmss/external/wots.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #ifndef XMSS_WOTS_H
 #define XMSS_WOTS_H
 

--- a/src/sig_stfl/xmss/external/xmss.c
+++ b/src/sig_stfl/xmss/external/xmss.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #include <stdint.h>
 
 #include "params.h"

--- a/src/sig_stfl/xmss/external/xmss.h
+++ b/src/sig_stfl/xmss/external/xmss.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #ifndef XMSS_H
 #define XMSS_H
 

--- a/src/sig_stfl/xmss/external/xmss_commons.c
+++ b/src/sig_stfl/xmss/external/xmss_commons.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>

--- a/src/sig_stfl/xmss/external/xmss_commons.h
+++ b/src/sig_stfl/xmss/external/xmss_commons.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #ifndef XMSS_COMMONS_H
 #define XMSS_COMMONS_H
 

--- a/src/sig_stfl/xmss/external/xmss_core.c
+++ b/src/sig_stfl/xmss/external/xmss_core.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>

--- a/src/sig_stfl/xmss/external/xmss_core.h
+++ b/src/sig_stfl/xmss/external/xmss_core.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #ifndef XMSS_CORE_H
 #define XMSS_CORE_H
 

--- a/src/sig_stfl/xmss/external/xmss_core_fast.c
+++ b/src/sig_stfl/xmss/external/xmss_core_fast.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss.h
+++ b/src/sig_stfl/xmss/sig_stfl_xmss.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #ifndef OQS_SIG_STFL_XMSS_H
 #define OQS_SIG_STFL_XMSS_H

--- a/src/sig_stfl/xmss/sig_stfl_xmss_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_functions.c
@@ -1,5 +1,4 @@
-// SPDX-License-Identifier: MIT
-
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 #include <string.h>
 #include <stdlib.h>
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <oqs/oqs.h>
 #include <string.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h10.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h16.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h20.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h10.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h16.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h20.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h10.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h16.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h20.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h10.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h16.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h20.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_functions.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_2.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_4.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_2.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_4.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_8.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_8.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_12.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_12.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_3.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_3.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_6.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_6.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_2.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_4.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_2.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_4.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_8.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_8.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_12.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_12.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_3.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_3.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_6.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_6.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0 AND MIT
 
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

XMSS software will be licensed under dual license: Apache 2.0 and MIT. 

