### PR TITLE
Downgrade zephyr container to v0.26.14 to avoid build failures

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -9,7 +9,8 @@ jobs:
 
   zephyr_test:
     runs-on: ubuntu-22.04
-    container: ghcr.io/zephyrproject-rtos/ci:latest
+    # Note: Revert to *ci:latest once https://github.com/zephyrproject-rtos/docker-image/issues/205 is resolved 
+    container: ghcr.io/zephyrproject-rtos/ci:v0.26.14
     env:
         CMAKE_PREFIX_PATH: /opt/toolchains
     strategy:


### PR DESCRIPTION
Workaround for #1948 
