### PR TITLE
set(OQS_USE_PTHREADS OFF) on MinGW/Cygwin

### DIFF
--- a/.CMake/compiler_opts.cmake
+++ b/.CMake/compiler_opts.cmake
@@ -206,6 +206,7 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
 endif()
 
 if(MINGW OR MSYS OR CYGWIN)
+    set(OQS_USE_PTHREADS OFF)
     add_compile_options(-Wno-maybe-uninitialized)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.13.0")
         add_link_options(-Wl,--stack,16777216)


### PR DESCRIPTION
Fixes #1693.
Looks like if cross-compiling from POSIX to Windows, the CMake detect pthreads as available on the host and sets OQS_USE_PTHREADS ON for compilation, which will not work on windows.