### PR TITLE
Remove hardcoded build paths & modify basic workflow to build in random path

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -67,25 +67,27 @@ jobs:
       KEM_NAME: ml_kem_768
       SIG_NAME: ml_dsa_65
     steps:
+      - name: Create random build folder
+        run: tmp_build=$(mktemp -d) && echo "RANDOM_BUILD_DIR=$tmp_build" >> $GITHUB_ENV
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
       - name: Configure
         run: |
-          mkdir build && \
-          cd build && \
-          cmake -GNinja -DOQS_STRICT_WARNINGS=ON \
+          cmake \
+            -B ${{ env.RANDOM_BUILD_DIR }} \
             -GNinja \
+            -DOQS_STRICT_WARNINGS=ON \
             -DOQS_MINIMAL_BUILD="KEM_$KEM_NAME;SIG_$SIG_NAME" \
-            --warn-uninitialized .. > config.log 2>&1 && \
+            --warn-uninitialized . > config.log 2>&1 && \
           cat config.log && \
-          cmake -LA -N .. && \
+          cmake -LA -N . && \
           ! (grep -i "uninitialized variable" config.log)
       - name: Build code
         run: ninja
-        working-directory: build
+        working-directory: ${{ env.RANDOM_BUILD_DIR }}
       - name: Build documentation
         run: ninja gen_docs
-        working-directory: build
+        working-directory: ${{ env.RANDOM_BUILD_DIR }}
 
   cppcheck:
     name: Check C++ linking with example program
@@ -94,28 +96,30 @@ jobs:
     env:
       SIG_NAME: dilithium_2
     steps:
+      - name: Create random build folder
+        run: tmp_build=$(mktemp -d) && echo "RANDOM_BUILD_DIR=$tmp_build" >> $GITHUB_ENV
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
       - name: Configure
         run: |
-          mkdir build && \
-          cd build && \
-          cmake -GNinja -DOQS_STRICT_WARNINGS=ON \
+          cmake \
+            -B ${{ env.RANDOM_BUILD_DIR }} \
             -GNinja \
+            -DOQS_STRICT_WARNINGS=ON \
             -DOQS_MINIMAL_BUILD="SIG_$SIG_NAME" \
-            --warn-uninitialized .. > config.log 2>&1 && \
+            --warn-uninitialized . > config.log 2>&1 && \
           cat config.log && \
-          cmake -LA -N .. && \
+          cmake -LA -N . && \
           ! (grep -i "uninitialized variable" config.log)
       - name: Build liboqs
         run: ninja
-        working-directory: build
+        working-directory: ${{ env.RANDOM_BUILD_DIR }}
       - name: Link with C++ program
         run: |
-          g++ ../cpp/sig_linking_test.cpp -g \
+          g++ "$GITHUB_WORKSPACE"/cpp/sig_linking_test.cpp -g \
           -I./include -L./lib -loqs -lcrypto -std=c++11 -o example_sig && \
           ./example_sig
-        working-directory: build
+        working-directory: ${{ env.RANDOM_BUILD_DIR }}
 
   fuzzbuildcheck:
     name: Check that code passes a basic fuzzing build
@@ -129,23 +133,26 @@ jobs:
       CFLAGS: -fsanitize=fuzzer-no-link,address
       LDFLAGS: -fsanitize=address
     steps:
+      - name: Create random build folder
+        run: tmp_build=$(mktemp -d) && echo "RANDOM_BUILD_DIR=$tmp_build" >> $GITHUB_ENV
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
       - name: Configure
         run: |
-          mkdir build && \
-          cd build && \
-          cmake -GNinja -DOQS_STRICT_WARNINGS=ON \
+          cmake \
+            -B ${{ env.RANDOM_BUILD_DIR }} \
+            -GNinja \
+            -DOQS_STRICT_WARNINGS=ON \
             -DOQS_BUILD_FUZZ_TESTS=ON \
             -DOQS_MINIMAL_BUILD="SIG_$SIG_NAME" \
-            --warn-uninitialized .. > config.log 2>&1 && \
+            --warn-uninitialized . > config.log 2>&1 && \
           cat config.log && \
-          cmake -LA -N .. && \
+          cmake -LA -N . && \
           ! (grep -i "uninitialized variable" config.log)
       - name: Build code
         run: ninja fuzz_test_sig
-        working-directory: build
+        working-directory: ${{ env.RANDOM_BUILD_DIR }}
 
       - name: Short fuzz check (30s)
         run: ./tests/fuzz_test_sig -max_total_time=30
-        working-directory: build
+        working-directory: ${{ env.RANDOM_BUILD_DIR }}

--- a/tests/test_acvp_vectors.py
+++ b/tests/test_acvp_vectors.py
@@ -120,9 +120,10 @@ def test_acvp_vec_sig_keygen(sig_name):
                     seed = testCase["seed"]
                     pk = testCase["pk"]
                     sk = testCase["sk"]
-                    
+
+                    build_dir = helpers.get_current_build_dir_name()
                     helpers.run_subprocess(
-                        ['build/tests/vectors_sig', sig_name, "keyGen", seed, pk, sk]
+                        [f'{build_dir}/tests/vectors_sig', sig_name, "keyGen", seed, pk, sk]
                     )
 
         assert(variantFound == True)
@@ -146,8 +147,10 @@ def test_acvp_vec_sig_gen_deterministic(sig_name):
                     sk = testCase["sk"]
                     message = testCase["message"]
                     signature = testCase["signature"]
+
+                    build_dir = helpers.get_current_build_dir_name()
                     helpers.run_subprocess(
-                        ['build/tests/vectors_sig', sig_name, "sigGen_det", sk, message, signature]
+                        [f'{build_dir}/tests/vectors_sig', sig_name, "sigGen_det", sk, message, signature]
                     )
 
         assert(variantFound == True)
@@ -173,8 +176,9 @@ def test_acvp_vec_sig_gen_randomized(sig_name):
                     signature = testCase["signature"]
                     rnd = testCase["rnd"]
                     
+                    build_dir = helpers.get_current_build_dir_name()
                     helpers.run_subprocess(
-                        ['build/tests/vectors_sig', sig_name, "sigGen_rnd", sk, message, signature, rnd]
+                        [f'{build_dir}/tests/vectors_sig', sig_name, "sigGen_rnd", sk, message, signature, rnd]
                     )
 
         assert(variantFound == True)
@@ -200,8 +204,9 @@ def test_acvp_vec_sig_ver(sig_name):
                     signature = testCase["signature"]
                     testPassed = "1" if testCase["testPassed"] else "0"
                     
+                    build_dir = helpers.get_current_build_dir_name()
                     helpers.run_subprocess(
-                        ['build/tests/vectors_sig', sig_name, "sigVer", pk, message, signature, testPassed]
+                        [f'{build_dir}/tests/vectors_sig', sig_name, "sigVer", pk, message, signature, testPassed]
                     )
 
         assert(variantFound == True)


### PR DESCRIPTION
This fixes #2018 using `helpers.get_current_build_dir_name()`

In addition, [the basic workflow](https://github.com/open-quantum-safe/liboqs/blob/main/.github/workflows/basic.yml) is modified to use a random build path. Hopefully, this small change will catch future changes that introduce hardcoded paths.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

