### PR TITLE
Always build "internal" library as static

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,7 +63,7 @@ add_library(oqs kem/kem.c
                 ${COMMON_OBJS})
 
 # Internal library to be used only by test programs
-add_library(oqs-internal ${INTERNAL_OBJS})
+add_library(oqs-internal STATIC ${INTERNAL_OBJS})
 
 if(DEFINED SANITIZER_LD_FLAGS)
     target_link_libraries(oqs PUBLIC ${SANITIZER_LD_FLAGS})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,10 @@ target_link_libraries(example_kem PRIVATE ${TEST_DEPS})
 
 add_executable(kat_kem kat_kem.c test_helpers.c)
 target_link_libraries(kat_kem PRIVATE ${TEST_DEPS})
+if(CMAKE_CROSSCOMPILING AND CMAKE_SYSTEM_NAME STREQUAL "Windows" AND BUILD_SHARED_LIBS)
+    # workaround for Windows .dll cross-compiling
+    target_link_options(kat_kem PRIVATE -Wl,--allow-multiple-definition)
+endif()
 
 add_executable(test_kem test_kem.c)
 target_link_libraries(test_kem PRIVATE ${TEST_DEPS})
@@ -82,6 +86,10 @@ target_link_libraries(example_sig PRIVATE ${TEST_DEPS})
 
 add_executable(kat_sig kat_sig.c test_helpers.c)
 target_link_libraries(kat_sig PRIVATE ${TEST_DEPS})
+if(CMAKE_CROSSCOMPILING AND CMAKE_SYSTEM_NAME STREQUAL "Windows" AND BUILD_SHARED_LIBS)
+    # workaround for Windows .dll cross-compiling
+    target_link_options(kat_sig PRIVATE -Wl,--allow-multiple-definition)
+endif()
 
 add_executable(test_sig test_sig.c)
 target_link_libraries(test_sig PRIVATE ${TEST_DEPS})


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
Since `liboqs-internal` (see #1667) is never actually installed on the user's system, it doesn't make sense to build it as a shared library and then link the test programs against it. This PR forces `liboqs-internal` to be built as a static library regardless of the `BUILD_SHARED_LIBS` variable.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
Fixes #1723.

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

