### PR TITLE
Clarify that copyright is held by authors and not the project itself [skip ci]

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -4,7 +4,7 @@ differently; the corresponding subfolder contains the license that applies in
 that case.
 
 
-Copyright (c) 2016-2021 Open Quantum Safe project
+Copyright (c) 2016-2024 The Open Quantum Safe project authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Update copyright year and note that the copyright is held by the authors of the contributions and not the project itself.
