### PR TITLE
Expose callback API for replacing low-level cryptographic primitives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,8 +150,12 @@ if(${OQS_USE_OPENSSL})
 endif()
 
 set(PUBLIC_HEADERS ${PROJECT_SOURCE_DIR}/src/oqs.h
+                   ${PROJECT_SOURCE_DIR}/src/common/aes/aes_ops.h
                    ${PROJECT_SOURCE_DIR}/src/common/common.h
                    ${PROJECT_SOURCE_DIR}/src/common/rand/rand.h
+                   ${PROJECT_SOURCE_DIR}/src/common/sha2/sha2_ops.h
+                   ${PROJECT_SOURCE_DIR}/src/common/sha3/sha3_ops.h
+                   ${PROJECT_SOURCE_DIR}/src/common/sha3/sha3x4_ops.h
                    ${PROJECT_SOURCE_DIR}/src/kem/kem.h
                    ${PROJECT_SOURCE_DIR}/src/sig/sig.h
                    ${PROJECT_SOURCE_DIR}/src/sig_stfl/sig_stfl.h)

--- a/docs/.Doxyfile
+++ b/docs/.Doxyfile
@@ -949,8 +949,12 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = src/common/common.h \
+INPUT                  = src/common/aes/aes_ops.h \
+                         src/common/common.h \
                          src/common/rand/rand.h \
+                         src/common/sha2/sha2_ops.h \
+                         src/common/sha3/sha3_ops.h \
+                         src/common/sha3/sha3x4_ops.h \
                          src/kem/kem.h \
                          src/sig/sig.h \
                          README.md \

--- a/src/common/aes/aes.h
+++ b/src/common/aes/aes.h
@@ -14,7 +14,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include <oqs/common.h>
+#include <oqs/aes_ops.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -148,86 +148,6 @@ void OQS_AES256_CTR_inc_stream_iv(const uint8_t *iv, size_t iv_len, const void *
  * @param out_blks    Length of output blocks to generate, where one block is 16 bytes.
  */
 void OQS_AES256_CTR_inc_stream_blks(void *ctx, uint8_t *out, size_t out_blks);
-
-/** Data structure implemented by cryptographic provider for AES operations.
- */
-struct OQS_AES_callbacks {
-	/**
-	 * Implementation of function OQS_AES128_ECB_load_schedule.
-	 */
-	void (*AES128_ECB_load_schedule)(const uint8_t *key, void **ctx);
-
-	/**
-	 * Implementation of function OQS_AES128_free_schedule.
-	 */
-	void (*AES128_free_schedule)(void *ctx);
-
-	/**
-	 * Implementation of function OQS_AES128_ECB_enc.
-	 */
-	void (*AES128_ECB_enc)(const uint8_t *plaintext, const size_t plaintext_len, const uint8_t *key, uint8_t *ciphertext);
-
-	/**
-	 * Implementation of function OQS_AES128_ECB_enc_sch.
-	 */
-	void (*AES128_ECB_enc_sch)(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext);
-
-	/**
-	 * Implementation of function OQS_AES256_ECB_load_schedule.
-	 */
-	void (*AES256_ECB_load_schedule)(const uint8_t *key, void **ctx);
-
-	/**
-	 * Implementation of function OQS_AES256_CTR_inc_init.
-	 */
-	void (*AES256_CTR_inc_init)(const uint8_t *key, void **ctx);
-
-	/**
-	 * Implementation of function OQS_AES256_CTR_inc_iv.
-	 */
-	void (*AES256_CTR_inc_iv)(const uint8_t *iv, size_t iv_len, void *ctx);
-
-	/**
-	 * Implementation of function OQS_AES256_CTR_inc_ivu64.
-	 */
-	void (*AES256_CTR_inc_ivu64)(uint64_t iv, void *ctx);
-
-	/**
-	 * Implementation of function OQS_AES256_free_schedule.
-	 */
-	void (*AES256_free_schedule)(void *ctx);
-
-	/**
-	 * Implementation of function OQS_AES256_ECB_enc.
-	 */
-	void (*AES256_ECB_enc)(const uint8_t *plaintext, const size_t plaintext_len, const uint8_t *key, uint8_t *ciphertext);
-
-	/**
-	 * Implementation of function OQS_AES256_ECB_enc_sch.
-	 */
-	void (*AES256_ECB_enc_sch)(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext);
-
-	/**
-	 * Implementation of function OQS_AES256_CTR_inc_stream_iv.
-	 */
-	void (*AES256_CTR_inc_stream_iv)(const uint8_t *iv, size_t iv_len, const void *ctx, uint8_t *out, size_t out_len);
-
-	/**
-	 * Implementation of function OQS_AES256_CTR_inc_stream_blks.
-	 */
-	void (*AES256_CTR_inc_stream_blks)(void *ctx, uint8_t *out, size_t out_blks);
-};
-
-/**
- * Set callback functions for AES operations.
- *
- * This function may be called before OQS_init to switch the
- * cryptographic provider for AES operations. If it is not called, the
- * default provider determined at build time will be used.
- *
- * @param[in] new_callbacks Callback functions defined in OQS_AES_callbacks
- */
-OQS_API void OQS_AES_set_callbacks(struct OQS_AES_callbacks *new_callbacks);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/src/common/aes/aes_ops.h
+++ b/src/common/aes/aes_ops.h
@@ -1,0 +1,104 @@
+/**
+ * \file aes_ops.h
+ * \brief Header defining the callback API for OQS AES
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef OQS_AES_OPS_H
+#define OQS_AES_OPS_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <oqs/common.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/** Data structure implemented by cryptographic provider for AES operations.
+ */
+struct OQS_AES_callbacks {
+	/**
+	 * Implementation of function OQS_AES128_ECB_load_schedule.
+	 */
+	void (*AES128_ECB_load_schedule)(const uint8_t *key, void **ctx);
+
+	/**
+	 * Implementation of function OQS_AES128_free_schedule.
+	 */
+	void (*AES128_free_schedule)(void *ctx);
+
+	/**
+	 * Implementation of function OQS_AES128_ECB_enc.
+	 */
+	void (*AES128_ECB_enc)(const uint8_t *plaintext, const size_t plaintext_len, const uint8_t *key, uint8_t *ciphertext);
+
+	/**
+	 * Implementation of function OQS_AES128_ECB_enc_sch.
+	 */
+	void (*AES128_ECB_enc_sch)(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext);
+
+	/**
+	 * Implementation of function OQS_AES256_ECB_load_schedule.
+	 */
+	void (*AES256_ECB_load_schedule)(const uint8_t *key, void **ctx);
+
+	/**
+	 * Implementation of function OQS_AES256_CTR_inc_init.
+	 */
+	void (*AES256_CTR_inc_init)(const uint8_t *key, void **ctx);
+
+	/**
+	 * Implementation of function OQS_AES256_CTR_inc_iv.
+	 */
+	void (*AES256_CTR_inc_iv)(const uint8_t *iv, size_t iv_len, void *ctx);
+
+	/**
+	 * Implementation of function OQS_AES256_CTR_inc_ivu64.
+	 */
+	void (*AES256_CTR_inc_ivu64)(uint64_t iv, void *ctx);
+
+	/**
+	 * Implementation of function OQS_AES256_free_schedule.
+	 */
+	void (*AES256_free_schedule)(void *ctx);
+
+	/**
+	 * Implementation of function OQS_AES256_ECB_enc.
+	 */
+	void (*AES256_ECB_enc)(const uint8_t *plaintext, const size_t plaintext_len, const uint8_t *key, uint8_t *ciphertext);
+
+	/**
+	 * Implementation of function OQS_AES256_ECB_enc_sch.
+	 */
+	void (*AES256_ECB_enc_sch)(const uint8_t *plaintext, const size_t plaintext_len, const void *schedule, uint8_t *ciphertext);
+
+	/**
+	 * Implementation of function OQS_AES256_CTR_inc_stream_iv.
+	 */
+	void (*AES256_CTR_inc_stream_iv)(const uint8_t *iv, size_t iv_len, const void *ctx, uint8_t *out, size_t out_len);
+
+	/**
+	 * Implementation of function OQS_AES256_CTR_inc_stream_blks.
+	 */
+	void (*AES256_CTR_inc_stream_blks)(void *ctx, uint8_t *out, size_t out_blks);
+};
+
+/**
+ * Set callback functions for AES operations.
+ *
+ * This function may be called before OQS_init to switch the
+ * cryptographic provider for AES operations. If it is not called, the
+ * default provider determined at build time will be used.
+ *
+ * @param[in] new_callbacks Callback functions defined in OQS_AES_callbacks
+ */
+OQS_API void OQS_AES_set_callbacks(struct OQS_AES_callbacks *new_callbacks);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // OQS_AES_OPS_H

