### PR TITLE
Update McEliece suppression files for generic config

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -16,7 +16,7 @@ jobs:
             container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
             CMAKE_ARGS: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=generic -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON
             PYTEST_ARGS: --numprocesses=auto -k 'test_constant_time'
-            SKIP_ALGS: 'SPHINCS\+-SHA*,Classic-McEliece-(.)*'
+            SKIP_ALGS: 'SPHINCS\+-SHA*,Classic-McEliece-[^3](.)*'
           - name: extensions
             container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
             CMAKE_ARGS: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=haswell -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON

--- a/tests/constant_time/kem/issues/classic-mceliece-348864
+++ b/tests/constant_time/kem/issues/classic-mceliece-348864
@@ -365,3 +365,51 @@
    # fun:gen_e
    fun:PQCLEAN_MCELIECE348864_AVX2_encrypt
 }
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:sk_gen.c:58
+   # fun:PQCLEAN_MCELIECE348864_CLEAN_genpoly_gen
+   fun:PQCLEAN_MCELIECE348864_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:66
+   # fun:PQCLEAN_MCELIECE348864_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE348864_CLEAN_crypto_kem_keypair
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:142
+   # fun:PQCLEAN_MCELIECE348864_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE348864_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:controlbits.c:243
+   # fun:PQCLEAN_MCELIECE348864_CLEAN_controlbitsfrompermutation
+   fun:PQCLEAN_MCELIECE348864_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:69
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE348864_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE348864_CLEAN_crypto_kem_enc
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:84
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE348864_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE348864_CLEAN_crypto_kem_enc
+}

--- a/tests/constant_time/kem/issues/classic-mceliece-348864f
+++ b/tests/constant_time/kem/issues/classic-mceliece-348864f
@@ -396,3 +396,59 @@
    # fun:gen_e
    fun:PQCLEAN_MCELIECE348864F_AVX2_encrypt
 }
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:sk_gen.c:58
+   # fun:PQCLEAN_MCELIECE348864F_CLEAN_genpoly_gen
+   fun:PQCLEAN_MCELIECE348864F_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:166
+   # fun:PQCLEAN_MCELIECE348864F_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE348864F_CLEAN_crypto_kem_keypair
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:248
+   # fun:PQCLEAN_MCELIECE348864F_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE348864F_CLEAN_crypto_kem_keypair
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:82
+   # fun:mov_columns
+   fun:PQCLEAN_MCELIECE348864F_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE348864F_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:controlbits.c:243
+   # fun:PQCLEAN_MCELIECE348864F_CLEAN_controlbitsfrompermutation
+   fun:PQCLEAN_MCELIECE348864F_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:69
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE348864F_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE348864F_CLEAN_crypto_kem_enc
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:84
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE348864F_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE348864F_CLEAN_crypto_kem_enc
+}

--- a/tests/constant_time/kem/issues/classic-mceliece-460896
+++ b/tests/constant_time/kem/issues/classic-mceliece-460896
@@ -341,3 +341,51 @@
    # fun:gen_e
    fun:PQCLEAN_MCELIECE460896_AVX2_encrypt
 }
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:sk_gen.c:58
+   # fun:PQCLEAN_MCELIECE460896_CLEAN_genpoly_gen
+   fun:PQCLEAN_MCELIECE460896_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:66
+   # fun:PQCLEAN_MCELIECE460896_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE460896_CLEAN_crypto_kem_keypair
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:142
+   # fun:PQCLEAN_MCELIECE460896_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE460896_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:controlbits.c:243
+   # fun:PQCLEAN_MCELIECE460896_CLEAN_controlbitsfrompermutation
+   fun:PQCLEAN_MCELIECE460896_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:69
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE460896_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE460896_CLEAN_crypto_kem_enc
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:84
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE460896_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE460896_CLEAN_crypto_kem_enc
+}

