### PR TITLE
Exendend api and modification for allow generate keypair from fixed seed for some sig algos.

### DIFF
--- a/src/sig/dilithium/oldpqclean_dilithium2_aarch64/api.h
+++ b/src/sig/dilithium/oldpqclean_dilithium2_aarch64/api.h
@@ -21,6 +21,8 @@ int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_signature(
     uint8_t *sig, size_t *siglen,
     const uint8_t *m, size_t mlen, const uint8_t *sk);

--- a/src/sig/dilithium/oldpqclean_dilithium2_aarch64/api.h
+++ b/src/sig/dilithium/oldpqclean_dilithium2_aarch64/api.h
@@ -19,6 +19,8 @@
 
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_signature(
     uint8_t *sig, size_t *siglen,
     const uint8_t *m, size_t mlen, const uint8_t *sk);

--- a/src/sig/dilithium/oldpqclean_dilithium2_aarch64/sign.c
+++ b/src/sig/dilithium/oldpqclean_dilithium2_aarch64/sign.c
@@ -97,6 +97,62 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair from fixed seed.
+*
+* Description: Generates public and private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    uint8_t seedbuf[2 * SEEDBYTES + CRHBYTES];
+    uint8_t tr[SEEDBYTES];
+    const uint8_t *rho, *rhoprime, *key;
+    polyvecl mat[K];
+    polyvecl s1, s1hat;
+    polyveck s2, t1, t0;
+
+    /* Use fixed seed for randomness for rho, rhoprime and key */
+    shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+    rho = seedbuf;
+    rhoprime = rho + SEEDBYTES;
+    key = rhoprime + CRHBYTES;
+
+    /* Expand matrix */
+    polyvec_matrix_expand(mat, rho);
+
+    /* Sample short vectors s1 and s2 */
+    polyvecl_uniform_eta(&s1, rhoprime, 0);
+    polyveck_uniform_eta(&s2, rhoprime, L);
+
+    /* Matrix-vector multiplication */
+    s1hat = s1;
+    polyvecl_ntt(&s1hat);
+    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+    polyveck_reduce(&t1);
+    polyveck_invntt_tomont(&t1);
+
+    /* Add error vector s2 */
+    polyveck_add(&t1, &t1, &s2);
+
+    /* Extract t1 and write public key */
+    polyveck_caddq(&t1);
+    polyveck_power2round(&t1, &t0, &t1);
+    pack_pk(pk, rho, &t1);
+
+    /* Compute H(rho, t1) and write secret key */
+    shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+    pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
+
+    return 0;
+}
+
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/oldpqclean_dilithium2_aarch64/sign.c
+++ b/src/sig/dilithium/oldpqclean_dilithium2_aarch64/sign.c
@@ -97,14 +97,20 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
-* Name:        crypto_sign_keypair from fixed seed.
+* Name:        crypto_sign_keypair_from_fseed
 *
-* Description: Generates public and private key.
+* Description: Generates public and private key from fixed seed.
 *
 * Arguments:   - uint8_t *pk: pointer to output public key (allocated
 *                             array of CRYPTO_PUBLICKEYBYTES bytes)
 *              - uint8_t *sk: pointer to output private key (allocated
 *                             array of CRYPTO_SECRETKEYBYTES bytes)
+*              - const uint8_t *seed: Pointer to the input fixed seed. 
+*                                     Must point to an array of SEEDBYTES bytes.
+*                                     The seed provides deterministic randomness 
+*                                     for key generation and must be unique and 
+*                                     securely generated for each keypair to 
+*                                     ensure security.
 *
 * Returns 0 (success)
 **************************************************/
@@ -151,6 +157,51 @@ int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed
     return 0;
 }
 
+/*************************************************
+* Name:        crypto_sign_pubkey_from_privkey
+*
+* Description: Generates public key from exist private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - const uint8_t *sk: pointer to the input private key (points
+*                                   to a read-only array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
+    uint8_t rho[SEEDBYTES];
+    uint8_t tr[SEEDBYTES];
+    uint8_t key[SEEDBYTES];
+    polyvecl s1, s1hat;
+    polyveck s2, t0, t1;
+    polyvecl mat[K];
+    
+    /* unpack privat key */
+    unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
+    
+    /* Expand matrix */
+    polyvec_matrix_expand(mat, rho);
+    
+    /* Matrix-vector multiplication */
+    s1hat = s1;
+    polyvecl_ntt(&s1hat);
+    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+    polyveck_reduce(&t1);
+    polyveck_invntt_tomont(&t1);
+    
+    /* Add error vector s2 */
+    polyveck_add(&t1, &t1, &s2);
+    
+    /* Extract t1 */
+    polyveck_caddq(&t1);
+    polyveck_power2round(&t1, &t0, &t1);
+    
+    /* Pack public key */
+    pack_pk(pk, rho, &t1);
+    
+    return 0;
+}
 
 /*************************************************
 * Name:        crypto_sign_signature

--- a/src/sig/dilithium/oldpqclean_dilithium2_aarch64/sign.h
+++ b/src/sig/dilithium/oldpqclean_dilithium2_aarch64/sign.h
@@ -24,6 +24,9 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 #define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
 int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(crypto_sign_signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/oldpqclean_dilithium2_aarch64/sign.h
+++ b/src/sig/dilithium/oldpqclean_dilithium2_aarch64/sign.h
@@ -21,6 +21,9 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(crypto_sign_keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(crypto_sign_signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/oldpqclean_dilithium3_aarch64/api.h
+++ b/src/sig/dilithium/oldpqclean_dilithium3_aarch64/api.h
@@ -21,6 +21,8 @@ int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_signature(
     uint8_t *sig, size_t *siglen,
     const uint8_t *m, size_t mlen, const uint8_t *sk);

--- a/src/sig/dilithium/oldpqclean_dilithium3_aarch64/api.h
+++ b/src/sig/dilithium/oldpqclean_dilithium3_aarch64/api.h
@@ -19,6 +19,8 @@
 
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_signature(
     uint8_t *sig, size_t *siglen,
     const uint8_t *m, size_t mlen, const uint8_t *sk);

--- a/src/sig/dilithium/oldpqclean_dilithium3_aarch64/sign.c
+++ b/src/sig/dilithium/oldpqclean_dilithium3_aarch64/sign.c
@@ -97,6 +97,62 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair from fixed seed.
+*
+* Description: Generates public and private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    uint8_t seedbuf[2 * SEEDBYTES + CRHBYTES];
+    uint8_t tr[SEEDBYTES];
+    const uint8_t *rho, *rhoprime, *key;
+    polyvecl mat[K];
+    polyvecl s1, s1hat;
+    polyveck s2, t1, t0;
+
+    /* Use fixed seed for randomness for rho, rhoprime and key */
+    shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+    rho = seedbuf;
+    rhoprime = rho + SEEDBYTES;
+    key = rhoprime + CRHBYTES;
+
+    /* Expand matrix */
+    polyvec_matrix_expand(mat, rho);
+
+    /* Sample short vectors s1 and s2 */
+    polyvecl_uniform_eta(&s1, rhoprime, 0);
+    polyveck_uniform_eta(&s2, rhoprime, L);
+
+    /* Matrix-vector multiplication */
+    s1hat = s1;
+    polyvecl_ntt(&s1hat);
+    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+    polyveck_reduce(&t1);
+    polyveck_invntt_tomont(&t1);
+
+    /* Add error vector s2 */
+    polyveck_add(&t1, &t1, &s2);
+
+    /* Extract t1 and write public key */
+    polyveck_caddq(&t1);
+    polyveck_power2round(&t1, &t0, &t1);
+    pack_pk(pk, rho, &t1);
+
+    /* Compute H(rho, t1) and write secret key */
+    shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+    pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
+
+    return 0;
+}
+
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/oldpqclean_dilithium3_aarch64/sign.c
+++ b/src/sig/dilithium/oldpqclean_dilithium3_aarch64/sign.c
@@ -97,14 +97,20 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
-* Name:        crypto_sign_keypair from fixed seed.
+* Name:        crypto_sign_keypair_from_fseed
 *
-* Description: Generates public and private key.
+* Description: Generates public and private key from fixed seed.
 *
 * Arguments:   - uint8_t *pk: pointer to output public key (allocated
 *                             array of CRYPTO_PUBLICKEYBYTES bytes)
 *              - uint8_t *sk: pointer to output private key (allocated
 *                             array of CRYPTO_SECRETKEYBYTES bytes)
+*              - const uint8_t *seed: Pointer to the input fixed seed. 
+*                                     Must point to an array of SEEDBYTES bytes.
+*                                     The seed provides deterministic randomness 
+*                                     for key generation and must be unique and 
+*                                     securely generated for each keypair to 
+*                                     ensure security.
 *
 * Returns 0 (success)
 **************************************************/
@@ -151,6 +157,51 @@ int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed
     return 0;
 }
 
+/*************************************************
+* Name:        crypto_sign_pubkey_from_privkey
+*
+* Description: Generates public key from exist private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - const uint8_t *sk: pointer to the input private key (points
+*                                   to a read-only array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
+    uint8_t rho[SEEDBYTES];
+    uint8_t tr[SEEDBYTES];
+    uint8_t key[SEEDBYTES];
+    polyvecl s1, s1hat;
+    polyveck s2, t0, t1;
+    polyvecl mat[K];
+    
+    /* unpack privat key */
+    unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
+    
+    /* Expand matrix */
+    polyvec_matrix_expand(mat, rho);
+    
+    /* Matrix-vector multiplication */
+    s1hat = s1;
+    polyvecl_ntt(&s1hat);
+    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+    polyveck_reduce(&t1);
+    polyveck_invntt_tomont(&t1);
+    
+    /* Add error vector s2 */
+    polyveck_add(&t1, &t1, &s2);
+    
+    /* Extract t1 */
+    polyveck_caddq(&t1);
+    polyveck_power2round(&t1, &t0, &t1);
+    
+    /* Pack public key */
+    pack_pk(pk, rho, &t1);
+    
+    return 0;
+}
 
 /*************************************************
 * Name:        crypto_sign_signature

--- a/src/sig/dilithium/oldpqclean_dilithium3_aarch64/sign.h
+++ b/src/sig/dilithium/oldpqclean_dilithium3_aarch64/sign.h
@@ -24,6 +24,9 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 #define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
 int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(crypto_sign_signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/oldpqclean_dilithium3_aarch64/sign.h
+++ b/src/sig/dilithium/oldpqclean_dilithium3_aarch64/sign.h
@@ -21,6 +21,9 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(crypto_sign_keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(crypto_sign_signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/oldpqclean_dilithium5_aarch64/api.h
+++ b/src/sig/dilithium/oldpqclean_dilithium5_aarch64/api.h
@@ -22,6 +22,8 @@ int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
 int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_signature(
     uint8_t *sig, size_t *siglen,
     const uint8_t *m, size_t mlen, const uint8_t *sk);

--- a/src/sig/dilithium/oldpqclean_dilithium5_aarch64/api.h
+++ b/src/sig/dilithium/oldpqclean_dilithium5_aarch64/api.h
@@ -20,6 +20,8 @@
 
 int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_signature(
     uint8_t *sig, size_t *siglen,
     const uint8_t *m, size_t mlen, const uint8_t *sk);

--- a/src/sig/dilithium/oldpqclean_dilithium5_aarch64/sign.c
+++ b/src/sig/dilithium/oldpqclean_dilithium5_aarch64/sign.c
@@ -97,14 +97,20 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
-* Name:        crypto_sign_keypair from fixed seed.
+* Name:        crypto_sign_keypair_from_fseed
 *
-* Description: Generates public and private key.
+* Description: Generates public and private key from fixed seed.
 *
 * Arguments:   - uint8_t *pk: pointer to output public key (allocated
 *                             array of CRYPTO_PUBLICKEYBYTES bytes)
 *              - uint8_t *sk: pointer to output private key (allocated
 *                             array of CRYPTO_SECRETKEYBYTES bytes)
+*              - const uint8_t *seed: Pointer to the input fixed seed. 
+*                                     Must point to an array of SEEDBYTES bytes.
+*                                     The seed provides deterministic randomness 
+*                                     for key generation and must be unique and 
+*                                     securely generated for each keypair to 
+*                                     ensure security.
 *
 * Returns 0 (success)
 **************************************************/
@@ -148,6 +154,52 @@ int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed
     shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
     pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
 
+    return 0;
+}
+
+/*************************************************
+* Name:        crypto_sign_pubkey_from_privkey
+*
+* Description: Generates public key from exist private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - const uint8_t *sk: pointer to the input private key (points
+*                                   to a read-only array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
+    uint8_t rho[SEEDBYTES];
+    uint8_t tr[SEEDBYTES];
+    uint8_t key[SEEDBYTES];
+    polyvecl s1, s1hat;
+    polyveck s2, t0, t1;
+    polyvecl mat[K];
+    
+    /* unpack privat key */
+    unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
+    
+    /* Expand matrix */
+    polyvec_matrix_expand(mat, rho);
+    
+    /* Matrix-vector multiplication */
+    s1hat = s1;
+    polyvecl_ntt(&s1hat);
+    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+    polyveck_reduce(&t1);
+    polyveck_invntt_tomont(&t1);
+    
+    /* Add error vector s2 */
+    polyveck_add(&t1, &t1, &s2);
+    
+    /* Extract t1 */
+    polyveck_caddq(&t1);
+    polyveck_power2round(&t1, &t0, &t1);
+    
+    /* Pack public key */
+    pack_pk(pk, rho, &t1);
+    
     return 0;
 }
 

