### PR TITLE
Fix test_alg_info.py on Windows platform

### DIFF
--- a/tests/test_alg_info.py
+++ b/tests/test_alg_info.py
@@ -16,7 +16,11 @@ def test_alg_info_kem(kem_name):
     alg_info = yaml.safe_load(output)['KEMs'][kem_name]
     assert(not(alg_info['isnull']))
     # find and load the datasheet
-    datasheet_filename = helpers.run_subprocess(['grep', '-r', '-l', kem_name, 'docs/algorithms/kem']).splitlines()[0]
+    if platform.system() == 'Windows':
+        command = f"Select-String -Path 'docs/algorithms/kem/*' -Pattern '{kem_name}' -SimpleMatch -List | Select-Object -ExpandProperty Path"
+        datasheet_filename = helpers.run_subprocess(['powershell', '-Command', command]).splitlines()[0]
+    else:
+        datasheet_filename = helpers.run_subprocess(['grep', '-r', '-l', kem_name, 'docs/algorithms/kem']).splitlines()[0]
     datasheet_filename = datasheet_filename.replace('.md','.yml')
     with open(datasheet_filename, 'r', encoding='utf8') as datasheet_fh:
         datasheet = yaml.safe_load(datasheet_fh.read())
@@ -45,7 +49,11 @@ def test_alg_info_sig(sig_name):
     alg_info = yaml.safe_load(output)['SIGs'][sig_name]
     assert(not(alg_info['isnull']))
     # find and load the datasheet
-    datasheet_filename = helpers.run_subprocess(['grep', '-r', '-l', sig_name, 'docs/algorithms/sig']).splitlines()[0]
+    if platform.system() == 'Windows':
+        command = f"Select-String -Path 'docs/algorithms/sig/*' -Pattern '{sig_name}' -SimpleMatch -List | Select-Object -ExpandProperty Path"
+        datasheet_filename = helpers.run_subprocess(['powershell', '-Command', command]).splitlines()[0]
+    else:
+        datasheet_filename = helpers.run_subprocess(['grep', '-r', '-l', sig_name, 'docs/algorithms/sig']).splitlines()[0]
     datasheet_filename = datasheet_filename.replace('.md','.yml')
     with open(datasheet_filename, 'r', encoding='utf8') as datasheet_fh:
         datasheet = yaml.safe_load(datasheet_fh.read())
@@ -66,5 +74,6 @@ def test_alg_info_sig(sig_name):
 
 if __name__ == "__main__":
     import sys
+    print("platform:",platform.system)
     pytest.main(sys.argv)
 

--- a/tests/test_alg_info.py
+++ b/tests/test_alg_info.py
@@ -74,6 +74,5 @@ def test_alg_info_sig(sig_name):
 
 if __name__ == "__main__":
     import sys
-    print("platform:",platform.system)
     pytest.main(sys.argv)
 


### PR DESCRIPTION
Fix test_alg_info.py on Windows which cause the ninja run_tests failure.

Since `gerp` is not available on Windows, making use of powershell is a good alternative way to replace grep.


