### PR TITLE
[NFCI] Move Keccak rhotates tables to rodata

### DIFF
--- a/scripts/copy_from_xkcp/patches/lib_low_KeccakP-1600_AVX2_KeccakP-1600-AVX2.s
+++ b/scripts/copy_from_xkcp/patches/lib_low_KeccakP-1600_AVX2_KeccakP-1600-AVX2.s
@@ -374,7 +374,7 @@
      pop             %rcx
      pop             %rdx
      pop             %rsi
-@@ -1010,9 +1038,9 @@
+@@ -1010,10 +1038,13 @@
      cmp             %rsi, %rcx
      jae             KeccakP1600_12rounds_FastLoop_Absorb_Not17Lanes
      jmp             KeccakP1600_12rounds_FastLoop_Absorb_Exit
@@ -384,6 +384,9 @@
 -.endif
 +#endif
  
++#ifndef old_gas_syntax
++.section .rodata
++#endif
  .equ    ALLON,        0xFFFFFFFFFFFFFFFF
  
 

--- a/src/common/sha3/xkcp_low/KeccakP-1600/avx2/KeccakP-1600-AVX2.S
+++ b/src/common/sha3/xkcp_low/KeccakP-1600/avx2/KeccakP-1600-AVX2.S
@@ -1042,6 +1042,9 @@ KeccakP1600_12rounds_FastLoop_Absorb_LanesAddLoop:
 .size   KeccakP1600_12rounds_FastLoop_Absorb,.-KeccakP1600_12rounds_FastLoop_Absorb
 #endif
 
+#ifndef old_gas_syntax
+.section .rodata
+#endif
 .equ    ALLON,        0xFFFFFFFFFFFFFFFF
 
 .balign 64


### PR DESCRIPTION
rhotates tables are placed to .text section which confuses tools such as
BOLT. Move them to rodata to unbreak and avoid polluting icache/iTLB
with data.

1. Update patch file using the steps in scripts/copy_from_xkcp/README
2. Apply the updated patch with scripts/copy_from_xkcp/package.sh

Sync with XKCP upstream: https://github.com/XKCP/XKCP/pull/137 
Similar fix in OpenSSL: https://github.com/openssl/openssl/pull/21440 
Redo of https://github.com/open-quantum-safe/liboqs/pull/1508

Signed-off-by: Amir Ayupov <aaupov@fb.com>

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

