### PR TITLE
Decode FORS indices similarly to WOTS

### DIFF
--- a/src/sig/sphincs/pqclean_sphincs-sha2-128f-simple_avx2/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-sha2-128f-simple_avx2/fors.c
@@ -120,7 +120,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-sha2-128f-simple_clean/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-sha2-128f-simple_clean/fors.c
@@ -53,7 +53,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-sha2-128s-simple_avx2/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-sha2-128s-simple_avx2/fors.c
@@ -120,7 +120,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-sha2-128s-simple_clean/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-sha2-128s-simple_clean/fors.c
@@ -53,7 +53,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-sha2-192f-simple_avx2/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-sha2-192f-simple_avx2/fors.c
@@ -120,7 +120,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-sha2-192f-simple_clean/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-sha2-192f-simple_clean/fors.c
@@ -53,7 +53,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-sha2-192s-simple_avx2/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-sha2-192s-simple_avx2/fors.c
@@ -120,7 +120,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-sha2-192s-simple_clean/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-sha2-192s-simple_clean/fors.c
@@ -53,7 +53,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-sha2-256f-simple_avx2/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-sha2-256f-simple_avx2/fors.c
@@ -120,7 +120,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-sha2-256f-simple_clean/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-sha2-256f-simple_clean/fors.c
@@ -53,7 +53,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-sha2-256s-simple_avx2/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-sha2-256s-simple_avx2/fors.c
@@ -120,7 +120,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-sha2-256s-simple_clean/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-sha2-256s-simple_clean/fors.c
@@ -53,7 +53,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-128f-simple_aarch64/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-128f-simple_aarch64/fors.c
@@ -86,7 +86,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-128f-simple_avx2/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-128f-simple_avx2/fors.c
@@ -97,7 +97,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-128f-simple_clean/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-128f-simple_clean/fors.c
@@ -53,7 +53,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-128s-simple_aarch64/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-128s-simple_aarch64/fors.c
@@ -86,7 +86,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-128s-simple_avx2/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-128s-simple_avx2/fors.c
@@ -97,7 +97,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-128s-simple_clean/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-128s-simple_clean/fors.c
@@ -53,7 +53,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-192f-simple_aarch64/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-192f-simple_aarch64/fors.c
@@ -86,7 +86,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-192f-simple_avx2/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-192f-simple_avx2/fors.c
@@ -97,7 +97,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-192f-simple_clean/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-192f-simple_clean/fors.c
@@ -53,7 +53,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-192s-simple_aarch64/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-192s-simple_aarch64/fors.c
@@ -86,7 +86,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-192s-simple_avx2/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-192s-simple_avx2/fors.c
@@ -97,7 +97,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-192s-simple_clean/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-192s-simple_clean/fors.c
@@ -53,7 +53,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-256f-simple_aarch64/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-256f-simple_aarch64/fors.c
@@ -86,7 +86,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-256f-simple_avx2/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-256f-simple_avx2/fors.c
@@ -97,7 +97,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-256f-simple_clean/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-256f-simple_clean/fors.c
@@ -53,7 +53,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-256s-simple_aarch64/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-256s-simple_aarch64/fors.c
@@ -86,7 +86,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-256s-simple_avx2/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-256s-simple_avx2/fors.c
@@ -97,7 +97,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }

--- a/src/sig/sphincs/pqclean_sphincs-shake-256s-simple_clean/fors.c
+++ b/src/sig/sphincs/pqclean_sphincs-shake-256s-simple_clean/fors.c
@@ -53,7 +53,7 @@ static void message_to_indices(uint32_t *indices, const unsigned char *m) {
     for (i = 0; i < SPX_FORS_TREES; i++) {
         indices[i] = 0;
         for (j = 0; j < SPX_FORS_HEIGHT; j++) {
-            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (offset & 0x7)) & 0x1) << j);
+            indices[i] ^= (uint32_t)(((m[offset >> 3] >> (~offset & 0x7)) & 0x1) << (SPX_FORS_HEIGHT-1-j));
             offset++;
         }
     }


### PR DESCRIPTION
Update the decoding of the FORS indices as proposed by latest NIST changes. This has already been proposed in the sphincsplus repo (https://github.com/sphincs/sphincsplus/pull/51). Would be good to have the same for liboqs as this change will eventually land. https://groups.google.com/a/list.nist.gov/g/pqc-forum/c/88tuvtb7nN4/m/DA1QCoJWBAAJ

* This changes breaks SPHINCS+ signature compatibility: Signatures generated before cannot be verified correctly with the implementation after this change. Also old implementation cannot verify correctly newly generate signatures.
* No change to available algorithms

relates to #1838
