### PR TITLE
Check workflows for issues during CI

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,14 @@
+# Labels of self-hosted runner in array of strings.
+
+# NB. oqs-arm64 is not self-hosted but this configuration
+#     is required for liboqs to lint correctly with actionlint v1.7.1
+
+self-hosted-runner:
+  # Labels of self-hosted runner in array of string
+  labels:
+    - oqs-arm64
+# Configuration variables in array of strings defined in your repository or organization
+config-variables:
+  # - DEFAULT_RUNNER
+  # - JOB_NAME
+  # - ENVIRONMENT_STAGE

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -7,8 +7,19 @@ on: [workflow_call, workflow_dispatch]
 
 jobs:
 
+  workflowcheck:
+    name: Check validity of GitHub workflows
+    runs-on: ubuntu-latest
+    container: openquantumsafe/ci-ubuntu-latest:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+      - name: Ensure GitHub actions are valid
+        run: actionlint -shellcheck "" # run *without* shellcheck
+
   stylecheck:
     name: Check code formatting
+    needs: [ workflowcheck ]
     runs-on: ubuntu-latest
     container: openquantumsafe/ci-ubuntu-latest:latest
     steps:
@@ -23,6 +34,7 @@ jobs:
 
   upstreamcheck:
     name: Check upstream code is properly integrated
+    needs: [ workflowcheck ]
     runs-on: ubuntu-latest
     container: openquantumsafe/ci-ubuntu-latest:latest
     steps:
@@ -47,7 +59,7 @@ jobs:
 
   buildcheck:
     name: Check that code passes a basic build
-    needs: [ stylecheck, upstreamcheck ]
+    needs: [ workflowcheck, stylecheck, upstreamcheck ]
     runs-on: ubuntu-latest
     container: openquantumsafe/ci-ubuntu-latest:latest
     env:

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -13,7 +13,7 @@ jobs:
     container: openquantumsafe/ci-ubuntu-latest:latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
       - name: Ensure GitHub actions are valid
         run: actionlint -shellcheck "" # run *without* shellcheck
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,20 @@ GitHub CI jobs. When executed in the main `liboqs` directory,
 
 When installing `act` as a GitHub extension, prefix the commands with `gh `.
 
+## Modifications to CI
+
+Modifications to GitHub Actions workflows are checked with [actionlint](https://github.com/rhysd/actionlint) during the [basic.yml](.github/workflows/basic.yml) job, protecting the CI chain and against wrong approval decisions based on improper CI runs.  Changes to these workflows can be validated locally with `actionlint`:
+
+```bash
+actionlint .github/workflows/*.yml
+```
+
+or running the CI locally (as above):
+
+```bash
+act workflow_call -W '.github/workflows/basic.yml'
+```
+
 ### New features
 
 Any PR introducing a new feature is expected to contain a test of this feature
@@ -70,6 +84,3 @@ add a tag to one or more of our [most active contributors](https://github.com/op
 
 If you feel like contributing but don't know what specific topic to work on,
 please check the [open issues tagged "good first issue" or "help wanted"](https://github.com/open-quantum-safe/liboqs/issues).
-
-
-


### PR DESCRIPTION
This PR adds an Actionlint workflow to validate GH actions as per #1866

This is an updated version of PR #1880, taking into account the discussion on that contribution.

Actionlint checking would have protected against the changes fixed in #1869 and #1902, e.g. (for the latter):
```
➜ actionlint .github/workflows/*.yml
.github/workflows/linux.yml:176:5: unexpected key "libjade-build" for "job" section. expected one of "concurrency", "container", "continue-on-error", "defaults", "env", "environment", "if", "name", "needs", "outputs", "permissions", "runs-on", "secrets", "services", "steps", "strategy", "timeout-minutes", "uses", "with" [syntax-check]
    |
176 |     libjade-build:
    |     ^~~~~~~~~~~~~~
.github/workflows/linux.yml:187:84: property "libjade-build" is not defined in object type {cmake_args: string; container: string; name: string; pytest_args: string; runner: string} [expression]
    |
187 |         run: mkdir build && cd build && cmake -GNinja ${{ matrix.CMAKE_ARGS }} ${{ matrix.libjade-build }} .. && cmake -LA -N ..
    |                                                                                    ^~~~~~~~~~~~~~~~~~~~
.github/workflows/platforms.yml:17:11: error while parsing reusable workflow "./.github/workflows/linux.yml": "workflow_call" event trigger is not found in "on:" at line:6, column:5 [workflow-call]
   |
17 |     uses: ./.github/workflows/linux.yml
   |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

~~* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)~~
~~* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)~~