--- a/src/sig/dilithium/oldpqclean_dilithium5_aarch64/sign.h
+++ b/src/sig/dilithium/oldpqclean_dilithium5_aarch64/sign.h
@@ -24,6 +24,9 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 #define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
 int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(crypto_sign_signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/oldpqclean_dilithium5_aarch64/sign.h
+++ b/src/sig/dilithium/oldpqclean_dilithium5_aarch64/sign.h
@@ -21,6 +21,9 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(crypto_sign_keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(crypto_sign_signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/api.h
@@ -16,6 +16,8 @@ int pqcrystals_dilithium2_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium2_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium2_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium2_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -39,6 +41,8 @@ int pqcrystals_dilithium2_avx2_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium2aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium2aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium2aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium2aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -68,6 +72,8 @@ int pqcrystals_dilithium3_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium3_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium3_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium3_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -91,6 +97,8 @@ int pqcrystals_dilithium3_avx2_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium3aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium3aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium3aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium3aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -120,6 +128,8 @@ int pqcrystals_dilithium5_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium5_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium5_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium5_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -143,6 +153,8 @@ int pqcrystals_dilithium5_avx2_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium5aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium5aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium5aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium5aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/api.h
@@ -14,6 +14,8 @@
 
 int pqcrystals_dilithium2_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium2_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium2_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -35,6 +37,8 @@ int pqcrystals_dilithium2_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium2aes_avx2_BYTES pqcrystals_dilithium2_avx2_BYTES
 
 int pqcrystals_dilithium2aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium2aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium2aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -62,6 +66,8 @@ int pqcrystals_dilithium2aes_avx2_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium3_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium3_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium3_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -83,6 +89,8 @@ int pqcrystals_dilithium3_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium3aes_avx2_BYTES pqcrystals_dilithium3_avx2_BYTES
 
 int pqcrystals_dilithium3aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium3aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium3aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -110,6 +118,8 @@ int pqcrystals_dilithium3aes_avx2_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium5_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium5_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium5_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -131,6 +141,8 @@ int pqcrystals_dilithium5_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium5aes_avx2_BYTES pqcrystals_dilithium5_avx2_BYTES
 
 int pqcrystals_dilithium5aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium5aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium5aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/sign.c
@@ -176,6 +176,124 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair from fixed seed.
+*
+* Description: Generates public and private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+  unsigned int i;
+  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
+  const uint8_t *rho, *rhoprime, *key;
+#ifdef DILITHIUM_USE_AES
+  uint64_t nonce;
+  aes256ctr_ctx aesctx;
+  polyvecl rowbuf[1];
+#else
+  polyvecl rowbuf[2];
+#endif
+  polyvecl s1, *row = rowbuf;
+  polyveck s2;
+  poly t1, t0;
+
+  /* Use fixed seed for randomness for rho, rhoprime and key */
+  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+  rho = seedbuf;
+  rhoprime = rho + SEEDBYTES;
+  key = rhoprime + CRHBYTES;
+
+  /* Store rho, key */
+  memcpy(pk, rho, SEEDBYTES);
+  memcpy(sk, rho, SEEDBYTES);
+  memcpy(sk + SEEDBYTES, key, SEEDBYTES);
+
+  /* Sample short vectors s1 and s2 */
+#ifdef DILITHIUM_USE_AES
+  aes256ctr_init_u64(&aesctx, rhoprime, 0);
+  for(i = 0; i < L; ++i) {
+    nonce = i;
+    aes256ctr_init_iv_u64(&aesctx, nonce);
+    poly_uniform_eta_preinit(&s1.vec[i], &aesctx);
+  }
+  for(i = 0; i < K; ++i) {
+    nonce = L + i;
+    aes256ctr_init_iv_u64(&aesctx, nonce);
+    poly_uniform_eta_preinit(&s2.vec[i], &aesctx);
+  }
+  aes256_ctx_release(&aesctx);
+#elif K == 4 && L == 4
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s2.vec[0], &s2.vec[1], &s2.vec[2], &s2.vec[3], rhoprime, 4, 5, 6, 7);
+#elif K == 6 && L == 5
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s1.vec[4], &s2.vec[0], &s2.vec[1], &s2.vec[2], rhoprime, 4, 5, 6, 7);
+  poly_uniform_eta_4x(&s2.vec[3], &s2.vec[4], &s2.vec[5], &t0, rhoprime, 8, 9, 10, 11);
+#elif K == 8 && L == 7
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s1.vec[4], &s1.vec[5], &s1.vec[6], &s2.vec[0], rhoprime, 4, 5, 6, 7);
+  poly_uniform_eta_4x(&s2.vec[1], &s2.vec[2], &s2.vec[3], &s2.vec[4], rhoprime, 8, 9, 10, 11);
+  poly_uniform_eta_4x(&s2.vec[5], &s2.vec[6], &s2.vec[7], &t0, rhoprime, 12, 13, 14, 15);
+#else
+#error
+#endif
+
+  /* Pack secret vectors */
+  for(i = 0; i < L; i++)
+    polyeta_pack(sk + 3*SEEDBYTES + i*POLYETA_PACKEDBYTES, &s1.vec[i]);
+  for(i = 0; i < K; i++)
+    polyeta_pack(sk + 3*SEEDBYTES + (L + i)*POLYETA_PACKEDBYTES, &s2.vec[i]);
+
+  /* Transform s1 */
+  polyvecl_ntt(&s1);
+
+#ifdef DILITHIUM_USE_AES
+  aes256ctr_init_u64(&aesctx, rho, 0);
+#endif
+
+  for(i = 0; i < K; i++) {
+    /* Expand matrix row */
+#ifdef DILITHIUM_USE_AES
+    for(unsigned int j = 0; j < L; j++) {
+      nonce = (i << 8) + j;
+      aes256ctr_init_iv_u64(&aesctx, nonce);
+      poly_uniform_preinit(&row->vec[j], &aesctx);
+      poly_nttunpack(&row->vec[j]);
+    }
+#else
+    polyvec_matrix_expand_row(&row, rowbuf, rho, i);
+#endif
+
+    /* Compute inner-product */
+    polyvecl_pointwise_acc_montgomery(&t1, row, &s1);
+    poly_invntt_tomont(&t1);
+
+    /* Add error polynomial */
+    poly_add(&t1, &t1, &s2.vec[i]);
+
+    /* Round t and pack t1, t0 */
+    poly_caddq(&t1);
+    poly_power2round(&t1, &t0, &t1);
+    polyt1_pack(pk + SEEDBYTES + i*POLYT1_PACKEDBYTES, &t1);
+    polyt0_pack(sk + 3*SEEDBYTES + (L+K)*POLYETA_PACKEDBYTES + i*POLYT0_PACKEDBYTES, &t0);
+  }
+
+#ifdef DILITHIUM_USE_AES
+  aes256_ctx_release(&aesctx);
+#endif
+
+  /* Compute H(rho, t1) and store in secret key */
+  shake256(sk + 2*SEEDBYTES, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+
+  return 0;
+}
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/sign.h
@@ -13,6 +13,9 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/sign.h
@@ -16,6 +16,9 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 #define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
 int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_ref/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_ref/api.h
@@ -16,6 +16,8 @@ int pqcrystals_dilithium2_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium2_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium2_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium2_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -39,6 +41,8 @@ int pqcrystals_dilithium2_ref_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium2aes_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium2aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium2aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium2aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -68,6 +72,8 @@ int pqcrystals_dilithium3_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium3_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium3_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium3_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -91,6 +97,8 @@ int pqcrystals_dilithium3_ref_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium3aes_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium3aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium3aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium3aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -120,6 +128,8 @@ int pqcrystals_dilithium5_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium5_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium5_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium5_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -143,6 +153,8 @@ int pqcrystals_dilithium5_ref_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium5aes_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium5aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium5aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium5aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_ref/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_ref/api.h
@@ -14,6 +14,8 @@
 
 int pqcrystals_dilithium2_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium2_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium2_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -35,6 +37,8 @@ int pqcrystals_dilithium2_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium2aes_ref_BYTES pqcrystals_dilithium2_ref_BYTES
 
 int pqcrystals_dilithium2aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium2aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium2aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -62,6 +66,8 @@ int pqcrystals_dilithium2aes_ref_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium3_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium3_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium3_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -83,6 +89,8 @@ int pqcrystals_dilithium3_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium3aes_ref_BYTES pqcrystals_dilithium3_ref_BYTES
 
 int pqcrystals_dilithium3aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium3aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium3aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -110,6 +118,8 @@ int pqcrystals_dilithium3aes_ref_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium5_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium5_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium5_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -131,6 +141,8 @@ int pqcrystals_dilithium5_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium5aes_ref_BYTES pqcrystals_dilithium5_ref_BYTES
 
 int pqcrystals_dilithium5aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium5aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium5aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_ref/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_ref/sign.c
@@ -65,6 +65,61 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair from fixed seed.
+*
+* Description: Generates public and private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
+  uint8_t tr[SEEDBYTES];
+  const uint8_t *rho, *rhoprime, *key;
+  polyvecl mat[K];
+  polyvecl s1, s1hat;
+  polyveck s2, t1, t0;
+
+  /* Use fixed seed for randomness for rho, rhoprime and key */
+  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+  rho = seedbuf;
+  rhoprime = rho + SEEDBYTES;
+  key = rhoprime + CRHBYTES;
+
+  /* Expand matrix */
+  polyvec_matrix_expand(mat, rho);
+
+  /* Sample short vectors s1 and s2 */
+  polyvecl_uniform_eta(&s1, rhoprime, 0);
+  polyveck_uniform_eta(&s2, rhoprime, L);
+
+  /* Matrix-vector multiplication */
+  s1hat = s1;
+  polyvecl_ntt(&s1hat);
+  polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+  polyveck_reduce(&t1);
+  polyveck_invntt_tomont(&t1);
+
+  /* Add error vector s2 */
+  polyveck_add(&t1, &t1, &s2);
+
+  /* Extract t1 and write public key */
+  polyveck_caddq(&t1);
+  polyveck_power2round(&t1, &t0, &t1);
+  pack_pk(pk, rho, &t1);
+
+  /* Compute H(rho, t1) and write secret key */
+  shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+  pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
+
+  return 0;
+}
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_ref/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_ref/sign.h
@@ -13,6 +13,9 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_ref/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_ref/sign.h
@@ -16,6 +16,9 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 #define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
 int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/api.h
@@ -16,6 +16,8 @@ int pqcrystals_dilithium2_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium2_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium2_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium2_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -39,6 +41,8 @@ int pqcrystals_dilithium2_avx2_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium2aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium2aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium2aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium2aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -68,6 +72,8 @@ int pqcrystals_dilithium3_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium3_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium3_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium3_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -91,6 +97,8 @@ int pqcrystals_dilithium3_avx2_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium3aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium3aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium3aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium3aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -120,6 +128,8 @@ int pqcrystals_dilithium5_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium5_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium5_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium5_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -143,6 +153,8 @@ int pqcrystals_dilithium5_avx2_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium5aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium5aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium5aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium5aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/api.h
@@ -14,6 +14,8 @@
 
 int pqcrystals_dilithium2_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium2_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium2_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -35,6 +37,8 @@ int pqcrystals_dilithium2_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium2aes_avx2_BYTES pqcrystals_dilithium2_avx2_BYTES
 
 int pqcrystals_dilithium2aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium2aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium2aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -62,6 +66,8 @@ int pqcrystals_dilithium2aes_avx2_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium3_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium3_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium3_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -83,6 +89,8 @@ int pqcrystals_dilithium3_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium3aes_avx2_BYTES pqcrystals_dilithium3_avx2_BYTES
 
 int pqcrystals_dilithium3aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium3aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium3aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -110,6 +118,8 @@ int pqcrystals_dilithium3aes_avx2_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium5_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium5_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium5_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -131,6 +141,8 @@ int pqcrystals_dilithium5_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium5aes_avx2_BYTES pqcrystals_dilithium5_avx2_BYTES
 
 int pqcrystals_dilithium5aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium5aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium5aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/sign.c
