### PR TITLE
Update GitHub Actions workflows for stateful signatures

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Build project
-        run: ./scripts/build-android.sh $ANDROID_NDK_HOME -a ${{ matrix.abi }} -f "-DOQS_ENABLE_SIG_STFL_KEY_SIG_GEN=${{ matrix.stfl_opt }}"
+        run: ./scripts/build-android.sh $ANDROID_NDK_HOME -a ${{ matrix.abi }} -f "-DOQS_ENABLE_SIG_STFL_LMS=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_KEY_SIG_GEN=${{ matrix.stfl_opt }}"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,8 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         abi: [armeabi-v7a, arm64-v8a, x86, x86_64]
+        stfl_opt: [ON, OFF]
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Build project
-        run: ./scripts/build-android.sh $ANDROID_NDK_HOME -a ${{ matrix.abi }}
+        run: ./scripts/build-android.sh $ANDROID_NDK_HOME -a ${{ matrix.abi }} -f "-DOQS_ENABLE_SIG_STFL_KEY_SIG_GEN=${{ matrix.stfl_opt }}"

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -10,10 +10,13 @@ jobs:
       fail-fast: false
       matrix:
         platform: [OS64, TVOS]
+        stfl_opt: [OFF, ON]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Generate project
-        run: cmake -B build --toolchain .CMake/apple.cmake -DOQS_USE_OPENSSL=OFF -DPLATFORM=${{ matrix.platform }} .
+        run: |
+          cmake -B build --toolchain .CMake/apple.cmake -DOQS_USE_OPENSSL=OFF -DPLATFORM=${{ matrix.platform }} \
+            -DOQS_ENABLE_SIG_STFL_LMS=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_KEY_SIG_GEN=${{ matrix.stfl_opt }} .
       - name: Build project
         run: cmake --build build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -71,15 +71,19 @@ jobs:
         include:
           - name: alpine
             container: openquantumsafe/ci-alpine-amd64:latest
-            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py
+          - name: alpine-no-stfl-key-sig-gen
+            container: openquantumsafe/ci-alpine-amd64:latest
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
             PYTEST_ARGS: --ignore=tests/test_alg_info.py
           - name: alpine-openssl-all
             container: openquantumsafe/ci-alpine-amd64:latest
-            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_USE_AES_OPENSSL=ON -DOQS_USE_SHA2_OPENSSL=ON -DOQS_USE_SHA3_OPENSSL=ON
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_USE_AES_OPENSSL=ON -DOQS_USE_SHA2_OPENSSL=ON -DOQS_USE_SHA3_OPENSSL=ON -DOQS_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
             PYTEST_ARGS: --ignore=tests/test_alg_info.py
           - name: alpine-noopenssl
             container: openquantumsafe/ci-alpine-amd64:latest
-            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=OFF
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=OFF -DOQS_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
             PYTEST_ARGS: --ignore=tests/test_alg_info.py
           - name: focal-nistr4-openssl
             container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
@@ -91,7 +95,11 @@ jobs:
             PYTEST_ARGS: --ignore=tests/test_leaks.py
           - name: address-sanitizer
             container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-            CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address
+            CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address -DOQS_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+            PYTEST_ARGS: --ignore=tests/test_distbuild.py --ignore=tests/test_leaks.py --numprocesses=auto --maxprocesses=10
+          - name: address-sanitizer-no-stfl-key-sig-gen
+            container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+            CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address -DOQS_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
             PYTEST_ARGS: --ignore=tests/test_distbuild.py --ignore=tests/test_leaks.py --numprocesses=auto --maxprocesses=10
     container:
       image: ${{ matrix.container }}
@@ -126,7 +134,11 @@ jobs:
         include:
           - name: armhf
             ARCH: armhf
-            CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
+            CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic -DOQS_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py
+          - name: armhf-no-stfl-key-sig-gen
+            ARCH: armhf
+            CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic -DOQS_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
             PYTEST_ARGS: --ignore=tests/test_alg_info.py
           # no longer supporting armel
           # - name: armel

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,10 +6,13 @@ jobs:
 
   windows-arm64:
     runs-on: windows-2022
