### PR TITLE
docs: add PQCA Discord Server badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![CircleCI Build Status](https://circleci.com/gh/open-quantum-safe/liboqs/tree/main.svg?style=shield) ![Build Status](https://img.shields.io/travis/com/open-quantum-safe/liboqs?logo=travis&label=travis%20ci)
+![CircleCI Build Status](https://circleci.com/gh/open-quantum-safe/liboqs/tree/main.svg?style=shield) ![Build Status](https://img.shields.io/travis/com/open-quantum-safe/liboqs?logo=travis&label=travis%20ci) [![PQCA Discord Server](https://img.shields.io/badge/PQCA%20Discord%20Server-7289DA?logo=discord&logoColor=white&style=flat-square)](https://discord.gg/pqca)
+
+
 
 liboqs
 ======================


### PR DESCRIPTION
- Added a Discord badge with the label "PQCA Discord Server" to the README.
- The badge links to the invite URL: https://discord.gg/pqca.

Note: This does not add new features, affect input/output behavior, or alter the list of algorithms. No version bump or downstream project updates are required.