### PR TITLE
Forward-declare OQS_SIG in sig_stfl.h

### DIFF
--- a/src/sig_stfl/sig_stfl.h
+++ b/src/sig_stfl/sig_stfl.h
@@ -179,6 +179,7 @@ OQS_API int OQS_SIG_STFL_alg_count(void);
 OQS_API int OQS_SIG_STFL_alg_is_enabled(const char *method_name);
 
 #ifndef OQS_ALLOW_STFL_KEY_AND_SIG_GEN
+typedef struct OQS_SIG OQS_SIG;
 #define OQS_SIG_STFL OQS_SIG
 #else
 /**


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
When an application (e.g., `oqs-provider`) includes `<oqs/sig.h>`, the following happens:

- `sig.h` includes `oqs.h` _at the top of the file_.
- `oqs.h` includes `sig.h`, but this include is skipped because of the `OQS_SIG_H` include guard.
- `oqs.h` includes `sig_stfl.h`.
- `sig_stfl.h` references `OQS_SIG`, which has not yet been defined.

This breaks the application's build: see https://github.com/open-quantum-safe/liboqs/issues/1815, https://github.com/open-quantum-safe/oqs-provider/issues/427, and https://github.com/open-quantum-safe/oqs-demos/issues/281.

This PR resolves the issue by forward-declaring the OQS_SIG type in `sig_stfl.h`. This fixes the failing `oqs-provider` build: see the downstream tests [before](https://github.com/open-quantum-safe/oqs-provider/actions/runs/9468608791/job/26085334692) and [after](https://github.com/open-quantum-safe/oqs-provider/actions/runs/9468780524/job/26085916757).

I don't believe that the forward-declaration violates any C programming rules / best practices, but it would be great if someone with more experience could confirm this.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

