### PR TITLE
Change XMSS License from `(Apache 2.0 AND MIT)` to `(Apache 2.0 OR MIT) AND CC0-1.0`

### DIFF
--- a/docs/algorithms/sig_stfl/xmss.md
+++ b/docs/algorithms/sig_stfl/xmss.md
@@ -7,7 +7,7 @@
 - **Specification version**: None.
 - **Primary Source**<a name="primary-source"></a>:
   - **Source**: https://github.com/XMSS/xmss-reference
-  - **Implementation license (SPDX-Identifier)**: Apache-2.0 AND MIT
+  - **Implementation license (SPDX-Identifier)**: (Apache-2.0 OR MIT) AND CC0-1.0
 
 
 ## Parameter set summary

--- a/docs/algorithms/sig_stfl/xmss.yml
+++ b/docs/algorithms/sig_stfl/xmss.yml
@@ -11,10 +11,10 @@ crypto-assumption: hash function second-preimage resistance
 website: https://www.rfc-editor.org/info/rfc8391
 nist-round: 
 spec-version: 
-spdx-license-identifier: Apache-2.0 AND MIT
+spdx-license-identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 primary-upstream:
   source: https://github.com/XMSS/xmss-reference
-  spdx-license-identifier: Apache-2.0 AND MIT
+  spdx-license-identifier: (Apache-2.0 OR MIT) AND CC0-1.0
   upstream-ancestors:
 parameter-sets:
 - name: XMSS-SHA2_10_256 

--- a/src/sig_stfl/xmss/CMakeLists.txt
+++ b/src/sig_stfl/xmss/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 set(_XMSS_OBJS "")
 

--- a/src/sig_stfl/xmss/LICENSE
+++ b/src/sig_stfl/xmss/LICENSE
@@ -1,6 +1,6 @@
 ## License
 
-This XMSS reference implementation is Copyright (c) 2024 SandboxAQ and licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) OR MIT License at your option.
+This XMSS reference implementation is Copyright (c) 2024 SandboxAQ and licensed under the CC0-1.0 AND ([Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) OR MIT License) at your option.
 
 ---------------------------------
 The MIT License (MIT)

--- a/src/sig_stfl/xmss/LICENSE
+++ b/src/sig_stfl/xmss/LICENSE
@@ -1,8 +1,18 @@
 ## License
 
