### PR TITLE
Use seed as private key format for ML-KEM

### DIFF
--- a/src/kem/ml_kem/kem_ml_kem.h
+++ b/src/kem/ml_kem/kem_ml_kem.h
@@ -7,7 +7,7 @@
 
 #if defined(OQS_ENABLE_KEM_ml_kem_512)
 #define OQS_KEM_ml_kem_512_length_public_key 800
-#define OQS_KEM_ml_kem_512_length_secret_key 1632
+#define OQS_KEM_ml_kem_512_length_secret_key 64
 #define OQS_KEM_ml_kem_512_length_ciphertext 768
 #define OQS_KEM_ml_kem_512_length_shared_secret 32
 OQS_KEM *OQS_KEM_ml_kem_512_new(void);
@@ -18,7 +18,7 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_512_decaps(uint8_t *shared_secret, const uint8
 
 #if defined(OQS_ENABLE_KEM_ml_kem_768)
 #define OQS_KEM_ml_kem_768_length_public_key 1184
-#define OQS_KEM_ml_kem_768_length_secret_key 2400
+#define OQS_KEM_ml_kem_768_length_secret_key 64
 #define OQS_KEM_ml_kem_768_length_ciphertext 1088
 #define OQS_KEM_ml_kem_768_length_shared_secret 32
 OQS_KEM *OQS_KEM_ml_kem_768_new(void);
@@ -29,7 +29,7 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_768_decaps(uint8_t *shared_secret, const uint8
 
 #if defined(OQS_ENABLE_KEM_ml_kem_1024)
 #define OQS_KEM_ml_kem_1024_length_public_key 1568
-#define OQS_KEM_ml_kem_1024_length_secret_key 3168
+#define OQS_KEM_ml_kem_1024_length_secret_key 64
 #define OQS_KEM_ml_kem_1024_length_ciphertext 1568
 #define OQS_KEM_ml_kem_1024_length_shared_secret 32
 OQS_KEM *OQS_KEM_ml_kem_1024_new(void);

--- a/src/kem/ml_kem/kem_ml_kem_512.c
+++ b/src/kem/ml_kem/kem_ml_kem_512.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 
 #include <oqs/kem_ml_kem.h>
+#include <randombytes.h>
 
 #if defined(OQS_ENABLE_KEM_ml_kem_512)
 
@@ -30,29 +31,36 @@ OQS_KEM *OQS_KEM_ml_kem_512_new(void) {
 	return kem;
 }
 
-extern int pqcrystals_ml_kem_512_ref_keypair(uint8_t *pk, uint8_t *sk);
+#define KYBER512_KEYPAIRCOINBYTES 64
+#define KYBER512_SECRETKEYBYTES 1632
+#define KYBER512_PUBLICKEYBYTES 800
+
+extern int pqcrystals_ml_kem_512_ref_keypair_derand(uint8_t *pk, uint8_t *sk, const uint8_t* coins);
 extern int pqcrystals_ml_kem_512_ref_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
 extern int pqcrystals_ml_kem_512_ref_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
 
 #if defined(OQS_ENABLE_KEM_ml_kem_512_avx2)
-extern int pqcrystals_ml_kem_512_avx2_keypair(uint8_t *pk, uint8_t *sk);
+extern int pqcrystals_ml_kem_512_avx2_keypair_derand(uint8_t *pk, uint8_t *sk, const uint8_t* coins);
 extern int pqcrystals_ml_kem_512_avx2_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
 extern int pqcrystals_ml_kem_512_avx2_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
 #endif
 
 OQS_API OQS_STATUS OQS_KEM_ml_kem_512_keypair(uint8_t *public_key, uint8_t *secret_key) {
+  uint8_t expanded_secret_key[KYBER512_SECRETKEYBYTES];
+  randombytes(secret_key, KYBER512_KEYPAIRCOINBYTES);
+
 #if defined(OQS_ENABLE_KEM_ml_kem_512_avx2)
 #if defined(OQS_DIST_BUILD)
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_BMI2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
 #endif /* OQS_DIST_BUILD */
-		return (OQS_STATUS) pqcrystals_ml_kem_512_avx2_keypair(public_key, secret_key);
+		return (OQS_STATUS) pqcrystals_ml_kem_512_avx2_keypair_derand(public_key, expanded_secret_key, secret_key);
 #if defined(OQS_DIST_BUILD)
 	} else {
-		return (OQS_STATUS) pqcrystals_ml_kem_512_ref_keypair(public_key, secret_key);
+		return (OQS_STATUS) pqcrystals_ml_kem_512_ref_keypair_derand(public_key, expanded_secret_key, secret_key);
 	}
 #endif /* OQS_DIST_BUILD */
 #else
-	return (OQS_STATUS) pqcrystals_ml_kem_512_ref_keypair(public_key, secret_key);
+	return (OQS_STATUS) pqcrystals_ml_kem_512_ref_keypair_derand(public_key, expanded_secret_key, secret_key);
 #endif
 }
 
@@ -73,17 +81,42 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_512_encaps(uint8_t *ciphertext, uint8_t *share
 }
 
 OQS_API OQS_STATUS OQS_KEM_ml_kem_512_decaps(uint8_t *shared_secret, const uint8_t *ciphertext, const uint8_t *secret_key) {
+  uint8_t public_key[KYBER512_PUBLICKEYBYTES];
+  uint8_t expanded_secret_key[KYBER512_SECRETKEYBYTES];
+  OQS_STATUS status;
+
 #if defined(OQS_ENABLE_KEM_ml_kem_512_avx2)
 #if defined(OQS_DIST_BUILD)
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_BMI2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
 #endif /* OQS_DIST_BUILD */
-		return (OQS_STATUS) pqcrystals_ml_kem_512_avx2_dec(shared_secret, ciphertext, secret_key);
+		status = (OQS_STATUS) pqcrystals_ml_kem_512_avx2_keypair_derand(public_key, expanded_secret_key, secret_key);
+    if (status != OQS_SUCCESS) {
+      OQS_MEM_cleanse(public_key, KYBER512_PUBLICKEYBYTES);
+      OQS_MEM_cleanse(expanded_secret_key, KYBER512_SECRETKEYBYTES);
+      return status;
+    }
+
+		return (OQS_STATUS) pqcrystals_ml_kem_512_avx2_dec(shared_secret, ciphertext, expanded_secret_key);
 #if defined(OQS_DIST_BUILD)
 	} else {
+		status = (OQS_STATUS) pqcrystals_ml_kem_512_ref_keypair_derand(public_key, expanded_secret_key, secret_key);
+    if (status != OQS_SUCCESS) {
+      OQS_MEM_cleanse(public_key, KYBER512_PUBLICKEYBYTES);
+      OQS_MEM_cleanse(expanded_secret_key, KYBER512_SECRETKEYBYTES);
+      return status;
+    }
+
 		return (OQS_STATUS) pqcrystals_ml_kem_512_ref_dec(shared_secret, ciphertext, secret_key);
 	}
 #endif /* OQS_DIST_BUILD */
 #else
+	status = (OQS_STATUS) pqcrystals_ml_kem_512_ref_keypair_derand(public_key, expanded_secret_key, secret_key);
+  if (status != OQS_SUCCESS) {
+    OQS_MEM_cleanse(public_key, KYBER512_PUBLICKEYBYTES);
+    OQS_MEM_cleanse(expanded_secret_key, KYBER512_SECRETKEYBYTES);
+    return status;
+  }
+
 	return (OQS_STATUS) pqcrystals_ml_kem_512_ref_dec(shared_secret, ciphertext, secret_key);
 #endif
 }


