### PR TITLE
Remove hardcoded build patch from test script

### DIFF
--- a/tests/test_acvp_vectors.py
+++ b/tests/test_acvp_vectors.py
@@ -36,9 +36,10 @@ def test_acvp_vec_kem_keygen(kem_name):
                     z = testCase["z"]
                     pk = testCase["ek"]
                     sk = testCase["dk"]
-                    
+
+                    build_dir = helpers.get_current_build_dir_name()
                     helpers.run_subprocess(
-                        ['build/tests/vectors_kem', kem_name, "keyGen", d+z, pk, sk]
+                        [f'{build_dir}/tests/vectors_kem', kem_name, "keyGen", d+z, pk, sk]
                     )
 
         assert(variantFound == True)
@@ -66,9 +67,10 @@ def test_acvp_vec_kem_encdec_aft(kem_name):
                     #expected results
                     k = testCase["k"]
                     c = testCase["c"]
-                                        
+
+                    build_dir = helpers.get_current_build_dir_name()
                     helpers.run_subprocess(
-                        ['build/tests/vectors_kem', kem_name, "encDecAFT", m, pk, k, c]
+                        [f'{build_dir}/tests/vectors_kem', kem_name, "encDecAFT", m, pk, k, c]
                     )
 
         assert(variantFound == True)
@@ -94,9 +96,10 @@ def test_acvp_vec_kem_encdec_val(kem_name):
                     c = testCase["c"]
                     #expected results
                     k = testCase["k"]
-                                        
+
+                    build_dir = helpers.get_current_build_dir_name()
                     helpers.run_subprocess(
-                        ['build/tests/vectors_kem', kem_name, "encDecVAL", sk, k, c]
+                        [f'{build_dir}/tests/vectors_kem', kem_name, "encDecVAL", sk, k, c]
                     )
 
         assert(variantFound == True)


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

If a user has passed a custom build path to cmake, and then calls for example `ninja -C <custom_build_path> run_tests`, the script test_acvp_vectors.py fails due to having "build" harcoded in the calls.

Instead, let's use `helpers.get_current_build_dir_name()` to get the build path and use that instead. This is already done in other scripts (e.g., test_binary.py)

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
Fixes #1937

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->