--- a/src/common/sha2/sha2.h
+++ b/src/common/sha2/sha2.h
@@ -18,21 +18,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <oqs/common.h>
+#include <oqs/sha2_ops.h>
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
-
-/** Data structure for the state of the SHA-224 incremental hashing API. */
-typedef struct {
-	/** Internal state */
-	void *ctx;
-	/** current number of bytes in data */
-	size_t data_len;
-	/** unprocessed data buffer */
-	uint8_t data[128];
-} OQS_SHA2_sha224_ctx;
 
 /**
  * \brief Process a message with SHA-256 and return the hash code in the output byte array.
@@ -44,16 +34,6 @@ typedef struct {
  * \param inplen The number of message bytes to process
  */
 void OQS_SHA2_sha256(uint8_t *output, const uint8_t *input, size_t inplen);
-
-/** Data structure for the state of the SHA-256 incremental hashing API. */
-typedef struct {
-	/** Internal state */
-	void *ctx;
-	/** current number of bytes in data */
-	size_t data_len;
-	/** unprocessed data buffer */
-	uint8_t data[128];
-} OQS_SHA2_sha256_ctx;
 
 /**
  * \brief Allocate and initialize the state for the SHA-256 incremental hashing API.
@@ -134,16 +114,6 @@ void OQS_SHA2_sha256_inc_ctx_release(OQS_SHA2_sha256_ctx *state);
  */
 void OQS_SHA2_sha384(uint8_t *output, const uint8_t *input, size_t inplen);
 
-/** Data structure for the state of the SHA-384 incremental hashing API. */
-typedef struct {
-	/** Internal state. */
-	void *ctx;
-	/** current number of bytes in data */
-	size_t data_len;
-	/** unprocessed data buffer */
-	uint8_t data[128];
-} OQS_SHA2_sha384_ctx;
-
 /**
  * \brief Allocate and initialize the state for the SHA-384 incremental hashing API.
  *
@@ -212,16 +182,6 @@ void OQS_SHA2_sha384_inc_ctx_release(OQS_SHA2_sha384_ctx *state);
  */
 void OQS_SHA2_sha512(uint8_t *output, const uint8_t *input, size_t inplen);
 
-/** Data structure for the state of the SHA-512 incremental hashing API. */
-typedef struct {
-	/** Internal state. */
-	void *ctx;
-	/** current number of bytes in data */
-	size_t data_len;
-	/** unprocessed data buffer */
-	uint8_t data[128];
-} OQS_SHA2_sha512_ctx;
-
 /**
  * \brief Allocate and initialize the state for the SHA-512 incremental hashing API.
  *
@@ -278,116 +238,6 @@ void OQS_SHA2_sha512_inc_finalize(uint8_t *out, OQS_SHA2_sha512_ctx *state, cons
  * \param state The state
  */
 void OQS_SHA2_sha512_inc_ctx_release(OQS_SHA2_sha512_ctx *state);
