### PR TITLE
Minor changes to ML_DSA ACVP tests

### DIFF
--- a/tests/test_sig.c
+++ b/tests/test_sig.c
@@ -153,7 +153,7 @@ static OQS_STATUS sig_test_correctness(const char *method_name) {
 		rc = OQS_SIG_sign_with_ctx_str(sig, signature, &signature_len, message, message_len, ctx, 257, secret_key);
 		OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
 		if (rc != OQS_ERROR) {
-			fprintf(stderr, "ERROR: OQS_SIG_sign_with_ctx_str should only support up to 256 byte contexts\n");
+			fprintf(stderr, "ERROR: OQS_SIG_sign_with_ctx_str should only support up to 255 byte contexts\n");
 			goto err;
 		}
 	} else {

--- a/tests/test_sig.c
+++ b/tests/test_sig.c
@@ -150,7 +150,7 @@ static OQS_STATUS sig_test_correctness(const char *method_name) {
 			}
 		}
 
-		rc = OQS_SIG_sign_with_ctx_str(sig, signature, &signature_len, message, message_len, ctx, 257, secret_key);
+		rc = OQS_SIG_sign_with_ctx_str(sig, signature, &signature_len, message, message_len, ctx, 256, secret_key);
 		OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
 		if (rc != OQS_ERROR) {
 			fprintf(stderr, "ERROR: OQS_SIG_sign_with_ctx_str should only support up to 255 byte contexts\n");

--- a/tests/vectors_sig.c
+++ b/tests/vectors_sig.c
@@ -208,7 +208,7 @@ algo_not_enabled:
 	ret = OQS_SUCCESS;
 
 cleanup:
-	if (secret_key != NULL) {
+	if (sig != NULL) {
 		OQS_MEM_secure_free(secret_key, sig->length_secret_key);
 	}
 	if (randombytes_free != NULL) {


### PR DESCRIPTION
This PR does the following:

1. add checks for malloc() failures
2. harden checks for random number length
3. add log messages in case of failure

Also, tried enabling ML-DSA ACVP tests on Windows but run into "character too long" on DSA-87