### PR TITLE
restrict Windows platform support documentation [skip ci]

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -52,14 +52,14 @@ In this policy, the words "must" and "must not" specify absolute requirements th
 
 ### Tier 2
 
-- x86_64/amd64/x64 for Windows 2022
+- x86_64/amd64/x64 for Windows (Visual Studio Toolchain) 2022
 - armeabi-v7a, arm64-v8a, x86, x86_64 for Android
 - aarch64 for Apple iOS and tvOS (CMake `-DPLATFORM=OS64` and `TVOS`)
 - arm64, arm (32 bit), x86, x86_64, riscv32, riscv64 for Zephyr
 
 ### Tier 3
 
-- x86 for Windows
+- x86 for Windows (Visual Studio Toolchain)
 - ppc64le for Ubuntu (Focal)
 - s390x for Ubuntu (Focal)
 


### PR DESCRIPTION
oqs-provider has been testing `cygwin` support also for `liboqs`. But this now fails for two reasons:
- OpenSSL 3.4 triggers a crash
- Activating the `pytest` toolchain in `cygwin` is [not seamlessly possible](https://github.com/open-quantum-safe/oqs-provider/pull/401/commits/aeb3ad296a70389711f267032c7be6b60ba8252b).

This PR therefore restricts stated Windows support to MSVC until a formal decision is taken to enhance Windows support beyond this (& adding CI in this project).

* [no] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [no] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)