@@ -176,6 +176,124 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair from fixed seed.
+*
+* Description: Generates public and private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+  unsigned int i;
+  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
+  const uint8_t *rho, *rhoprime, *key;
+#ifdef DILITHIUM_USE_AES
+  uint64_t nonce;
+  aes256ctr_ctx aesctx;
+  polyvecl rowbuf[1];
+#else
+  polyvecl rowbuf[2];
+#endif
+  polyvecl s1, *row = rowbuf;
+  polyveck s2;
+  poly t1, t0;
+
+  /* Use fixed seed for randomness for rho, rhoprime and key */
+  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+  rho = seedbuf;
+  rhoprime = rho + SEEDBYTES;
+  key = rhoprime + CRHBYTES;
+
+  /* Store rho, key */
+  memcpy(pk, rho, SEEDBYTES);
+  memcpy(sk, rho, SEEDBYTES);
+  memcpy(sk + SEEDBYTES, key, SEEDBYTES);
+
+  /* Sample short vectors s1 and s2 */
+#ifdef DILITHIUM_USE_AES
+  aes256ctr_init_u64(&aesctx, rhoprime, 0);
+  for(i = 0; i < L; ++i) {
+    nonce = i;
+    aes256ctr_init_iv_u64(&aesctx, nonce);
+    poly_uniform_eta_preinit(&s1.vec[i], &aesctx);
+  }
+  for(i = 0; i < K; ++i) {
+    nonce = L + i;
+    aes256ctr_init_iv_u64(&aesctx, nonce);
+    poly_uniform_eta_preinit(&s2.vec[i], &aesctx);
+  }
+  aes256_ctx_release(&aesctx);
+#elif K == 4 && L == 4
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s2.vec[0], &s2.vec[1], &s2.vec[2], &s2.vec[3], rhoprime, 4, 5, 6, 7);
+#elif K == 6 && L == 5
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s1.vec[4], &s2.vec[0], &s2.vec[1], &s2.vec[2], rhoprime, 4, 5, 6, 7);
+  poly_uniform_eta_4x(&s2.vec[3], &s2.vec[4], &s2.vec[5], &t0, rhoprime, 8, 9, 10, 11);
+#elif K == 8 && L == 7
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s1.vec[4], &s1.vec[5], &s1.vec[6], &s2.vec[0], rhoprime, 4, 5, 6, 7);
+  poly_uniform_eta_4x(&s2.vec[1], &s2.vec[2], &s2.vec[3], &s2.vec[4], rhoprime, 8, 9, 10, 11);
+  poly_uniform_eta_4x(&s2.vec[5], &s2.vec[6], &s2.vec[7], &t0, rhoprime, 12, 13, 14, 15);
+#else
+#error
+#endif
+
+  /* Pack secret vectors */
+  for(i = 0; i < L; i++)
+    polyeta_pack(sk + 3*SEEDBYTES + i*POLYETA_PACKEDBYTES, &s1.vec[i]);
+  for(i = 0; i < K; i++)
+    polyeta_pack(sk + 3*SEEDBYTES + (L + i)*POLYETA_PACKEDBYTES, &s2.vec[i]);
+
+  /* Transform s1 */
+  polyvecl_ntt(&s1);
+
+#ifdef DILITHIUM_USE_AES
+  aes256ctr_init_u64(&aesctx, rho, 0);
+#endif
+
+  for(i = 0; i < K; i++) {
+    /* Expand matrix row */
+#ifdef DILITHIUM_USE_AES
+    for(unsigned int j = 0; j < L; j++) {
+      nonce = (i << 8) + j;
+      aes256ctr_init_iv_u64(&aesctx, nonce);
+      poly_uniform_preinit(&row->vec[j], &aesctx);
+      poly_nttunpack(&row->vec[j]);
+    }
+#else
+    polyvec_matrix_expand_row(&row, rowbuf, rho, i);
+#endif
+
+    /* Compute inner-product */
+    polyvecl_pointwise_acc_montgomery(&t1, row, &s1);
+    poly_invntt_tomont(&t1);
+
+    /* Add error polynomial */
+    poly_add(&t1, &t1, &s2.vec[i]);
+
+    /* Round t and pack t1, t0 */
+    poly_caddq(&t1);
+    poly_power2round(&t1, &t0, &t1);
+    polyt1_pack(pk + SEEDBYTES + i*POLYT1_PACKEDBYTES, &t1);
+    polyt0_pack(sk + 3*SEEDBYTES + (L+K)*POLYETA_PACKEDBYTES + i*POLYT0_PACKEDBYTES, &t0);
+  }
+
+#ifdef DILITHIUM_USE_AES
+  aes256_ctx_release(&aesctx);
+#endif
+
+  /* Compute H(rho, t1) and store in secret key */
+  shake256(sk + 2*SEEDBYTES, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+
+  return 0;
+}
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/sign.h
@@ -13,6 +13,9 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/sign.h
@@ -16,6 +16,9 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 #define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
 int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/api.h
@@ -16,6 +16,8 @@ int pqcrystals_dilithium2_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium2_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium2_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium2_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -39,6 +41,8 @@ int pqcrystals_dilithium2_ref_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium2aes_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium2aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium2aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium2aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -68,6 +72,8 @@ int pqcrystals_dilithium3_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium3_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium3_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium3_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -91,6 +97,8 @@ int pqcrystals_dilithium3_ref_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium3aes_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium3aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium3aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium3aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -120,6 +128,8 @@ int pqcrystals_dilithium5_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium5_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium5_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium5_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -143,6 +153,8 @@ int pqcrystals_dilithium5_ref_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium5aes_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium5aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium5aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium5aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/api.h
@@ -14,6 +14,8 @@
 
 int pqcrystals_dilithium2_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium2_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium2_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -35,6 +37,8 @@ int pqcrystals_dilithium2_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium2aes_ref_BYTES pqcrystals_dilithium2_ref_BYTES
 
 int pqcrystals_dilithium2aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium2aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium2aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -62,6 +66,8 @@ int pqcrystals_dilithium2aes_ref_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium3_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium3_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium3_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -83,6 +89,8 @@ int pqcrystals_dilithium3_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium3aes_ref_BYTES pqcrystals_dilithium3_ref_BYTES
 
 int pqcrystals_dilithium3aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium3aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium3aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -110,6 +118,8 @@ int pqcrystals_dilithium3aes_ref_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium5_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium5_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium5_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -131,6 +141,8 @@ int pqcrystals_dilithium5_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium5aes_ref_BYTES pqcrystals_dilithium5_ref_BYTES
 
 int pqcrystals_dilithium5aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium5aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium5aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/sign.c
@@ -65,6 +65,61 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair from fixed seed.
+*
+* Description: Generates public and private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
+  uint8_t tr[SEEDBYTES];
+  const uint8_t *rho, *rhoprime, *key;
+  polyvecl mat[K];
+  polyvecl s1, s1hat;
+  polyveck s2, t1, t0;
+
+  /* Use fixed seed for randomness for rho, rhoprime and key */
+  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+  rho = seedbuf;
+  rhoprime = rho + SEEDBYTES;
+  key = rhoprime + CRHBYTES;
+
+  /* Expand matrix */
+  polyvec_matrix_expand(mat, rho);
+
+  /* Sample short vectors s1 and s2 */
+  polyvecl_uniform_eta(&s1, rhoprime, 0);
+  polyveck_uniform_eta(&s2, rhoprime, L);
+
+  /* Matrix-vector multiplication */
+  s1hat = s1;
+  polyvecl_ntt(&s1hat);
+  polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+  polyveck_reduce(&t1);
+  polyveck_invntt_tomont(&t1);
+
+  /* Add error vector s2 */
+  polyveck_add(&t1, &t1, &s2);
+
+  /* Extract t1 and write public key */
+  polyveck_caddq(&t1);
+  polyveck_power2round(&t1, &t0, &t1);
+  pack_pk(pk, rho, &t1);
+
+  /* Compute H(rho, t1) and write secret key */
+  shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+  pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
+
+  return 0;
+}
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/sign.h
@@ -13,6 +13,9 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/sign.h
@@ -16,6 +16,9 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 #define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
 int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/api.h
@@ -14,6 +14,8 @@
 
 int pqcrystals_dilithium2_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium2_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium2_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -35,6 +37,9 @@ int pqcrystals_dilithium2_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium2aes_avx2_BYTES pqcrystals_dilithium2_avx2_BYTES
 
 int pqcrystals_dilithium2aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium2aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 
 int pqcrystals_dilithium2aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -62,6 +67,8 @@ int pqcrystals_dilithium2aes_avx2_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium3_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium3_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium3_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -83,6 +90,8 @@ int pqcrystals_dilithium3_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium3aes_avx2_BYTES pqcrystals_dilithium3_avx2_BYTES
 
 int pqcrystals_dilithium3aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium3aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium3aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -110,6 +119,8 @@ int pqcrystals_dilithium3aes_avx2_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium5_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium5_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium5_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -131,6 +142,8 @@ int pqcrystals_dilithium5_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium5aes_avx2_BYTES pqcrystals_dilithium5_avx2_BYTES
 
 int pqcrystals_dilithium5aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium5aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium5aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/api.h
@@ -16,6 +16,8 @@ int pqcrystals_dilithium2_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium2_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium2_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium2_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -40,6 +42,7 @@ int pqcrystals_dilithium2aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium2aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium2aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium2aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -69,6 +72,8 @@ int pqcrystals_dilithium3_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium3_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium3_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium3_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -92,6 +97,8 @@ int pqcrystals_dilithium3_avx2_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium3aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium3aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium3aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium3aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -121,6 +128,8 @@ int pqcrystals_dilithium5_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium5_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium5_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium5_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -144,6 +153,8 @@ int pqcrystals_dilithium5_avx2_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium5aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium5aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium5aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium5aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/sign.c
@@ -176,6 +176,124 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair from fixed seed.
+*
+* Description: Generates public and private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+  unsigned int i;
+  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
+  const uint8_t *rho, *rhoprime, *key;
+#ifdef DILITHIUM_USE_AES
+  uint64_t nonce;
+  aes256ctr_ctx aesctx;
+  polyvecl rowbuf[1];
+#else
+  polyvecl rowbuf[2];
+#endif
+  polyvecl s1, *row = rowbuf;
+  polyveck s2;
+  poly t1, t0;
+
+  /* Use fixed seed for randomness for rho, rhoprime and key */
+  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+  rho = seedbuf;
+  rhoprime = rho + SEEDBYTES;
+  key = rhoprime + CRHBYTES;
+
+  /* Store rho, key */
+  memcpy(pk, rho, SEEDBYTES);
+  memcpy(sk, rho, SEEDBYTES);
+  memcpy(sk + SEEDBYTES, key, SEEDBYTES);
+
+  /* Sample short vectors s1 and s2 */
+#ifdef DILITHIUM_USE_AES
+  aes256ctr_init_u64(&aesctx, rhoprime, 0);
+  for(i = 0; i < L; ++i) {
+    nonce = i;
+    aes256ctr_init_iv_u64(&aesctx, nonce);
+    poly_uniform_eta_preinit(&s1.vec[i], &aesctx);
+  }
+  for(i = 0; i < K; ++i) {
+    nonce = L + i;
+    aes256ctr_init_iv_u64(&aesctx, nonce);
+    poly_uniform_eta_preinit(&s2.vec[i], &aesctx);
+  }
+  aes256_ctx_release(&aesctx);
+#elif K == 4 && L == 4
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s2.vec[0], &s2.vec[1], &s2.vec[2], &s2.vec[3], rhoprime, 4, 5, 6, 7);
+#elif K == 6 && L == 5
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s1.vec[4], &s2.vec[0], &s2.vec[1], &s2.vec[2], rhoprime, 4, 5, 6, 7);
+  poly_uniform_eta_4x(&s2.vec[3], &s2.vec[4], &s2.vec[5], &t0, rhoprime, 8, 9, 10, 11);
+#elif K == 8 && L == 7
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s1.vec[4], &s1.vec[5], &s1.vec[6], &s2.vec[0], rhoprime, 4, 5, 6, 7);
+  poly_uniform_eta_4x(&s2.vec[1], &s2.vec[2], &s2.vec[3], &s2.vec[4], rhoprime, 8, 9, 10, 11);
+  poly_uniform_eta_4x(&s2.vec[5], &s2.vec[6], &s2.vec[7], &t0, rhoprime, 12, 13, 14, 15);
+#else
+#error
+#endif
+
+  /* Pack secret vectors */
+  for(i = 0; i < L; i++)
+    polyeta_pack(sk + 3*SEEDBYTES + i*POLYETA_PACKEDBYTES, &s1.vec[i]);
+  for(i = 0; i < K; i++)
+    polyeta_pack(sk + 3*SEEDBYTES + (L + i)*POLYETA_PACKEDBYTES, &s2.vec[i]);
+
+  /* Transform s1 */
+  polyvecl_ntt(&s1);
+
+#ifdef DILITHIUM_USE_AES
+  aes256ctr_init_u64(&aesctx, rho, 0);
+#endif
+
+  for(i = 0; i < K; i++) {
+    /* Expand matrix row */
+#ifdef DILITHIUM_USE_AES
+    for(unsigned int j = 0; j < L; j++) {
+      nonce = (i << 8) + j;
+      aes256ctr_init_iv_u64(&aesctx, nonce);
+      poly_uniform_preinit(&row->vec[j], &aesctx);
+      poly_nttunpack(&row->vec[j]);
+    }
+#else
+    polyvec_matrix_expand_row(&row, rowbuf, rho, i);
+#endif
+
+    /* Compute inner-product */
+    polyvecl_pointwise_acc_montgomery(&t1, row, &s1);
+    poly_invntt_tomont(&t1);
+
+    /* Add error polynomial */
+    poly_add(&t1, &t1, &s2.vec[i]);
+
+    /* Round t and pack t1, t0 */
+    poly_caddq(&t1);
+    poly_power2round(&t1, &t0, &t1);
+    polyt1_pack(pk + SEEDBYTES + i*POLYT1_PACKEDBYTES, &t1);
+    polyt0_pack(sk + 3*SEEDBYTES + (L+K)*POLYETA_PACKEDBYTES + i*POLYT0_PACKEDBYTES, &t0);
+  }
+
+#ifdef DILITHIUM_USE_AES
+  aes256_ctx_release(&aesctx);
+#endif
+
+  /* Compute H(rho, t1) and store in secret key */
+  shake256(sk + 2*SEEDBYTES, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+
+  return 0;
+}
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/sign.h
@@ -13,6 +13,9 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/sign.h
@@ -16,6 +16,9 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 #define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
 int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_ref/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_ref/api.h