--- a/tests/constant_time/kem/issues/classic-mceliece-460896f
+++ b/tests/constant_time/kem/issues/classic-mceliece-460896f
@@ -501,3 +501,67 @@
    # fun:gen_e
    fun:PQCLEAN_MCELIECE460896F_AVX2_encrypt
 }
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:91
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE460896F_AVX2_encrypt
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:sk_gen.c:58
+   # fun:PQCLEAN_MCELIECE460896F_CLEAN_genpoly_gen
+   fun:PQCLEAN_MCELIECE460896F_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:166
+   # fun:PQCLEAN_MCELIECE460896F_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE460896F_CLEAN_crypto_kem_keypair
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:248
+   # fun:PQCLEAN_MCELIECE460896F_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE460896F_CLEAN_crypto_kem_keypair
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:82
+   # fun:mov_columns
+   fun:PQCLEAN_MCELIECE460896F_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE460896F_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:controlbits.c:243
+   # fun:PQCLEAN_MCELIECE460896F_CLEAN_controlbitsfrompermutation
+   fun:PQCLEAN_MCELIECE460896F_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:69
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE460896F_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE460896F_CLEAN_crypto_kem_enc
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:84
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE460896F_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE460896F_CLEAN_crypto_kem_enc
+}

--- a/tests/constant_time/kem/issues/classic-mceliece-6688128
+++ b/tests/constant_time/kem/issues/classic-mceliece-6688128
@@ -437,3 +437,51 @@
    # fun:gen_e
    fun:PQCLEAN_MCELIECE6688128_AVX2_encrypt
 }
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:sk_gen.c:58
+   # fun:PQCLEAN_MCELIECE6688128_CLEAN_genpoly_gen
+   fun:PQCLEAN_MCELIECE6688128_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:66
+   # fun:PQCLEAN_MCELIECE6688128_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE6688128_CLEAN_crypto_kem_keypair
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:142
+   # fun:PQCLEAN_MCELIECE6688128_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE6688128_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:controlbits.c:243
+   # fun:PQCLEAN_MCELIECE6688128_CLEAN_controlbitsfrompermutation
+   fun:PQCLEAN_MCELIECE6688128_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:69
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE6688128_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE6688128_CLEAN_crypto_kem_enc
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:84
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE6688128_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE6688128_CLEAN_crypto_kem_enc
+}

--- a/tests/constant_time/kem/issues/classic-mceliece-6688128f
+++ b/tests/constant_time/kem/issues/classic-mceliece-6688128f
@@ -736,3 +736,58 @@
    fun:PQCLEAN_MCELIECE6688128F_AVX2_encrypt
 }
 
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:sk_gen.c:58
+   # fun:PQCLEAN_MCELIECE6688128F_CLEAN_genpoly_gen
+   fun:PQCLEAN_MCELIECE6688128F_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:166
+   # fun:PQCLEAN_MCELIECE6688128F_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE6688128F_CLEAN_crypto_kem_keypair
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:248
+   # fun:PQCLEAN_MCELIECE6688128F_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE6688128F_CLEAN_crypto_kem_keypair
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:82
+   # fun:mov_columns
+   fun:PQCLEAN_MCELIECE6688128F_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE6688128F_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:controlbits.c:243
+   # fun:PQCLEAN_MCELIECE6688128F_CLEAN_controlbitsfrompermutation
+   fun:PQCLEAN_MCELIECE6688128F_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:69
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE6688128F_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE6688128F_CLEAN_crypto_kem_enc
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:84
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE6688128F_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE6688128F_CLEAN_crypto_kem_enc
+}

--- a/tests/constant_time/kem/issues/classic-mceliece-6960119
+++ b/tests/constant_time/kem/issues/classic-mceliece-6960119
@@ -397,3 +397,51 @@
    # fun:gen_e
    fun:PQCLEAN_MCELIECE6960119_AVX2_encrypt
 }
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:sk_gen.c:58
+   # fun:PQCLEAN_MCELIECE6960119_CLEAN_genpoly_gen
+   fun:PQCLEAN_MCELIECE6960119_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:68
+   # fun:PQCLEAN_MCELIECE6960119_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE6960119_CLEAN_crypto_kem_keypair
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:144
+   # fun:PQCLEAN_MCELIECE6960119_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE6960119_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:controlbits.c:243
+   # fun:PQCLEAN_MCELIECE6960119_CLEAN_controlbitsfrompermutation
+   fun:PQCLEAN_MCELIECE6960119_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:69
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE6960119_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE6960119_CLEAN_crypto_kem_enc
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:84
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE6960119_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE6960119_CLEAN_crypto_kem_enc
+}