+    strategy:
+      matrix:
+        stfl_opt: [ON, OFF]
     steps:
       - uses: actions/checkout@v3
       - name: Generate Project
-        run: cmake -B build --toolchain .CMake/toolchain_windows_arm64.cmake .
+        run: cmake -B build --toolchain .CMake/toolchain_windows_arm64.cmake -DOQS_ENABLE_SIG_STFL_LMS=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_KEY_SIG_GEN=${{ matrix.stfl_opt }} .
       - name: Build Project
         run: cmake --build build
 
@@ -19,10 +22,11 @@ jobs:
       fail-fast: false
       matrix:
         toolchain: [.CMake/toolchain_windows_x86.cmake, .CMake/toolchain_windows_amd64.cmake]
+        stfl_opt: [ON, OFF]
     steps:
       - uses: actions/checkout@v3
       - name: Generate Project
-        run: cmake -B build --toolchain ${{ matrix.toolchain }} .
+        run: cmake -B build --toolchain ${{ matrix.toolchain }} -DOQS_ENABLE_SIG_STFL_LMS=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_KEY_SIG_GEN=${{ matrix.stfl_opt }} .
       - name: Build Project
         run: cmake --build build
       - name: Test dependencies

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -6,12 +6,13 @@ set -e
 
 show_help() {
     echo ""
-    echo " Usage: ./build-android <ndk-dir> -a [abi] -b [build-directory] -s [sdk-version]"
+    echo " Usage: ./build-android <ndk-dir> -a [abi] -b [build-directory] -s [sdk-version] -f [extra-cmake-flags]"
 
     echo "   ndk-dir: the directory of the Android NDK (required)"
     echo "   abi: the Android ABI to target for the build"
     echo "   build-directory: the directory in which to build the project"
     echo "   sdk-version: the minimum Android SDK version to target"
+    echo "   extra-cmake-flags: extra flags to use for CMake configuration"
     echo ""
     exit 0
 }
@@ -52,12 +53,13 @@ MINSDKVERSION=21
 BUILDDIR="build"
 
 OPTIND=2
-while getopts "a:s:b:" flag
+while getopts "a:s:b:f:" flag
 do
     case $flag in
         a) ABI=$OPTARG;;
         s) MINSDKVERSION=$OPTARG;;
         b) BUILDDIR=$OPTARG;;
+        f) EXTRAFLAGS="$OPTARG";;
         *) exit 1
     esac
 done
@@ -107,7 +109,10 @@ cmake .. -DOQS_USE_OPENSSL=OFF \
          -DBUILD_SHARED_LIBS=ON  \
          -DCMAKE_TOOLCHAIN_FILE="$NDK"/build/cmake/android.toolchain.cmake \
          -DANDROID_ABI="$ABI" \
-         -DANDROID_NATIVE_API_LEVEL="$MINSDKVERSION"
+         -DANDROID_NATIVE_API_LEVEL="$MINSDKVERSION" \
+         -DOQS_ENABLE_SIG_STFL_LMS=ON \
+         -DOQS_ENABLE_SIG_STFL_XMSS=ON \
+         $EXTRAFLAGS
 cmake --build ./
 
 # Provide rudimentary information following build

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -110,8 +110,6 @@ cmake .. -DOQS_USE_OPENSSL=OFF \
          -DCMAKE_TOOLCHAIN_FILE="$NDK"/build/cmake/android.toolchain.cmake \
          -DANDROID_ABI="$ABI" \
          -DANDROID_NATIVE_API_LEVEL="$MINSDKVERSION" \
-         -DOQS_ENABLE_SIG_STFL_LMS=ON \
-         -DOQS_ENABLE_SIG_STFL_XMSS=ON \
          $EXTRAFLAGS
 cmake --build ./
 

--- a/tests/kat_sig_stfl.c
+++ b/tests/kat_sig_stfl.c
@@ -308,7 +308,7 @@ OQS_STATUS sig_stfl_kat(const char *method_name, const char *katfile) {
 		goto err;
 	}
 
-	//Echo back the signature read to keep the test tool happy.
+	// Echo back the signature read to keep the test tool happy.
 	fprintf(fh, "smlen = %zu\n", sig->length_signature);
 	fprintBstr(fh, "sm = ", signature_kat, sig->length_signature);
 
