### PR TITLE
Use explicit_memset if available. NetBSD has support for it:

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -124,13 +124,19 @@ if(CMAKE_HAVE_MEMALIGN)
     target_compile_definitions(internal PRIVATE OQS_HAVE_MEMALIGN)
 endif()
 
-# check if explicit_bzero exists or memset_s
+# check if explicit_bzero, or explicit_memset exists or memset_s
 check_symbol_exists(explicit_bzero string.h CMAKE_HAVE_EXPLICIT_BZERO)
+check_symbol_exists(explicit_memset string.h CMAKE_HAVE_EXPLICIT_MEMSET)
 check_symbol_exists(memset_s string.h CMAKE_HAVE_MEMSET_S)
 
 if(CMAKE_HAVE_EXPLICIT_BZERO)
     target_compile_definitions(common PRIVATE OQS_HAVE_EXPLICIT_BZERO)
     target_compile_definitions(internal PRIVATE OQS_HAVE_EXPLICIT_BZERO)
+endif()
+
+if(CMAKE_HAVE_EXPLICIT_MEMSET)
+    target_compile_definitions(common PRIVATE OQS_HAVE_EXPLICIT_MEMSET)
+    target_compile_definitions(internal PRIVATE OQS_HAVE_EXPLICIT_MEMSET)
 endif()
 
 if(CMAKE_HAVE_MEMSET_S)

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 AND MIT
 
-#if !defined(OQS_USE_OPENSSL) && !defined(_WIN32) && !defined(OQS_HAVE_EXPLICIT_BZERO)
+#if !defined(OQS_USE_OPENSSL) && !defined(_WIN32) && !defined(OQS_HAVE_EXPLICIT_BZERO) && !defined(OQS_HAVE_EXPLICIT_MEMSET)
 // Request memset_s
 #define __STDC_WANT_LIB_EXT1__ 1
 #endif
@@ -262,6 +262,8 @@ OQS_API void OQS_MEM_cleanse(void *ptr, size_t len) {
 	SecureZeroMemory(ptr, len);
 #elif defined(OQS_HAVE_EXPLICIT_BZERO)
 	explicit_bzero(ptr, len);
+#elif defined(OQS_HAVE_EXPLICIT_MEMSET)
+	explicit_memset(ptr, 0, len);
 #elif defined(__STDC_LIB_EXT1__) || defined(OQS_HAVE_MEMSET_S)
 	if (0U < len && memset_s(ptr, (rsize_t)len, 0, (rsize_t)len) != 0) {
 		abort();


### PR DESCRIPTION
https://man.netbsd.org/NetBSD-10.0/explicit_memset.3

Work done together with Ritesh Gomind & Ali Koheeallee from University of Mauritius RICRG while porting liboqs to NetBSD.



