### PR TITLE
Patch Kyber to fix ASAN error on ARM64

### DIFF
--- a/scripts/copy_from_upstream/copy_from_upstream.yml
+++ b/scripts/copy_from_upstream/copy_from_upstream.yml
@@ -8,7 +8,8 @@ upstreams:
     sig_meta_path: 'crypto_sign/{pqclean_scheme}/META.yml'
     kem_scheme_path: 'crypto_kem/{pqclean_scheme}'
     sig_scheme_path: 'crypto_sign/{pqclean_scheme}'
-    patches: [pqclean-dilithium-arm-randomized-signing.patch, pqclean-kyber-armneon-shake-fixes.patch, pqclean-kyber-armneon-768-1024-fixes.patch, pqclean-kyber-armneon-variable-timing-fix.patch]
+    patches: [pqclean-dilithium-arm-randomized-signing.patch, pqclean-kyber-armneon-shake-fixes.patch, pqclean-kyber-armneon-768-1024-fixes.patch, pqclean-kyber-armneon-variable-timing-fix.patch,
+    pqclean-kyber-armneon-asan.patch]
     ignore: pqclean_sphincs-shake-256s-simple_aarch64, pqclean_sphincs-shake-256s-simple_aarch64, pqclean_sphincs-shake-256f-simple_aarch64, pqclean_sphincs-shake-192s-simple_aarch64, pqclean_sphincs-shake-192f-simple_aarch64, pqclean_sphincs-shake-128s-simple_aarch64, pqclean_sphincs-shake-128f-simple_aarch64
   -
     name: pqclean

