### PR TITLE
Errors not printed out when OPENSSL_NO_STDIO is set

### DIFF
--- a/src/common/rand/rand_nist.c
+++ b/src/common/rand/rand_nist.c
@@ -39,7 +39,9 @@ __declspec(noreturn)
 __attribute__((noreturn))
 # endif
 static void handleErrors(void) {
+#ifndef OPENSSL_NO_STDIO
 	OSSL_FUNC(ERR_print_errors_fp)(stderr);
+#endif
 	abort();
 }
 #endif


### PR DESCRIPTION
The handleErrors function should print out errors when OPENSSL_NO_STDIO is set. The ERR_clear_error function is called instead since ERR_print_errors_fp would empty the error queue.