### PR TITLE
Avoid OpenSSL functions are unconditionally called at OQS_destroy

### DIFF
--- a/src/common/ossl_helpers.c
+++ b/src/common/ossl_helpers.c
@@ -45,31 +45,41 @@ static void fetch_ossl_objects(void) {
 	}
 }
 
+static inline void cleanup_evp_md(EVP_MD **mdp) {
+	/* Always check argument is non-NULL before calling EVP_MD_free
+	 * to avoid OpenSSL functions being used when they are
+	 * overridden with OQS_*_set_callbacks.
+	 */
+	if (*mdp) {
+		OSSL_FUNC(EVP_MD_free)(*mdp);
+		*mdp = NULL;
+	}
+}
+
+static inline void cleanup_evp_cipher(EVP_CIPHER **cipherp) {
+	/* Always check argument is non-NULL before calling EVP_CIPHER_free
+	 * to avoid OpenSSL functions being used when they are
+	 * overridden with OQS_*_set_callbacks.
+	 */
+	if (*cipherp) {
+		OSSL_FUNC(EVP_CIPHER_free)(*cipherp);
+		*cipherp = NULL;
+	}
+}
+
 static void free_ossl_objects(void) {
-	OSSL_FUNC(EVP_MD_free)(sha256_ptr);
-	sha256_ptr = NULL;
-	OSSL_FUNC(EVP_MD_free)(sha384_ptr);
-	sha384_ptr = NULL;
-	OSSL_FUNC(EVP_MD_free)(sha512_ptr);
-	sha512_ptr = NULL;
-	OSSL_FUNC(EVP_MD_free)(sha3_256_ptr);
-	sha3_256_ptr = NULL;
-	OSSL_FUNC(EVP_MD_free)(sha3_384_ptr);
-	sha3_384_ptr = NULL;
-	OSSL_FUNC(EVP_MD_free)(sha3_512_ptr);
-	sha3_512_ptr = NULL;
-	OSSL_FUNC(EVP_MD_free)(shake128_ptr);
-	shake128_ptr = NULL;
-	OSSL_FUNC(EVP_MD_free)(shake256_ptr);
-	shake256_ptr = NULL;
-	OSSL_FUNC(EVP_CIPHER_free)(aes128_ecb_ptr);
-	aes128_ecb_ptr = NULL;
-	OSSL_FUNC(EVP_CIPHER_free)(aes128_ctr_ptr);
-	aes128_ctr_ptr = NULL;
-	OSSL_FUNC(EVP_CIPHER_free)(aes256_ecb_ptr);
-	aes256_ecb_ptr = NULL;
-	OSSL_FUNC(EVP_CIPHER_free)(aes256_ctr_ptr);
-	aes256_ctr_ptr = NULL;
+	cleanup_evp_md(&sha256_ptr);
+	cleanup_evp_md(&sha384_ptr);
+	cleanup_evp_md(&sha512_ptr);
+	cleanup_evp_md(&sha3_256_ptr);
+	cleanup_evp_md(&sha3_384_ptr);
+	cleanup_evp_md(&sha3_512_ptr);
+	cleanup_evp_md(&shake128_ptr);
+	cleanup_evp_md(&shake256_ptr);
+	cleanup_evp_cipher(&aes128_ecb_ptr);
+	cleanup_evp_cipher(&aes128_ctr_ptr);
+	cleanup_evp_cipher(&aes256_ecb_ptr);
+	cleanup_evp_cipher(&aes256_ctr_ptr);
 }
 #endif // OPENSSL_VERSION_NUMBER >= 0x30000000L
 


### PR DESCRIPTION
When OQS_DLOPEN_OPENSSL is designated and low-level primitives are overridden with OQS_*_set_callbacks, OQS_destroy still indirectly calls EVP_*_free from OpenSSL. This adds a extra NULL check to avoid that.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