@@ -16,6 +16,8 @@ int pqcrystals_dilithium2_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium2_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium2_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium2_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -39,6 +41,8 @@ int pqcrystals_dilithium2_ref_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium2aes_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium2aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium2aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium2aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -68,6 +72,8 @@ int pqcrystals_dilithium3_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium3_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium3_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium3_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -91,6 +97,8 @@ int pqcrystals_dilithium3_ref_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium3aes_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium3aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium3aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium3aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -120,6 +128,8 @@ int pqcrystals_dilithium5_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium5_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+int pqcrystals_dilithium5_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium5_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -143,6 +153,8 @@ int pqcrystals_dilithium5_ref_open(uint8_t *m, size_t *mlen,
 int pqcrystals_dilithium5aes_ref_keypair(uint8_t *pk, uint8_t *sk);
 
 int pqcrystals_dilithium5aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int pqcrystals_dilithium5aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium5aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_ref/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_ref/api.h
@@ -14,6 +14,8 @@
 
 int pqcrystals_dilithium2_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium2_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium2_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -35,6 +37,8 @@ int pqcrystals_dilithium2_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium2aes_ref_BYTES pqcrystals_dilithium2_ref_BYTES
 
 int pqcrystals_dilithium2aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium2aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium2aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -62,6 +66,8 @@ int pqcrystals_dilithium2aes_ref_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium3_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium3_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium3_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -83,6 +89,8 @@ int pqcrystals_dilithium3_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium3aes_ref_BYTES pqcrystals_dilithium3_ref_BYTES
 
 int pqcrystals_dilithium3aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium3aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium3aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -110,6 +118,8 @@ int pqcrystals_dilithium3aes_ref_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium5_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium5_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 int pqcrystals_dilithium5_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -131,6 +141,8 @@ int pqcrystals_dilithium5_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium5aes_ref_BYTES pqcrystals_dilithium5_ref_BYTES
 
 int pqcrystals_dilithium5aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium5aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 int pqcrystals_dilithium5aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_ref/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_ref/sign.c
@@ -65,6 +65,61 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair from fixed seed.
+*
+* Description: Generates public and private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
+  uint8_t tr[SEEDBYTES];
+  const uint8_t *rho, *rhoprime, *key;
+  polyvecl mat[K];
+  polyvecl s1, s1hat;
+  polyveck s2, t1, t0;
+
+  /* Use fixed seed for randomness for rho, rhoprime and key */
+  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+  rho = seedbuf;
+  rhoprime = rho + SEEDBYTES;
+  key = rhoprime + CRHBYTES;
+
+  /* Expand matrix */
+  polyvec_matrix_expand(mat, rho);
+
+  /* Sample short vectors s1 and s2 */
+  polyvecl_uniform_eta(&s1, rhoprime, 0);
+  polyveck_uniform_eta(&s2, rhoprime, L);
+
+  /* Matrix-vector multiplication */
+  s1hat = s1;
+  polyvecl_ntt(&s1hat);
+  polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+  polyveck_reduce(&t1);
+  polyveck_invntt_tomont(&t1);
+
+  /* Add error vector s2 */
+  polyveck_add(&t1, &t1, &s2);
+
+  /* Extract t1 and write public key */
+  polyveck_caddq(&t1);
+  polyveck_power2round(&t1, &t0, &t1);
+  pack_pk(pk, rho, &t1);
+
+  /* Compute H(rho, t1) and write secret key */
+  shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+  pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
+
+  return 0;
+}
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_ref/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_ref/sign.h
@@ -13,6 +13,9 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_ref/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_ref/sign.h
@@ -16,6 +16,9 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 #define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
 int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/sig_dilithium.h
+++ b/src/sig/dilithium/sig_dilithium.h
@@ -12,6 +12,7 @@
 
 OQS_SIG *OQS_SIG_dilithium_2_new(void);
 OQS_API OQS_STATUS OQS_SIG_dilithium_2_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_dilithium_2_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_SIG_dilithium_2_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_2_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_2_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -25,6 +26,7 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_2_verify_with_ctx_str(const uint8_t *messag
 
 OQS_SIG *OQS_SIG_dilithium_3_new(void);
 OQS_API OQS_STATUS OQS_SIG_dilithium_3_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_dilithium_3_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_SIG_dilithium_3_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_3_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_3_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -38,6 +40,7 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_3_verify_with_ctx_str(const uint8_t *messag
 
 OQS_SIG *OQS_SIG_dilithium_5_new(void);
 OQS_API OQS_STATUS OQS_SIG_dilithium_5_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_dilithium_5_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_SIG_dilithium_5_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_5_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_5_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);

--- a/src/sig/dilithium/sig_dilithium.h
+++ b/src/sig/dilithium/sig_dilithium.h
@@ -13,6 +13,7 @@
 OQS_SIG *OQS_SIG_dilithium_2_new(void);
 OQS_API OQS_STATUS OQS_SIG_dilithium_2_keypair(uint8_t *public_key, uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_2_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_dilithium_2_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_2_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_2_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_2_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -27,6 +28,7 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_2_verify_with_ctx_str(const uint8_t *messag
 OQS_SIG *OQS_SIG_dilithium_3_new(void);
 OQS_API OQS_STATUS OQS_SIG_dilithium_3_keypair(uint8_t *public_key, uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_3_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_dilithium_3_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_3_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_3_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_3_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -41,6 +43,7 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_3_verify_with_ctx_str(const uint8_t *messag
 OQS_SIG *OQS_SIG_dilithium_5_new(void);
 OQS_API OQS_STATUS OQS_SIG_dilithium_5_keypair(uint8_t *public_key, uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_5_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_dilithium_5_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_5_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_5_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_5_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);

--- a/src/sig/dilithium/sig_dilithium_2.c
+++ b/src/sig/dilithium/sig_dilithium_2.c
@@ -23,6 +23,7 @@ OQS_SIG *OQS_SIG_dilithium_2_new(void) {
 	sig->length_signature = OQS_SIG_dilithium_2_length_signature;
 
 	sig->keypair = OQS_SIG_dilithium_2_keypair;
+	sig->keypair_from_fseed = OQS_SIG_dilithium_2_keypair_from_fseed;
 	sig->sign = OQS_SIG_dilithium_2_sign;
 	sig->verify = OQS_SIG_dilithium_2_verify;
 	sig->sign_with_ctx_str = OQS_SIG_dilithium_2_sign_with_ctx_str;
@@ -32,17 +33,20 @@ OQS_SIG *OQS_SIG_dilithium_2_new(void) {
 }
 
 extern int pqcrystals_dilithium2_ref_keypair(uint8_t *pk, uint8_t *sk);
+extern int pqcrystals_dilithium2_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int pqcrystals_dilithium2_ref_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium2_ref_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_dilithium_2_avx2)
 extern int pqcrystals_dilithium2_avx2_keypair(uint8_t *pk, uint8_t *sk);
+extern int pqcrystals_dilithium2_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int pqcrystals_dilithium2_avx2_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium2_avx2_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
 
 #if defined(OQS_ENABLE_SIG_dilithium_2_aarch64)
 extern int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -70,6 +74,32 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_2_keypair(uint8_t *public_key, uint8_t *sec
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) pqcrystals_dilithium2_ref_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_dilithium_2_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_dilithium_2_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) pqcrystals_dilithium2_avx2_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium2_ref_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_dilithium_2_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium2_ref_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) pqcrystals_dilithium2_ref_keypair_from_fseed(public_key, secret_key, seed);
 #endif
 }
 

--- a/src/sig/dilithium/sig_dilithium_2.c
+++ b/src/sig/dilithium/sig_dilithium_2.c
@@ -24,6 +24,7 @@ OQS_SIG *OQS_SIG_dilithium_2_new(void) {
 
 	sig->keypair = OQS_SIG_dilithium_2_keypair;
 	sig->keypair_from_fseed = OQS_SIG_dilithium_2_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_dilithium_2_pubkey_from_privkey;
 	sig->sign = OQS_SIG_dilithium_2_sign;
 	sig->verify = OQS_SIG_dilithium_2_verify;
 	sig->sign_with_ctx_str = OQS_SIG_dilithium_2_sign_with_ctx_str;
@@ -34,12 +35,14 @@ OQS_SIG *OQS_SIG_dilithium_2_new(void) {
 
 extern int pqcrystals_dilithium2_ref_keypair(uint8_t *pk, uint8_t *sk);
 extern int pqcrystals_dilithium2_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int pqcrystals_dilithium2_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_dilithium2_ref_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium2_ref_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_dilithium_2_avx2)
 extern int pqcrystals_dilithium2_avx2_keypair(uint8_t *pk, uint8_t *sk);
 extern int pqcrystals_dilithium2_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int pqcrystals_dilithium2_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_dilithium2_avx2_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium2_avx2_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -47,6 +50,7 @@ extern int pqcrystals_dilithium2_avx2_verify(const uint8_t *sig, size_t siglen, 
 #if defined(OQS_ENABLE_SIG_dilithium_2_aarch64)
 extern int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -100,6 +104,32 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_2_keypair_from_fseed(uint8_t *public_key, u
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) pqcrystals_dilithium2_ref_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_dilithium_2_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_dilithium_2_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) pqcrystals_dilithium2_avx2_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium2_ref_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_dilithium_2_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium2_ref_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) pqcrystals_dilithium2_ref_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/dilithium/sig_dilithium_3.c
+++ b/src/sig/dilithium/sig_dilithium_3.c
@@ -23,6 +23,7 @@ OQS_SIG *OQS_SIG_dilithium_3_new(void) {
 	sig->length_signature = OQS_SIG_dilithium_3_length_signature;
 
 	sig->keypair = OQS_SIG_dilithium_3_keypair;
+	sig->keypair_from_fseed = OQS_SIG_dilithium_3_keypair_from_fseed;
 	sig->sign = OQS_SIG_dilithium_3_sign;
 	sig->verify = OQS_SIG_dilithium_3_verify;
 	sig->sign_with_ctx_str = OQS_SIG_dilithium_3_sign_with_ctx_str;
@@ -32,17 +33,20 @@ OQS_SIG *OQS_SIG_dilithium_3_new(void) {
 }
 
 extern int pqcrystals_dilithium3_ref_keypair(uint8_t *pk, uint8_t *sk);
+extern int pqcrystals_dilithium3_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int pqcrystals_dilithium3_ref_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium3_ref_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_dilithium_3_avx2)
 extern int pqcrystals_dilithium3_avx2_keypair(uint8_t *pk, uint8_t *sk);
+extern int pqcrystals_dilithium3_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int pqcrystals_dilithium3_avx2_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium3_avx2_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
 
 #if defined(OQS_ENABLE_SIG_dilithium_3_aarch64)
 extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -70,6 +74,32 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_3_keypair(uint8_t *public_key, uint8_t *sec
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) pqcrystals_dilithium3_ref_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_dilithium_3_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_dilithium_3_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) pqcrystals_dilithium3_avx2_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium3_ref_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_dilithium_3_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium3_ref_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) pqcrystals_dilithium3_ref_keypair_from_fseed(public_key, secret_key, seed);
 #endif
 }
 

