### PR TITLE
Use `abort()` instead of `exit()` to get the trace log.

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -279,7 +279,7 @@ void *OQS_MEM_checked_malloc(size_t len) {
 	void *ptr = malloc(len);
 	if (ptr == NULL) {
 		fprintf(stderr, "Memory allocation failed\n");
-		exit(EXIT_FAILURE);
+		abort();
 	}
 
 	return ptr;
@@ -289,7 +289,7 @@ void *OQS_MEM_checked_aligned_alloc(size_t alignment, size_t size) {
 	void *ptr = OQS_MEM_aligned_alloc(alignment, size);
 	if (ptr == NULL) {
 		fprintf(stderr, "Memory allocation failed\n");
-		exit(EXIT_FAILURE);
+		abort();
 	}
 
 	return ptr;


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

I find that if we use `exit()`, we don't know where it goes wrong. 

So if we switch to `abort()`, we will have the trace where it crashed. 

```
abort() causes abnormal program termination and does not call functions registered with atexit() or destructors for objects with automatic storage duration.[[1]](https://en.cppreference.com/w/c/program/abort) It is generally used to immediately terminate the program when a fatal error occurs.
```

also, `abort()` will cause a signal, and it's up to application to decide what to do with the signal. 

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

