### PR TITLE
Fix for the Zephyr CI tests

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -17,23 +17,35 @@ jobs:
             - zephyr-ref: v3.5.0
 
     steps:
-        - name: Init west workspace
-          run: west init --mr ${{ matrix.config.zephyr-ref }} zephyr
-
-        - name: Update west.yml
-          working-directory: zephyr/zephyr
+        - name: Init Zephyr workspace
           run: |
-            REF=$(echo '${{ github.ref }}' | sed -e 's/\//\\\//g')
-            sed -e 's/remotes:/remotes:\n    \- name: liboqs\n      url\-base: https:\/\/github.com\/${{ github.repository_owner }}/' -i west.yml
-            sed -e "s/projects:/projects:\n    \- name: liboqs\n      path: modules\/crypto\/liboqs\n      remote: liboqs\n      revision: $REF/" -i west.yml
+            mkdir zephyr && cd zephyr
+            mkdir manifest && cd manifest
+            echo "manifest:" > west.yml
+            echo "  remotes:" >> west.yml
+            echo "    - name: zephyr" >> west.yml
+            echo "      url-base: https://github.com/zephyrproject-rtos" >> west.yml
+            echo "    - name: liboqs" >> west.yml
+            echo "      url-base: https://github.com/${{ github.repository_owner }}" >> west.yml
+            echo "  projects:" >> west.yml
+            echo "    - name: zephyr" >> west.yml
+            echo "      remote: zephyr" >> west.yml
+            echo "      repo-path: zephyr" >> west.yml
+            echo "      revision: ${{ matrix.config.zephyr-ref }}" >> west.yml
+            echo "      import:" >> west.yml
+            echo "        name-allowlist:" >> west.yml
+            echo "          - picolibc" >> west.yml
+            echo "    - name: liboqs" >> west.yml
+            echo "      remote: liboqs" >> west.yml
+            echo "      revision: $(echo '${{ github.ref }}' | sed -e 's/refs\/heads\///')" >> west.yml
+            echo "      path: modules/crypto/liboqs" >> west.yml
+            west init -l --mf west.yml .
 
         - name: Update west workspace
           working-directory: zephyr
-          run: west update -n -o=--depth=1
-
-        - name: Export zephyr
-          working-directory: zephyr
-          run: west zephyr-export
+          run: |
+            west update -n -o=--depth=1
+            west zephyr-export
 
         - name: Run Signature test
           working-directory: zephyr

--- a/zephyr/samples/Signatures/sample.yaml
+++ b/zephyr/samples/Signatures/sample.yaml
@@ -10,7 +10,7 @@ common:
 
 tests:
   sample.crypto.liboqs_signature_example:
-    timeout: 600
+    timeout: 900
     integration_platforms:
       - qemu_x86
       - qemu_cortex_a53


### PR DESCRIPTION
The Zephyr Github CI Actions used a complete Zephyr installation to build and run the test code. The resulting size of the data has been up to several GBs, overfilling the Github runner storage space.

With this patch of the Zephyr workflow, only a minimal Zephyr installation is created to run the tests, resulting in a much smaller space footprint.

Furthermore, the timeout of the Signature test has been increased, as sometimes the tests take longer than the prior 10 minutes.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) and [OQS-OpenSSH](https://github.com/open-quantum-safe/openssh) will also need to be ready for review and merge by the time this is merged.)