--- a/src/sig/dilithium/sig_dilithium_3.c
+++ b/src/sig/dilithium/sig_dilithium_3.c
@@ -24,6 +24,7 @@ OQS_SIG *OQS_SIG_dilithium_3_new(void) {
 
 	sig->keypair = OQS_SIG_dilithium_3_keypair;
 	sig->keypair_from_fseed = OQS_SIG_dilithium_3_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_dilithium_3_pubkey_from_privkey;
 	sig->sign = OQS_SIG_dilithium_3_sign;
 	sig->verify = OQS_SIG_dilithium_3_verify;
 	sig->sign_with_ctx_str = OQS_SIG_dilithium_3_sign_with_ctx_str;
@@ -34,12 +35,14 @@ OQS_SIG *OQS_SIG_dilithium_3_new(void) {
 
 extern int pqcrystals_dilithium3_ref_keypair(uint8_t *pk, uint8_t *sk);
 extern int pqcrystals_dilithium3_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int pqcrystals_dilithium3_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_dilithium3_ref_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium3_ref_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_dilithium_3_avx2)
 extern int pqcrystals_dilithium3_avx2_keypair(uint8_t *pk, uint8_t *sk);
 extern int pqcrystals_dilithium3_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int pqcrystals_dilithium3_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_dilithium3_avx2_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium3_avx2_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -47,6 +50,7 @@ extern int pqcrystals_dilithium3_avx2_verify(const uint8_t *sig, size_t siglen, 
 #if defined(OQS_ENABLE_SIG_dilithium_3_aarch64)
 extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -100,6 +104,32 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_3_keypair_from_fseed(uint8_t *public_key, u
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) pqcrystals_dilithium3_ref_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_dilithium_3_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_dilithium_3_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) pqcrystals_dilithium3_avx2_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium3_ref_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_dilithium_3_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium3_ref_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) pqcrystals_dilithium3_ref_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/dilithium/sig_dilithium_5.c
+++ b/src/sig/dilithium/sig_dilithium_5.c
@@ -24,6 +24,7 @@ OQS_SIG *OQS_SIG_dilithium_5_new(void) {
 
 	sig->keypair = OQS_SIG_dilithium_5_keypair;
 	sig->keypair_from_fseed = OQS_SIG_dilithium_5_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_dilithium_5_pubkey_from_privkey;
 	sig->sign = OQS_SIG_dilithium_5_sign;
 	sig->verify = OQS_SIG_dilithium_5_verify;
 	sig->sign_with_ctx_str = OQS_SIG_dilithium_5_sign_with_ctx_str;
@@ -34,12 +35,14 @@ OQS_SIG *OQS_SIG_dilithium_5_new(void) {
 
 extern int pqcrystals_dilithium5_ref_keypair(uint8_t *pk, uint8_t *sk);
 extern int pqcrystals_dilithium5_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int pqcrystals_dilithium5_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_dilithium5_ref_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium5_ref_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_dilithium_5_avx2)
 extern int pqcrystals_dilithium5_avx2_keypair(uint8_t *pk, uint8_t *sk);
 extern int pqcrystals_dilithium5_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int pqcrystals_dilithium5_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_dilithium5_avx2_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium5_avx2_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -47,6 +50,7 @@ extern int pqcrystals_dilithium5_avx2_verify(const uint8_t *sig, size_t siglen, 
 #if defined(OQS_ENABLE_SIG_dilithium_5_aarch64)
 extern int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -103,6 +107,31 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_5_keypair_from_fseed(uint8_t *public_key, u
 #endif
 }
 
+OQS_API OQS_STATUS OQS_SIG_dilithium_5_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_dilithium_5_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) pqcrystals_dilithium5_avx2_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium5_ref_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_dilithium_5_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium5_ref_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) pqcrystals_dilithium5_ref_pubkey_from_privkey(public_key, secret_key);
+#endif
+}
 
 OQS_API OQS_STATUS OQS_SIG_dilithium_5_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key) {
 #if defined(OQS_ENABLE_SIG_dilithium_5_avx2)

--- a/src/sig/dilithium/sig_dilithium_5.c
+++ b/src/sig/dilithium/sig_dilithium_5.c
@@ -23,6 +23,7 @@ OQS_SIG *OQS_SIG_dilithium_5_new(void) {
 	sig->length_signature = OQS_SIG_dilithium_5_length_signature;
 
 	sig->keypair = OQS_SIG_dilithium_5_keypair;
+	sig->keypair_from_fseed = OQS_SIG_dilithium_5_keypair_from_fseed;
 	sig->sign = OQS_SIG_dilithium_5_sign;
 	sig->verify = OQS_SIG_dilithium_5_verify;
 	sig->sign_with_ctx_str = OQS_SIG_dilithium_5_sign_with_ctx_str;
@@ -32,17 +33,20 @@ OQS_SIG *OQS_SIG_dilithium_5_new(void) {
 }
 
 extern int pqcrystals_dilithium5_ref_keypair(uint8_t *pk, uint8_t *sk);
+extern int pqcrystals_dilithium5_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int pqcrystals_dilithium5_ref_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium5_ref_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_dilithium_5_avx2)
 extern int pqcrystals_dilithium5_avx2_keypair(uint8_t *pk, uint8_t *sk);
+extern int pqcrystals_dilithium5_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int pqcrystals_dilithium5_avx2_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium5_avx2_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
 
 #if defined(OQS_ENABLE_SIG_dilithium_5_aarch64)
 extern int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -72,6 +76,33 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_5_keypair(uint8_t *public_key, uint8_t *sec
 	return (OQS_STATUS) pqcrystals_dilithium5_ref_keypair(public_key, secret_key);
 #endif
 }
+
+OQS_API OQS_STATUS OQS_SIG_dilithium_5_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_dilithium_5_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) pqcrystals_dilithium5_avx2_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium5_ref_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_dilithium_5_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium5_ref_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) pqcrystals_dilithium5_ref_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
 
 OQS_API OQS_STATUS OQS_SIG_dilithium_5_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key) {
 #if defined(OQS_ENABLE_SIG_dilithium_5_avx2)

--- a/src/sig/falcon/pqclean_falcon-1024_aarch64/api.h
+++ b/src/sig/falcon/pqclean_falcon-1024_aarch64/api.h
@@ -24,6 +24,17 @@ int PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-1024_aarch64/api.h
+++ b/src/sig/falcon/pqclean_falcon-1024_aarch64/api.h
@@ -26,8 +26,8 @@ int PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair(
 /*
  * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */
@@ -37,8 +37,8 @@ int PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair_from_fseed(
 /*
  * Generate Public key from Privat key.
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */

--- a/src/sig/falcon/pqclean_falcon-1024_aarch64/api.h
+++ b/src/sig/falcon/pqclean_falcon-1024_aarch64/api.h
@@ -35,6 +35,17 @@ int PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair_from_fseed(
     uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 /*
+ * Generate Public key from Privat key.
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON1024_AARCH64_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-1024_aarch64/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-1024_aarch64/pqclean.c
@@ -108,6 +108,82 @@ PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[28 * FALCON_N];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
+    uint16_t h[FALCON_N];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCON1024_AARCH64_keygen(&rng, f, g, F, NULL, h, FALCON_LOGN, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + FALCON_LOGN;
+    u = 1;
+    v = PQCLEAN_FALCON1024_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            f, PQCLEAN_FALCON1024_AARCH64_max_fg_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            g, PQCLEAN_FALCON1024_AARCH64_max_fg_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            F, PQCLEAN_FALCON1024_AARCH64_max_FG_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + FALCON_LOGN;
+    v = PQCLEAN_FALCON1024_AARCH64_modq_encode(
+            pk + 1, PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
+            h, FALCON_LOGN);
+    if (v != PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-1024_aarch64/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-1024_aarch64/pqclean.c
@@ -190,8 +190,8 @@ PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair_from_fseed(
  * to regenerate the corresponding public key (h).
  * The generated public key is then encoded into the provided pk array.
  * 
- * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
- * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES in size).
  * @return 0 if the public key was successfully generated, or -1 in case of an error.
  */
 int PQCLEAN_FALCON1024_AARCH64_crypto_sign_pubkey_from_privkey(

--- a/src/sig/falcon/pqclean_falcon-1024_aarch64/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-1024_aarch64/pqclean.c
@@ -185,6 +185,80 @@ PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair_from_fseed(
 }
 
 /*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f, g, F) and then uses them 
+ * to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ * 
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @return 0 if the public key was successfully generated, or -1 in case of an error.
+ */
+int PQCLEAN_FALCON1024_AARCH64_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[28 * FALCON_N];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
+    uint16_t h[FALCON_N];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + FALCON_LOGN) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCON1024_AARCH64_trim_i8_decode(
+            f, PQCLEAN_FALCON1024_AARCH64_max_fg_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_AARCH64_trim_i8_decode(
+            g, PQCLEAN_FALCON1024_AARCH64_max_fg_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_AARCH64_trim_i8_decode(
+            F, PQCLEAN_FALCON1024_AARCH64_max_FG_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCON1024_AARCH64_compute_public(h, f, g, FALCON_LOGN, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + FALCON_LOGN;
+    v = PQCLEAN_FALCON1024_AARCH64_modq_encode(
+            pk + 1, PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
+            h, FALCON_LOGN);
+    if (v != PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce
  * or header byte), with *sigbuflen providing the maximum value length and

--- a/src/sig/falcon/pqclean_falcon-1024_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-1024_avx2/api.h
@@ -35,6 +35,17 @@ int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair_from_fseed(
     uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 /*
+ * Generate Public key from Privat key.
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON1024_AVX2_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-1024_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-1024_avx2/api.h
@@ -26,8 +26,8 @@ int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(
 /*
  * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */
@@ -37,8 +37,8 @@ int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair_from_fseed(
 /*
  * Generate Public key from Privat key.
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */

--- a/src/sig/falcon/pqclean_falcon-1024_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-1024_avx2/api.h
@@ -24,6 +24,17 @@ int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-1024_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-1024_avx2/pqclean.c
@@ -185,6 +185,80 @@ PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair_from_fseed(
 }
 
 /*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f, g, F) and then uses them 
+ * to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ * 
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @return 0 if the public key was successfully generated, or -1 in case of an error.
+ */
+int PQCLEAN_FALCON1024_AVX2_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_10];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[1024], g[1024], F[1024];
+    uint16_t h[1024];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + 10) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCON1024_AVX2_trim_i8_decode(
+            f, 10, PQCLEAN_FALCON1024_AVX2_max_fg_bits[10],
+            sk + u, PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_AVX2_trim_i8_decode(
+            g, 10, PQCLEAN_FALCON1024_AVX2_max_fg_bits[10],
+            sk + u, PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_AVX2_trim_i8_decode(
+            F, 10, PQCLEAN_FALCON1024_AVX2_max_FG_bits[10],
+            sk + u, PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCON1024_AVX2_compute_public(h, f, g, 10, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 10;
+    v = PQCLEAN_FALCON1024_AVX2_modq_encode(
+            pk + 1, PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 10);
+    if (v != PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce
  * or header byte), with *sigbuflen providing the maximum value length and

--- a/src/sig/falcon/pqclean_falcon-1024_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-1024_avx2/pqclean.c
@@ -190,8 +190,8 @@ PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair_from_fseed(
  * to regenerate the corresponding public key (h).
  * The generated public key is then encoded into the provided pk array.
  * 
- * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
- * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES in size).
  * @return 0 if the public key was successfully generated, or -1 in case of an error.
  */
 int PQCLEAN_FALCON1024_AVX2_crypto_sign_pubkey_from_privkey(

--- a/src/sig/falcon/pqclean_falcon-1024_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-1024_avx2/pqclean.c
@@ -108,6 +108,82 @@ PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_10];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[1024], g[1024], F[1024];
+    uint16_t h[1024];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCON1024_AVX2_keygen(&rng, f, g, F, NULL, h, 10, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + 10;
+    u = 1;
+    v = PQCLEAN_FALCON1024_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            f, 10, PQCLEAN_FALCON1024_AVX2_max_fg_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            g, 10, PQCLEAN_FALCON1024_AVX2_max_fg_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            F, 10, PQCLEAN_FALCON1024_AVX2_max_FG_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 10;
+    v = PQCLEAN_FALCON1024_AVX2_modq_encode(
+            pk + 1, PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 10);
+    if (v != PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-1024_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-1024_clean/api.h
@@ -24,6 +24,17 @@ int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-1024_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-1024_clean/api.h
@@ -35,6 +35,17 @@ int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(
     uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 /*
+ * Generate Public key from Privat key.
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON1024_CLEAN_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-1024_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-1024_clean/api.h
@@ -26,8 +26,8 @@ int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(
 /*
  * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */
@@ -37,8 +37,8 @@ int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(
 /*
  * Generate Public key from Privat key.
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */

--- a/src/sig/falcon/pqclean_falcon-1024_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-1024_clean/pqclean.c
@@ -108,6 +108,82 @@ PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_10];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[1024], g[1024], F[1024];
+    uint16_t h[1024];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCON1024_CLEAN_keygen(&rng, f, g, F, NULL, h, 10, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + 10;
+    u = 1;
+    v = PQCLEAN_FALCON1024_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            f, 10, PQCLEAN_FALCON1024_CLEAN_max_fg_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            g, 10, PQCLEAN_FALCON1024_CLEAN_max_fg_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            F, 10, PQCLEAN_FALCON1024_CLEAN_max_FG_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 10;
+    v = PQCLEAN_FALCON1024_CLEAN_modq_encode(
+            pk + 1, PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 10);
+    if (v != PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-1024_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-1024_clean/pqclean.c
@@ -185,6 +185,81 @@ PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(
 }
 
 /*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f, g, F) and then uses them 
+ * to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ * 
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @return 0 if the public key was successfully generated, or -1 in case of an error.
+ */
+int 
+PQCLEAN_FALCON1024_CLEAN_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_10];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[1024], g[1024], F[1024];
+    uint16_t h[1024];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + 10) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCON1024_CLEAN_trim_i8_decode(
+            f, 10, PQCLEAN_FALCON1024_CLEAN_max_fg_bits[10],
+            sk + u, PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_CLEAN_trim_i8_decode(
+            g, 10, PQCLEAN_FALCON1024_CLEAN_max_fg_bits[10],
+            sk + u, PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_CLEAN_trim_i8_decode(
+            F, 10, PQCLEAN_FALCON1024_CLEAN_max_FG_bits[10],
+            sk + u, PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCON1024_CLEAN_compute_public(h, f, g, 10, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 10;
+    v = PQCLEAN_FALCON1024_CLEAN_modq_encode(
+            pk + 1, PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 10);
+    if (v != PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce
  * or header byte), with *sigbuflen providing the maximum value length and

--- a/src/sig/falcon/pqclean_falcon-512_aarch64/api.h
+++ b/src/sig/falcon/pqclean_falcon-512_aarch64/api.h
@@ -35,6 +35,17 @@ int PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair_from_fseed(
     uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 /*
+ * Generate Public key from Privat key.
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON512_AARCH64_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-512_aarch64/api.h
+++ b/src/sig/falcon/pqclean_falcon-512_aarch64/api.h
@@ -26,8 +26,8 @@ int PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair(
 /*
  * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */
@@ -37,8 +37,8 @@ int PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair_from_fseed(
 /*
  * Generate Public key from Privat key.
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */

--- a/src/sig/falcon/pqclean_falcon-512_aarch64/api.h
+++ b/src/sig/falcon/pqclean_falcon-512_aarch64/api.h
@@ -24,6 +24,17 @@ int PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-512_aarch64/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-512_aarch64/pqclean.c
@@ -190,8 +190,8 @@ PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair_from_fseed(
  * to regenerate the corresponding public key (h).
  * The generated public key is then encoded into the provided pk array.
  * 
- * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
- * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES in size).
  * @return 0 if the public key was successfully generated, or -1 in case of an error.
  */
 int

--- a/src/sig/falcon/pqclean_falcon-512_aarch64/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-512_aarch64/pqclean.c
@@ -108,6 +108,82 @@ PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[28 * FALCON_N];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
+    uint16_t h[FALCON_N];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCON512_AARCH64_keygen(&rng, f, g, F, NULL, h, FALCON_LOGN, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + FALCON_LOGN;
+    u = 1;
+    v = PQCLEAN_FALCON512_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            f, PQCLEAN_FALCON512_AARCH64_max_fg_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            g, PQCLEAN_FALCON512_AARCH64_max_fg_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            F, PQCLEAN_FALCON512_AARCH64_max_FG_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + FALCON_LOGN;
+    v = PQCLEAN_FALCON512_AARCH64_modq_encode(
+            pk + 1, PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
+            h, FALCON_LOGN);
+    if (v != PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-512_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-512_avx2/api.h
@@ -24,6 +24,17 @@ int PQCLEAN_FALCON512_AVX2_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON512_AVX2_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-512_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-512_avx2/api.h
@@ -35,6 +35,17 @@ int PQCLEAN_FALCON512_AVX2_crypto_sign_keypair_from_fseed(
     uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 /*
+ * Generate Public key from Privat key.
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON512_AVX2_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-512_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-512_avx2/pqclean.c
@@ -190,8 +190,8 @@ PQCLEAN_FALCON512_AVX2_crypto_sign_keypair_from_fseed(
  * to regenerate the corresponding public key (h).
  * The generated public key is then encoded into the provided pk array.
  * 
- * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
- * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES in size).
  * @return 0 if the public key was successfully generated, or -1 in case of an error.
  */
 int

--- a/src/sig/falcon/pqclean_falcon-512_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-512_avx2/pqclean.c
@@ -108,6 +108,82 @@ PQCLEAN_FALCON512_AVX2_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCON512_AVX2_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_9];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[512], g[512], F[512];
+    uint16_t h[512];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCON512_AVX2_keygen(&rng, f, g, F, NULL, h, 9, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + 9;
+    u = 1;
+    v = PQCLEAN_FALCON512_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            f, 9, PQCLEAN_FALCON512_AVX2_max_fg_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            g, 9, PQCLEAN_FALCON512_AVX2_max_fg_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            F, 9, PQCLEAN_FALCON512_AVX2_max_FG_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 9;
+    v = PQCLEAN_FALCON512_AVX2_modq_encode(
+            pk + 1, PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 9);
+    if (v != PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-512_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-512_clean/api.h
@@ -26,8 +26,8 @@ int PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(
 /*
  * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */
@@ -37,8 +37,8 @@ int PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(
 /*
  * Generate Public key from Privat key.
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */

--- a/src/sig/falcon/pqclean_falcon-512_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-512_clean/api.h
@@ -24,6 +24,17 @@ int PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-512_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-512_clean/api.h
@@ -35,6 +35,17 @@ int PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(
     uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 /*
+ * Generate Public key from Privat key.
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON512_CLEAN_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-512_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-512_clean/pqclean.c
@@ -185,6 +185,81 @@ PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(
 }
 
 /*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f, g, F) and then uses them 
+ * to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ * 
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @return 0 if the public key was successfully generated, or -1 in case of an error.
+ */
+int
+PQCLEAN_FALCON512_CLEAN_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_9];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[512], g[512], F[512];
+    uint16_t h[512];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + 9) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCON512_CLEAN_trim_i8_decode(
+            f, 9, PQCLEAN_FALCON512_CLEAN_max_fg_bits[9],
+            sk + u, PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_CLEAN_trim_i8_decode(
+            g, 9, PQCLEAN_FALCON512_CLEAN_max_fg_bits[9],
+            sk + u, PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_CLEAN_trim_i8_decode(
+            F, 9, PQCLEAN_FALCON512_CLEAN_max_FG_bits[9],
+            sk + u, PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCON512_CLEAN_compute_public(h, f, g, 9, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 9;
+    v = PQCLEAN_FALCON512_CLEAN_modq_encode(
+            pk + 1, PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 9);
+    if (v != PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce
  * or header byte), with *sigbuflen providing the maximum value length and

--- a/src/sig/falcon/pqclean_falcon-512_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-512_clean/pqclean.c
@@ -190,8 +190,8 @@ PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(
  * to regenerate the corresponding public key (h).
  * The generated public key is then encoded into the provided pk array.
  * 
- * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
- * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
  * @return 0 if the public key was successfully generated, or -1 in case of an error.
  */
 int

--- a/src/sig/falcon/pqclean_falcon-512_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-512_clean/pqclean.c
@@ -108,6 +108,82 @@ PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_9];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[512], g[512], F[512];
+    uint16_t h[512];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCON512_CLEAN_keygen(&rng, f, g, F, NULL, h, 9, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + 9;
+    u = 1;
+    v = PQCLEAN_FALCON512_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            f, 9, PQCLEAN_FALCON512_CLEAN_max_fg_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            g, 9, PQCLEAN_FALCON512_CLEAN_max_fg_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            F, 9, PQCLEAN_FALCON512_CLEAN_max_FG_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 9;
+    v = PQCLEAN_FALCON512_CLEAN_modq_encode(
+            pk + 1, PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 9);
+    if (v != PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-padded-1024_aarch64/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_aarch64/api.h
@@ -24,8 +24,8 @@ int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair(
 /*
  * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */
@@ -35,8 +35,8 @@ int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair_from_fseed(
 /*
  * Generate Public key from Privat key.
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */

--- a/src/sig/falcon/pqclean_falcon-padded-1024_aarch64/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_aarch64/api.h
@@ -33,6 +33,17 @@ int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair_from_fseed(
     uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 /*
+ * Generate Public key from Privat key.
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-1024_aarch64/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_aarch64/api.h
@@ -22,6 +22,17 @@ int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-1024_aarch64/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_aarch64/pqclean.c
@@ -187,8 +187,8 @@ PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair_from_fseed(
  * to regenerate the corresponding public key (h).
  * The generated public key is then encoded into the provided pk array.
  * 
- * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
- * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES in size).
  * @return 0 if the public key was successfully generated, or -1 in case of an error.
  */
 int

--- a/src/sig/falcon/pqclean_falcon-padded-1024_aarch64/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_aarch64/pqclean.c
@@ -105,6 +105,82 @@ PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[28 * FALCON_N];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
+    uint16_t h[FALCON_N];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCONPADDED1024_AARCH64_keygen(&rng, f, g, F, NULL, h, FALCON_LOGN, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + FALCON_LOGN;
+    u = 1;
+    v = PQCLEAN_FALCONPADDED1024_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            f, PQCLEAN_FALCONPADDED1024_AARCH64_max_fg_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            g, PQCLEAN_FALCONPADDED1024_AARCH64_max_fg_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            F, PQCLEAN_FALCONPADDED1024_AARCH64_max_FG_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + FALCON_LOGN;
+    v = PQCLEAN_FALCONPADDED1024_AARCH64_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
+            h, FALCON_LOGN);
+    if (v != PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-padded-1024_aarch64/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_aarch64/pqclean.c
@@ -182,6 +182,81 @@ PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair_from_fseed(
 }
 
 /*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f, g, F) and then uses them 
+ * to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ * 
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @return 0 if the public key was successfully generated, or -1 in case of an error.
+ */
+int
+PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[28 * FALCON_N];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
+    uint16_t h[FALCON_N];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + FALCON_LOGN) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCONPADDED1024_AARCH64_trim_i8_decode(
+            f, PQCLEAN_FALCONPADDED1024_AARCH64_max_fg_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_AARCH64_trim_i8_decode(
+            g, PQCLEAN_FALCONPADDED1024_AARCH64_max_fg_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_AARCH64_trim_i8_decode(
+            F, PQCLEAN_FALCONPADDED1024_AARCH64_max_FG_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCONPADDED1024_AARCH64_compute_public(h, f, g, FALCON_LOGN, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + FALCON_LOGN;
+    v = PQCLEAN_FALCONPADDED1024_AARCH64_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
+            h, FALCON_LOGN);
+    if (v != PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce
  * or header byte), with sigbuflen providing the maximum value length.

--- a/src/sig/falcon/pqclean_falcon-padded-1024_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_avx2/api.h
@@ -22,6 +22,17 @@ int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-1024_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_avx2/api.h
@@ -33,6 +33,17 @@ int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair_from_fseed(
     uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 /*
+ * Generate Public key from Privat key.
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-1024_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_avx2/api.h
@@ -24,8 +24,8 @@ int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair(
 /*
  * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */
@@ -35,8 +35,8 @@ int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair_from_fseed(
 /*
  * Generate Public key from Privat key.
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */

--- a/src/sig/falcon/pqclean_falcon-padded-1024_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_avx2/pqclean.c
@@ -182,6 +182,81 @@ PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair_from_fseed(
 }
 
 /*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f, g, F) and then uses them 
+ * to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ * 
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @return 0 if the public key was successfully generated, or -1 in case of an error.
+ */
+int
+PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_10];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[1024], g[1024], F[1024];
+    uint16_t h[1024];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + 10) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCONPADDED1024_AVX2_trim_i8_decode(
+            f, 10, PQCLEAN_FALCONPADDED1024_AVX2_max_fg_bits[10],
+            sk + u, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_AVX2_trim_i8_decode(
+            g, 10, PQCLEAN_FALCONPADDED1024_AVX2_max_fg_bits[10],
+            sk + u, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_AVX2_trim_i8_decode(
+            F, 10, PQCLEAN_FALCONPADDED1024_AVX2_max_FG_bits[10],
+            sk + u, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCONPADDED1024_AVX2_compute_public(h, f, g, 10, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 10;
+    v = PQCLEAN_FALCONPADDED1024_AVX2_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 10);
+    if (v != PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce
  * or header byte), with sigbuflen providing the maximum value length.

--- a/src/sig/falcon/pqclean_falcon-padded-1024_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_avx2/pqclean.c
@@ -105,6 +105,82 @@ PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_10];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[1024], g[1024], F[1024];
+    uint16_t h[1024];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCONPADDED1024_AVX2_keygen(&rng, f, g, F, NULL, h, 10, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + 10;
+    u = 1;
+    v = PQCLEAN_FALCONPADDED1024_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            f, 10, PQCLEAN_FALCONPADDED1024_AVX2_max_fg_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            g, 10, PQCLEAN_FALCONPADDED1024_AVX2_max_fg_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            F, 10, PQCLEAN_FALCONPADDED1024_AVX2_max_FG_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 10;
+    v = PQCLEAN_FALCONPADDED1024_AVX2_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 10);
+    if (v != PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-padded-1024_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_avx2/pqclean.c
@@ -187,8 +187,8 @@ PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair_from_fseed(
  * to regenerate the corresponding public key (h).
  * The generated public key is then encoded into the provided pk array.
  * 
- * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
- * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES in size).
  * @return 0 if the public key was successfully generated, or -1 in case of an error.
  */
 int

--- a/src/sig/falcon/pqclean_falcon-padded-1024_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_clean/api.h
@@ -22,6 +22,17 @@ int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-1024_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_clean/api.h
@@ -24,8 +24,8 @@ int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair(
 /*
  * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */
@@ -35,8 +35,8 @@ int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(
 /*
  * Generate Public key from Privat key.
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */

--- a/src/sig/falcon/pqclean_falcon-padded-1024_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_clean/api.h
@@ -33,6 +33,17 @@ int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(
     uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 /*
+ * Generate Public key from Privat key.
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-1024_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_clean/pqclean.c
@@ -105,6 +105,82 @@ PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_10];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[1024], g[1024], F[1024];
+    uint16_t h[1024];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCONPADDED1024_CLEAN_keygen(&rng, f, g, F, NULL, h, 10, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + 10;
+    u = 1;
+    v = PQCLEAN_FALCONPADDED1024_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            f, 10, PQCLEAN_FALCONPADDED1024_CLEAN_max_fg_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            g, 10, PQCLEAN_FALCONPADDED1024_CLEAN_max_fg_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            F, 10, PQCLEAN_FALCONPADDED1024_CLEAN_max_FG_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 10;
+    v = PQCLEAN_FALCONPADDED1024_CLEAN_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 10);
+    if (v != PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-padded-1024_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_clean/pqclean.c
@@ -187,8 +187,8 @@ PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(
  * to regenerate the corresponding public key (h).
  * The generated public key is then encoded into the provided pk array.
  * 
- * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
- * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
  * @return 0 if the public key was successfully generated, or -1 in case of an error.
  */
 int

--- a/src/sig/falcon/pqclean_falcon-padded-1024_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_clean/pqclean.c
@@ -182,6 +182,81 @@ PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(
 }
 
 /*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f, g, F) and then uses them 
+ * to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ * 
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @return 0 if the public key was successfully generated, or -1 in case of an error.
+ */
+int
+PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_10];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[1024], g[1024], F[1024];
+    uint16_t h[1024];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + 10) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCONPADDED1024_CLEAN_trim_i8_decode(
+            f, 10, PQCLEAN_FALCONPADDED1024_CLEAN_max_fg_bits[10],
+            sk + u, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_CLEAN_trim_i8_decode(
+            g, 10, PQCLEAN_FALCONPADDED1024_CLEAN_max_fg_bits[10],
+            sk + u, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_CLEAN_trim_i8_decode(
+            F, 10, PQCLEAN_FALCONPADDED1024_CLEAN_max_FG_bits[10],
+            sk + u, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCONPADDED1024_CLEAN_compute_public(h, f, g, 10, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 10;
+    v = PQCLEAN_FALCONPADDED1024_CLEAN_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 10);
+    if (v != PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce
  * or header byte), with sigbuflen providing the maximum value length.

--- a/src/sig/falcon/pqclean_falcon-padded-512_aarch64/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-512_aarch64/api.h
@@ -33,6 +33,17 @@ int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair_from_fseed(
     uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 /*
+ * Generate Public key from Privat key.
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-512_aarch64/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-512_aarch64/api.h
@@ -24,8 +24,8 @@ int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair(
 /*
  * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */
@@ -35,8 +35,8 @@ int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair_from_fseed(
 /*
  * Generate Public key from Privat key.
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */

--- a/src/sig/falcon/pqclean_falcon-padded-512_aarch64/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-512_aarch64/api.h
@@ -22,6 +22,17 @@ int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-512_aarch64/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-512_aarch64/pqclean.c
@@ -105,6 +105,82 @@ PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[28 * FALCON_N];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
+    uint16_t h[FALCON_N];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCONPADDED512_AARCH64_keygen(&rng, f, g, F, NULL, h, FALCON_LOGN, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + FALCON_LOGN;
+    u = 1;
+    v = PQCLEAN_FALCONPADDED512_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            f, PQCLEAN_FALCONPADDED512_AARCH64_max_fg_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            g, PQCLEAN_FALCONPADDED512_AARCH64_max_fg_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            F, PQCLEAN_FALCONPADDED512_AARCH64_max_FG_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + FALCON_LOGN;
+    v = PQCLEAN_FALCONPADDED512_AARCH64_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
+            h, FALCON_LOGN);
+    if (v != PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-padded-512_aarch64/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-512_aarch64/pqclean.c
@@ -182,6 +182,81 @@ PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair_from_fseed(
 }
 
 /*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f, g, F) and then uses them 
+ * to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ * 
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @return 0 if the public key was successfully generated, or -1 in case of an error.
+ */
+int
+PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[28 * FALCON_N];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
+    uint16_t h[FALCON_N];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + FALCON_LOGN) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCONPADDED512_AARCH64_trim_i8_decode(
+            f, PQCLEAN_FALCONPADDED512_AARCH64_max_fg_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_AARCH64_trim_i8_decode(
+            g, PQCLEAN_FALCONPADDED512_AARCH64_max_fg_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_AARCH64_trim_i8_decode(
+            F, PQCLEAN_FALCONPADDED512_AARCH64_max_FG_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCONPADDED512_AARCH64_compute_public(h, f, g, FALCON_LOGN, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + FALCON_LOGN;
+    v = PQCLEAN_FALCONPADDED512_AARCH64_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
+            h, FALCON_LOGN);
+    if (v != PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce
  * or header byte), with sigbuflen providing the maximum value length.

--- a/src/sig/falcon/pqclean_falcon-padded-512_aarch64/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-512_aarch64/pqclean.c
@@ -187,8 +187,8 @@ PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair_from_fseed(
  * to regenerate the corresponding public key (h).
  * The generated public key is then encoded into the provided pk array.
  * 
- * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
- * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @param pk  The output buffer where the public key will be stored (must be at least PPQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES in size).
  * @return 0 if the public key was successfully generated, or -1 in case of an error.
  */
 int

--- a/src/sig/falcon/pqclean_falcon-padded-512_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-512_avx2/api.h
@@ -22,6 +22,17 @@ int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-512_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-512_avx2/api.h
@@ -33,6 +33,17 @@ int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair_from_fseed(
     uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 /*
+ * Generate Public key from Privat key.
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-512_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-512_avx2/api.h
@@ -24,8 +24,8 @@ int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair(
 /*
  * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */
@@ -35,8 +35,8 @@ int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair_from_fseed(
 /*
  * Generate Public key from Privat key.
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */

--- a/src/sig/falcon/pqclean_falcon-padded-512_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-512_avx2/pqclean.c
@@ -182,6 +182,81 @@ PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair_from_fseed(
 }
 
 /*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f, g, F) and then uses them 
+ * to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ * 
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @return 0 if the public key was successfully generated, or -1 in case of an error.
+ */
+int
+PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_9];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[512], g[512], F[512];
+    uint16_t h[512];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + 9) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCONPADDED512_AVX2_trim_i8_decode(
+            f, 9, PQCLEAN_FALCONPADDED512_AVX2_max_fg_bits[9],
+            sk + u, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_AVX2_trim_i8_decode(
+            g, 9, PQCLEAN_FALCONPADDED512_AVX2_max_fg_bits[9],
+            sk + u, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_AVX2_trim_i8_decode(
+            F, 9, PQCLEAN_FALCONPADDED512_AVX2_max_FG_bits[9],
+            sk + u, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCONPADDED512_AVX2_compute_public(h, f, g, 9, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 9;
+    v = PQCLEAN_FALCONPADDED512_AVX2_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 9);
+    if (v != PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce
  * or header byte), with sigbuflen providing the maximum value length.

--- a/src/sig/falcon/pqclean_falcon-padded-512_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-512_avx2/pqclean.c
@@ -187,8 +187,8 @@ PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair_from_fseed(
  * to regenerate the corresponding public key (h).
  * The generated public key is then encoded into the provided pk array.
  * 
- * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
- * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES in size).
  * @return 0 if the public key was successfully generated, or -1 in case of an error.
  */
 int

--- a/src/sig/falcon/pqclean_falcon-padded-512_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-512_avx2/pqclean.c
@@ -105,6 +105,82 @@ PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_9];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[512], g[512], F[512];
+    uint16_t h[512];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCONPADDED512_AVX2_keygen(&rng, f, g, F, NULL, h, 9, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + 9;
+    u = 1;
+    v = PQCLEAN_FALCONPADDED512_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            f, 9, PQCLEAN_FALCONPADDED512_AVX2_max_fg_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            g, 9, PQCLEAN_FALCONPADDED512_AVX2_max_fg_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            F, 9, PQCLEAN_FALCONPADDED512_AVX2_max_FG_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 9;
+    v = PQCLEAN_FALCONPADDED512_AVX2_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 9);
+    if (v != PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-padded-512_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-512_clean/api.h
@@ -33,6 +33,17 @@ int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(
     uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 
 /*
+ * Generate Public key from Privat key.
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-512_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-512_clean/api.h
@@ -22,6 +22,17 @@ int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-512_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-512_clean/api.h
@@ -24,8 +24,8 @@ int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair(
 /*
  * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */
@@ -35,8 +35,8 @@ int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(
 /*
  * Generate Public key from Privat key.
  * Key sizes are exact (in bytes):
- *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
- *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   public (pk): PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES
  *
  * Return value: 0 on success, -1 on error.
  */

--- a/src/sig/falcon/pqclean_falcon-padded-512_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-512_clean/pqclean.c
@@ -182,6 +182,81 @@ PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(
 }
 
 /*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f, g, F) and then uses them 
+ * to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ * 
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @return 0 if the public key was successfully generated, or -1 in case of an error.
+ */
+int
+PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_9];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[512], g[512], F[512];
+    uint16_t h[512];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + 9) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCONPADDED512_CLEAN_trim_i8_decode(
+            f, 9, PQCLEAN_FALCONPADDED512_CLEAN_max_fg_bits[9],
+            sk + u, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_CLEAN_trim_i8_decode(
+            g, 9, PQCLEAN_FALCONPADDED512_CLEAN_max_fg_bits[9],
+            sk + u, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_CLEAN_trim_i8_decode(
+            F, 9, PQCLEAN_FALCONPADDED512_CLEAN_max_FG_bits[9],
+            sk + u, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCONPADDED512_CLEAN_compute_public(h, f, g, 9, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 9;
+    v = PQCLEAN_FALCONPADDED512_CLEAN_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 9);
+    if (v != PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce
  * or header byte), with sigbuflen providing the maximum value length.

--- a/src/sig/falcon/pqclean_falcon-padded-512_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-512_clean/pqclean.c
@@ -105,6 +105,82 @@ PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_9];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[512], g[512], F[512];
+    uint16_t h[512];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCONPADDED512_CLEAN_keygen(&rng, f, g, F, NULL, h, 9, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + 9;
+    u = 1;
+    v = PQCLEAN_FALCONPADDED512_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            f, 9, PQCLEAN_FALCONPADDED512_CLEAN_max_fg_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            g, 9, PQCLEAN_FALCONPADDED512_CLEAN_max_fg_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            F, 9, PQCLEAN_FALCONPADDED512_CLEAN_max_FG_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 9;
+    v = PQCLEAN_FALCONPADDED512_CLEAN_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 9);
+    if (v != PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-padded-512_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-512_clean/pqclean.c
@@ -187,8 +187,8 @@ PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(
  * to regenerate the corresponding public key (h).
  * The generated public key is then encoded into the provided pk array.
  * 
- * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
- * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * @param pk  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * @param sk  The input secret key (private key) in byte array format (must be PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
  * @return 0 if the public key was successfully generated, or -1 in case of an error.
  */
 int

--- a/src/sig/falcon/sig_falcon.h
+++ b/src/sig/falcon/sig_falcon.h
@@ -13,6 +13,7 @@
 OQS_SIG *OQS_SIG_falcon_512_new(void);
 OQS_API OQS_STATUS OQS_SIG_falcon_512_keypair(uint8_t *public_key, uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_512_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_falcon_512_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_512_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_512_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_512_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -27,6 +28,7 @@ OQS_API OQS_STATUS OQS_SIG_falcon_512_verify_with_ctx_str(const uint8_t *message
 OQS_SIG *OQS_SIG_falcon_1024_new(void);
 OQS_API OQS_STATUS OQS_SIG_falcon_1024_keypair(uint8_t *public_key, uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_1024_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_falcon_1024_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_1024_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_1024_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_1024_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -41,6 +43,7 @@ OQS_API OQS_STATUS OQS_SIG_falcon_1024_verify_with_ctx_str(const uint8_t *messag
 OQS_SIG *OQS_SIG_falcon_padded_512_new(void);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_keypair(uint8_t *public_key, uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -55,6 +58,7 @@ OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_verify_with_ctx_str(const uint8_t *
 OQS_SIG *OQS_SIG_falcon_padded_1024_new(void);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_keypair(uint8_t *public_key, uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);

--- a/src/sig/falcon/sig_falcon.h
+++ b/src/sig/falcon/sig_falcon.h
@@ -12,6 +12,7 @@
 
 OQS_SIG *OQS_SIG_falcon_512_new(void);
 OQS_API OQS_STATUS OQS_SIG_falcon_512_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_falcon_512_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_SIG_falcon_512_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_512_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_512_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -25,6 +26,7 @@ OQS_API OQS_STATUS OQS_SIG_falcon_512_verify_with_ctx_str(const uint8_t *message
 
 OQS_SIG *OQS_SIG_falcon_1024_new(void);
 OQS_API OQS_STATUS OQS_SIG_falcon_1024_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_falcon_1024_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_SIG_falcon_1024_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_1024_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_1024_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -38,6 +40,7 @@ OQS_API OQS_STATUS OQS_SIG_falcon_1024_verify_with_ctx_str(const uint8_t *messag
 
 OQS_SIG *OQS_SIG_falcon_padded_512_new(void);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -51,6 +54,7 @@ OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_verify_with_ctx_str(const uint8_t *
 
 OQS_SIG *OQS_SIG_falcon_padded_1024_new(void);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);

--- a/src/sig/falcon/sig_falcon_1024.c
+++ b/src/sig/falcon/sig_falcon_1024.c
@@ -24,6 +24,7 @@ OQS_SIG *OQS_SIG_falcon_1024_new(void) {
 
 	sig->keypair = OQS_SIG_falcon_1024_keypair;
 	sig->keypair_from_fseed = OQS_SIG_falcon_1024_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_falcon_1024_pubkey_from_privkey;
 	sig->sign = OQS_SIG_falcon_1024_sign;
 	sig->verify = OQS_SIG_falcon_1024_verify;
 	sig->sign_with_ctx_str = OQS_SIG_falcon_1024_sign_with_ctx_str;
@@ -34,12 +35,14 @@ OQS_SIG *OQS_SIG_falcon_1024_new(void) {
 
 extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_falcon_1024_avx2)
 extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -47,6 +50,7 @@ extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_verify(const uint8_t *sig, size_t
 #if defined(OQS_ENABLE_SIG_falcon_1024_aarch64)
 extern int PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCON1024_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -100,6 +104,32 @@ OQS_API OQS_STATUS OQS_SIG_falcon_1024_keypair_from_fseed(uint8_t *public_key, u
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_falcon_1024_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_falcon_1024_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCON1024_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_falcon_1024_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCON1024_AARCH64_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/falcon/sig_falcon_1024.c
+++ b/src/sig/falcon/sig_falcon_1024.c
@@ -23,6 +23,7 @@ OQS_SIG *OQS_SIG_falcon_1024_new(void) {
 	sig->length_signature = OQS_SIG_falcon_1024_length_signature;
 
 	sig->keypair = OQS_SIG_falcon_1024_keypair;
+	sig->keypair_from_fseed = OQS_SIG_falcon_1024_keypair_from_fseed;
 	sig->sign = OQS_SIG_falcon_1024_sign;
 	sig->verify = OQS_SIG_falcon_1024_verify;
 	sig->sign_with_ctx_str = OQS_SIG_falcon_1024_sign_with_ctx_str;
@@ -32,17 +33,20 @@ OQS_SIG *OQS_SIG_falcon_1024_new(void) {
 }
 
 extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_falcon_1024_avx2)
 extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
 
 #if defined(OQS_ENABLE_SIG_falcon_1024_aarch64)
 extern int PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int PQCLEAN_FALCON1024_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -70,6 +74,32 @@ OQS_API OQS_STATUS OQS_SIG_falcon_1024_keypair(uint8_t *public_key, uint8_t *sec
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_falcon_1024_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_falcon_1024_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_falcon_1024_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
 #endif
 }
 

--- a/src/sig/falcon/sig_falcon_512.c
+++ b/src/sig/falcon/sig_falcon_512.c
@@ -23,6 +23,7 @@ OQS_SIG *OQS_SIG_falcon_512_new(void) {
 	sig->length_signature = OQS_SIG_falcon_512_length_signature;
 
 	sig->keypair = OQS_SIG_falcon_512_keypair;
+	sig->keypair_from_fseed = OQS_SIG_falcon_512_keypair_from_fseed;
 	sig->sign = OQS_SIG_falcon_512_sign;
 	sig->verify = OQS_SIG_falcon_512_verify;
 	sig->sign_with_ctx_str = OQS_SIG_falcon_512_sign_with_ctx_str;
@@ -32,17 +33,20 @@ OQS_SIG *OQS_SIG_falcon_512_new(void) {
 }
 
 extern int PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int PQCLEAN_FALCON512_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON512_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_falcon_512_avx2)
 extern int PQCLEAN_FALCON512_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCON512_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int PQCLEAN_FALCON512_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON512_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
 
 #if defined(OQS_ENABLE_SIG_falcon_512_aarch64)
 extern int PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int PQCLEAN_FALCON512_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON512_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -72,6 +76,33 @@ OQS_API OQS_STATUS OQS_SIG_falcon_512_keypair(uint8_t *public_key, uint8_t *secr
 	return (OQS_STATUS) PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(public_key, secret_key);
 #endif
 }
+
+OQS_API OQS_STATUS OQS_SIG_falcon_512_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_falcon_512_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCON512_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_falcon_512_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
 
 OQS_API OQS_STATUS OQS_SIG_falcon_512_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key) {
 #if defined(OQS_ENABLE_SIG_falcon_512_avx2)

--- a/src/sig/falcon/sig_falcon_512.c
+++ b/src/sig/falcon/sig_falcon_512.c
@@ -24,6 +24,7 @@ OQS_SIG *OQS_SIG_falcon_512_new(void) {
 
 	sig->keypair = OQS_SIG_falcon_512_keypair;
 	sig->keypair_from_fseed = OQS_SIG_falcon_512_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_falcon_512_pubkey_from_privkey;
 	sig->sign = OQS_SIG_falcon_512_sign;
 	sig->verify = OQS_SIG_falcon_512_verify;
 	sig->sign_with_ctx_str = OQS_SIG_falcon_512_sign_with_ctx_str;
@@ -34,12 +35,14 @@ OQS_SIG *OQS_SIG_falcon_512_new(void) {
 
 extern int PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCON512_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCON512_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON512_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_falcon_512_avx2)
 extern int PQCLEAN_FALCON512_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_FALCON512_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCON512_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCON512_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON512_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -47,6 +50,7 @@ extern int PQCLEAN_FALCON512_AVX2_crypto_sign_verify(const uint8_t *sig, size_t 
 #if defined(OQS_ENABLE_SIG_falcon_512_aarch64)
 extern int PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCON512_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCON512_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON512_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -103,6 +107,31 @@ OQS_API OQS_STATUS OQS_SIG_falcon_512_keypair_from_fseed(uint8_t *public_key, ui
 #endif
 }
 
+OQS_API OQS_STATUS OQS_SIG_falcon_512_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_falcon_512_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCON512_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCON512_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_falcon_512_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCON512_AARCH64_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCON512_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_FALCON512_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#endif
+}
 
 OQS_API OQS_STATUS OQS_SIG_falcon_512_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key) {
 #if defined(OQS_ENABLE_SIG_falcon_512_avx2)

--- a/src/sig/falcon/sig_falcon_padded_1024.c
+++ b/src/sig/falcon/sig_falcon_padded_1024.c
@@ -24,6 +24,7 @@ OQS_SIG *OQS_SIG_falcon_padded_1024_new(void) {
 
 	sig->keypair = OQS_SIG_falcon_padded_1024_keypair;
 	sig->keypair_from_fseed = OQS_SIG_falcon_padded_1024_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_falcon_padded_1024_pubkey_from_privkey;
 	sig->sign = OQS_SIG_falcon_padded_1024_sign;
 	sig->verify = OQS_SIG_falcon_padded_1024_verify;
 	sig->sign_with_ctx_str = OQS_SIG_falcon_padded_1024_sign_with_ctx_str;
@@ -34,12 +35,14 @@ OQS_SIG *OQS_SIG_falcon_padded_1024_new(void) {
 
 extern int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_falcon_padded_1024_avx2)
 extern int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -47,6 +50,7 @@ extern int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_verify(const uint8_t *sig, 
 #if defined(OQS_ENABLE_SIG_falcon_padded_1024_aarch64)
 extern int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -100,6 +104,32 @@ OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_keypair_from_fseed(uint8_t *public
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_falcon_padded_1024_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_falcon_padded_1024_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/falcon/sig_falcon_padded_1024.c
+++ b/src/sig/falcon/sig_falcon_padded_1024.c
@@ -23,6 +23,7 @@ OQS_SIG *OQS_SIG_falcon_padded_1024_new(void) {
 	sig->length_signature = OQS_SIG_falcon_padded_1024_length_signature;
 
 	sig->keypair = OQS_SIG_falcon_padded_1024_keypair;
+	sig->keypair_from_fseed = OQS_SIG_falcon_padded_1024_keypair_from_fseed;
 	sig->sign = OQS_SIG_falcon_padded_1024_sign;
 	sig->verify = OQS_SIG_falcon_padded_1024_verify;
 	sig->sign_with_ctx_str = OQS_SIG_falcon_padded_1024_sign_with_ctx_str;
@@ -32,17 +33,20 @@ OQS_SIG *OQS_SIG_falcon_padded_1024_new(void) {
 }
 
 extern int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_falcon_padded_1024_avx2)
 extern int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
 
 #if defined(OQS_ENABLE_SIG_falcon_padded_1024_aarch64)
 extern int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -70,6 +74,32 @@ OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_keypair(uint8_t *public_key, uint8
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_falcon_padded_1024_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_falcon_padded_1024_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
 #endif
 }
 

--- a/src/sig/falcon/sig_falcon_padded_512.c
+++ b/src/sig/falcon/sig_falcon_padded_512.c
@@ -23,6 +23,7 @@ OQS_SIG *OQS_SIG_falcon_padded_512_new(void) {
 	sig->length_signature = OQS_SIG_falcon_padded_512_length_signature;
 
 	sig->keypair = OQS_SIG_falcon_padded_512_keypair;
+	sig->keypair_from_fseed = OQS_SIG_falcon_padded_512_keypair_from_fseed;
 	sig->sign = OQS_SIG_falcon_padded_512_sign;
 	sig->verify = OQS_SIG_falcon_padded_512_verify;
 	sig->sign_with_ctx_str = OQS_SIG_falcon_padded_512_sign_with_ctx_str;
@@ -32,17 +33,20 @@ OQS_SIG *OQS_SIG_falcon_padded_512_new(void) {
 }
 
 extern int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_falcon_padded_512_avx2)
 extern int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
 
 #if defined(OQS_ENABLE_SIG_falcon_padded_512_aarch64)
 extern int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -70,6 +74,32 @@ OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_keypair(uint8_t *public_key, uint8_
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_falcon_padded_512_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_falcon_padded_512_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
 #endif
 }
 

--- a/src/sig/falcon/sig_falcon_padded_512.c
+++ b/src/sig/falcon/sig_falcon_padded_512.c
@@ -24,6 +24,7 @@ OQS_SIG *OQS_SIG_falcon_padded_512_new(void) {
 
 	sig->keypair = OQS_SIG_falcon_padded_512_keypair;
 	sig->keypair_from_fseed = OQS_SIG_falcon_padded_512_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_falcon_padded_512_pubkey_from_privkey;
 	sig->sign = OQS_SIG_falcon_padded_512_sign;
 	sig->verify = OQS_SIG_falcon_padded_512_verify;
 	sig->sign_with_ctx_str = OQS_SIG_falcon_padded_512_sign_with_ctx_str;
@@ -34,12 +35,14 @@ OQS_SIG *OQS_SIG_falcon_padded_512_new(void) {
 
 extern int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_falcon_padded_512_avx2)
 extern int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -47,6 +50,7 @@ extern int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_verify(const uint8_t *sig, s
 #if defined(OQS_ENABLE_SIG_falcon_padded_512_aarch64)
 extern int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -100,6 +104,32 @@ OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_keypair_from_fseed(uint8_t *public_
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_falcon_padded_512_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_falcon_padded_512_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/sig.c
+++ b/src/sig/sig.c
@@ -718,6 +718,14 @@ OQS_API OQS_STATUS OQS_SIG_keypair(const OQS_SIG *sig, uint8_t *public_key, uint
 	}
 }
 
+OQS_API OQS_STATUS OQS_SIG_keypair_from_fseed(const OQS_SIG *sig, uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+	if (sig == NULL || sig->keypair_from_fseed(public_key, secret_key, seed) != OQS_SUCCESS) {
+		return OQS_ERROR;
+	} else {
+		return OQS_SUCCESS;
+	}
+}
+
 OQS_API OQS_STATUS OQS_SIG_sign(const OQS_SIG *sig, uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key) {
 	if (sig == NULL || sig->sign(signature, signature_len, message, message_len, secret_key) != OQS_SUCCESS) {
 		return OQS_ERROR;

--- a/src/sig/sig.c
+++ b/src/sig/sig.c
@@ -726,6 +726,14 @@ OQS_API OQS_STATUS OQS_SIG_keypair_from_fseed(const OQS_SIG *sig, uint8_t *publi
 	}
 }
 
+OQS_API OQS_STATUS OQS_SIG_pubkey_from_privkey(const OQS_SIG *sig, uint8_t *public_key, const uint8_t *secret_key) {
+	if (sig == NULL || sig->pubkey_from_privkey(public_key, secret_key) != OQS_SUCCESS) {
+		return OQS_ERROR;
+	} else {
+		return OQS_SUCCESS;
+	}
+}
+
 OQS_API OQS_STATUS OQS_SIG_sign(const OQS_SIG *sig, uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key) {
 	if (sig == NULL || sig->sign(signature, signature_len, message, message_len, secret_key) != OQS_SUCCESS) {
 		return OQS_ERROR;

--- a/src/sig/sig.h
+++ b/src/sig/sig.h
@@ -208,6 +208,11 @@ typedef struct OQS_SIG {
 	OQS_STATUS (*keypair_from_fseed)(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 
 	/**
+	* Public key generation from exist private key.
+	*/
+	OQS_STATUS (*pubkey_from_privkey)(uint8_t *public_key, const uint8_t *secret_key);
+
+	/**
 	 * Signature generation algorithm.
 	 *
 	 * Caller is responsible for allocating sufficient memory for `signature`,
@@ -299,6 +304,11 @@ OQS_API OQS_STATUS OQS_SIG_keypair(const OQS_SIG *sig, uint8_t *public_key, uint
  * Keypair generation algorithm but can generate keypair from fixed seed or other random source.
  */
 OQS_API OQS_STATUS OQS_SIG_keypair_from_fseed(const OQS_SIG *sig, uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+
+/**
+ * Public key generation from exist private key.
+ */
+OQS_API OQS_STATUS OQS_SIG_pubkey_from_privkey(const OQS_SIG *sig, uint8_t *public_key, const uint8_t *secret_key);
 
 /**
  * Signature generation algorithm.

--- a/src/sig/sig.h
+++ b/src/sig/sig.h
@@ -201,6 +201,11 @@ typedef struct OQS_SIG {
 	 * @return OQS_SUCCESS or OQS_ERROR
 	 */
 	OQS_STATUS (*keypair)(uint8_t *public_key, uint8_t *secret_key);
+	
+	/**
+	 * Keypair generation algorithm but can generate keypair from fixed seed or other random source.
+	 */
+	OQS_STATUS (*keypair_from_fseed)(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 
 	/**
 	 * Signature generation algorithm.
@@ -289,6 +294,11 @@ OQS_API OQS_SIG *OQS_SIG_new(const char *method_name);
  * @return OQS_SUCCESS or OQS_ERROR
  */
 OQS_API OQS_STATUS OQS_SIG_keypair(const OQS_SIG *sig, uint8_t *public_key, uint8_t *secret_key);
+
+/**
+ * Keypair generation algorithm but can generate keypair from fixed seed or other random source.
+ */
+OQS_API OQS_STATUS OQS_SIG_keypair_from_fseed(const OQS_SIG *sig, uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 
 /**
  * Signature generation algorithm.


### PR DESCRIPTION
Exendend api and modification for allow generate keypair from fixed seed for some sig algos.

suporeted now .

all variants of Dilithium
all variants of Falcon

Todo add testvectors. ( tested over python calls  by hands for now.)
Todo add dirrect generation public key from private key. (done)

`OQS_SIG_keypair_from_fseed(const OQS_SIG *sig, uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);`

expect seed at args. ( 48 byte string for Falcon and 32 byte string for Dilithium)

need deep review . But seems it works as expected.
