### PR TITLE
Trigger liboqs-java and liboqs-rust downstream CI

### DIFF
--- a/.github/workflows/downstream-basic.yml
+++ b/.github/workflows/downstream-basic.yml
@@ -93,3 +93,15 @@ jobs:
                --data '{"event_type":"liboqs-upstream-trigger"}' \
                https://api.github.com/repos/open-quantum-safe/liboqs-java/dispatches | tee curl_out \
           && grep -q "204" curl_out
+      - name: Trigger liboqs-rust CI
+        if: ${{ !cancelled() }} # run all steps independent of failures
+        run: |
+          curl --silent \
+               --write-out "\n%{response_code}\n" \
+               --request POST \
+               --header "Accept: application/vnd.github+json" \
+               --header "Authorization: Bearer ${{ secrets.OQSBOT_GITHUB_ACTIONS }}" \
+               --header "X-GitHub-Api-Version: 2022-11-28" \
+               --data '{"event_type":"liboqs-upstream-trigger"}' \
+               https://api.github.com/repos/open-quantum-safe/liboqs-rust/dispatches | tee curl_out \
+          && grep -q "204" curl_out

--- a/.github/workflows/downstream-basic.yml
+++ b/.github/workflows/downstream-basic.yml
@@ -81,3 +81,15 @@ jobs:
                --data '{"event_type":"liboqs-upstream-trigger"}' \
                https://api.github.com/repos/open-quantum-safe/liboqs-python/dispatches | tee curl_out \
           && grep -q "204" curl_out
+      - name: Trigger liboqs-java CI
+        if: ${{ !cancelled() }} # run all steps independent of failures
+        run: |
+          curl --silent \
+               --write-out "\n%{response_code}\n" \
+               --request POST \
+               --header "Accept: application/vnd.github+json" \
+               --header "Authorization: Bearer ${{ secrets.OQSBOT_GITHUB_ACTIONS }}" \
+               --header "X-GitHub-Api-Version: 2022-11-28" \
+               --data '{"event_type":"liboqs-upstream-trigger"}' \
+               https://api.github.com/repos/open-quantum-safe/liboqs-java/dispatches | tee curl_out \
+          && grep -q "204" curl_out


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
This PR adds triggers for liboqs-java and liboqs-rust to the `trigger-downstream-basic` workflow.

Marked as draft pending merge of downstream PRs https://github.com/open-quantum-safe/liboqs-rust/pull/271 and https://github.com/open-quantum-safe/liboqs-java/pull/30.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

