### PR TITLE
Move Linux ARM64 "build" test from CircleCI to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,47 +144,6 @@ jobs:
           command: scan-build-15 --status-bugs ninja
           working_directory: build
 
-  arm_machine:
-    description: A template for running liboqs tests on ARM(presently only 64) machines
-    parameters:
-      CMAKE_ARGS:
-        description: "Arguments to pass to CMake."
-        type: string
-        default: ''
-      PYTEST_ARGS:
-        description: "Arguments to pass to pytest."
-        type: string
-        # Not every executor handles --numprocesses=auto being passed to pytest well
-        # See https://github.com/open-quantum-safe/liboqs/issues/738#issuecomment-621394744
-        default: --numprocesses=auto
-    machine:
-      image: default # analogous to ubuntu-latest on GH Actions
-    resource_class: arm.medium
-    steps:
-      - checkout
-      # It seems the machine doesn't contain all preprequisites, and we don't have permission to add them explicitly, 
-      # so we can only run in a prepared ARM64 CI image
-      - run:
-          name: Build and run tests in docker 
-          no_output_timeout: 1h
-          command: |2
-            docker run -it -e CMAKE_ARGS="<< parameters.CMAKE_ARGS >>" \
-                           -e PYTEST_ARGS="<< parameters.PYTEST_ARGS >>" \
-                           -v `pwd`:/root/project \
-                           openquantumsafe/ci-ubuntu-focal-arm64:latest bash \
-                           -c 'cd /root/project && \
-                               uname -a && \
-                               mkdir build && cd build && source ~/.bashrc && \
-                               cmake -GNinja -DOQS_STRICT_WARNINGS=ON $CMAKE_ARGS .. && cmake -LA .. && ninja && \
-                               cd .. && mkdir -p tmp && \
-                               python3 -m pytest --verbose \
-                                                 --ignore=tests/test_code_conventions.py \
-                                                 --junitxml=build/test-results/pytest/test-results.xml $PYTEST_ARGS'
-      - store_test_results: # Note that this command will fail when running CircleCI locally, that is expected behaviour
-          path: build/test-results
-      - store_artifacts:
-          path: build/test-results
-
   trigger-downstream-ci:
     docker:
       - image: cimg/base:2020.01
@@ -340,11 +299,6 @@ workflows:
           CONTAINER: openquantumsafe/ci-ubuntu-bionic-i386:latest
           CMAKE_ARGS: -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_x86.cmake
           PYTEST_ARGS: --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py
-      - arm_machine:
-          <<: *require_buildcheck
-          name: arm64
-          PYTEST_ARGS: --numprocesses=auto --maxprocesses=10 --ignore=tests/test_kat_all.py
-          CMAKE_ARGS: -DOQS_ENABLE_SIG_STFL_LMS=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON
 
   commit-to-main:
     when:

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Build documentation
         run: ninja gen_docs
         working-directory: build
+        if: matrix.arch == "x86_64"
 
           #linux_intel:
           #  needs: buildcheck

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -38,9 +38,16 @@ jobs:
 
   buildcheck:
     name: Check that code passes a basic build before starting heavier tests
-    container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
     needs: [stylecheck, upstreamcheck]
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: arm64
+            runner: oqs-arm64
+          - arch: x86_64
+            runner: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    container: openquantumsafe/ci-ubuntu-focal-${{ matrix.arch }}:latest
     env:
       KEM_NAME: kyber_768
       SIG_NAME: dilithium_3
@@ -65,222 +72,222 @@ jobs:
         run: ninja gen_docs
         working-directory: build
 
