### PR TITLE
Fix downstream CI trigger

### DIFF
--- a/.github/workflows/commit-to-main.yml
+++ b/.github/workflows/commit-to-main.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    #branches: [ "main" ]
+    branches: [ "main" ]
 
 jobs:
   trigger-downstream-ci:

--- a/.github/workflows/commit-to-main.yml
+++ b/.github/workflows/commit-to-main.yml
@@ -13,14 +13,14 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     env:
-      BUILD_TRIGGER_TOKEN: ${{ secrets.BUILD_TRIGGER_TOKEN }}
+      { secrets.BUILD_TRIGGER_TOKEN }: ${{ secrets.{ secrets.BUILD_TRIGGER_TOKEN } }}
     steps:
       # TODO: missing projects?
       - name: Trigger OQS-OpenSSL CI
         run: |
           curl --silent \
                --write-out "\n%{response_code}\n" \
-               --user ${BUILD_TRIGGER_TOKEN}: \
+               --user ${{ secrets.BUILD_TRIGGER_TOKEN }}: \
                --request POST \
                --header "Content-Type: application/json" \
                --data '{ "branch": "OQS-OpenSSL_1_1_1-stable", "parameters": { "run_downstream_tests": true } }' \
@@ -30,7 +30,7 @@ jobs:
         run: |
           curl --silent \
                --write-out "\n%{response_code}\n" \
-               --user ${BUILD_TRIGGER_TOKEN}: \
+               --user ${{ secrets.BUILD_TRIGGER_TOKEN }}: \
                --request POST \
                --header "Content-Type: application/json" \
                --data '{ "branch": "master", "parameters": { "run_downstream_tests": true } }' \
@@ -40,7 +40,7 @@ jobs:
         run: |
           curl --silent \
                --write-out "\n%{response_code}\n" \
-               --user ${BUILD_TRIGGER_TOKEN}: \
+               --user ${{ secrets.BUILD_TRIGGER_TOKEN }}: \
                --request POST \
                --header "Content-Type: application/json" \
                --data '{ "branch": "OQS-v8", "parameters": { "run_downstream_tests": true } }' \
@@ -50,7 +50,7 @@ jobs:
         run: |
           curl --silent \
                --write-out "\n%{response_code}\n" \
-               --user ${BUILD_TRIGGER_TOKEN}: \
+               --user ${{ secrets.BUILD_TRIGGER_TOKEN }}: \
                --request POST \
                --header "Content-Type: application/json" \
                --data '{ "branch": "main" }' \
@@ -60,7 +60,7 @@ jobs:
         run: |
           curl --silent \
                --write-out "\n%{response_code}\n" \
-               --user ${BUILD_TRIGGER_TOKEN}: \
+               --user ${{ secrets.BUILD_TRIGGER_TOKEN }}: \
                --request POST \
                --header "Content-Type: application/json" \
                --data '{ "branch": "master" }' \
@@ -70,7 +70,7 @@ jobs:
         run: |
           curl --silent \
                --write-out "\n%{response_code}\n" \
-               --user ${BUILD_TRIGGER_TOKEN}: \
+               --user ${{ secrets.BUILD_TRIGGER_TOKEN }}: \
                --request POST \
                --header "Content-Type: application/json" \
                --data '{ "branch": "master" }' \
@@ -82,7 +82,7 @@ jobs:
                --write-out "\n%{response_code}\n" \
                --request POST \
                --header "Accept: application/vnd.github+json" \
-               --header "Authorization: Bearer $OQSBOT_GITHUB_ACTIONS" \
+               --header "Authorization: Bearer ${{ secrets.OQSBOT_GITHUB_ACTIONS }}" \
                --header "X-GitHub-Api-Version: 2022-11-28" \
                --data '{"event_type":"liboqs-upstream-trigger"}' \
                https://api.github.com/repos/open-quantum-safe/liboqs-python/dispatches | tee curl_out \

--- a/.github/workflows/commit-to-main.yml
+++ b/.github/workflows/commit-to-main.yml
@@ -12,6 +12,8 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
+    env:
+      BUILD_TRIGGER_TOKEN: ${{ secrets.BUILD_TRIGGER_TOKEN }}
     steps:
       # TODO: missing projects?
       - name: Trigger OQS-OpenSSL CI

--- a/.github/workflows/commit-to-main.yml
+++ b/.github/workflows/commit-to-main.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    branches: [ "main" ]
+    #branches: [ "main" ]
 
 jobs:
   trigger-downstream-ci:

--- a/.github/workflows/commit-to-main.yml
+++ b/.github/workflows/commit-to-main.yml
@@ -12,8 +12,6 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
-    env:
-      { secrets.BUILD_TRIGGER_TOKEN }: ${{ secrets.{ secrets.BUILD_TRIGGER_TOKEN } }}
     steps:
       # TODO: missing projects?
       - name: Trigger OQS-OpenSSL CI


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
Corrects my incorrect use of GitHub environment variables in https://github.com/open-quantum-safe/liboqs/pull/1849, making the downstream trigger pass.

I had previously tested the scripts locally but not in CI. The workflow for this PR is CI-tested here: https://github.com/open-quantum-safe/liboqs/actions/runs/10083919855

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