-This XMSS reference implementation is Copyright (c) 2024 SandboxAQ and licensed under both the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) and [MIT License](LICENSE-MIT).
+This XMSS reference implementation is Copyright (c) 2024 SandboxAQ and licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt) OR MIT License at your option.
 
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+---------------------------------
+The MIT License (MIT)
+
+Copyright © 2024 SandboxAQ
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+---------------------------------
 
 This XMSS reference implementation is based on the [XMSS reference implementation written by Andreas Hülsing and Joost Rijneveld](https://github.com/XMSS/xmss-reference#license) provided under the CC0 1.0 Universal Public Domain Dedication.
 

--- a/src/sig_stfl/xmss/LICENSE-MIT
+++ b/src/sig_stfl/xmss/LICENSE-MIT
@@ -1,9 +1,0 @@
-The MIT License (MIT)
-
-Copyright © 2024 SandboxAQ
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/sig_stfl/xmss/external/core_hash.c
+++ b/src/sig_stfl/xmss/external/core_hash.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #include <oqs/sha2.h>
 #include <oqs/sha3.h>
 #include "core_hash.h"

--- a/src/sig_stfl/xmss/external/core_hash.c
+++ b/src/sig_stfl/xmss/external/core_hash.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #include <oqs/sha2.h>
 #include <oqs/sha3.h>
 #include "core_hash.h"

--- a/src/sig_stfl/xmss/external/core_hash.h
+++ b/src/sig_stfl/xmss/external/core_hash.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #ifndef CORE_HASH
 #define CORE_HASH
 

--- a/src/sig_stfl/xmss/external/core_hash.h
+++ b/src/sig_stfl/xmss/external/core_hash.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #ifndef CORE_HASH
 #define CORE_HASH
 

--- a/src/sig_stfl/xmss/external/hash.c
+++ b/src/sig_stfl/xmss/external/hash.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #include <stdint.h>
 #include <string.h>
 

--- a/src/sig_stfl/xmss/external/hash.c
+++ b/src/sig_stfl/xmss/external/hash.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #include <stdint.h>
 #include <string.h>
 

--- a/src/sig_stfl/xmss/external/hash.h
+++ b/src/sig_stfl/xmss/external/hash.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #ifndef XMSS_HASH_H
 #define XMSS_HASH_H
 

--- a/src/sig_stfl/xmss/external/hash.h
+++ b/src/sig_stfl/xmss/external/hash.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #ifndef XMSS_HASH_H
 #define XMSS_HASH_H
 

--- a/src/sig_stfl/xmss/external/hash_address.c
+++ b/src/sig_stfl/xmss/external/hash_address.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #include <stdint.h>
 #include "hash_address.h"
 

--- a/src/sig_stfl/xmss/external/hash_address.c
+++ b/src/sig_stfl/xmss/external/hash_address.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #include <stdint.h>
 #include "hash_address.h"
 

--- a/src/sig_stfl/xmss/external/hash_address.h
+++ b/src/sig_stfl/xmss/external/hash_address.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #ifndef XMSS_HASH_ADDRESS_H
 #define XMSS_HASH_ADDRESS_H
 

--- a/src/sig_stfl/xmss/external/hash_address.h
+++ b/src/sig_stfl/xmss/external/hash_address.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #ifndef XMSS_HASH_ADDRESS_H
 #define XMSS_HASH_ADDRESS_H
 

--- a/src/sig_stfl/xmss/external/namespace.h
+++ b/src/sig_stfl/xmss/external/namespace.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #ifndef XMSS_NAMESPACE_H
 #define XMSS_NAMESPACE_H
 

--- a/src/sig_stfl/xmss/external/namespace.h
+++ b/src/sig_stfl/xmss/external/namespace.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #ifndef XMSS_NAMESPACE_H
 #define XMSS_NAMESPACE_H
 

--- a/src/sig_stfl/xmss/external/params.c
+++ b/src/sig_stfl/xmss/external/params.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #include <stdint.h>
 #include <string.h>
 

--- a/src/sig_stfl/xmss/external/params.c
+++ b/src/sig_stfl/xmss/external/params.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #include <stdint.h>
 #include <string.h>
 

--- a/src/sig_stfl/xmss/external/params.h
+++ b/src/sig_stfl/xmss/external/params.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #ifndef XMSS_PARAMS_H
 #define XMSS_PARAMS_H
 

--- a/src/sig_stfl/xmss/external/params.h
+++ b/src/sig_stfl/xmss/external/params.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #ifndef XMSS_PARAMS_H
 #define XMSS_PARAMS_H
 

--- a/src/sig_stfl/xmss/external/utils.c
+++ b/src/sig_stfl/xmss/external/utils.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #include "utils.h"
 
 /**

--- a/src/sig_stfl/xmss/external/utils.c
+++ b/src/sig_stfl/xmss/external/utils.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #include "utils.h"
 
 /**

--- a/src/sig_stfl/xmss/external/utils.h
+++ b/src/sig_stfl/xmss/external/utils.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #ifndef XMSS_UTILS_H
 #define XMSS_UTILS_H
 

--- a/src/sig_stfl/xmss/external/utils.h
+++ b/src/sig_stfl/xmss/external/utils.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #ifndef XMSS_UTILS_H
 #define XMSS_UTILS_H
 

--- a/src/sig_stfl/xmss/external/wots.c
+++ b/src/sig_stfl/xmss/external/wots.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #include <stdint.h>
 #include <string.h>
 

--- a/src/sig_stfl/xmss/external/wots.c
+++ b/src/sig_stfl/xmss/external/wots.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #include <stdint.h>
 #include <string.h>
 

--- a/src/sig_stfl/xmss/external/wots.h
+++ b/src/sig_stfl/xmss/external/wots.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #ifndef XMSS_WOTS_H
 #define XMSS_WOTS_H
 

--- a/src/sig_stfl/xmss/external/wots.h
+++ b/src/sig_stfl/xmss/external/wots.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #ifndef XMSS_WOTS_H
 #define XMSS_WOTS_H
 

--- a/src/sig_stfl/xmss/external/xmss.c
+++ b/src/sig_stfl/xmss/external/xmss.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #include <stdint.h>
 
 #include "params.h"

--- a/src/sig_stfl/xmss/external/xmss.c
+++ b/src/sig_stfl/xmss/external/xmss.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #include <stdint.h>
 
 #include "params.h"

--- a/src/sig_stfl/xmss/external/xmss.h
+++ b/src/sig_stfl/xmss/external/xmss.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #ifndef XMSS_H
 #define XMSS_H
 

--- a/src/sig_stfl/xmss/external/xmss.h
+++ b/src/sig_stfl/xmss/external/xmss.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #ifndef XMSS_H
 #define XMSS_H
 

--- a/src/sig_stfl/xmss/external/xmss_commons.c
+++ b/src/sig_stfl/xmss/external/xmss_commons.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>

--- a/src/sig_stfl/xmss/external/xmss_commons.c
+++ b/src/sig_stfl/xmss/external/xmss_commons.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>

--- a/src/sig_stfl/xmss/external/xmss_commons.h
+++ b/src/sig_stfl/xmss/external/xmss_commons.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #ifndef XMSS_COMMONS_H
 #define XMSS_COMMONS_H
 

--- a/src/sig_stfl/xmss/external/xmss_commons.h
+++ b/src/sig_stfl/xmss/external/xmss_commons.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #ifndef XMSS_COMMONS_H
 #define XMSS_COMMONS_H
 

--- a/src/sig_stfl/xmss/external/xmss_core.c
+++ b/src/sig_stfl/xmss/external/xmss_core.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>

--- a/src/sig_stfl/xmss/external/xmss_core.c
+++ b/src/sig_stfl/xmss/external/xmss_core.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>

--- a/src/sig_stfl/xmss/external/xmss_core.h
+++ b/src/sig_stfl/xmss/external/xmss_core.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #ifndef XMSS_CORE_H
 #define XMSS_CORE_H
 

--- a/src/sig_stfl/xmss/external/xmss_core.h
+++ b/src/sig_stfl/xmss/external/xmss_core.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #ifndef XMSS_CORE_H
 #define XMSS_CORE_H
 

--- a/src/sig_stfl/xmss/external/xmss_core_fast.c
+++ b/src/sig_stfl/xmss/external/xmss_core_fast.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>

--- a/src/sig_stfl/xmss/external/xmss_core_fast.c
+++ b/src/sig_stfl/xmss/external/xmss_core_fast.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss.h
+++ b/src/sig_stfl/xmss/sig_stfl_xmss.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #ifndef OQS_SIG_STFL_XMSS_H
 #define OQS_SIG_STFL_XMSS_H

--- a/src/sig_stfl/xmss/sig_stfl_xmss.h
+++ b/src/sig_stfl/xmss/sig_stfl_xmss.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #ifndef OQS_SIG_STFL_XMSS_H
 #define OQS_SIG_STFL_XMSS_H

--- a/src/sig_stfl/xmss/sig_stfl_xmss_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_functions.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 #include <string.h>
 #include <stdlib.h>
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_functions.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 #include <string.h>
 #include <stdlib.h>
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include <oqs/oqs.h>
 #include <string.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include <oqs/oqs.h>
 #include <string.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h10.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h10.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h16.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h16.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h20.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha256_h20.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h10.c
@@ -1,6 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 
 // ======================== XMSS-SHA2_10_512 ======================== //
+
 XMSS_ALG(, _sha512_h10, _SHA512_H10)

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h10.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h16.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h16.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h20.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_sha512_h20.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h10.c
@@ -1,6 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 
 // ======================== XMSS-SHAKE_10_256 ======================== //
+
 XMSS_ALG(, _shake128_h10, _SHAKE128_H10)

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h10.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h16.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h16.c
@@ -1,6 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 
 // ======================== XMSS-SHAKE_10_256 ======================== //
+
 XMSS_ALG(, _shake128_h16, _SHAKE128_H16)

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h20.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake128_h20.c
@@ -1,6 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 
 // ======================== XMSS-SHAKE_10_256 ======================== //
+
 XMSS_ALG(, _shake128_h20, _SHAKE128_H20)

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h10.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h10.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h10.c
@@ -1,6 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 
 // ======================== XMSS-SHAKE_10_512 ======================== //
+
 XMSS_ALG(, _shake256_h10, _SHAKE256_H10)

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h16.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h16.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h16.c
@@ -1,6 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 
 // ======================== XMSS-SHAKE_16_512 ======================== //
+
 XMSS_ALG(, _shake256_h16, _SHAKE256_H16)

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h20.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h20.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_shake256_h20.c
@@ -1,6 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 
 // ======================== XMSS-SHAKE_20_512 ======================== //
+
 XMSS_ALG(, _shake256_h20, _SHAKE256_H20)

--- a/src/sig_stfl/xmss/sig_stfl_xmss_xmssmt.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_xmssmt.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmss_xmssmt.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_xmssmt.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_functions.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_functions.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_2.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_2.c
@@ -1,6 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 
 // ======================== XMSSMT-SHA2_20/2_256 ======================== //
+
 XMSS_ALG(mt, mt_sha256_h20_2, MT_SHA256_H20_2)

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_4.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h20_4.c
@@ -1,6 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 
 // ======================== XMSSMT-SHA2_20/4_256 ======================== //
+
 XMSS_ALG(mt, mt_sha256_h20_4, MT_SHA256_H20_4)

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_2.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_2.c
@@ -1,6 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 
 // ======================== XMSSMT-SHA2_40/2_256 ======================== //
+
 XMSS_ALG(mt, mt_sha256_h40_2, MT_SHA256_H40_2)

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_4.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_4.c
@@ -1,6 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 
 // ======================== XMSSMT-SHA2_40/4_256 ======================== //
+
 XMSS_ALG(mt, mt_sha256_h40_4, MT_SHA256_H40_4)

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_8.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_8.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_8.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h40_8.c
@@ -1,7 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 
 // ======================== XMSSMT-SHA2_40/8_256 ======================== //
-XMSS_ALG(mt, mt_sha256_h40_8, MT_SHA256_H40_8)
 
+XMSS_ALG(mt, mt_sha256_h40_8, MT_SHA256_H40_8)

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_12.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_12.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_12.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_12.c
@@ -1,7 +1,6 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
-
 
 // ======================== XMSSMT-SHA2_60/12_256 ======================== //
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_3.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_3.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_3.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_3.c
@@ -1,6 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 
 // ======================== XMSSMT-SHA2_60/3_256 ======================== //
+
 XMSS_ALG(mt, mt_sha256_h60_3, MT_SHA256_H60_3)

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_6.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_6.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_6.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_sha256_h60_6.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_2.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_2.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_4.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h20_4.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_2.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_2.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_2.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_4.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_4.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_4.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_8.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_8.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_8.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h40_8.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_12.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_12.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_12.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_12.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_3.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_3.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_3.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_3.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_6.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_6.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0-1.0
 
 #include "sig_stfl_xmss_xmssmt.c"
 

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_6.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_shake128_h60_6.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-License-Identifier: (Apache-2.0 OR MIT) AND CC0
 
 #include "sig_stfl_xmss_xmssmt.c"
 


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

According to liboqs maintainer request, this PR change the license of XMSS contribution from 
`(Apache 2.0 AND MIT)` to `(Apache 2.0 OR MIT) AND CC0-1.0`.


1. Moved standalone LICENSE-MIT into LICENSE file.
2. A few newlines, spaces format. 



<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