### PR DESCRIPTION
This PR is a WIP demonstrating an approach to storing ML-KEM decapsulation keys in the form of a 64-byte seed, as opposed to the expanded form currently.  Currently, the proposed scheme is implemented (a) for ML-KEM-512 only, and (b) in-place, as opposed to defining a new scheme.  I am posting it in this state to get feedback on whether the structure of the change looks good, because the remainder of the PR will basically just be copy/pasting to cover the other parameter sets and maybe make a new KEM scheme.

If maintainers could answer the following questions, I can implement the rest of the PR:

* Does the approach shown here look correct from an OQS structure / coding standards point of view?
* Should this be implemented in the current ML-KEM provider, or as a new provider?
    * If the latter, it would be nice to key them both off of the same compile-time switches
    * For example, this could avoid having to build two copies of the PQCrystals library, which could cause symbol conflicts
    * ... since you could have one provider own the back-end library, and the other just link against it.

Fixes #1985 

Tests are currently failing because they are providing / looking for the expanded private key.  The ACVP test vectors do provide the seed values (`d` and `z`), so it should be possible to fix the tests simply by using those values instead of the expanded values (`dk`).

* [X] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
    * This PR changes the format of the decapsulation keys  used with ML-KEM
    * If this is undesirable, we could add a parallel KEM implementation, as discussed in #1985
* [X] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)
    * Not currently, since the changes are made in-place.
    * If we go with the backward-compatible approach, it will define a new algorithm.