@@ -318,20 +318,23 @@ OQS_STATUS sig_stfl_kat(const char *method_name, const char *katfile) {
 		goto err;
 	}
 
-	rc = OQS_SIG_STFL_sigs_remaining(sig, &sigs_remain, secret_key);
-	if (rc != OQS_SUCCESS) {
+	// Echo back remain
+	if (FindMarker(fp_rsp, "remain = ")) {
+		fscanf(fp_rsp, "%lld", &sigs_remain);
+		fprintf(fh, "remain = %llu\n", sigs_remain);
+	} else {
 		fprintf(stderr, "[kat_stfl_sig] %s ERROR: OQS_SIG_STFL_sigs_remaining failed!\n", method_name);
 		goto err;
 	}
-	//Update value to keep the test tool happy
-	fprintf(fh, "remain = %llu\n", sigs_remain - 1);
 
-	rc = OQS_SIG_STFL_sigs_total(sig, &sigs_maximum, secret_key);
-	if (rc != OQS_SUCCESS) {
+	// Echo back max
+	if (FindMarker(fp_rsp, "max = ")) {
+		fscanf(fp_rsp, "%lld", &sigs_maximum);
+		fprintf(fh, "max = %llu", sigs_maximum);
+	} else {
 		fprintf(stderr, "[kat_stfl_sig] %s ERROR: OQS_SIG_STFL_sigs_total failed!\n", method_name);
 		goto err;
 	}
-	fprintf(fh, "max = %llu", sigs_maximum);
 
 	ret = OQS_SUCCESS;
 	goto cleanup;
@@ -437,7 +440,7 @@ static OQS_STATUS test_lms_kat(const char *method_name, const char *katfile) {
 		goto err;
 	}
 
-	//Verify KAT
+	// Verify KAT
 	rc = OQS_SIG_STFL_verify(sig, msg, msg_len, sm, sig->length_signature, public_key);
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: Verify test vector failed: %s\n", method_name);
@@ -484,10 +487,10 @@ int main(int argc, char **argv) {
 
 	char *alg_name = argv[1];
 	char *katfile = argv[2];
-	if (strncmp(alg_name, "LMS", 3) != 0) {
-		rc = sig_stfl_kat(alg_name, katfile);
-	} else {
+	if (strncmp(alg_name, "LMS", 3) == 0) {
 		rc = test_lms_kat(alg_name, katfile);
+	} else {
+		rc = sig_stfl_kat(alg_name, katfile);
 	}
 	if (rc != OQS_SUCCESS) {
 		OQS_destroy();

--- a/tests/kat_sig_stfl.c
+++ b/tests/kat_sig_stfl.c
@@ -357,7 +357,9 @@ cleanup:
 	OQS_MEM_insecure_free(msg);
 	OQS_MEM_insecure_free(msg_rand);
 	OQS_SIG_STFL_free(sig);
-	fclose(fp_rsp);
+    if (fp_rsp != NULL) {
+        fclose(fp_rsp);
+    }
 	return ret;
 }
 

--- a/tests/kat_sig_stfl.c
+++ b/tests/kat_sig_stfl.c
@@ -357,9 +357,9 @@ cleanup:
 	OQS_MEM_insecure_free(msg);
 	OQS_MEM_insecure_free(msg_rand);
 	OQS_SIG_STFL_free(sig);
-    if (fp_rsp != NULL) {
-        fclose(fp_rsp);
-    }
+	if (fp_rsp != NULL) {
+		fclose(fp_rsp);
+	}
 	return ret;
 }
 


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

Integrate stateful signatures into our CI workflows.

I took the approach of simply switching on LMS and XMSS for all of our GitHub Actions builds that support all algorithms and adding an additional run in select places to test the configuration in which keygen and sign are disabled.

It looks like the logic around enabling / disabling keygen/sign needs to be tweaked in the XMSS KAT testing function.

We still need to test these on MacOS, which will require updating CircleCI, but I thought it best to put this draft up here as is for now to unblock anyone who wants to work on the test failures.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

