### PR TITLE
Add return status for XMSS lock/unlock functions.

### DIFF
--- a/src/sig_stfl/xmss/sig_stfl_xmss.h
+++ b/src/sig_stfl/xmss/sig_stfl_xmss.h
@@ -582,9 +582,9 @@ void OQS_SECRET_KEY_XMSS_set_store_cb(OQS_SIG_STFL_SECRET_KEY *sk, secure_store_
 void OQS_SECRET_KEY_XMSS_free(OQS_SIG_STFL_SECRET_KEY *sk);
 
 /* Lock the key if possible */
-void OQS_SECRET_KEY_XMSS_acquire_lock(const OQS_SIG_STFL_SECRET_KEY *sk);
+OQS_STATUS OQS_SECRET_KEY_XMSS_acquire_lock(const OQS_SIG_STFL_SECRET_KEY *sk);
 
 /* Unlock the key if possible */
-void OQS_SECRET_KEY_XMSS_release_lock(const OQS_SIG_STFL_SECRET_KEY *sk);
+OQS_STATUS OQS_SECRET_KEY_XMSS_release_lock(const OQS_SIG_STFL_SECRET_KEY *sk);
 
 #endif /* OQS_SIG_STFL_XMSS_H */

--- a/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
@@ -151,7 +151,7 @@ OQS_STATUS OQS_SECRET_KEY_XMSS_acquire_lock(const OQS_SIG_STFL_SECRET_KEY *sk) {
 		return OQS_ERROR;
 	}
 
-	/* Lock the key if possible, otherwise return SUCCESS because the lock_key, unlock_key and mutex are not defined.*/
+	/* Lock the key if possible, otherwise return OQS_ERROR because the lock_key, unlock_key and mutex are not defined.*/
 	if ((sk->lock_key != NULL) && (sk->mutex != NULL) && (sk->unlock_key != NULL)) {
 		if (sk->lock_key(sk->mutex) != OQS_SUCCESS) {
 			return OQS_ERROR;
@@ -166,7 +166,7 @@ OQS_STATUS OQS_SECRET_KEY_XMSS_release_lock(const OQS_SIG_STFL_SECRET_KEY *sk) {
 		return OQS_ERROR;
 	}
 
-	/* Unlock the key if possible, otherwise return SUCCESS because the lock_key, unlock_key and mutex are not defined. */
+	/* Unlock the key if possible, otherwise return OQS_ERROR because the lock_key, unlock_key and mutex are not defined. */
 	if ((sk->unlock_key != NULL) && (sk->mutex != NULL) && (sk->lock_key != NULL)) {
 		if (sk->unlock_key(sk->mutex) != OQS_SUCCESS) {
 			return OQS_ERROR;

--- a/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
@@ -11,8 +11,7 @@
 #define XMSS_UNUSED_ATT
 #endif
 
-extern inline
-OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_new(size_t length_secret_key) {
+extern inline OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_new(size_t length_secret_key) {
 
 	// Initialize the secret key in the heap with adequate memory
 	OQS_SIG_STFL_SECRET_KEY *sk = malloc(sizeof(OQS_SIG_STFL_SECRET_KEY));
@@ -71,7 +70,9 @@ OQS_STATUS OQS_SECRET_KEY_XMSS_serialize_key(uint8_t **sk_buf_ptr, size_t *sk_le
 	}
 
 	/* Lock the key if possible */
-	OQS_SECRET_KEY_XMSS_acquire_lock(sk);
+	if (OQS_SECRET_KEY_XMSS_acquire_lock(sk) != OQS_SUCCESS) {
+		return OQS_ERROR;
+	}
 
 	uint8_t *sk_buf = malloc(sk->length_secret_key * sizeof(uint8_t));
 	if (sk_buf == NULL) {
@@ -85,7 +86,9 @@ OQS_STATUS OQS_SECRET_KEY_XMSS_serialize_key(uint8_t **sk_buf_ptr, size_t *sk_le
 	*sk_len = sk->length_secret_key;
 
 	/* Unlock the key if possible */
-	OQS_SECRET_KEY_XMSS_release_lock(sk);
+	if (OQS_SECRET_KEY_XMSS_release_lock(sk) != OQS_SUCCESS) {
+		return OQS_ERROR;
+	}
 
 	return OQS_SUCCESS;
 }
@@ -143,24 +146,32 @@ void OQS_SECRET_KEY_XMSS_free(OQS_SIG_STFL_SECRET_KEY *sk) {
 	sk->secret_key_data = NULL;
 }
 
-void OQS_SECRET_KEY_XMSS_acquire_lock(const OQS_SIG_STFL_SECRET_KEY *sk) {
+OQS_STATUS OQS_SECRET_KEY_XMSS_acquire_lock(const OQS_SIG_STFL_SECRET_KEY *sk) {
 	if (sk == NULL) {
-		return;
+		return OQS_ERROR;
 	}
 
-	/* Lock the key if possible */
-	if ((sk->lock_key != NULL) && (sk->mutex != NULL)) {
-		sk->lock_key(sk->mutex);
+	/* Lock the key if possible, otherwise return SUCCESS because the lock_key, unlock_key and mutex are not defined.*/
+	if ((sk->lock_key != NULL) && (sk->mutex != NULL) && (sk->unlock_key != NULL)) {
+		if (sk->lock_key(sk->mutex) != OQS_SUCCESS) {
+			return OQS_ERROR;
+		}
 	}
+
+	return OQS_SUCCESS;
 }
 
-void OQS_SECRET_KEY_XMSS_release_lock(const OQS_SIG_STFL_SECRET_KEY *sk) {
+OQS_STATUS OQS_SECRET_KEY_XMSS_release_lock(const OQS_SIG_STFL_SECRET_KEY *sk) {
 	if (sk == NULL) {
-		return;
+		return OQS_ERROR;
 	}
 
-	/* Unlock the key if possible */
-	if ((sk->unlock_key != NULL) && (sk->mutex != NULL)) {
-		sk->unlock_key(sk->mutex);
+	/* Unlock the key if possible, otherwise return SUCCESS because the lock_key, unlock_key and mutex are not defined. */
+	if ((sk->unlock_key != NULL) && (sk->mutex != NULL) && (sk->lock_key != NULL)) {
+		if (sk->unlock_key(sk->mutex) != OQS_SUCCESS) {
+			return OQS_ERROR;
+		}
 	}
+
+	return OQS_SUCCESS;
 }


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->


* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