--- a/tests/constant_time/kem/issues/classic-mceliece-6960119f
+++ b/tests/constant_time/kem/issues/classic-mceliece-6960119f
@@ -645,3 +645,59 @@
    # fun:gen_e
    fun:PQCLEAN_MCELIECE6960119F_AVX2_encrypt
 }
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:sk_gen.c:58
+   # fun:PQCLEAN_MCELIECE6960119F_CLEAN_genpoly_gen
+   fun:PQCLEAN_MCELIECE6960119F_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:192
+   # fun:PQCLEAN_MCELIECE6960119F_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE6960119F_CLEAN_crypto_kem_keypair
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:274
+   # fun:PQCLEAN_MCELIECE6960119F_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE6960119F_CLEAN_crypto_kem_keypair
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:91
+   # fun:mov_columns
+   fun:PQCLEAN_MCELIECE6960119F_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE6960119F_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:controlbits.c:243
+   # fun:PQCLEAN_MCELIECE6960119F_CLEAN_controlbitsfrompermutation
+   fun:PQCLEAN_MCELIECE6960119F_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:69
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE6960119F_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE6960119F_CLEAN_crypto_kem_enc
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:84
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE6960119F_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE6960119F_CLEAN_crypto_kem_enc
+}

--- a/tests/constant_time/kem/issues/classic-mceliece-8192128
+++ b/tests/constant_time/kem/issues/classic-mceliece-8192128
@@ -333,3 +333,43 @@
    # fun:gen_e
    fun:PQCLEAN_MCELIECE8192128_AVX2_encrypt
 }
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:sk_gen.c:58
+   # fun:PQCLEAN_MCELIECE8192128_CLEAN_genpoly_gen
+   fun:PQCLEAN_MCELIECE8192128_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:66
+   # fun:PQCLEAN_MCELIECE8192128_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE8192128_CLEAN_crypto_kem_keypair
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:142
+   # fun:PQCLEAN_MCELIECE8192128_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE8192128_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:controlbits.c:243
+   # fun:PQCLEAN_MCELIECE8192128_CLEAN_controlbitsfrompermutation
+   fun:PQCLEAN_MCELIECE8192128_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:60
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE8192128_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE8192128_CLEAN_crypto_kem_enc
+}

--- a/tests/constant_time/kem/issues/classic-mceliece-8192128f
+++ b/tests/constant_time/kem/issues/classic-mceliece-8192128f
@@ -598,3 +598,51 @@
    # fun:gen_e
    fun:PQCLEAN_MCELIECE8192128F_AVX2_encrypt
 }
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:sk_gen.c:58
+   # fun:PQCLEAN_MCELIECE8192128F_CLEAN_genpoly_gen
+   fun:PQCLEAN_MCELIECE8192128F_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:166
+   # fun:PQCLEAN_MCELIECE8192128F_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE8192128F_CLEAN_crypto_kem_keypair
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:248
+   # fun:PQCLEAN_MCELIECE8192128F_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE8192128F_CLEAN_crypto_kem_keypair
+}
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:pk_gen.c:82
+   # fun:mov_columns
+   fun:PQCLEAN_MCELIECE8192128F_CLEAN_pk_gen
+   fun:PQCLEAN_MCELIECE8192128F_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:controlbits.c:243
+   # fun:PQCLEAN_MCELIECE8192128F_CLEAN_controlbitsfrompermutation
+   fun:PQCLEAN_MCELIECE8192128F_CLEAN_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:encrypt.c:60
+   # fun:gen_e
+   fun:PQCLEAN_MCELIECE8192128F_CLEAN_encrypt
+   fun:PQCLEAN_MCELIECE8192128F_CLEAN_crypto_kem_enc
+}


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
This PR updates the suppression files for the "clean" (pure C) implementation of Classic McEliece. I've run the tests both in a container built from the CI image and locally on my machine.

For now, I've labelled all of these as "issues", as I'm not knowledgeable enough about McEliece to confidently classify them as false positives or true instances of secret-dependent behaviour. I believe that this is in line with what we had done previously for the AVX2 constant-time failures.

To test:
```bash
rm -rf build && mkdir build && cd build
cmake -GNinja -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=generic -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON .. && ninja ; cd -
python3 -m pytest -n=auto -k "McEliece" -v tests/test_constant_time.py
```

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

Partially addresses #1666.

I suspect that this may also address #1540. @bhess @praveksharma is it plausible that the "env-specific" constant-time errors were simply caused by building without AVX2 optimization? There were previously no suppressions for the "clean" implementation.

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

