### PR TITLE
properly document release support level [skip ci]

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,14 @@
 
 We only support the most recent release.
 
+Using any prior code is strongly discouraged due to a [known security vulnerability in Kyber](https://github.com/open-quantum-safe/liboqs/releases/tag/0.9.2).
+
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.8.0   | :white_check_mark: |
+| 0.9.2   | :white_check_mark: |
+| 0.9.1   | :x:                |
+| 0.9.0   | :x:                |
+| 0.8.0   | :x:                |
 | < 0.8   | :x:                |
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
Update security status of library releases. [Release wiki](https://github.com/open-quantum-safe/liboqs/wiki/Release-process#code-change) has been amended to avoid such omissions from happening again.

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