-
-/** Data structure implemented by cryptographic provider for SHA-2 operations.
- */
-struct OQS_SHA2_callbacks {
-	/**
-	 * Implementation of function OQS_SHA2_sha256.
-	 */
-	void (*SHA2_sha256)(uint8_t *output, const uint8_t *input, size_t inplen);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha256_inc_init.
-	 */
-	void (*SHA2_sha256_inc_init)(OQS_SHA2_sha256_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha256_inc_ctx_clone.
-	 */
-	void (*SHA2_sha256_inc_ctx_clone)(OQS_SHA2_sha256_ctx *dest, const OQS_SHA2_sha256_ctx *src);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha256_inc.
-	 */
-	void (*SHA2_sha256_inc)(OQS_SHA2_sha256_ctx *state, const uint8_t *in, size_t len);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha256_inc_blocks.
-	 */
-	void (*SHA2_sha256_inc_blocks)(OQS_SHA2_sha256_ctx *state, const uint8_t *in, size_t inblocks);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha256_inc_finalize.
-	 */
-	void (*SHA2_sha256_inc_finalize)(uint8_t *out, OQS_SHA2_sha256_ctx *state, const uint8_t *in, size_t inlen);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha256_inc_ctx_release.
-	 */
-	void (*SHA2_sha256_inc_ctx_release)(OQS_SHA2_sha256_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha384.
-	 */
-	void (*SHA2_sha384)(uint8_t *output, const uint8_t *input, size_t inplen);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha384_inc_init.
-	 */
-	void (*SHA2_sha384_inc_init)(OQS_SHA2_sha384_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha384_inc_ctx_clone.
-	 */
-	void (*SHA2_sha384_inc_ctx_clone)(OQS_SHA2_sha384_ctx *dest, const OQS_SHA2_sha384_ctx *src);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha384_inc_blocks.
-	 */
-	void (*SHA2_sha384_inc_blocks)(OQS_SHA2_sha384_ctx *state, const uint8_t *in, size_t inblocks);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha384_inc_finalize.
-	 */
-	void (*SHA2_sha384_inc_finalize)(uint8_t *out, OQS_SHA2_sha384_ctx *state, const uint8_t *in, size_t inlen);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha384_inc_ctx_release.
-	 */
-	void (*SHA2_sha384_inc_ctx_release)(OQS_SHA2_sha384_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha512.
-	 */
-	void (*SHA2_sha512)(uint8_t *output, const uint8_t *input, size_t inplen);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha512_inc_init.
-	 */
-	void (*SHA2_sha512_inc_init)(OQS_SHA2_sha512_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha512_inc_ctx_clone.
-	 */
-	void (*SHA2_sha512_inc_ctx_clone)(OQS_SHA2_sha512_ctx *dest, const OQS_SHA2_sha512_ctx *src);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha512_inc_blocks.
-	 */
-	void (*SHA2_sha512_inc_blocks)(OQS_SHA2_sha512_ctx *state, const uint8_t *in, size_t inblocks);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha512_inc_finalize.
-	 */
-	void (*SHA2_sha512_inc_finalize)(uint8_t *out, OQS_SHA2_sha512_ctx *state, const uint8_t *in, size_t inlen);
-
-	/**
-	 * Implementation of function OQS_SHA2_sha512_inc_ctx_release.
-	 */
-	void (*SHA2_sha512_inc_ctx_release)(OQS_SHA2_sha512_ctx *state);
-};
-
-/**
- * Set callback functions for SHA2 operations.
- *
- * This function may be called before OQS_init to switch the
- * cryptographic provider for SHA2 operations. If it is not called,
- * the default provider determined at build time will be used.
- *
- * @param[in] new_callbacks Callback functions defined in OQS_SHA2_callbacks
- */
-OQS_API void OQS_SHA2_set_callbacks(struct OQS_SHA2_callbacks *new_callbacks);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/src/common/sha2/sha2_ops.h
+++ b/src/common/sha2/sha2_ops.h
@@ -1,0 +1,176 @@
+/**
+ * \file sha2_ops.h
+ * \brief Header defining the callback API for OQS SHA2
+ *
+ * \author Douglas Stebila
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef OQS_SHA2_OPS_H
+#define OQS_SHA2_OPS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <oqs/common.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/** Data structure for the state of the SHA-224 incremental hashing API. */
+typedef struct {
+	/** Internal state */
+	void *ctx;
+	/** current number of bytes in data */
+	size_t data_len;
+	/** unprocessed data buffer */
+	uint8_t data[128];
+} OQS_SHA2_sha224_ctx;
+
+/** Data structure for the state of the SHA-256 incremental hashing API. */
+typedef struct {
+	/** Internal state */
+	void *ctx;
+	/** current number of bytes in data */
+	size_t data_len;
+	/** unprocessed data buffer */
+	uint8_t data[128];
+} OQS_SHA2_sha256_ctx;
+
+/** Data structure for the state of the SHA-384 incremental hashing API. */
+typedef struct {
+	/** Internal state. */
+	void *ctx;
+	/** current number of bytes in data */
+	size_t data_len;
+	/** unprocessed data buffer */
+	uint8_t data[128];
+} OQS_SHA2_sha384_ctx;
+
+/** Data structure for the state of the SHA-512 incremental hashing API. */
+typedef struct {
+	/** Internal state. */
+	void *ctx;
+	/** current number of bytes in data */
+	size_t data_len;
+	/** unprocessed data buffer */
+	uint8_t data[128];
+} OQS_SHA2_sha512_ctx;
+
+/** Data structure implemented by cryptographic provider for SHA-2 operations.
+ */
+struct OQS_SHA2_callbacks {
+	/**
+	 * Implementation of function OQS_SHA2_sha256.
+	 */
+	void (*SHA2_sha256)(uint8_t *output, const uint8_t *input, size_t inplen);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha256_inc_init.
+	 */
+	void (*SHA2_sha256_inc_init)(OQS_SHA2_sha256_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha256_inc_ctx_clone.
+	 */
+	void (*SHA2_sha256_inc_ctx_clone)(OQS_SHA2_sha256_ctx *dest, const OQS_SHA2_sha256_ctx *src);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha256_inc.
+	 */
+	void (*SHA2_sha256_inc)(OQS_SHA2_sha256_ctx *state, const uint8_t *in, size_t len);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha256_inc_blocks.
+	 */
+	void (*SHA2_sha256_inc_blocks)(OQS_SHA2_sha256_ctx *state, const uint8_t *in, size_t inblocks);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha256_inc_finalize.
+	 */
+	void (*SHA2_sha256_inc_finalize)(uint8_t *out, OQS_SHA2_sha256_ctx *state, const uint8_t *in, size_t inlen);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha256_inc_ctx_release.
+	 */
+	void (*SHA2_sha256_inc_ctx_release)(OQS_SHA2_sha256_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha384.
+	 */
+	void (*SHA2_sha384)(uint8_t *output, const uint8_t *input, size_t inplen);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha384_inc_init.
+	 */
+	void (*SHA2_sha384_inc_init)(OQS_SHA2_sha384_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha384_inc_ctx_clone.
+	 */
+	void (*SHA2_sha384_inc_ctx_clone)(OQS_SHA2_sha384_ctx *dest, const OQS_SHA2_sha384_ctx *src);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha384_inc_blocks.
+	 */
+	void (*SHA2_sha384_inc_blocks)(OQS_SHA2_sha384_ctx *state, const uint8_t *in, size_t inblocks);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha384_inc_finalize.
+	 */
+	void (*SHA2_sha384_inc_finalize)(uint8_t *out, OQS_SHA2_sha384_ctx *state, const uint8_t *in, size_t inlen);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha384_inc_ctx_release.
+	 */
+	void (*SHA2_sha384_inc_ctx_release)(OQS_SHA2_sha384_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha512.
+	 */
+	void (*SHA2_sha512)(uint8_t *output, const uint8_t *input, size_t inplen);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha512_inc_init.
+	 */
+	void (*SHA2_sha512_inc_init)(OQS_SHA2_sha512_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha512_inc_ctx_clone.
+	 */
+	void (*SHA2_sha512_inc_ctx_clone)(OQS_SHA2_sha512_ctx *dest, const OQS_SHA2_sha512_ctx *src);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha512_inc_blocks.
+	 */
+	void (*SHA2_sha512_inc_blocks)(OQS_SHA2_sha512_ctx *state, const uint8_t *in, size_t inblocks);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha512_inc_finalize.
+	 */
+	void (*SHA2_sha512_inc_finalize)(uint8_t *out, OQS_SHA2_sha512_ctx *state, const uint8_t *in, size_t inlen);
+
+	/**
+	 * Implementation of function OQS_SHA2_sha512_inc_ctx_release.
+	 */
+	void (*SHA2_sha512_inc_ctx_release)(OQS_SHA2_sha512_ctx *state);
+};
+
+/**
+ * Set callback functions for SHA2 operations.
+ *
+ * This function may be called before OQS_init to switch the
+ * cryptographic provider for SHA2 operations. If it is not called,
+ * the default provider determined at build time will be used.
+ *
+ * @param[in] new_callbacks Callback functions defined in OQS_SHA2_callbacks
+ */
+OQS_API void OQS_SHA2_set_callbacks(struct OQS_SHA2_callbacks *new_callbacks);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // OQS_SHA2_OPS_H

--- a/src/common/sha3/sha3.h
+++ b/src/common/sha3/sha3.h
@@ -18,7 +18,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <oqs/common.h>
+#include <oqs/sha3_ops.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -39,12 +39,6 @@ extern "C" {
  * \param inplen The number of message bytes to process
  */
 void OQS_SHA3_sha3_256(uint8_t *output, const uint8_t *input, size_t inplen);
-
-/** Data structure for the state of the incremental SHA3-256 API. */
-typedef struct {
-	/** Internal state. */
-	void *ctx;
-} OQS_SHA3_sha3_256_inc_ctx;
 
 /**
  * \brief Initialize the state for the incremental SHA3-256 API.
@@ -115,12 +109,6 @@ void OQS_SHA3_sha3_256_inc_ctx_clone(OQS_SHA3_sha3_256_inc_ctx *dest, const OQS_
  */
 void OQS_SHA3_sha3_384(uint8_t *output, const uint8_t *input, size_t inplen);
 
-/** Data structure for the state of the incremental SHA3-384 API. */
-typedef struct {
-	/** Internal state. */
-	void *ctx;
-} OQS_SHA3_sha3_384_inc_ctx;
-
 /**
  * \brief Initialize the state for the incremental SHA3-384 API.
  *
@@ -189,12 +177,6 @@ void OQS_SHA3_sha3_384_inc_ctx_clone(OQS_SHA3_sha3_384_inc_ctx *dest, const OQS_
  * \param inplen The number of message bytes to process
  */
 void OQS_SHA3_sha3_512(uint8_t *output, const uint8_t *input, size_t inplen);
-
-/** Data structure for the state of the incremental SHA3-512 API. */
-typedef struct {
-	/** Internal state. */
-	void *ctx;
-} OQS_SHA3_sha3_512_inc_ctx;
 
 /**
  * \brief Initialize the state for the incremental SHA3-512 API.
@@ -267,12 +249,6 @@ void OQS_SHA3_sha3_512_inc_ctx_clone(OQS_SHA3_sha3_512_inc_ctx *dest, const OQS_
  * \param inplen The number of seed bytes to process
  */
 void OQS_SHA3_shake128(uint8_t *output, size_t outlen, const uint8_t *input, size_t inplen);
-
-/** Data structure for the state of the incremental SHAKE-128 API. */
-typedef struct {
-	/** Internal state. */
-	void *ctx;
-} OQS_SHA3_shake128_inc_ctx;
 
 /**
  * \brief Initialize the state for the incremental SHAKE-128 API.
@@ -355,12 +331,6 @@ void OQS_SHA3_shake128_inc_ctx_reset(OQS_SHA3_shake128_inc_ctx *state);
  */
 void OQS_SHA3_shake256(uint8_t *output, size_t outlen, const uint8_t *input, size_t inplen);
 
-/** Data structure for the state of the incremental SHAKE-256 API. */
-typedef struct {
-	/** Internal state. */
-	void *ctx;
-} OQS_SHA3_shake256_inc_ctx;
-
 /**
  * \brief Initialize the state for the incremental SHAKE-256 API.
  *
@@ -422,206 +392,6 @@ void OQS_SHA3_shake256_inc_ctx_clone(OQS_SHA3_shake256_inc_ctx *dest, const OQS_
  * \param state The function state; must be initialized
  */
 void OQS_SHA3_shake256_inc_ctx_reset(OQS_SHA3_shake256_inc_ctx *state);
-
-/** Data structure implemented by cryptographic provider for SHA-3 operations.
- */
-struct OQS_SHA3_callbacks {
-	/**
-	 * Implementation of function OQS_SHA3_sha3_256.
-	 */
-	void (*SHA3_sha3_256)(uint8_t *output, const uint8_t *input, size_t inplen);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_256_inc_init.
-	 */
-	void (*SHA3_sha3_256_inc_init)(OQS_SHA3_sha3_256_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_256_inc_absorb.
-	 */
-	void (*SHA3_sha3_256_inc_absorb)(OQS_SHA3_sha3_256_inc_ctx *state, const uint8_t *input, size_t inlen);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_256_inc_finalize.
-	 */
-	void (*SHA3_sha3_256_inc_finalize)(uint8_t *output, OQS_SHA3_sha3_256_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_256_inc_ctx_release.
-	 */
-	void (*SHA3_sha3_256_inc_ctx_release)(OQS_SHA3_sha3_256_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_256_inc_ctx_reset.
-	 */
-	void (*SHA3_sha3_256_inc_ctx_reset)(OQS_SHA3_sha3_256_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_256_inc_ctx_clone.
-	 */
-	void (*SHA3_sha3_256_inc_ctx_clone)(OQS_SHA3_sha3_256_inc_ctx *dest, const OQS_SHA3_sha3_256_inc_ctx *src);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_384.
-	 */
-	void (*SHA3_sha3_384)(uint8_t *output, const uint8_t *input, size_t inplen);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_384_inc_init.
-	 */
-	void (*SHA3_sha3_384_inc_init)(OQS_SHA3_sha3_384_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_384_inc_absorb.
-	 */
-	void (*SHA3_sha3_384_inc_absorb)(OQS_SHA3_sha3_384_inc_ctx *state, const uint8_t *input, size_t inlen);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_384_inc_finalize.
-	 */
-	void (*SHA3_sha3_384_inc_finalize)(uint8_t *output, OQS_SHA3_sha3_384_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_384_inc_ctx_release.
-	 */
-	void (*SHA3_sha3_384_inc_ctx_release)(OQS_SHA3_sha3_384_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_384_inc_ctx_reset.
-	 */
-	void (*SHA3_sha3_384_inc_ctx_reset)(OQS_SHA3_sha3_384_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_384_inc_ctx_clone.
-	 */
-	void (*SHA3_sha3_384_inc_ctx_clone)(OQS_SHA3_sha3_384_inc_ctx *dest, const OQS_SHA3_sha3_384_inc_ctx *src);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_512.
-	 */
-	void (*SHA3_sha3_512)(uint8_t *output, const uint8_t *input, size_t inplen);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_512_inc_init.
-	 */
-	void (*SHA3_sha3_512_inc_init)(OQS_SHA3_sha3_512_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_512_inc_absorb.
-	 */
-	void (*SHA3_sha3_512_inc_absorb)(OQS_SHA3_sha3_512_inc_ctx *state, const uint8_t *input, size_t inlen);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_512_inc_finalize.
-	 */
-	void (*SHA3_sha3_512_inc_finalize)(uint8_t *output, OQS_SHA3_sha3_512_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_512_inc_ctx_release.
-	 */
-	void (*SHA3_sha3_512_inc_ctx_release)(OQS_SHA3_sha3_512_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_512_inc_ctx_reset.
-	 */
-	void (*SHA3_sha3_512_inc_ctx_reset)(OQS_SHA3_sha3_512_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_sha3_512_inc_ctx_clone.
-	 */
-	void (*SHA3_sha3_512_inc_ctx_clone)(OQS_SHA3_sha3_512_inc_ctx *dest, const OQS_SHA3_sha3_512_inc_ctx *src);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake128.
-	 */
-	void (*SHA3_shake128)(uint8_t *output, size_t outlen, const uint8_t *input, size_t inplen);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake128_inc_init.
-	 */
-	void (*SHA3_shake128_inc_init)(OQS_SHA3_shake128_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake128_inc_absorb.
-	 */
-	void (*SHA3_shake128_inc_absorb)(OQS_SHA3_shake128_inc_ctx *state, const uint8_t *input, size_t inlen);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake128_inc_finalize.
-	 */
-	void (*SHA3_shake128_inc_finalize)(OQS_SHA3_shake128_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake128_inc_squeeze.
-	 */
-	void (*SHA3_shake128_inc_squeeze)(uint8_t *output, size_t outlen, OQS_SHA3_shake128_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake128_inc_ctx_release.
-	 */
-	void (*SHA3_shake128_inc_ctx_release)(OQS_SHA3_shake128_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake128_inc_ctx_clone.
-	 */
-	void (*SHA3_shake128_inc_ctx_clone)(OQS_SHA3_shake128_inc_ctx *dest, const OQS_SHA3_shake128_inc_ctx *src);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake128_inc_ctx_reset.
-	 */
-	void (*SHA3_shake128_inc_ctx_reset)(OQS_SHA3_shake128_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake256.
-	 */
-	void (*SHA3_shake256)(uint8_t *output, size_t outlen, const uint8_t *input, size_t inplen);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake256_inc_init.
-	 */
-	void (*SHA3_shake256_inc_init)(OQS_SHA3_shake256_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake256_inc_absorb.
-	 */
-	void (*SHA3_shake256_inc_absorb)(OQS_SHA3_shake256_inc_ctx *state, const uint8_t *input, size_t inlen);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake256_inc_finalize.
-	 */
-	void (*SHA3_shake256_inc_finalize)(OQS_SHA3_shake256_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake256_inc_squeeze.
-	 */
-	void (*SHA3_shake256_inc_squeeze)(uint8_t *output, size_t outlen, OQS_SHA3_shake256_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake256_inc_ctx_release.
-	 */
-	void (*SHA3_shake256_inc_ctx_release)(OQS_SHA3_shake256_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake256_inc_ctx_clone.
-	 */
-	void (*SHA3_shake256_inc_ctx_clone)(OQS_SHA3_shake256_inc_ctx *dest, const OQS_SHA3_shake256_inc_ctx *src);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake256_inc_ctx_reset.
-	 */
-	void (*SHA3_shake256_inc_ctx_reset)(OQS_SHA3_shake256_inc_ctx *state);
-};
-
-/**
- * Set callback functions for SHA3 operations.
- *
- * This function may be called before OQS_init to switch the
- * cryptographic provider for SHA3 operations. If it is not called,
- * the default provider determined at build time will be used.
- *
- * @param new_callbacks Callback functions defined in OQS_SHA3_callbacks struct
- */
-OQS_API void OQS_SHA3_set_callbacks(struct OQS_SHA3_callbacks *new_callbacks);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/src/common/sha3/sha3_ops.h
+++ b/src/common/sha3/sha3_ops.h
@@ -1,0 +1,256 @@
+/**
+ * \file sha3_ops.h
+ * \brief Header defining the callback API for OQS SHA3 and SHAKE
+ *
+ * \author John Underhill, Douglas Stebila
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef OQS_SHA3_OPS_H
+#define OQS_SHA3_OPS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <oqs/common.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/** Data structure for the state of the incremental SHA3-256 API. */
+typedef struct {
+	/** Internal state. */
+	void *ctx;
+} OQS_SHA3_sha3_256_inc_ctx;
+
+/** Data structure for the state of the incremental SHA3-384 API. */
+typedef struct {
+	/** Internal state. */
+	void *ctx;
+} OQS_SHA3_sha3_384_inc_ctx;
+
+/** Data structure for the state of the incremental SHA3-512 API. */
+typedef struct {
+	/** Internal state. */
+	void *ctx;
+} OQS_SHA3_sha3_512_inc_ctx;
+
+/** Data structure for the state of the incremental SHAKE-128 API. */
+typedef struct {
+	/** Internal state. */
+	void *ctx;
+} OQS_SHA3_shake128_inc_ctx;
+
+/** Data structure for the state of the incremental SHAKE-256 API. */
+typedef struct {
+	/** Internal state. */
+	void *ctx;
+} OQS_SHA3_shake256_inc_ctx;
+
+/** Data structure implemented by cryptographic provider for SHA-3 operations.
+ */
+struct OQS_SHA3_callbacks {
+	/**
+	 * Implementation of function OQS_SHA3_sha3_256.
+	 */
+	void (*SHA3_sha3_256)(uint8_t *output, const uint8_t *input, size_t inplen);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_256_inc_init.
+	 */
+	void (*SHA3_sha3_256_inc_init)(OQS_SHA3_sha3_256_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_256_inc_absorb.
+	 */
+	void (*SHA3_sha3_256_inc_absorb)(OQS_SHA3_sha3_256_inc_ctx *state, const uint8_t *input, size_t inlen);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_256_inc_finalize.
+	 */
+	void (*SHA3_sha3_256_inc_finalize)(uint8_t *output, OQS_SHA3_sha3_256_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_256_inc_ctx_release.
+	 */
+	void (*SHA3_sha3_256_inc_ctx_release)(OQS_SHA3_sha3_256_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_256_inc_ctx_reset.
+	 */
+	void (*SHA3_sha3_256_inc_ctx_reset)(OQS_SHA3_sha3_256_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_256_inc_ctx_clone.
+	 */
+	void (*SHA3_sha3_256_inc_ctx_clone)(OQS_SHA3_sha3_256_inc_ctx *dest, const OQS_SHA3_sha3_256_inc_ctx *src);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_384.
+	 */
+	void (*SHA3_sha3_384)(uint8_t *output, const uint8_t *input, size_t inplen);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_384_inc_init.
+	 */
+	void (*SHA3_sha3_384_inc_init)(OQS_SHA3_sha3_384_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_384_inc_absorb.
+	 */
+	void (*SHA3_sha3_384_inc_absorb)(OQS_SHA3_sha3_384_inc_ctx *state, const uint8_t *input, size_t inlen);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_384_inc_finalize.
+	 */
+	void (*SHA3_sha3_384_inc_finalize)(uint8_t *output, OQS_SHA3_sha3_384_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_384_inc_ctx_release.
+	 */
+	void (*SHA3_sha3_384_inc_ctx_release)(OQS_SHA3_sha3_384_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_384_inc_ctx_reset.
+	 */
+	void (*SHA3_sha3_384_inc_ctx_reset)(OQS_SHA3_sha3_384_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_384_inc_ctx_clone.
+	 */
+	void (*SHA3_sha3_384_inc_ctx_clone)(OQS_SHA3_sha3_384_inc_ctx *dest, const OQS_SHA3_sha3_384_inc_ctx *src);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_512.
+	 */
+	void (*SHA3_sha3_512)(uint8_t *output, const uint8_t *input, size_t inplen);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_512_inc_init.
+	 */
+	void (*SHA3_sha3_512_inc_init)(OQS_SHA3_sha3_512_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_512_inc_absorb.
+	 */
+	void (*SHA3_sha3_512_inc_absorb)(OQS_SHA3_sha3_512_inc_ctx *state, const uint8_t *input, size_t inlen);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_512_inc_finalize.
+	 */
+	void (*SHA3_sha3_512_inc_finalize)(uint8_t *output, OQS_SHA3_sha3_512_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_512_inc_ctx_release.
+	 */
+	void (*SHA3_sha3_512_inc_ctx_release)(OQS_SHA3_sha3_512_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_512_inc_ctx_reset.
+	 */
+	void (*SHA3_sha3_512_inc_ctx_reset)(OQS_SHA3_sha3_512_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_sha3_512_inc_ctx_clone.
+	 */
+	void (*SHA3_sha3_512_inc_ctx_clone)(OQS_SHA3_sha3_512_inc_ctx *dest, const OQS_SHA3_sha3_512_inc_ctx *src);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake128.
+	 */
+	void (*SHA3_shake128)(uint8_t *output, size_t outlen, const uint8_t *input, size_t inplen);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake128_inc_init.
+	 */
+	void (*SHA3_shake128_inc_init)(OQS_SHA3_shake128_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake128_inc_absorb.
+	 */
+	void (*SHA3_shake128_inc_absorb)(OQS_SHA3_shake128_inc_ctx *state, const uint8_t *input, size_t inlen);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake128_inc_finalize.
+	 */
+	void (*SHA3_shake128_inc_finalize)(OQS_SHA3_shake128_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake128_inc_squeeze.
+	 */
+	void (*SHA3_shake128_inc_squeeze)(uint8_t *output, size_t outlen, OQS_SHA3_shake128_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake128_inc_ctx_release.
+	 */
+	void (*SHA3_shake128_inc_ctx_release)(OQS_SHA3_shake128_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake128_inc_ctx_clone.
+	 */
+	void (*SHA3_shake128_inc_ctx_clone)(OQS_SHA3_shake128_inc_ctx *dest, const OQS_SHA3_shake128_inc_ctx *src);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake128_inc_ctx_reset.
+	 */
+	void (*SHA3_shake128_inc_ctx_reset)(OQS_SHA3_shake128_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake256.
+	 */
+	void (*SHA3_shake256)(uint8_t *output, size_t outlen, const uint8_t *input, size_t inplen);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake256_inc_init.
+	 */
+	void (*SHA3_shake256_inc_init)(OQS_SHA3_shake256_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake256_inc_absorb.
+	 */
+	void (*SHA3_shake256_inc_absorb)(OQS_SHA3_shake256_inc_ctx *state, const uint8_t *input, size_t inlen);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake256_inc_finalize.
+	 */
+	void (*SHA3_shake256_inc_finalize)(OQS_SHA3_shake256_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake256_inc_squeeze.
+	 */
+	void (*SHA3_shake256_inc_squeeze)(uint8_t *output, size_t outlen, OQS_SHA3_shake256_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake256_inc_ctx_release.
+	 */
+	void (*SHA3_shake256_inc_ctx_release)(OQS_SHA3_shake256_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake256_inc_ctx_clone.
+	 */
+	void (*SHA3_shake256_inc_ctx_clone)(OQS_SHA3_shake256_inc_ctx *dest, const OQS_SHA3_shake256_inc_ctx *src);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake256_inc_ctx_reset.
+	 */
+	void (*SHA3_shake256_inc_ctx_reset)(OQS_SHA3_shake256_inc_ctx *state);
+};
+
+/**
+ * Set callback functions for SHA3 operations.
+ *
+ * This function may be called before OQS_init to switch the
+ * cryptographic provider for SHA3 operations. If it is not called,
+ * the default provider determined at build time will be used.
+ *
+ * @param new_callbacks Callback functions defined in OQS_SHA3_callbacks struct
+ */
+OQS_API void OQS_SHA3_set_callbacks(struct OQS_SHA3_callbacks *new_callbacks);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // OQS_SHA3_OPS_H

--- a/src/common/sha3/sha3x4.h
+++ b/src/common/sha3/sha3x4.h
@@ -1,5 +1,5 @@
 /**
- * \file shakex4.h
+ * \file sha3x4.h
  * \brief SHA3, SHAKE, and cSHAKE functions; not part of the OQS public API
  *
  * Contains the API and documentation for SHA3 digest and SHAKE implementations.
@@ -18,7 +18,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <oqs/common.h>
+#include <oqs/sha3x4_ops.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -51,12 +51,6 @@ void OQS_SHA3_shake128_x4(
     const uint8_t *in2,
     const uint8_t *in3,
     size_t inlen);
-
-/** Data structure for the state of the four-way parallel incremental SHAKE-128 API. */
-typedef struct {
-	/** Internal state. */
-	void *ctx;
-} OQS_SHA3_shake128_x4_inc_ctx;
 
 /**
  * \brief Initialize the state for four-way parallel incremental SHAKE-128 API.
@@ -169,12 +163,6 @@ void OQS_SHA3_shake256_x4(
     const uint8_t *in3,
     size_t inlen);
 
-/** Data structure for the state of the four-way parallel incremental SHAKE-256 API. */
-typedef struct {
-	/** Internal state. */
-	void *ctx;
-} OQS_SHA3_shake256_x4_inc_ctx;
-
 /**
  * \brief Initialize the state for four-way parallel incremental SHAKE-256 API.
  *
@@ -257,152 +245,8 @@ void OQS_SHA3_shake256_x4_inc_ctx_clone(
  */
 void OQS_SHA3_shake256_x4_inc_ctx_reset(OQS_SHA3_shake256_x4_inc_ctx *state);
 
-/** Data structure implemented by cryptographic provider for the
- * four-way parallel incremental SHAKE-256 operations.
- */
-struct OQS_SHA3_x4_callbacks {
-	/**
-	 * Implementation of function OQS_SHA3_shake128_x4.
-	 */
-	void (*SHA3_shake128_x4)(
-	    uint8_t *out0,
-	    uint8_t *out1,
-	    uint8_t *out2,
-	    uint8_t *out3,
-	    size_t outlen,
-	    const uint8_t *in0,
-	    const uint8_t *in1,
-	    const uint8_t *in2,
-	    const uint8_t *in3,
-	    size_t inlen);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake128_x4_inc_init.
-	 */
-	void (*SHA3_shake128_x4_inc_init)(OQS_SHA3_shake128_x4_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake128_x4_inc_absorb.
-	 */
-	void (*SHA3_shake128_x4_inc_absorb)(
-	    OQS_SHA3_shake128_x4_inc_ctx *state,
-	    const uint8_t *in0,
-	    const uint8_t *in1,
-	    const uint8_t *in2,
-	    const uint8_t *in3,
-	    size_t inlen);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake128_x4_inc_finalize.
-	 */
-	void (*SHA3_shake128_x4_inc_finalize)(OQS_SHA3_shake128_x4_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake128_x4_inc_squeeze.
-	 */
-	void (*SHA3_shake128_x4_inc_squeeze)(
-	    uint8_t *out0,
-	    uint8_t *out1,
-	    uint8_t *out2,
-	    uint8_t *out3,
-	    size_t outlen,
-	    OQS_SHA3_shake128_x4_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake128_x4_inc_ctx_release.
-	 */
-	void (*SHA3_shake128_x4_inc_ctx_release)(OQS_SHA3_shake128_x4_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake128_x4_inc_ctx_clone.
-	 */
-	void (*SHA3_shake128_x4_inc_ctx_clone)(
-	    OQS_SHA3_shake128_x4_inc_ctx *dest,
-	    const OQS_SHA3_shake128_x4_inc_ctx *src);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake128_x4_inc_ctx_reset.
-	 */
-	void (*SHA3_shake128_x4_inc_ctx_reset)(OQS_SHA3_shake128_x4_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake256_x4.
-	 */
-	void (*SHA3_shake256_x4)(
-	    uint8_t *out0,
-	    uint8_t *out1,
-	    uint8_t *out2,
-	    uint8_t *out3,
-	    size_t outlen,
-	    const uint8_t *in0,
-	    const uint8_t *in1,
-	    const uint8_t *in2,
-	    const uint8_t *in3,
-	    size_t inlen);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake256_x4_inc_init.
-	 */
-	void (*SHA3_shake256_x4_inc_init)(OQS_SHA3_shake256_x4_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake256_x4_inc_absorb.
-	 */
-	void (*SHA3_shake256_x4_inc_absorb)(
-	    OQS_SHA3_shake256_x4_inc_ctx *state,
-	    const uint8_t *in0,
-	    const uint8_t *in1,
-	    const uint8_t *in2,
-	    const uint8_t *in3,
-	    size_t inlen);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake256_x4_inc_finalize.
-	 */
-	void (*SHA3_shake256_x4_inc_finalize)(OQS_SHA3_shake256_x4_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake256_x4_inc_squeeze.
-	 */
-	void (*SHA3_shake256_x4_inc_squeeze)(
-	    uint8_t *out0,
-	    uint8_t *out1,
-	    uint8_t *out2,
-	    uint8_t *out3,
-	    size_t outlen,
-	    OQS_SHA3_shake256_x4_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake256_x4_inc_ctx_release.
-	 */
-	void (*SHA3_shake256_x4_inc_ctx_release)(OQS_SHA3_shake256_x4_inc_ctx *state);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake256_x4_inc_ctx_clone.
-	 */
-	void (*SHA3_shake256_x4_inc_ctx_clone)(
-	    OQS_SHA3_shake256_x4_inc_ctx *dest,
-	    const OQS_SHA3_shake256_x4_inc_ctx *src);
-
-	/**
-	 * Implementation of function OQS_SHA3_shake256_x4_inc_ctx_reset.
-	 */
-	void (*SHA3_shake256_x4_inc_ctx_reset)(OQS_SHA3_shake256_x4_inc_ctx *state);
-};
-
-/**
- * Set callback functions for 4-parallel SHA3 operations.
- *
- * This function may be called before OQS_init to switch the
- * cryptographic provider for 4-parallel SHA3 operations. If it is not
- * called, the default provider determined at build time will be used.
- *
- * @param new_callbacks Callback functions defined in OQS_SHA3_x4_callbacks struct
- */
-OQS_API void OQS_SHA3_x4_set_callbacks(struct OQS_SHA3_x4_callbacks *new_callbacks);
-
 #if defined(__cplusplus)
 } // extern "C"
 #endif
 
-#endif // OQS_SHA3_H
+#endif // OQS_SHA3X4_H

--- a/src/common/sha3/sha3x4_ops.h
+++ b/src/common/sha3/sha3x4_ops.h
@@ -1,0 +1,182 @@
+/**
+ * \file sha3x4_ops.h
+ * \brief Header defining the callback API for OQS SHA3 and SHAKE
+ *
+ * \author John Underhill, Douglas Stebila
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef OQS_SHA3X4_OPS_H
+#define OQS_SHA3X4_OPS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <oqs/common.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/** Data structure for the state of the four-way parallel incremental SHAKE-128 API. */
+typedef struct {
+	/** Internal state. */
+	void *ctx;
+} OQS_SHA3_shake128_x4_inc_ctx;
+
+/** Data structure for the state of the four-way parallel incremental SHAKE-256 API. */
+typedef struct {
+	/** Internal state. */
+	void *ctx;
+} OQS_SHA3_shake256_x4_inc_ctx;
+
+/** Data structure implemented by cryptographic provider for the
+ * four-way parallel incremental SHAKE-256 operations.
+ */
+struct OQS_SHA3_x4_callbacks {
+	/**
+	 * Implementation of function OQS_SHA3_shake128_x4.
+	 */
+	void (*SHA3_shake128_x4)(
+	    uint8_t *out0,
+	    uint8_t *out1,
+	    uint8_t *out2,
+	    uint8_t *out3,
+	    size_t outlen,
+	    const uint8_t *in0,
+	    const uint8_t *in1,
+	    const uint8_t *in2,
+	    const uint8_t *in3,
+	    size_t inlen);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake128_x4_inc_init.
+	 */
+	void (*SHA3_shake128_x4_inc_init)(OQS_SHA3_shake128_x4_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake128_x4_inc_absorb.
+	 */
+	void (*SHA3_shake128_x4_inc_absorb)(
+	    OQS_SHA3_shake128_x4_inc_ctx *state,
+	    const uint8_t *in0,
+	    const uint8_t *in1,
+	    const uint8_t *in2,
+	    const uint8_t *in3,
+	    size_t inlen);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake128_x4_inc_finalize.
+	 */
+	void (*SHA3_shake128_x4_inc_finalize)(OQS_SHA3_shake128_x4_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake128_x4_inc_squeeze.
+	 */
+	void (*SHA3_shake128_x4_inc_squeeze)(
+	    uint8_t *out0,
+	    uint8_t *out1,
+	    uint8_t *out2,
+	    uint8_t *out3,
+	    size_t outlen,
+	    OQS_SHA3_shake128_x4_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake128_x4_inc_ctx_release.
+	 */
+	void (*SHA3_shake128_x4_inc_ctx_release)(OQS_SHA3_shake128_x4_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake128_x4_inc_ctx_clone.
+	 */
+	void (*SHA3_shake128_x4_inc_ctx_clone)(
+	    OQS_SHA3_shake128_x4_inc_ctx *dest,
+	    const OQS_SHA3_shake128_x4_inc_ctx *src);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake128_x4_inc_ctx_reset.
+	 */
+	void (*SHA3_shake128_x4_inc_ctx_reset)(OQS_SHA3_shake128_x4_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake256_x4.
+	 */
+	void (*SHA3_shake256_x4)(
+	    uint8_t *out0,
+	    uint8_t *out1,
+	    uint8_t *out2,
+	    uint8_t *out3,
+	    size_t outlen,
+	    const uint8_t *in0,
+	    const uint8_t *in1,
+	    const uint8_t *in2,
+	    const uint8_t *in3,
+	    size_t inlen);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake256_x4_inc_init.
+	 */
+	void (*SHA3_shake256_x4_inc_init)(OQS_SHA3_shake256_x4_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake256_x4_inc_absorb.
+	 */
+	void (*SHA3_shake256_x4_inc_absorb)(
+	    OQS_SHA3_shake256_x4_inc_ctx *state,
+	    const uint8_t *in0,
+	    const uint8_t *in1,
+	    const uint8_t *in2,
+	    const uint8_t *in3,
+	    size_t inlen);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake256_x4_inc_finalize.
+	 */
+	void (*SHA3_shake256_x4_inc_finalize)(OQS_SHA3_shake256_x4_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake256_x4_inc_squeeze.
+	 */
+	void (*SHA3_shake256_x4_inc_squeeze)(
+	    uint8_t *out0,
+	    uint8_t *out1,
+	    uint8_t *out2,
+	    uint8_t *out3,
+	    size_t outlen,
+	    OQS_SHA3_shake256_x4_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake256_x4_inc_ctx_release.
+	 */
+	void (*SHA3_shake256_x4_inc_ctx_release)(OQS_SHA3_shake256_x4_inc_ctx *state);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake256_x4_inc_ctx_clone.
+	 */
+	void (*SHA3_shake256_x4_inc_ctx_clone)(
+	    OQS_SHA3_shake256_x4_inc_ctx *dest,
+	    const OQS_SHA3_shake256_x4_inc_ctx *src);
+
+	/**
+	 * Implementation of function OQS_SHA3_shake256_x4_inc_ctx_reset.
+	 */
+	void (*SHA3_shake256_x4_inc_ctx_reset)(OQS_SHA3_shake256_x4_inc_ctx *state);
+};
+
+/**
+ * Set callback functions for 4-parallel SHA3 operations.
+ *
+ * This function may be called before OQS_init to switch the
+ * cryptographic provider for 4-parallel SHA3 operations. If it is not
+ * called, the default provider determined at build time will be used.
+ *
+ * @param new_callbacks Callback functions defined in OQS_SHA3_x4_callbacks struct
+ */
+OQS_API void OQS_SHA3_x4_set_callbacks(struct OQS_SHA3_x4_callbacks *new_callbacks);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // OQS_SHA3X4_OPS_H

--- a/src/oqs.h
+++ b/src/oqs.h
@@ -18,5 +18,9 @@
 #include <oqs/kem.h>
 #include <oqs/sig.h>
 #include <oqs/sig_stfl.h>
+#include <oqs/aes_ops.h>
+#include <oqs/sha2_ops.h>
+#include <oqs/sha3_ops.h>
+#include <oqs/sha3x4_ops.h>
 
 #endif // OQS_H


### PR DESCRIPTION
This makes the callback API to replace low-level cryptographic implementation public again after open-quantum-safe#1667.

<!-- Please give a brief explanation of the purpose of this pull request. -->
The purpose of this PR is to replace the implementation of symmetric primitives such as SHA3 used in ML-KEM, through the public API. That was my intention in #1603 but I didn't realize that `<oqs/aes.h>` and co. are moved to internal-only and no longer installed. This patch would make the GnuTLS liboqs [integration](https://gitlab.com/gnutls/gnutls/-/merge_requests/1842) self-contained.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

