### PR TITLE
Adapt existing sig fuzz harness including more algorithms

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -113,9 +113,9 @@ jobs:
           cmake -LA -N .. && \
           ! (grep -i "uninitialized variable" config.log)
       - name: Build code
-        run: ninja
+        run: ninja fuzz_test_sig
         working-directory: build
 
       - name: Short fuzz check (30s)
-        run: ./tests/fuzz_test_dilithium2 -max_total_time=30
+        run: ./tests/fuzz_test_sig -max_total_time=30
         working-directory: build

--- a/docs/FUZZING.md
+++ b/docs/FUZZING.md
@@ -15,14 +15,11 @@ errors, helping developers identify and fix bugs and security loopholes.
   - [ ] ml_kem
   - [ ] ntruprime
 - [ ] sig
-  - [ ] dilithium
-    - [x] dilithium2
-    - [ ] dilithium3
-    - [ ] dilithium5
-  - [ ] falcon
-  - [ ] mayo
-  - [ ] ml_dsa
-  - [ ] sphincs
+  - [x] dilithium
+  - [x] falcon
+  - [x] mayo
+  - [x] ml_dsa
+  - [x] sphincs
 - [ ] sig_stfl
   - [ ] lms
   - [ ] sig_stfl

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,9 +95,9 @@ add_executable(example_sig example_sig.c)
 target_link_libraries(example_sig PRIVATE ${TEST_DEPS})
 
 if(OQS_BUILD_FUZZ_TESTS AND '${CMAKE_C_COMPILER_ID}' STREQUAL 'Clang')
-    add_executable(fuzz_test_dilithium2 fuzz_test_dilithium2.c)
-    target_link_libraries(fuzz_test_dilithium2 PRIVATE ${TEST_DEPS})
-    set_target_properties(fuzz_test_dilithium2 PROPERTIES
+    add_executable(fuzz_test_sig fuzz_test_sig.c)
+    target_link_libraries(fuzz_test_sig PRIVATE ${TEST_DEPS})
+    set_target_properties(fuzz_test_sig PROPERTIES
         COMPILE_FLAGS "${FUZZING_COMPILE_FLAGS}"
         LINK_FLAGS "${FUZZING_LINK_FLAGS}"
     )


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

Adapts existing fuzz-harness to support more algorithms.

This is a continuation of the effort described in #1215 

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

