### PR TITLE
Install test binaries

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,15 +41,19 @@ if(NOT WIN32)
 
     add_executable(test_aes test_aes.c)
     target_link_libraries(test_aes PRIVATE ${TEST_DEPS})
+    install (TARGETS test_aes RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
     add_executable(test_hash test_hash.c)
     target_link_libraries(test_hash PRIVATE ${TEST_DEPS})
+    install (TARGETS test_hash RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
     add_executable(test_sha3 test_sha3.c)
     target_link_libraries(test_sha3 PRIVATE ${TEST_DEPS})
+    install (TARGETS test_sha3 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
     add_executable(speed_common speed_common.c)
     target_link_libraries(speed_common PRIVATE ${TEST_DEPS})
+    install (TARGETS speed_common RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
     set(UNIX_TESTS test_aes test_hash test_sha3 speed_common)
 
@@ -61,9 +65,11 @@ endif()
 # KEM API tests
 add_executable(example_kem example_kem.c)
 target_link_libraries(example_kem PRIVATE ${TEST_DEPS})
+install (TARGETS example_kem RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_executable(kat_kem kat_kem.c test_helpers.c)
 target_link_libraries(kat_kem PRIVATE ${TEST_DEPS})
+install (TARGETS kat_kem RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND BUILD_SHARED_LIBS)
     # workaround for Windows .dll
     if(MINGW OR MSYS OR CYGWIN OR CMAKE_CROSSCOMPILING)
@@ -75,25 +81,31 @@ endif()
 
 add_executable(test_kem test_kem.c)
 target_link_libraries(test_kem PRIVATE ${TEST_DEPS})
+install (TARGETS test_kem RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_executable(test_kem_mem test_kem_mem.c)
 target_link_libraries(test_kem_mem PRIVATE ${TEST_DEPS})
+install (TARGETS test_kem_mem RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_executable(speed_kem speed_kem.c)
 target_link_libraries(speed_kem PRIVATE ${TEST_DEPS})
+install (TARGETS speed_kem RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 set(KEM_TESTS example_kem kat_kem test_kem test_kem_mem speed_kem vectors_kem)
 
 # SIG API tests
 add_executable(example_sig example_sig.c)
 target_link_libraries(example_sig PRIVATE ${TEST_DEPS})
+install (TARGETS example_sig RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Stateful SIG API tests
 add_executable(example_sig_stfl example_sig_stfl.c)
 target_link_libraries(example_sig_stfl PRIVATE ${TEST_DEPS})
+install (TARGETS example_sig_stfl RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_executable(kat_sig kat_sig.c test_helpers.c)
 target_link_libraries(kat_sig PRIVATE ${TEST_DEPS})
+install (TARGETS kat_sig RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND BUILD_SHARED_LIBS)
     # workaround for Windows .dll
     if(MINGW OR MSYS OR CYGWIN OR CMAKE_CROSSCOMPILING)
@@ -105,6 +117,7 @@ endif()
 
 add_executable(kat_sig_stfl kat_sig_stfl.c test_helpers.c)
 target_link_libraries(kat_sig_stfl PRIVATE ${TEST_DEPS})
+install (TARGETS kat_sig_stfl RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND BUILD_SHARED_LIBS)
     # workaround for Windows .dll
     if(CMAKE_CROSSCOMPILING)
@@ -116,17 +129,21 @@ endif()
 
 add_executable(test_sig test_sig.c)
 target_link_libraries(test_sig PRIVATE ${TEST_DEPS})
+install (TARGETS test_sig RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_executable(test_sig_mem test_sig_mem.c)
 target_link_libraries(test_sig_mem PRIVATE ${TEST_DEPS})
+install (TARGETS test_sig_mem RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_executable(speed_sig speed_sig.c)
 target_link_libraries(speed_sig PRIVATE ${TEST_DEPS})
+install (TARGETS speed_sig RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 set(SIG_TESTS example_sig kat_sig test_sig test_sig_mem speed_sig vectors_sig)
 
 # SIG_STFL API tests
 add_executable(test_sig_stfl test_sig_stfl.c)
+install (TARGETS test_sig_stfl RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 if((CMAKE_C_COMPILER_ID MATCHES "Clang") OR (CMAKE_C_COMPILER_ID STREQUAL "GNU"))
     target_link_libraries(test_sig_stfl PRIVATE ${TEST_DEPS} Threads::Threads)
 else ()
@@ -137,13 +154,16 @@ set(SIG_STFL_TESTS kat_sig_stfl test_sig_stfl)
 
 add_executable(dump_alg_info dump_alg_info.c)
 target_link_libraries(dump_alg_info PRIVATE ${TEST_DEPS})
+install (TARGETS dump_alg_info RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Intermediate values vector tests
 add_executable(vectors_sig vectors_sig.c)
 target_link_libraries(vectors_sig PRIVATE ${TEST_DEPS})
+install (TARGETS vectors_sig RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_executable(vectors_kem vectors_kem.c)
 target_link_libraries(vectors_kem PRIVATE ${TEST_DEPS})
+install (TARGETS vectors_kem RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Enable Valgrind-based timing side-channel analysis for test_kem and test_sig
 if(OQS_ENABLE_TEST_CONSTANT_TIME AND NOT OQS_DEBUG_BUILD)


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

I am creating a Yocto Embedded Linux layer to automate building liboqs into Yocto images so people can test.

ref: https://github.com/DynamicDevices/meta-quantum-safe

As I've been working on this I see the test examples aren't setup to be installed within the CMakeFiles.txt. Yocto takes the installed output of CMake and then installs those files via packages into embedded target images.

I feel it would be really helpful to have the option to install these onto target systems so I've  created this PR which does this. Perhaps we could have a chat about whether you can accept this?

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->


<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

Testing: This installs the tests rather than adding a feature that needs testing

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [No] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)


* [No] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