--- a/scripts/copy_from_upstream/patches/pqclean-kyber-armneon-asan.patch
+++ b/scripts/copy_from_upstream/patches/pqclean-kyber-armneon-asan.patch
@@ -1,0 +1,72 @@
+diff --git a/crypto_kem/kyber1024/aarch64/neon_symmetric-shake.c b/crypto_kem/kyber1024/aarch64/neon_symmetric-shake.c
+index 8aced5e4..364d9fdd 100644
+--- a/crypto_kem/kyber1024/aarch64/neon_symmetric-shake.c
++++ b/crypto_kem/kyber1024/aarch64/neon_symmetric-shake.c
+@@ -56,8 +56,8 @@ void neon_kyber_shake128_absorb(keccakx2_state *state,
+                                 uint8_t y1, uint8_t y2)
+ {
+   unsigned int i;
+-  uint8_t extseed1[KYBER_SYMBYTES+2];
+-  uint8_t extseed2[KYBER_SYMBYTES+2];
++  uint8_t extseed1[KYBER_SYMBYTES+2+6];
++  uint8_t extseed2[KYBER_SYMBYTES+2+6];
+ 
+   for(i=0;i<KYBER_SYMBYTES;i++){
+     extseed1[i] = seed[i];
+@@ -69,7 +69,7 @@ void neon_kyber_shake128_absorb(keccakx2_state *state,
+   extseed2[KYBER_SYMBYTES  ] = x2;
+   extseed2[KYBER_SYMBYTES+1] = y2;
+ 
+-  shake128x2_absorb(state, extseed1, extseed2, sizeof(extseed1));
++  shake128x2_absorb(state, extseed1, extseed2, KYBER_SYMBYTES+2);
+ }
+ 
+ /*************************************************
+diff --git a/crypto_kem/kyber512/aarch64/neon_symmetric-shake.c b/crypto_kem/kyber512/aarch64/neon_symmetric-shake.c
+index 8aced5e4..364d9fdd 100644
+--- a/crypto_kem/kyber512/aarch64/neon_symmetric-shake.c
++++ b/crypto_kem/kyber512/aarch64/neon_symmetric-shake.c
+@@ -56,8 +56,8 @@ void neon_kyber_shake128_absorb(keccakx2_state *state,
+                                 uint8_t y1, uint8_t y2)
+ {
+   unsigned int i;
+-  uint8_t extseed1[KYBER_SYMBYTES+2];
+-  uint8_t extseed2[KYBER_SYMBYTES+2];
++  uint8_t extseed1[KYBER_SYMBYTES+2+6];
++  uint8_t extseed2[KYBER_SYMBYTES+2+6];
+ 
+   for(i=0;i<KYBER_SYMBYTES;i++){
+     extseed1[i] = seed[i];
+@@ -69,7 +69,7 @@ void neon_kyber_shake128_absorb(keccakx2_state *state,
+   extseed2[KYBER_SYMBYTES  ] = x2;
+   extseed2[KYBER_SYMBYTES+1] = y2;
+ 
+-  shake128x2_absorb(state, extseed1, extseed2, sizeof(extseed1));
++  shake128x2_absorb(state, extseed1, extseed2, KYBER_SYMBYTES+2);
+ }
+ 
+ /*************************************************
+diff --git a/crypto_kem/kyber768/aarch64/neon_symmetric-shake.c b/crypto_kem/kyber768/aarch64/neon_symmetric-shake.c
+index 8aced5e4..364d9fdd 100644
+--- a/crypto_kem/kyber768/aarch64/neon_symmetric-shake.c
++++ b/crypto_kem/kyber768/aarch64/neon_symmetric-shake.c
+@@ -56,8 +56,8 @@ void neon_kyber_shake128_absorb(keccakx2_state *state,
+                                 uint8_t y1, uint8_t y2)
+ {
+   unsigned int i;
+-  uint8_t extseed1[KYBER_SYMBYTES+2];
+-  uint8_t extseed2[KYBER_SYMBYTES+2];
++  uint8_t extseed1[KYBER_SYMBYTES+2+6];
++  uint8_t extseed2[KYBER_SYMBYTES+2+6];
+ 
+   for(i=0;i<KYBER_SYMBYTES;i++){
+     extseed1[i] = seed[i];
+@@ -69,7 +69,7 @@ void neon_kyber_shake128_absorb(keccakx2_state *state,
+   extseed2[KYBER_SYMBYTES  ] = x2;
+   extseed2[KYBER_SYMBYTES+1] = y2;
+ 
+-  shake128x2_absorb(state, extseed1, extseed2, sizeof(extseed1));
++  shake128x2_absorb(state, extseed1, extseed2, KYBER_SYMBYTES+2);
+ }
+ 
+ /*************************************************

--- a/src/kem/kyber/oldpqclean_kyber1024_aarch64/neon_symmetric-shake.c
+++ b/src/kem/kyber/oldpqclean_kyber1024_aarch64/neon_symmetric-shake.c
@@ -56,8 +56,8 @@ void neon_kyber_shake128_absorb(keccakx2_state *state,
                                 uint8_t y1, uint8_t y2)
 {
   unsigned int i;
-  uint8_t extseed1[KYBER_SYMBYTES+2];
-  uint8_t extseed2[KYBER_SYMBYTES+2];
+  uint8_t extseed1[KYBER_SYMBYTES+2+6];
+  uint8_t extseed2[KYBER_SYMBYTES+2+6];
 
   for(i=0;i<KYBER_SYMBYTES;i++){
     extseed1[i] = seed[i];
@@ -69,7 +69,7 @@ void neon_kyber_shake128_absorb(keccakx2_state *state,
   extseed2[KYBER_SYMBYTES  ] = x2;
   extseed2[KYBER_SYMBYTES+1] = y2;
 
-  shake128x2_absorb(state, extseed1, extseed2, sizeof(extseed1));
+  shake128x2_absorb(state, extseed1, extseed2, KYBER_SYMBYTES+2);
 }
 
 /*************************************************

--- a/src/kem/kyber/oldpqclean_kyber512_aarch64/neon_symmetric-shake.c
+++ b/src/kem/kyber/oldpqclean_kyber512_aarch64/neon_symmetric-shake.c
@@ -56,8 +56,8 @@ void neon_kyber_shake128_absorb(keccakx2_state *state,
                                 uint8_t y1, uint8_t y2)
 {
   unsigned int i;
-  uint8_t extseed1[KYBER_SYMBYTES+2];
-  uint8_t extseed2[KYBER_SYMBYTES+2];
+  uint8_t extseed1[KYBER_SYMBYTES+2+6];
+  uint8_t extseed2[KYBER_SYMBYTES+2+6];
 
   for(i=0;i<KYBER_SYMBYTES;i++){
     extseed1[i] = seed[i];
@@ -69,7 +69,7 @@ void neon_kyber_shake128_absorb(keccakx2_state *state,
   extseed2[KYBER_SYMBYTES  ] = x2;
   extseed2[KYBER_SYMBYTES+1] = y2;
 
-  shake128x2_absorb(state, extseed1, extseed2, sizeof(extseed1));
+  shake128x2_absorb(state, extseed1, extseed2, KYBER_SYMBYTES+2);
 }
 
 /*************************************************

--- a/src/kem/kyber/oldpqclean_kyber768_aarch64/neon_symmetric-shake.c
+++ b/src/kem/kyber/oldpqclean_kyber768_aarch64/neon_symmetric-shake.c
@@ -56,8 +56,8 @@ void neon_kyber_shake128_absorb(keccakx2_state *state,
                                 uint8_t y1, uint8_t y2)
 {
   unsigned int i;
-  uint8_t extseed1[KYBER_SYMBYTES+2];
-  uint8_t extseed2[KYBER_SYMBYTES+2];
+  uint8_t extseed1[KYBER_SYMBYTES+2+6];
+  uint8_t extseed2[KYBER_SYMBYTES+2+6];
 
   for(i=0;i<KYBER_SYMBYTES;i++){
     extseed1[i] = seed[i];
@@ -69,7 +69,7 @@ void neon_kyber_shake128_absorb(keccakx2_state *state,
   extseed2[KYBER_SYMBYTES  ] = x2;
   extseed2[KYBER_SYMBYTES+1] = y2;
 
-  shake128x2_absorb(state, extseed1, extseed2, sizeof(extseed1));
+  shake128x2_absorb(state, extseed1, extseed2, KYBER_SYMBYTES+2);
 }
 
 /*************************************************


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
Patch Kyber to fix address sanitiser issue on ARM64 as described in #1914. Patch copied from [PQClean](https://github.com/PQClean/PQClean/blob/0c5bb143456333cd6ac85435d344b08b351b27a8/crypto_kem/kyber512/aarch64/neon_symmetric-shake.c#L59-L60), in line with fix submitted in #1914. 

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [No] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [No] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

