### PR TITLE
Rename weekly runs and skip Falcon-1024 [skip ci]

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,4 +1,4 @@
-name: Weekly constant time tests
+name: Weekly extended tests
 
 on:
   schedule:
@@ -46,10 +46,12 @@ jobs:
             container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
             CMAKE_ARGS: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=generic
             PYTEST_ARGS: --numprocesses=auto -k 'test_kat_all'
+            SKIP_ALGS: 'Falcon-1024' # re-enable when #1561 is resolved
           - name: extensions
             container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
             CMAKE_ARGS: -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=haswell
             PYTEST_ARGS: --numprocesses=auto -k 'test_kat_all'
+            SKIP_ALGS: 'Falcon-1024' # re-enable when #1561 is resolved
     container:
       image: ${{ matrix.container }}
     steps:


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
As expected, Falcon-1024 fails the weekly extended KAT tests. This will be the case until #1561 is resolved. For now, the failure creates unnecessary noise. This PR
1. renames the weekly test workflow to reflect that it's no longer just a constant-time test run and
2. skips the Falcon-1024 extended KAT tests.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

