### PR TITLE
Update and fix CI status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[CircleCI](https://circleci.com/gh/open-quantum-safe/liboqs/tree/main): ![Build status image](https://circleci.com/gh/open-quantum-safe/liboqs/tree/main.svg?style=svg), [TravisCI](https://travis-ci.com/github/open-quantum-safe/liboqs): [![Build Status](https://travis-ci.com/open-quantum-safe/liboqs.svg?branch=main)](https://travis-ci.com/open-quantum-safe/liboqs)
+![CircleCI Build Status](https://circleci.com/gh/open-quantum-safe/liboqs/tree/main.svg?style=shield) ![Build Status](https://img.shields.io/travis/com/open-quantum-safe/liboqs?logo=travis&label=travis%20ci)
 
 liboqs
 ======================


### PR DESCRIPTION
This PR updates and fixes the CI status badges in the README.

Changes made:

1. Removed redundant text labels preceding the badges.
2. Corrected the broken Travis CI badge and URL and switched to shields.io for the badge to include the logo.
3. Updated the CircleCI badge to use the shield style for visual consistency with the other badge.

Note: This is a purely cosmetic change to the markdown file. It does not add new features, affect input/output behavior, or alter the list of algorithms. No version bump or downstream project updates are required.