### PR TITLE
Zephyr: CMake fixes

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -8,32 +8,22 @@ if(CONFIG_LIBOQS)
                 # Workaround as the generic name "arm" is not a supported architecture in liboqs.
                 # In Zephyr, however, it is exclusively used for 32-bit ARM architectures.
                 set(CMAKE_SYSTEM_PROCESSOR "armv7")
-                # We have to set that manually as CMake can't detect it properly in Zephyr
-                set(CMAKE_SIZEOF_VOID_P 4)
         elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv")
-                if(BOARD STREQUAL "qemu_riscv32")
-                        set(CMAKE_SYSTEM_PROCESSOR "riscv32")
-                        # We have to set that manually as CMake can't detect it properly in Zephyr
-                        set(CMAKE_SIZEOF_VOID_P 4)
-                elseif(BOARD STREQUAL "hifive1_revb")
-                        set(CMAKE_SYSTEM_PROCESSOR "riscv32")
-                        # We have to set that manually as CMake can't detect it properly in Zephyr
-                        set(CMAKE_SIZEOF_VOID_P 4)
-                elseif(BOARD STREQUAL "qemu_riscv64")
+                # Zephyr doesn't distinguish between 32-bit and 64-bit RISC-V architectures.
+                if(CONFIG_64BIT)
                         set(CMAKE_SYSTEM_PROCESSOR "riscv64")
-                        # We have to set that manually as CMake can't detect it properly in Zephyr
-                        set(CMAKE_SIZEOF_VOID_P 8)
                 else()
-                        message(FATAL_ERROR "Unsupported board ${BOARD} with riscv architecture")
+                        set(CMAKE_SYSTEM_PROCESSOR "riscv32")
                 endif()
         elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "posix")
                 # Workaround to enable the native Zephyr builds on the Linux host system.
-                if(BOARD STREQUAL "native_posix|native_sim")
+                if(BOARD MATCHES "native_posix|native_sim")
                         set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_HOST_SYSTEM_PROCESSOR})
                 else()
                         message(FATAL_ERROR "Unsupported board ${BOARD} with posix architecture")
                 endif()
         elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86")
+                # Zephyr doesn't distinguish between 32-bit and 64-bit x86 architectures.
                 if(CONFIG_64BIT)
                         set(CMAKE_SYSTEM_PROCESSOR "x86_64")
                 endif()
@@ -161,11 +151,14 @@ if(CONFIG_LIBOQS)
         # Include the liboqs headers
         zephyr_include_directories(${CMAKE_CURRENT_BINARY_DIR}/build/include)
 
+        # Undo the Zephyr workarounds from above to not interfere with other modules
         if(CMAKE_SYSTEM_PROCESSOR STREQUAL "armv7")
-                # Undo the workaround from above to not interfere with other modules
                 set(CMAKE_SYSTEM_PROCESSOR "arm")
         elseif(CMAKE_SYSTEM_PROCESSOR EQUAL CMAKE_HOST_SYSTEM_PROCESSOR)
-                # Undo the workaround from above to not interfere with other modules
                 set(CMAKE_SYSTEM_PROCESSOR "posix")
+        elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "riscv")
+                set(CMAKE_SYSTEM_PROCESSOR "riscv")
+        elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+                set(CMAKE_SYSTEM_PROCESSOR "x86")
         endif()
 endif()


### PR DESCRIPTION
* Minor fixes for the `CMakeLists.txt` file in the `zephyr` directory propably happened during rebasing of #1641.
* Minor improvements to the Zephyr specific CMake workarounds
* RiscV distinct board references have been removed to support all RiscV boards Zephyr supports.