### PR TITLE
Check return value of fscanf in LMS/XMSS KAT tests

### DIFF
--- a/tests/kat_sig_stfl.c
+++ b/tests/kat_sig_stfl.c
@@ -311,7 +311,10 @@ OQS_STATUS sig_stfl_kat(const char *method_name, const char *katfile) {
 
 	// Echo back remain
 	if (FindMarker(fp_rsp, "remain = ")) {
-		fscanf(fp_rsp, "%llu", &sigs_remain);
+		if (EOF == fscanf(fp_rsp, "%llu", &sigs_remain)) {
+            fprintf(stderr, "[kat_stfl_sig] %s ERROR: unable to read 'remain' from <%s>\n", method_name, katfile);
+            goto err;
+        };
 		fprintf(fh, "remain = %llu\n", sigs_remain);
 	} else {
 		fprintf(stderr, "[kat_stfl_sig] %s ERROR: OQS_SIG_STFL_sigs_remaining failed!\n", method_name);
@@ -320,7 +323,10 @@ OQS_STATUS sig_stfl_kat(const char *method_name, const char *katfile) {
 
 	// Echo back max
 	if (FindMarker(fp_rsp, "max = ")) {
-		fscanf(fp_rsp, "%llu", &sigs_maximum);
+		if (EOF == fscanf(fp_rsp, "%llu", &sigs_maximum)) {
+            fprintf(stderr, "[kat_stfl_sig] %s ERROR: unable to read 'max' from <%s>\n", method_name, katfile);
+            goto err;
+        };
 		fprintf(fh, "max = %llu\n", sigs_maximum);
 	} else {
 		fprintf(stderr, "[kat_stfl_sig] %s ERROR: OQS_SIG_STFL_sigs_total failed!\n", method_name);

--- a/tests/kat_sig_stfl.c
+++ b/tests/kat_sig_stfl.c
@@ -312,9 +312,9 @@ OQS_STATUS sig_stfl_kat(const char *method_name, const char *katfile) {
 	// Echo back remain
 	if (FindMarker(fp_rsp, "remain = ")) {
 		if (EOF == fscanf(fp_rsp, "%llu", &sigs_remain)) {
-            fprintf(stderr, "[kat_stfl_sig] %s ERROR: unable to read 'remain' from <%s>\n", method_name, katfile);
-            goto err;
-        };
+			fprintf(stderr, "[kat_stfl_sig] %s ERROR: unable to read 'remain' from <%s>\n", method_name, katfile);
+			goto err;
+		};
 		fprintf(fh, "remain = %llu\n", sigs_remain);
 	} else {
 		fprintf(stderr, "[kat_stfl_sig] %s ERROR: OQS_SIG_STFL_sigs_remaining failed!\n", method_name);
@@ -324,9 +324,9 @@ OQS_STATUS sig_stfl_kat(const char *method_name, const char *katfile) {
 	// Echo back max
 	if (FindMarker(fp_rsp, "max = ")) {
 		if (EOF == fscanf(fp_rsp, "%llu", &sigs_maximum)) {
-            fprintf(stderr, "[kat_stfl_sig] %s ERROR: unable to read 'max' from <%s>\n", method_name, katfile);
-            goto err;
-        };
+			fprintf(stderr, "[kat_stfl_sig] %s ERROR: unable to read 'max' from <%s>\n", method_name, katfile);
+			goto err;
+		};
 		fprintf(fh, "max = %llu\n", sigs_maximum);
 	} else {
 		fprintf(stderr, "[kat_stfl_sig] %s ERROR: OQS_SIG_STFL_sigs_total failed!\n", method_name);


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
Gets rid of some annoying compiler warnings.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
Fixes #1871.

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

