### PR TITLE
Don't include dlfcn.h for Windows

### DIFF
--- a/src/common/ossl_helpers.c
+++ b/src/common/ossl_helpers.c
@@ -4,7 +4,9 @@
 #define OQS_OSSL_NO_EXTERN 1
 #include "ossl_helpers.h"
 #include <assert.h>
+#if !defined(_WIN32)
 #include <dlfcn.h>
+#endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #if defined(OQS_USE_PTHREADS)


### PR DESCRIPTION
dlfcn.h is a Posix library not natively available on Windows. Only include the header for non-Windows builds. 

Fixes #1935