### PR TITLE
Add a convenience script for consistent astyle formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,11 +26,12 @@ them before the final "Review" stage.
 
 This project has adopted a slightly modified [Google code formatting style](https://astyle.sourceforge.net/astyle.html#_style=google) for the core components
 of the library as documented in the [style template](.astylerc).
-
-To check adherence of any new code to this, it therefore is highly recommended to
-run the following command in the project main directory prior to finishing a PR:
-
-    find src tests -name '*.[ch]' | grep -v '/external/' | grep -v 'kem/.*/.*/.*' | grep -v 'sig/.*/.*/.*' | xargs astyle --dry-run --options=.astylerc | grep Format
+The `astyle` tool is used to check formatting in CI.
+Due to variations in behaviour across version and platforms, it is possible to encounter CI failures even if code has been locally formatted with `astyle`.
+To assist with this inconvenience, we provide a convenience script which runs `astyle` in the same Docker image that we use for the CI checks:
+```bash
+LIBOQS_DIR=<liboqs directory> ./scripts/format_code.sh
+```
 
 ### Running CI locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ To assist with this inconvenience, we provide a convenience script which runs `a
 ```bash
 LIBOQS_DIR=<liboqs directory> ./scripts/format_code.sh
 ```
+This script has been tested on x86\_64 Ubuntu and arm64 macOS. Contributions for other platforms are welcome and appreciated!
 
 ### Running CI locally
 

--- a/scripts/format_code.sh
+++ b/scripts/format_code.sh
@@ -2,10 +2,18 @@
 
 # SPDX-License-Identifier: MIT
 
-if [ ! -d "$LIBOQS_DIR" ]
+arch=$(uname -m)
+
+if [ "$arch" != "x86_64" ] && [ "$arch" != "arm64" ]
 then
-	echo Must set environment variable LIBOQS_DIR
+	echo "This script does not currently support systems where \`uname -m\` returns $arch."
 	exit 1
 fi
 
-docker run --rm -v"$LIBOQS_DIR":/root/liboqs -w /root/liboqs openquantumsafe/ci-ubuntu-focal-x86_64:latest ./tests/run_astyle.sh --no-dry-run
+if [ ! -d "$LIBOQS_DIR" ]
+then
+	echo Please set the environment variable LIBOQS_DIR to point to your liboqs directory.
+	exit 1
+fi
+
+docker run --rm -v"$LIBOQS_DIR":/root/liboqs -w /root/liboqs openquantumsafe/ci-ubuntu-focal-$arch:latest ./tests/run_astyle.sh --no-dry-run

--- a/scripts/format_code.sh
+++ b/scripts/format_code.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MIT
+
+if [ ! -d "$LIBOQS_DIR" ]
+then
+	echo Must set environment variable LIBOQS_DIR
+	exit 1
+fi
+
+docker run --rm -v"$LIBOQS_DIR":/root/liboqs -w /root/liboqs openquantumsafe/ci-ubuntu-focal-x86_64:latest ./tests/run_astyle.sh --no-dry-run

--- a/scripts/format_code.sh
+++ b/scripts/format_code.sh
@@ -2,8 +2,11 @@
 
 # SPDX-License-Identifier: MIT
 
+# usage: LIBOQS_DIR=<liboqs dir> ./scripts/format_code.sh
+
 arch=$(uname -m)
 
+# tested on Ubuntu 22 / x86_64 and macOS 13 / arm64
 if [ "$arch" != "x86_64" ] && [ "$arch" != "arm64" ]
 then
 	echo "This script does not currently support systems where \`uname -m\` returns $arch."
@@ -12,7 +15,7 @@ fi
 
 if [ ! -d "$LIBOQS_DIR" ]
 then
-	echo Please set the environment variable LIBOQS_DIR to point to your liboqs directory.
+	echo "Please set the environment variable LIBOQS_DIR to point to your liboqs directory."
 	exit 1
 fi
 

--- a/tests/run_astyle.sh
+++ b/tests/run_astyle.sh
@@ -3,8 +3,14 @@
 
 rv=0
 
+if [ "$1" = "--no-dry-run" ]; then
+	dryrun=""
+else
+	dryrun="--dry-run"
+fi
+
 # check style of non-external code:
-find src tests -name '*.[ch]' | grep -v '/external/' | grep -v 'kem/.*/.*/.*' | grep -v 'sig/.*/.*/.*' | xargs astyle --dry-run --options=.astylerc | grep Format
+find src tests -name '*.[ch]' | grep -v '/external/' | grep -v 'kem/.*/.*/.*' | grep -v 'sig/.*/.*/.*' | xargs astyle $dryrun --options=.astylerc | grep Format
 if [ $? -ne 1 ]; then
    echo "Error: Some files need reformatting. Check output above."
    rv=-1


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
The behaviour of `astyle` varies across versions and platforms, which means it can sometimes be a pain to get PRs to pass CI formatting checks. This PR adds a convenience script which runs `astyle` over local code in the CI Docker image, ensuring that local formatting matches what's expected by CI.

My hope is that this script will reduce friction for new contributors and busywork for regular ones. I've been using this approach for a while myself.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

