### PR TITLE
Update BIKE documentation to exclude x86

### DIFF
--- a/.CMake/alg_support.cmake
+++ b/.CMake/alg_support.cmake
@@ -75,10 +75,10 @@ if(OQS_DIST_X86_64_BUILD OR OQS_USE_AVX2_INSTRUCTIONS)
 endif()
 endif()
 
-# BIKE is not supported on Windows, 32-bit ARM, S390X (big endian) and PPC64 (big endian)
+# BIKE is not supported on Windows, 32-bit ARM, X86, S390X (big endian) and PPC64 (big endian)
 cmake_dependent_option(OQS_ENABLE_KEM_BIKE "Enable BIKE algorithm family" ON "NOT WIN32; NOT ARCH_ARM32v7; NOT ARCH_X86; NOT ARCH_S390X; NOT ARCH_PPC64" OFF)
-# BIKE doesn't work on any 32bit platform except x86:
-if(CMAKE_SIZEOF_VOID_P MATCHES "4" AND NOT ARCH_X86)
+# BIKE doesn't work on any 32-bit platform
+if(CMAKE_SIZEOF_VOID_P MATCHES "4")
 set(OQS_ENABLE_KEM_BIKE OFF)
 endif()
 cmake_dependent_option(OQS_ENABLE_KEM_bike_l1 "" ON "OQS_ENABLE_KEM_BIKE" OFF)

--- a/docs/algorithms/kem/bike.md
+++ b/docs/algorithms/kem/bike.md
@@ -23,7 +23,7 @@
 
 |       Implementation source       | Identifier in upstream   | Supported architecture(s)   | Supported operating system(s)   | CPU extension(s) used   | No branching-on-secrets claimed?   | No branching-on-secrets checked by valgrind?   | Large stack usage?‡   |
 |:---------------------------------:|:-------------------------|:----------------------------|:--------------------------------|:------------------------|:-----------------------------------|:-----------------------------------------------|:----------------------|
-| [Primary Source](#primary-source) | master                   | little endian               | Linux,Darwin                    | None                    | True                               | True                                           | False                 |
+| [Primary Source](#primary-source) | master                   | 64-bit little-endian        | Linux,Darwin                    | None                    | True                               | True                                           | False                 |
 | [Primary Source](#primary-source) | master                   | x86\_64                     | Linux,Darwin                    | AVX2,AVX512,PCLMUL,SSE2 | True                               | True                                           | False                 |
 
 Are implementations chosen based on runtime CPU feature detection? **Yes**.
@@ -34,7 +34,7 @@ Are implementations chosen based on runtime CPU feature detection? **Yes**.
 
 |       Implementation source       | Identifier in upstream   | Supported architecture(s)   | Supported operating system(s)   | CPU extension(s) used   | No branching-on-secrets claimed?   | No branching-on-secrets checked by valgrind?   | Large stack usage?   |
 |:---------------------------------:|:-------------------------|:----------------------------|:--------------------------------|:------------------------|:-----------------------------------|:-----------------------------------------------|:---------------------|
-| [Primary Source](#primary-source) | master                   | little endian               | Linux,Darwin                    | None                    | True                               | True                                           | False                |
+| [Primary Source](#primary-source) | master                   | 64-bit little-endian        | Linux,Darwin                    | None                    | True                               | True                                           | False                |
 | [Primary Source](#primary-source) | master                   | x86\_64                     | Linux,Darwin                    | AVX2,AVX512,PCLMUL,SSE2 | True                               | True                                           | False                |
 
 Are implementations chosen based on runtime CPU feature detection? **Yes**.
@@ -43,7 +43,7 @@ Are implementations chosen based on runtime CPU feature detection? **Yes**.
 
 |       Implementation source       | Identifier in upstream   | Supported architecture(s)   | Supported operating system(s)   | CPU extension(s) used   | No branching-on-secrets claimed?   | No branching-on-secrets checked by valgrind?   | Large stack usage?   |
 |:---------------------------------:|:-------------------------|:----------------------------|:--------------------------------|:------------------------|:-----------------------------------|:-----------------------------------------------|:---------------------|
-| [Primary Source](#primary-source) | master                   | little endian               | Linux,Darwin                    | None                    | True                               | True                                           | False                |
+| [Primary Source](#primary-source) | master                   | 64-bit little-endian        | Linux,Darwin                    | None                    | True                               | True                                           | False                |
 | [Primary Source](#primary-source) | master                   | x86\_64                     | Linux,Darwin                    | AVX2,AVX512,PCLMUL,SSE2 | True                               | True                                           | False                |
 
 Are implementations chosen based on runtime CPU feature detection? **Yes**.

--- a/docs/algorithms/kem/bike.yml
+++ b/docs/algorithms/kem/bike.yml
@@ -40,7 +40,7 @@ parameter-sets:
   - upstream: primary-upstream
     upstream-id: master
     supported-platforms:
-    - architecture: little endian
+    - architecture: 64-bit little-endian
       operating_systems:
       - Linux
       - Darwin
@@ -76,7 +76,7 @@ parameter-sets:
   - upstream: primary-upstream
     upstream-id: master
     supported-platforms:
-    - architecture: little endian
+    - architecture: 64-bit little-endian
       operating_systems:
       - Linux
       - Darwin
@@ -112,7 +112,7 @@ parameter-sets:
   - upstream: primary-upstream
     upstream-id: master
     supported-platforms:
-    - architecture: little endian
+    - architecture: 64-bit little-endian
       operating_systems:
       - Linux
       - Darwin


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

We don't enable BIKE in x86 builds, and [enabling it on x86 leads to CI failures](https://app.circleci.com/pipelines/github/open-quantum-safe/liboqs/3279/workflows/e8d367d9-2717-4105-a2f4-4bee216b0de3/jobs/26246). This PR is to bring documentation in line with the build configuration.

Fixes #1443.

Notably, the [upstream implementation](https://github.com/awslabs/bike-kem/tree/master) does apparently support x86, so this is something we may wish to look into.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)
No to both.

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