-  linux_intel:
-    needs: buildcheck
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: alpine
-            container: openquantumsafe/ci-alpine-amd64:latest
-            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
-          - name: alpine-no-stfl-key-sig-gen
-            container: openquantumsafe/ci-alpine-amd64:latest
-            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
-          - name: alpine-openssl-all
-            container: openquantumsafe/ci-alpine-amd64:latest
-            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_USE_AES_OPENSSL=ON -DOQS_USE_SHA2_OPENSSL=ON -DOQS_USE_SHA3_OPENSSL=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
-          - name: alpine-noopenssl
-            container: openquantumsafe/ci-alpine-amd64:latest
-            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=OFF -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
-          - name: focal-nistr4-openssl
-            container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=NIST_R4
-            PYTEST_ARGS: --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py
-          - name: jammy-std-openssl3
-            container: openquantumsafe/ci-ubuntu-jammy:latest
-            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=STD -DBUILD_SHARED_LIBS=ON
-            PYTEST_ARGS: --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py
-          - name: jammy-std-openssl3-dlopen
-            container: openquantumsafe/ci-ubuntu-jammy:latest
-            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=STD -DBUILD_SHARED_LIBS=ON -DOQS_DLOPEN_OPENSSL=ON
-            PYTEST_ARGS: --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py
-          - name: address-sanitizer
-            container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-            CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-            PYTEST_ARGS: --ignore=tests/test_distbuild.py --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py --numprocesses=auto --maxprocesses=10
-          - name: address-sanitizer-no-stfl-key-sig-gen
-            container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-            CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-            PYTEST_ARGS: --ignore=tests/test_distbuild.py --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py --numprocesses=auto --maxprocesses=10
-    container:
-      image: ${{ matrix.container }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Configure
-        run: mkdir build && cd build && cmake -GNinja ${{ matrix.CMAKE_ARGS }} .. && cmake -LA ..
-      - name: Build
-        run: ninja
-        working-directory: build
-      - name: Run tests
-        timeout-minutes: 60
-        run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}
-      - name: Package .deb
-        if: ${{ matrix.name }} == 'jammy-std-openssl3'
-        run: cpack
-        working-directory: build
-      - name: Retain .deb file
-        if: ${{ matrix.name }} == 'jammy-std-openssl3'
-        uses: actions/upload-artifact@v3
-        with:
-          name: liboqs-openssl3-shared-x64
-          path: build/*.deb
-      - name: Check STD algorithm and alias
-        if: matrix.name == 'jammy-std-openssl3'
-        run: 'tests/dump_alg_info | grep -zoP "ML-DSA-44:\n    isnull: false" && tests/dump_alg_info | grep -zoP "ML-DSA-44-ipd:\n    isnull: true" && tests/dump_alg_info | grep -zoP "ML-KEM-512:\n    isnull: false" && tests/dump_alg_info | grep -zoP "ML-KEM-512-ipd:\n    isnull: true"'
-        working-directory: build
+          #linux_intel:
+          #  needs: buildcheck
+          #  runs-on: ubuntu-latest
+          #  strategy:
+          #    fail-fast: false
+          #    matrix:
+          #      include:
+          #        - name: alpine
+          #          container: openquantumsafe/ci-alpine-amd64:latest
+          #          CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+          #          PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
+          #        - name: alpine-no-stfl-key-sig-gen
+          #          container: openquantumsafe/ci-alpine-amd64:latest
+          #          CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+          #          PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
+          #        - name: alpine-openssl-all
+          #          container: openquantumsafe/ci-alpine-amd64:latest
+          #          CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_USE_AES_OPENSSL=ON -DOQS_USE_SHA2_OPENSSL=ON -DOQS_USE_SHA3_OPENSSL=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+          #          PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
+          #        - name: alpine-noopenssl
+          #          container: openquantumsafe/ci-alpine-amd64:latest
+          #          CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=OFF -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+          #          PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
+          #        - name: focal-nistr4-openssl
+          #          container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+          #          CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=NIST_R4
+          #          PYTEST_ARGS: --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py
+          #        - name: jammy-std-openssl3
+          #          container: openquantumsafe/ci-ubuntu-jammy:latest
+          #          CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=STD -DBUILD_SHARED_LIBS=ON
+          #          PYTEST_ARGS: --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py
+          #        - name: jammy-std-openssl3-dlopen
+          #          container: openquantumsafe/ci-ubuntu-jammy:latest
+          #          CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=STD -DBUILD_SHARED_LIBS=ON -DOQS_DLOPEN_OPENSSL=ON
+          #          PYTEST_ARGS: --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py
+          #        - name: address-sanitizer
+          #          container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+          #          CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+          #          PYTEST_ARGS: --ignore=tests/test_distbuild.py --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py --numprocesses=auto --maxprocesses=10
+          #        - name: address-sanitizer-no-stfl-key-sig-gen
+          #          container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+          #          CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+          #          PYTEST_ARGS: --ignore=tests/test_distbuild.py --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py --numprocesses=auto --maxprocesses=10
+          #  container:
+          #    image: ${{ matrix.container }}
+          #  steps:
+          #    - name: Checkout code
+          #      uses: actions/checkout@v4
+          #    - name: Configure
+          #      run: mkdir build && cd build && cmake -GNinja ${{ matrix.CMAKE_ARGS }} .. && cmake -LA ..
+          #    - name: Build
+          #      run: ninja
+          #      working-directory: build
+          #    - name: Run tests
+          #      timeout-minutes: 60
+          #      run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}
+          #    - name: Package .deb
+          #      if: ${{ matrix.name }} == 'jammy-std-openssl3'
+          #      run: cpack
+          #      working-directory: build
+          #    - name: Retain .deb file
+          #      if: ${{ matrix.name }} == 'jammy-std-openssl3'
+          #      uses: actions/upload-artifact@v3
+          #      with:
+          #        name: liboqs-openssl3-shared-x64
+          #        path: build/*.deb
+          #    - name: Check STD algorithm and alias
+          #      if: matrix.name == 'jammy-std-openssl3'
+          #      run: 'tests/dump_alg_info | grep -zoP "ML-DSA-44:\n    isnull: false" && tests/dump_alg_info | grep -zoP "ML-DSA-44-ipd:\n    isnull: true" && tests/dump_alg_info | grep -zoP "ML-KEM-512:\n    isnull: false" && tests/dump_alg_info | grep -zoP "ML-KEM-512-ipd:\n    isnull: true"'
+          #      working-directory: build
 
-  linux_arm_emulated:
-    needs: buildcheck
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: armhf
-            ARCH: armhf
-            CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
-          - name: armhf-no-stfl-key-sig-gen
-            ARCH: armhf
-            CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
-          # no longer supporting armel
-          # - name: armel
-          #   ARCH: armel
-          #   CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Install the emulation handlers
-        run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
-      - name: Build in an x86_64 container
-        run: |
-          docker run --rm \
-                     -v `pwd`:`pwd` \
-                     -w `pwd` \
-                     openquantumsafe/ci-debian-buster-amd64:latest /bin/bash \
-                     -c "mkdir build && \
-                         (cd build && \
-                          cmake .. -GNinja ${{ matrix.CMAKE_ARGS }} \
-                                   -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_${{ matrix.ARCH }}.cmake && \
-                          cmake -LA .. && \
-                          ninja)"
-      - name: Run the tests in an ${{ matrix.ARCH }} container
-        timeout-minutes: 60
-        run: |
-          docker run --rm -e SKIP_TESTS=style,mem_kem,mem_sig \
-                          -v `pwd`:`pwd` \
-                          -w `pwd` \
-                          openquantumsafe/ci-debian-buster-${{ matrix.ARCH }}:latest /bin/bash \
-                          -c "mkdir -p tmp && \
-                              python3 -m pytest --verbose \
-                                                --numprocesses=auto \
-                                                --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}"
+          #linux_arm_emulated:
+          #  needs: buildcheck
+          #  runs-on: ubuntu-latest
+          #  strategy:
+          #    fail-fast: false
+          #    matrix:
+          #      include:
+          #        - name: armhf
+          #          ARCH: armhf
+          #          CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+          #          PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
+          #        - name: armhf-no-stfl-key-sig-gen
+          #          ARCH: armhf
+          #          CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+          #          PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
+          #        # no longer supporting armel
+          #        # - name: armel
+          #        #   ARCH: armel
+          #        #   CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
+          #  steps:
+          #    - name: Checkout code
+          #      uses: actions/checkout@v4
+          #    - name: Install the emulation handlers
+          #      run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
+          #    - name: Build in an x86_64 container
+          #      run: |
+          #        docker run --rm \
+          #                   -v `pwd`:`pwd` \
+          #                   -w `pwd` \
+          #                   openquantumsafe/ci-debian-buster-amd64:latest /bin/bash \
+          #                   -c "mkdir build && \
+          #                       (cd build && \
+          #                        cmake .. -GNinja ${{ matrix.CMAKE_ARGS }} \
+          #                                 -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_${{ matrix.ARCH }}.cmake && \
+          #                        cmake -LA .. && \
+          #                        ninja)"
+          #    - name: Run the tests in an ${{ matrix.ARCH }} container
+          #      timeout-minutes: 60
+          #      run: |
+          #        docker run --rm -e SKIP_TESTS=style,mem_kem,mem_sig \
+          #                        -v `pwd`:`pwd` \
+          #                        -w `pwd` \
+          #                        openquantumsafe/ci-debian-buster-${{ matrix.ARCH }}:latest /bin/bash \
+          #                        -c "mkdir -p tmp && \
+          #                            python3 -m pytest --verbose \
+          #                                              --numprocesses=auto \
+          #                                              --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}"
 
-  linux_cross_compile:
-    needs: buildcheck
-    runs-on: ubuntu-latest
-    container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: windows-binaries
-            CMAKE_ARGS: -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_windows-amd64.cmake
-          - name: windows-dll
-            CMAKE_ARGS: -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_windows-amd64.cmake -DBUILD_SHARED_LIBS=ON
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Configure
-        run: mkdir build && cd build && cmake -GNinja ${{ matrix.CMAKE_ARGS }} .. && cmake -LA ..
-      - name: Build
-        run: ninja
-        working-directory: build
+          #linux_cross_compile:
+          #  needs: buildcheck
+          #  runs-on: ubuntu-latest
+          #  container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+          #  strategy:
+          #    fail-fast: false
+          #    matrix:
+          #      include:
+          #        - name: windows-binaries
+          #          CMAKE_ARGS: -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_windows-amd64.cmake
+          #        - name: windows-dll
+          #          CMAKE_ARGS: -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_windows-amd64.cmake -DBUILD_SHARED_LIBS=ON
+          #  steps:
+          #    - name: Checkout code
+          #      uses: actions/checkout@v4
+          #    - name: Configure
+          #      run: mkdir build && cd build && cmake -GNinja ${{ matrix.CMAKE_ARGS }} .. && cmake -LA ..
+          #    - name: Build
+          #      run: ninja
+          #      working-directory: build
 
-  macos:
-    needs: buildcheck
-    strategy:
-      fail-fast: false
-      matrix:
-        os: # macos-14 runs on aarch64; the others run on x64
-          - macos-12
-          - macos-13
-          - macos-14
-        CMAKE_ARGS:
-          - -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-          - -DCMAKE_C_COMPILER=gcc-13
-          - -DOQS_USE_OPENSSL=OFF
-          - -DBUILD_SHARED_LIBS=ON -DOQS_DIST_BUILD=OFF
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Install dependencies
-        run: env HOMEBREW_NO_AUTO_UPDATE=1 brew install ninja && pip3 install --break-system-packages pytest pytest-xdist pyyaml
-      - name: Patch GCC 
-        run: env HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall --ignore-dependencies gcc@13 && wget https://raw.githubusercontent.com/Homebrew/homebrew-core/eb6dd225d093b66054e18e07d56509cf670793b1/Formula/g/gcc%4013.rb && env HOMEBREW_NO_AUTO_UPDATE=1 brew install --ignore-dependencies gcc@13.rb
-      - name: Get system information
-        run: sysctl -a | grep machdep.cpu
-      - name: Configure
-        run: mkdir -p build && cd build && source ~/.bashrc && cmake -GNinja -DOQS_STRICT_WARNINGS=ON ${{ matrix.CMAKE_ARGS }} .. && cmake -LA ..
-      - name: Build
-        run: ninja
-        working-directory: build
-      - name: Run tests
-        run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --ignore=tests/test_kat_all.py ${{ matrix.PYTEST_ARGS }}
-        timeout-minutes: 60
+          #macos:
+          #  needs: buildcheck
+          #  strategy:
+          #    fail-fast: false
+          #    matrix:
+          #      os: # macos-14 runs on aarch64; the others run on x64
+          #        - macos-12
+          #        - macos-13
+          #        - macos-14
+          #      CMAKE_ARGS:
+          #        - -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+          #        - -DCMAKE_C_COMPILER=gcc-13
+          #        - -DOQS_USE_OPENSSL=OFF
+          #        - -DBUILD_SHARED_LIBS=ON -DOQS_DIST_BUILD=OFF
+          #  runs-on: ${{ matrix.os }}
+          #  steps:
+          #    - name: Checkout code
+          #      uses: actions/checkout@v4
+          #    - name: Install dependencies
+          #      run: env HOMEBREW_NO_AUTO_UPDATE=1 brew install ninja && pip3 install --break-system-packages pytest pytest-xdist pyyaml
+          #    - name: Patch GCC 
+          #      run: env HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall --ignore-dependencies gcc@13 && wget https://raw.githubusercontent.com/Homebrew/homebrew-core/eb6dd225d093b66054e18e07d56509cf670793b1/Formula/g/gcc%4013.rb && env HOMEBREW_NO_AUTO_UPDATE=1 brew install --ignore-dependencies gcc@13.rb
+          #    - name: Get system information
+          #      run: sysctl -a | grep machdep.cpu
+          #    - name: Configure
+          #      run: mkdir -p build && cd build && source ~/.bashrc && cmake -GNinja -DOQS_STRICT_WARNINGS=ON ${{ matrix.CMAKE_ARGS }} .. && cmake -LA ..
+          #    - name: Build
+          #      run: ninja
+          #      working-directory: build
+          #    - name: Run tests
+          #      run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --ignore=tests/test_kat_all.py ${{ matrix.PYTEST_ARGS }}
+          #      timeout-minutes: 60
 
-  linux_openssl330-dev:
-    needs: buildcheck
-    runs-on: ubuntu-latest
-    container:
-      image: openquantumsafe/ci-ubuntu-jammy:latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Retrieve OpenSSL330 from cache
-        id: cache-openssl330
-        uses: actions/cache@v3
-        with:
-          path: .localopenssl330
-          key: ${{ runner.os }}-openssl330
-      - name: Checkout the OpenSSL v3.3.0 commit
-        if: steps.cache-openssl330.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
-        with:
-          repository: 'openssl/openssl'
-          ref: 'openssl-3.3.0-beta1'
-          path: openssl
-      - name: Prepare the OpenSSL build directory
-        if: steps.cache-openssl330.outputs.cache-hit != 'true'
-        run: mkdir .localopenssl330
-        working-directory: openssl
-      - name: Build openssl3 if not cached
-        if: steps.cache-openssl330.outputs.cache-hit != 'true'
-        run: |
-          ./config --prefix=`pwd`/../.localopenssl330 && make -j 4 && make install_sw install_ssldirs
-        working-directory: openssl
-      - name: Save OpenSSL
-        id: cache-openssl-save
-        if: steps.cache-openssl330.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            .localopenssl330
-          key: ${{ runner.os }}-openssl330
-      - name: Configure
-        run: mkdir build && cd build && cmake -GNinja -DOQS_STRICT_WARNINGS=ON -DOPENSSL_ROOT_DIR=../.localopenssl330 -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_USE_AES_OPENSSL=ON -DOQS_USE_SHA2_OPENSSL=ON -DOQS_USE_SHA3_OPENSSL=ON .. && cmake -LA ..
-      - name: Build
-        run: ninja
-        working-directory: build
-      - name: Run tests
-        timeout-minutes: 60
-        run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py
+          #linux_openssl330-dev:
+          #  needs: buildcheck
+          #  runs-on: ubuntu-latest
+          #  container:
+          #    image: openquantumsafe/ci-ubuntu-jammy:latest
+          #  steps:
+          #    - name: Checkout code
+          #      uses: actions/checkout@v4
+          #    - name: Retrieve OpenSSL330 from cache
+          #      id: cache-openssl330
+          #      uses: actions/cache@v3
+          #      with:
+          #        path: .localopenssl330
+          #        key: ${{ runner.os }}-openssl330
+          #    - name: Checkout the OpenSSL v3.3.0 commit
+          #      if: steps.cache-openssl330.outputs.cache-hit != 'true'
+          #      uses: actions/checkout@v4
+          #      with:
+          #        repository: 'openssl/openssl'
+          #        ref: 'openssl-3.3.0-beta1'
+          #        path: openssl
+          #    - name: Prepare the OpenSSL build directory
+          #      if: steps.cache-openssl330.outputs.cache-hit != 'true'
+          #      run: mkdir .localopenssl330
+          #      working-directory: openssl
+          #    - name: Build openssl3 if not cached
+          #      if: steps.cache-openssl330.outputs.cache-hit != 'true'
+          #      run: |
+          #        ./config --prefix=`pwd`/../.localopenssl330 && make -j 4 && make install_sw install_ssldirs
+          #      working-directory: openssl
+          #    - name: Save OpenSSL
+          #      id: cache-openssl-save
+          #      if: steps.cache-openssl330.outputs.cache-hit != 'true'
+          #      uses: actions/cache/save@v3
+          #      with:
+          #        path: |
+          #          .localopenssl330
+          #        key: ${{ runner.os }}-openssl330
+          #    - name: Configure
+          #      run: mkdir build && cd build && cmake -GNinja -DOQS_STRICT_WARNINGS=ON -DOPENSSL_ROOT_DIR=../.localopenssl330 -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_USE_AES_OPENSSL=ON -DOQS_USE_SHA2_OPENSSL=ON -DOQS_USE_SHA3_OPENSSL=ON .. && cmake -LA ..
+          #    - name: Build
+          #      run: ninja
+          #      working-directory: build
+          #    - name: Run tests
+          #      timeout-minutes: 60
+          #      run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -73,222 +73,236 @@ jobs:
         working-directory: build
         if: matrix.arch == 'x86_64'
 
-          #linux_intel:
-          #  needs: buildcheck
-          #  runs-on: ubuntu-latest
-          #  strategy:
-          #    fail-fast: false
-          #    matrix:
-          #      include:
-          #        - name: alpine
-          #          container: openquantumsafe/ci-alpine-amd64:latest
-          #          CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-          #          PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
-          #        - name: alpine-no-stfl-key-sig-gen
-          #          container: openquantumsafe/ci-alpine-amd64:latest
-          #          CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-          #          PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
-          #        - name: alpine-openssl-all
-          #          container: openquantumsafe/ci-alpine-amd64:latest
-          #          CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_USE_AES_OPENSSL=ON -DOQS_USE_SHA2_OPENSSL=ON -DOQS_USE_SHA3_OPENSSL=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-          #          PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
-          #        - name: alpine-noopenssl
-          #          container: openquantumsafe/ci-alpine-amd64:latest
-          #          CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=OFF -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-          #          PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
-          #        - name: focal-nistr4-openssl
-          #          container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-          #          CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=NIST_R4
-          #          PYTEST_ARGS: --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py
-          #        - name: jammy-std-openssl3
-          #          container: openquantumsafe/ci-ubuntu-jammy:latest
-          #          CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=STD -DBUILD_SHARED_LIBS=ON
-          #          PYTEST_ARGS: --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py
-          #        - name: jammy-std-openssl3-dlopen
-          #          container: openquantumsafe/ci-ubuntu-jammy:latest
-          #          CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=STD -DBUILD_SHARED_LIBS=ON -DOQS_DLOPEN_OPENSSL=ON
-          #          PYTEST_ARGS: --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py
-          #        - name: address-sanitizer
-          #          container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-          #          CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-          #          PYTEST_ARGS: --ignore=tests/test_distbuild.py --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py --numprocesses=auto --maxprocesses=10
-          #        - name: address-sanitizer-no-stfl-key-sig-gen
-          #          container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-          #          CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-          #          PYTEST_ARGS: --ignore=tests/test_distbuild.py --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py --numprocesses=auto --maxprocesses=10
-          #  container:
-          #    image: ${{ matrix.container }}
-          #  steps:
-          #    - name: Checkout code
-          #      uses: actions/checkout@v4
-          #    - name: Configure
-          #      run: mkdir build && cd build && cmake -GNinja ${{ matrix.CMAKE_ARGS }} .. && cmake -LA ..
-          #    - name: Build
-          #      run: ninja
-          #      working-directory: build
-          #    - name: Run tests
-          #      timeout-minutes: 60
-          #      run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}
-          #    - name: Package .deb
-          #      if: ${{ matrix.name }} == 'jammy-std-openssl3'
-          #      run: cpack
-          #      working-directory: build
-          #    - name: Retain .deb file
-          #      if: ${{ matrix.name }} == 'jammy-std-openssl3'
-          #      uses: actions/upload-artifact@v3
-          #      with:
-          #        name: liboqs-openssl3-shared-x64
-          #        path: build/*.deb
-          #    - name: Check STD algorithm and alias
-          #      if: matrix.name == 'jammy-std-openssl3'
-          #      run: 'tests/dump_alg_info | grep -zoP "ML-DSA-44:\n    isnull: false" && tests/dump_alg_info | grep -zoP "ML-DSA-44-ipd:\n    isnull: true" && tests/dump_alg_info | grep -zoP "ML-KEM-512:\n    isnull: false" && tests/dump_alg_info | grep -zoP "ML-KEM-512-ipd:\n    isnull: true"'
-          #      working-directory: build
+  linux:
+    needs: buildcheck
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: arm64
+            runner: oqs-arm64
+            container: openquantumsafe/ci-ubuntu-focal-arm64:latest
+            PYTEST_ARGS: --numprocesses=auto --maxprocesses=10 --ignore=tests/test_kat_all.py
+            CMAKE_ARGS: -DOQS_ENABLE_SIG_STFL_LMS=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON
+          - name: alpine
+            runner: ubuntu-latest
+            container: openquantumsafe/ci-alpine-amd64:latest
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
+          - name: alpine-no-stfl-key-sig-gen
+            runner: ubuntu-latest
+            container: openquantumsafe/ci-alpine-amd64:latest
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
+          - name: alpine-openssl-all
+            runner: ubuntu-latest
+            container: openquantumsafe/ci-alpine-amd64:latest
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_USE_AES_OPENSSL=ON -DOQS_USE_SHA2_OPENSSL=ON -DOQS_USE_SHA3_OPENSSL=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
+          - name: alpine-noopenssl
+            runner: ubuntu-latest
+            container: openquantumsafe/ci-alpine-amd64:latest
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=OFF -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
+          - name: focal-nistr4-openssl
+            runner: ubuntu-latest
+            container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=NIST_R4
+            PYTEST_ARGS: --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py
+          - name: jammy-std-openssl3
+            runner: ubuntu-latest
+            container: openquantumsafe/ci-ubuntu-jammy:latest
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=STD -DBUILD_SHARED_LIBS=ON
+            PYTEST_ARGS: --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py
+          - name: jammy-std-openssl3-dlopen
+            runner: ubuntu-latest
+            container: openquantumsafe/ci-ubuntu-jammy:latest
+            CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_ALGS_ENABLED=STD -DBUILD_SHARED_LIBS=ON -DOQS_DLOPEN_OPENSSL=ON
+            PYTEST_ARGS: --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py
+          - name: address-sanitizer
+            runner: ubuntu-latest
+            container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+            CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+            PYTEST_ARGS: --ignore=tests/test_distbuild.py --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py --numprocesses=auto --maxprocesses=10
+          - name: address-sanitizer-no-stfl-key-sig-gen
+            runner: ubuntu-latest
+            container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+            CMAKE_ARGS: -DCMAKE_C_COMPILER=clang-9 -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+            PYTEST_ARGS: --ignore=tests/test_distbuild.py --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py --numprocesses=auto --maxprocesses=10
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ${{ matrix.container }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Configure
+        run: mkdir build && cd build && cmake -GNinja ${{ matrix.CMAKE_ARGS }} .. && cmake -LA ..
+      - name: Build
+        run: ninja
+        working-directory: build
+      - name: Run tests
+        timeout-minutes: 60
+        run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}
+      - name: Package .deb
+        if: ${{ matrix.name }} == 'jammy-std-openssl3'
+        run: cpack
+        working-directory: build
+      - name: Retain .deb file
+        if: ${{ matrix.name }} == 'jammy-std-openssl3'
+        uses: actions/upload-artifact@v3
+        with:
+          name: liboqs-openssl3-shared-x64
+          path: build/*.deb
+      - name: Check STD algorithm and alias
+        if: matrix.name == 'jammy-std-openssl3'
+        run: 'tests/dump_alg_info | grep -zoP "ML-DSA-44:\n    isnull: false" && tests/dump_alg_info | grep -zoP "ML-DSA-44-ipd:\n    isnull: true" && tests/dump_alg_info | grep -zoP "ML-KEM-512:\n    isnull: false" && tests/dump_alg_info | grep -zoP "ML-KEM-512-ipd:\n    isnull: true"'
+        working-directory: build
 
-          #linux_arm_emulated:
-          #  needs: buildcheck
-          #  runs-on: ubuntu-latest
-          #  strategy:
-          #    fail-fast: false
-          #    matrix:
-          #      include:
-          #        - name: armhf
-          #          ARCH: armhf
-          #          CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-          #          PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
-          #        - name: armhf-no-stfl-key-sig-gen
-          #          ARCH: armhf
-          #          CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-          #          PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
-          #        # no longer supporting armel
-          #        # - name: armel
-          #        #   ARCH: armel
-          #        #   CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
-          #  steps:
-          #    - name: Checkout code
-          #      uses: actions/checkout@v4
-          #    - name: Install the emulation handlers
-          #      run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
-          #    - name: Build in an x86_64 container
-          #      run: |
-          #        docker run --rm \
-          #                   -v `pwd`:`pwd` \
-          #                   -w `pwd` \
-          #                   openquantumsafe/ci-debian-buster-amd64:latest /bin/bash \
-          #                   -c "mkdir build && \
-          #                       (cd build && \
-          #                        cmake .. -GNinja ${{ matrix.CMAKE_ARGS }} \
-          #                                 -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_${{ matrix.ARCH }}.cmake && \
-          #                        cmake -LA .. && \
-          #                        ninja)"
-          #    - name: Run the tests in an ${{ matrix.ARCH }} container
-          #      timeout-minutes: 60
-          #      run: |
-          #        docker run --rm -e SKIP_TESTS=style,mem_kem,mem_sig \
-          #                        -v `pwd`:`pwd` \
-          #                        -w `pwd` \
-          #                        openquantumsafe/ci-debian-buster-${{ matrix.ARCH }}:latest /bin/bash \
-          #                        -c "mkdir -p tmp && \
-          #                            python3 -m pytest --verbose \
-          #                                              --numprocesses=auto \
-          #                                              --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}"
+  linux_arm_emulated:
+    needs: buildcheck
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: armhf
+            ARCH: armhf
+            CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
+          - name: armhf-no-stfl-key-sig-gen
+            ARCH: armhf
+            CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
+          # no longer supporting armel
+          # - name: armel
+          #   ARCH: armel
+          #   CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_OPT_TARGET=generic
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install the emulation handlers
+        run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      - name: Build in an x86_64 container
+        run: |
+          docker run --rm \
+                     -v `pwd`:`pwd` \
+                     -w `pwd` \
+                     openquantumsafe/ci-debian-buster-amd64:latest /bin/bash \
+                     -c "mkdir build && \
+                         (cd build && \
+                          cmake .. -GNinja ${{ matrix.CMAKE_ARGS }} \
+                                   -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_${{ matrix.ARCH }}.cmake && \
+                          cmake -LA .. && \
+                          ninja)"
+      - name: Run the tests in an ${{ matrix.ARCH }} container
+        timeout-minutes: 60
+        run: |
+          docker run --rm -e SKIP_TESTS=style,mem_kem,mem_sig \
+                          -v `pwd`:`pwd` \
+                          -w `pwd` \
+                          openquantumsafe/ci-debian-buster-${{ matrix.ARCH }}:latest /bin/bash \
+                          -c "mkdir -p tmp && \
+                              python3 -m pytest --verbose \
+                                                --numprocesses=auto \
+                                                --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}"
 
-          #linux_cross_compile:
-          #  needs: buildcheck
-          #  runs-on: ubuntu-latest
-          #  container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
-          #  strategy:
-          #    fail-fast: false
-          #    matrix:
-          #      include:
-          #        - name: windows-binaries
-          #          CMAKE_ARGS: -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_windows-amd64.cmake
-          #        - name: windows-dll
-          #          CMAKE_ARGS: -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_windows-amd64.cmake -DBUILD_SHARED_LIBS=ON
-          #  steps:
-          #    - name: Checkout code
-          #      uses: actions/checkout@v4
-          #    - name: Configure
-          #      run: mkdir build && cd build && cmake -GNinja ${{ matrix.CMAKE_ARGS }} .. && cmake -LA ..
-          #    - name: Build
-          #      run: ninja
-          #      working-directory: build
+  linux_cross_compile:
+    needs: buildcheck
+    runs-on: ubuntu-latest
+    container: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: windows-binaries
+            CMAKE_ARGS: -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_windows-amd64.cmake
+          - name: windows-dll
+            CMAKE_ARGS: -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_windows-amd64.cmake -DBUILD_SHARED_LIBS=ON
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Configure
+        run: mkdir build && cd build && cmake -GNinja ${{ matrix.CMAKE_ARGS }} .. && cmake -LA ..
+      - name: Build
+        run: ninja
+        working-directory: build
 
-          #macos:
-          #  needs: buildcheck
-          #  strategy:
-          #    fail-fast: false
-          #    matrix:
-          #      os: # macos-14 runs on aarch64; the others run on x64
-          #        - macos-12
-          #        - macos-13
-          #        - macos-14
-          #      CMAKE_ARGS:
-          #        - -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-          #        - -DCMAKE_C_COMPILER=gcc-13
-          #        - -DOQS_USE_OPENSSL=OFF
-          #        - -DBUILD_SHARED_LIBS=ON -DOQS_DIST_BUILD=OFF
-          #  runs-on: ${{ matrix.os }}
-          #  steps:
-          #    - name: Checkout code
-          #      uses: actions/checkout@v4
-          #    - name: Install dependencies
-          #      run: env HOMEBREW_NO_AUTO_UPDATE=1 brew install ninja && pip3 install --break-system-packages pytest pytest-xdist pyyaml
-          #    - name: Patch GCC 
-          #      run: env HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall --ignore-dependencies gcc@13 && wget https://raw.githubusercontent.com/Homebrew/homebrew-core/eb6dd225d093b66054e18e07d56509cf670793b1/Formula/g/gcc%4013.rb && env HOMEBREW_NO_AUTO_UPDATE=1 brew install --ignore-dependencies gcc@13.rb
-          #    - name: Get system information
-          #      run: sysctl -a | grep machdep.cpu
-          #    - name: Configure
-          #      run: mkdir -p build && cd build && source ~/.bashrc && cmake -GNinja -DOQS_STRICT_WARNINGS=ON ${{ matrix.CMAKE_ARGS }} .. && cmake -LA ..
-          #    - name: Build
-          #      run: ninja
-          #      working-directory: build
-          #    - name: Run tests
-          #      run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --ignore=tests/test_kat_all.py ${{ matrix.PYTEST_ARGS }}
-          #      timeout-minutes: 60
+  macos:
+    needs: buildcheck
+    strategy:
+      fail-fast: false
+      matrix:
+        os: # macos-14 runs on aarch64; the others run on x64
+          - macos-12
+          - macos-13
+          - macos-14
+        CMAKE_ARGS:
+          - -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+          - -DCMAKE_C_COMPILER=gcc-13
+          - -DOQS_USE_OPENSSL=OFF
+          - -DBUILD_SHARED_LIBS=ON -DOQS_DIST_BUILD=OFF
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: env HOMEBREW_NO_AUTO_UPDATE=1 brew install ninja && pip3 install --break-system-packages pytest pytest-xdist pyyaml
+      - name: Patch GCC 
+        run: env HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall --ignore-dependencies gcc@13 && wget https://raw.githubusercontent.com/Homebrew/homebrew-core/eb6dd225d093b66054e18e07d56509cf670793b1/Formula/g/gcc%4013.rb && env HOMEBREW_NO_AUTO_UPDATE=1 brew install --ignore-dependencies gcc@13.rb
+      - name: Get system information
+        run: sysctl -a | grep machdep.cpu
+      - name: Configure
+        run: mkdir -p build && cd build && source ~/.bashrc && cmake -GNinja -DOQS_STRICT_WARNINGS=ON ${{ matrix.CMAKE_ARGS }} .. && cmake -LA ..
+      - name: Build
+        run: ninja
+        working-directory: build
+      - name: Run tests
+        run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --ignore=tests/test_kat_all.py ${{ matrix.PYTEST_ARGS }}
+        timeout-minutes: 60
 
-          #linux_openssl330-dev:
-          #  needs: buildcheck
-          #  runs-on: ubuntu-latest
-          #  container:
-          #    image: openquantumsafe/ci-ubuntu-jammy:latest
-          #  steps:
-          #    - name: Checkout code
-          #      uses: actions/checkout@v4
-          #    - name: Retrieve OpenSSL330 from cache
-          #      id: cache-openssl330
-          #      uses: actions/cache@v3
-          #      with:
-          #        path: .localopenssl330
-          #        key: ${{ runner.os }}-openssl330
-          #    - name: Checkout the OpenSSL v3.3.0 commit
-          #      if: steps.cache-openssl330.outputs.cache-hit != 'true'
-          #      uses: actions/checkout@v4
-          #      with:
-          #        repository: 'openssl/openssl'
-          #        ref: 'openssl-3.3.0-beta1'
-          #        path: openssl
-          #    - name: Prepare the OpenSSL build directory
-          #      if: steps.cache-openssl330.outputs.cache-hit != 'true'
-          #      run: mkdir .localopenssl330
-          #      working-directory: openssl
-          #    - name: Build openssl3 if not cached
-          #      if: steps.cache-openssl330.outputs.cache-hit != 'true'
-          #      run: |
-          #        ./config --prefix=`pwd`/../.localopenssl330 && make -j 4 && make install_sw install_ssldirs
-          #      working-directory: openssl
-          #    - name: Save OpenSSL
-          #      id: cache-openssl-save
-          #      if: steps.cache-openssl330.outputs.cache-hit != 'true'
-          #      uses: actions/cache/save@v3
-          #      with:
-          #        path: |
-          #          .localopenssl330
-          #        key: ${{ runner.os }}-openssl330
-          #    - name: Configure
-          #      run: mkdir build && cd build && cmake -GNinja -DOQS_STRICT_WARNINGS=ON -DOPENSSL_ROOT_DIR=../.localopenssl330 -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_USE_AES_OPENSSL=ON -DOQS_USE_SHA2_OPENSSL=ON -DOQS_USE_SHA3_OPENSSL=ON .. && cmake -LA ..
-          #    - name: Build
-          #      run: ninja
-          #      working-directory: build
-          #    - name: Run tests
-          #      timeout-minutes: 60
-          #      run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py
+  linux_openssl330-dev:
+    needs: buildcheck
+    runs-on: ubuntu-latest
+    container:
+      image: openquantumsafe/ci-ubuntu-jammy:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Retrieve OpenSSL330 from cache
+        id: cache-openssl330
+        uses: actions/cache@v3
+        with:
+          path: .localopenssl330
+          key: ${{ runner.os }}-openssl330
+      - name: Checkout the OpenSSL v3.3.0 commit
+        if: steps.cache-openssl330.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: 'openssl/openssl'
+          ref: 'openssl-3.3.0-beta1'
+          path: openssl
+      - name: Prepare the OpenSSL build directory
+        if: steps.cache-openssl330.outputs.cache-hit != 'true'
+        run: mkdir .localopenssl330
+        working-directory: openssl
+      - name: Build openssl3 if not cached
+        if: steps.cache-openssl330.outputs.cache-hit != 'true'
+        run: |
+          ./config --prefix=`pwd`/../.localopenssl330 && make -j 4 && make install_sw install_ssldirs
+        working-directory: openssl
+      - name: Save OpenSSL
+        id: cache-openssl-save
+        if: steps.cache-openssl330.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            .localopenssl330
+          key: ${{ runner.os }}-openssl330
+      - name: Configure
+        run: mkdir build && cd build && cmake -GNinja -DOQS_STRICT_WARNINGS=ON -DOPENSSL_ROOT_DIR=../.localopenssl330 -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_USE_AES_OPENSSL=ON -DOQS_USE_SHA2_OPENSSL=ON -DOQS_USE_SHA3_OPENSSL=ON .. && cmake -LA ..
+      - name: Build
+        run: ninja
+        working-directory: build
+      - name: Run tests
+        timeout-minutes: 60
+        run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Build documentation
         run: ninja gen_docs
         working-directory: build
-        if: matrix.arch == "x86_64"
+        if: matrix.arch == 'x86_64'
 
           #linux_intel:
           #  needs: buildcheck

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -144,11 +144,11 @@ jobs:
         timeout-minutes: 60
         run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}
       - name: Package .deb
-        if: ${{ matrix.name }} == 'jammy-std-openssl3'
+        if: matrix.name == 'jammy-std-openssl3'
         run: cpack
         working-directory: build
       - name: Retain .deb file
-        if: ${{ matrix.name }} == 'jammy-std-openssl3'
+        if: matrix.name == 'jammy-std-openssl3'
         uses: actions/upload-artifact@v3
         with:
           name: liboqs-openssl3-shared-x64


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
This PR moves the CircleCI ARM64 Linux "build" test over to GitHub Actions, using the new oqs-arm64 runner.

It also fixes some GitHub syntax so that jobs are skipped when we expect them to be.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
Makes progress on #1795.

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

