### PR TITLE
#1830 update scorecard to v5 (gh action 2.4.0)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -259,7 +259,7 @@ jobs:
     container: openquantumsafe/ci-ubuntu-latest:latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
       - name: Configure
         run: mkdir build && cd build && scan-build --status-bugs cmake -GNinja ..
       - name: Build

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -47,7 +47,7 @@ jobs:
           # For private repositories:
           #   - `publish_results` will always be set to `false`, regardless
           #     of the value entered here.
-          publish_results: false
+          publish_results: true
 
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
@@ -56,9 +56,9 @@ jobs:
         with:
           name: SARIF file
           path: results.sarif
-          retention-days: 5
+          retention-days: 28
       # Upload the results to GitHub's code scanning dashboard.
-      #- name: "Upload to code-scanning"
-      #  uses: github/codeql-action/upload-sarif@e949a1676c32f4c215780f7429eb9f00ff18b225 # pin@v2
-      #  with:
-      #    sarif_file: results.sarif
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@2c779ab0d087cd7fe7b826087247c2c81f27bfa6 # pin@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,6 +9,7 @@ on:
   workflow_call:
   workflow_dispatch:
 
+
 jobs:
   analysis:
     name: Scorecard analysis
@@ -24,12 +25,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # pin@v2.3.1
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # pin@v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
@@ -51,7 +52,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # pin@v4
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # pin@v4
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
 - Updates to use scorecard v5
 - re-pinned actions in scorecard.yaml to latest levels
 - fixed report of unpinned dependencies in unix.yml
 - enabled publishing of scorecard results

Note: Results are published by the openssf team at https://scorecard.dev/viewer/?uri=github.com%2Fopen-quantum-safe%2Fliboqs
Enabling our own scan is recommended by openssf, allows us to enable badges, and permits some tweaking of rules
The current scan results are [here](https://scorecard.dev/viewer/?uri=github.com%2Fopen-quantum-safe%2Fliboqs)

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
Fixes #1830 

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->
n/a

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

No change to crypto. This is build pipeline only.

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

