### PR TITLE
Add return check for lock/unlock function

### DIFF
--- a/src/sig_stfl/xmss/sig_stfl_xmss_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_functions.c
@@ -37,7 +37,9 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sign(uint8_t *signature, size_t *signat
 	}
 
 	/* Lock secret to ensure OTS use */
-	OQS_SECRET_KEY_XMSS_acquire_lock(secret_key);
+	if (OQS_SECRET_KEY_XMSS_acquire_lock(secret_key) != OQS_SUCCESS) {
+		return OQS_ERROR;
+	}
 
 	if (xmss_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
 		status = OQS_ERROR;
@@ -59,8 +61,10 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss_sign(uint8_t *signature, size_t *signat
 	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
 
 err:
-	/* Unlock secret to ensure OTS use */
-	OQS_SECRET_KEY_XMSS_release_lock(secret_key);
+	/* Unlock the key if possible */
+	if (OQS_SECRET_KEY_XMSS_release_lock(secret_key) != OQS_SUCCESS) {
+		return OQS_ERROR;
+	}
 
 	return status;
 }

--- a/src/sig_stfl/xmss/sig_stfl_xmssmt_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmssmt_functions.c
@@ -38,7 +38,9 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sign(uint8_t *signature, size_t *sign
 	}
 
 	/* Lock secret to ensure OTS use */
-	OQS_SECRET_KEY_XMSS_acquire_lock(secret_key);
+	if (OQS_SECRET_KEY_XMSS_acquire_lock(secret_key) != OQS_SUCCESS) {
+		return OQS_ERROR;
+	}
 
 	if (xmssmt_sign(secret_key->secret_key_data, signature, &sig_length, message, message_len)) {
 		status = OQS_ERROR;
@@ -60,8 +62,10 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmssmt_sign(uint8_t *signature, size_t *sign
 	OQS_MEM_secure_free(sk_key_buf_ptr, sk_key_buf_len);
 
 err:
-	/* Unlock secret to ensure OTS use */
-	OQS_SECRET_KEY_XMSS_release_lock(secret_key);
+	/* Unlock the key if possible */
+	if (OQS_SECRET_KEY_XMSS_release_lock(secret_key) != OQS_SUCCESS) {
+		return OQS_ERROR;
+	}
 
 	return status;
 }


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

Fix missing lock/unlock check in XMSS. 



<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

