### PR TITLE
extended api for allow use fixed seed for generate key pair and generate public key from private key in Signature schemes

### DIFF
--- a/docs/algorithms/sig/falcon.md
+++ b/docs/algorithms/sig/falcon.md
@@ -7,9 +7,9 @@
 - **Authors' website**: https://falcon-sign.info
 - **Specification version**: 20211101.
 - **Primary Source**<a name="primary-source"></a>:
-  - **Source**: https://github.com/PQClean/PQClean/commit/1eacfdafc15ddc5d5759d0b85b4cef26627df181
+  - **Source**: https://github.com/PQClean/PQClean/commit/1eacfdafc15ddc5d5759d0b85b4cef26627df181 with copy_from_upstream patches
   - **Implementation license (SPDX-Identifier)**: MIT
-- **Optimized Implementation sources**: https://github.com/PQClean/PQClean/commit/1eacfdafc15ddc5d5759d0b85b4cef26627df181
+- **Optimized Implementation sources**: https://github.com/PQClean/PQClean/commit/1eacfdafc15ddc5d5759d0b85b4cef26627df181 with copy_from_upstream patches
   - **pqclean-aarch64**:<a name="pqclean-aarch64"></a>
       - **Source**: https://github.com/PQClean/PQClean/commit/7707d1bcc8ae7f9ffd296dd13b1d76d2767d14f8
       - **Implementation license (SPDX-Identifier)**: Apache-2.0

--- a/docs/algorithms/sig/falcon.yml
+++ b/docs/algorithms/sig/falcon.yml
@@ -19,6 +19,7 @@ nist-round: 3
 spec-version: 20211101
 primary-upstream:
   source: https://github.com/PQClean/PQClean/commit/1eacfdafc15ddc5d5759d0b85b4cef26627df181
+    with copy_from_upstream patches
   spdx-license-identifier: MIT
   upstream-ancestors:
   - https://www.falcon-sign.info

--- a/scripts/copy_from_upstream/copy_from_upstream.yml
+++ b/scripts/copy_from_upstream/copy_from_upstream.yml
@@ -20,7 +20,7 @@ upstreams:
     sig_meta_path: 'crypto_sign/{pqclean_scheme}/META.yml'
     kem_scheme_path: 'crypto_kem/{pqclean_scheme}'
     sig_scheme_path: 'crypto_sign/{pqclean_scheme}'
-    patches: [pqclean-sphincs.patch]
+    patches: [pqclean-sphincs.patch, pqclean_falcon_512_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch, pqclean_falcon_512_avx2_keypair_from_fixed_seed_and_pubkey_from_privkey.patch, pqclean_falcon_512_aarch64_keypair_from_fixed_seed_and_pubkey_from_privkey.patch, pqclean_falcon_1024_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch, pqclean_falcon_1024_avx2_keypair_from_fixed_seed_and_pubkey_from_privkey.patch, pqclean_falcon_1024_aarch64_keypair_from_fixed_seed_and_pubkey_from_privkey.patch, pqclean_falcon_padded_512_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch, pqclean_falcon_padded_512_avx2_keypair_from_fixed_seed_and_pubkey_from_privkey.patch, pqclean_falcon_padded_512_aarch64_keypair_from_fixed_seed_and_pubkey_from_privkey.patch, pqclean_falcon_padded_1024_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch, pqclean_falcon_padded_1024_avx2_keypair_from_fixed_seed_and_pubkey_from_privkey.patch, pqclean_falcon_padded_1024_aarch64_keypair_from_fixed_seed_and_pubkey_from_privkey.patch]
     ignore: pqclean_sphincs-shake-256s-simple_aarch64, pqclean_sphincs-shake-256s-simple_aarch64, pqclean_sphincs-shake-256f-simple_aarch64, pqclean_sphincs-shake-192s-simple_aarch64, pqclean_sphincs-shake-192f-simple_aarch64, pqclean_sphincs-shake-128s-simple_aarch64, pqclean_sphincs-shake-128f-simple_aarch64, pqclean_kyber512_aarch64, pqclean_kyber1024_aarch64, pqclean_kyber768_aarch64, pqclean_dilithium2_aarch64, pqclean_dilithium3_aarch64, pqclean_dilithium5_aarch64
   -
     name: pqcrystals-kyber

--- a/scripts/copy_from_upstream/copy_from_upstream.yml
+++ b/scripts/copy_from_upstream/copy_from_upstream.yml
@@ -45,7 +45,7 @@ upstreams:
     git_commit: 3e9b9f1412f6c7435dbeb4e10692ea58f181ee51
     sig_meta_path: '{pretty_name_full}_META.yml'
     sig_scheme_path: '.'
-    patches: [pqcrystals-dilithium-yml.patch, pqcrystals-dilithium-ref-shake-aes.patch, pqcrystals-dilithium-avx2-shake-aes.patch, pqcrystals_dilithium_ref_avx2_2_5_keypair_from_fixed_seed_and_pubkey_from_privkey_function.patch]
+    patches: [pqcrystals-dilithium-yml.patch, pqcrystals-dilithium-ref-shake-aes.patch, pqcrystals-dilithium-avx2-shake-aes.patch, pqcrystals_dilithium_ref_avx2_2_5_keypair_from_fixed_seed_and_pubkey_from_privkey_function.patch, fix_pqcrystals_dilithium_implementations.patch]
   -
     name: pqcrystals-dilithium-standard
     git_url: https://github.com/pq-crystals/dilithium.git

--- a/scripts/copy_from_upstream/copy_from_upstream.yml
+++ b/scripts/copy_from_upstream/copy_from_upstream.yml
@@ -9,7 +9,7 @@ upstreams:
     kem_scheme_path: 'crypto_kem/{pqclean_scheme}'
     sig_scheme_path: 'crypto_sign/{pqclean_scheme}'
     patches: [pqclean-dilithium-arm-randomized-signing.patch, pqclean-kyber-armneon-shake-fixes.patch, pqclean-kyber-armneon-768-1024-fixes.patch, pqclean-kyber-armneon-variable-timing-fix.patch,
-    pqclean-kyber-armneon-asan.patch]
+    pqclean-kyber-armneon-asan.patch, oldpqclean_dilithium2_aarch64_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch, oldpqclean_dilithium3_aarch64_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch, oldpqclean_dilithium5_aarch64_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch]
     ignore: pqclean_sphincs-shake-256s-simple_aarch64, pqclean_sphincs-shake-256s-simple_aarch64, pqclean_sphincs-shake-256f-simple_aarch64, pqclean_sphincs-shake-192s-simple_aarch64, pqclean_sphincs-shake-192f-simple_aarch64, pqclean_sphincs-shake-128s-simple_aarch64, pqclean_sphincs-shake-128f-simple_aarch64
   -
     name: pqclean

--- a/scripts/copy_from_upstream/copy_from_upstream.yml
+++ b/scripts/copy_from_upstream/copy_from_upstream.yml
@@ -45,7 +45,7 @@ upstreams:
     git_commit: 3e9b9f1412f6c7435dbeb4e10692ea58f181ee51
     sig_meta_path: '{pretty_name_full}_META.yml'
     sig_scheme_path: '.'
-    patches: [pqcrystals-dilithium-yml.patch, pqcrystals-dilithium-ref-shake-aes.patch, pqcrystals-dilithium-avx2-shake-aes.patch]
+    patches: [pqcrystals-dilithium-yml.patch, pqcrystals-dilithium-ref-shake-aes.patch, pqcrystals-dilithium-avx2-shake-aes.patch, pqcrystals_dilithium_ref_avx2_2_5_keypair_from_fixed_seed_and_pubkey_from_privkey_function.patch]
   -
     name: pqcrystals-dilithium-standard
     git_url: https://github.com/pq-crystals/dilithium.git

--- a/scripts/copy_from_upstream/patches/fix_pqcrystals_dilithium_implementations.patch
+++ b/scripts/copy_from_upstream/patches/fix_pqcrystals_dilithium_implementations.patch
@@ -1,0 +1,67 @@
+4e6cde79c650375eb42245cf48f69b8ee7e500ba
+diff --git a/Dilithium2_META.yml b/Dilithium2_META.yml
+index f4b7e8f..a6a1a00 100644
+--- a/Dilithium2_META.yml
++++ b/Dilithium2_META.yml
+@@ -22,6 +22,8 @@ implementations:
+     folder_name: ref
+     compile_opts: -DDILITHIUM_MODE=2 -DDILITHIUM_RANDOMIZED_SIGNING
+     signature_keypair: pqcrystals_dilithium2_ref_keypair
++    signature_keypair_from_fseed: pqcrystals_dilithium2_ref_keypair_from_fseed
++    signature_pubkey_from_privkey: pqcrystals_dilithium2_ref_pubkey_from_privkey
+     signature_signature: pqcrystals_dilithium2_ref_signature
+     signature_verify: pqcrystals_dilithium2_ref_verify
+     sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c
+@@ -29,6 +31,8 @@ implementations:
+     version: https://github.com/pq-crystals/dilithium/commit/d9c885d3f2e11c05529eeeb7d70d808c972b8409
+     compile_opts: -DDILITHIUM_MODE=2 -DDILITHIUM_RANDOMIZED_SIGNING
+     signature_keypair: pqcrystals_dilithium2_avx2_keypair
++    signature_keypair_from_fseed: pqcrystals_dilithium2_avx2_keypair_from_fseed
++    signature_pubkey_from_privkey: pqcrystals_dilithium2_avx2_pubkey_from_privkey
+     signature_signature: pqcrystals_dilithium2_avx2_signature
+     signature_verify: pqcrystals_dilithium2_avx2_verify
+     sources: ../LICENSE api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-shake.c
+diff --git a/Dilithium3_META.yml b/Dilithium3_META.yml
+index f45c859..f68c064 100644
+--- a/Dilithium3_META.yml
++++ b/Dilithium3_META.yml
+@@ -22,6 +22,8 @@ implementations:
+     folder_name: ref
+     compile_opts: -DDILITHIUM_MODE=3 -DDILITHIUM_RANDOMIZED_SIGNING
+     signature_keypair: pqcrystals_dilithium3_ref_keypair
++    signature_keypair_from_fseed: pqcrystals_dilithium3_ref_keypair_from_fseed
++    signature_pubkey_from_privkey: pqcrystals_dilithium3_ref_pubkey_from_privkey
+     signature_signature: pqcrystals_dilithium3_ref_signature
+     signature_verify: pqcrystals_dilithium3_ref_verify
+     sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c
+@@ -29,6 +31,8 @@ implementations:
+     version: https://github.com/pq-crystals/dilithium/commit/d9c885d3f2e11c05529eeeb7d70d808c972b8409
+     compile_opts: -DDILITHIUM_MODE=3 -DDILITHIUM_RANDOMIZED_SIGNING
+     signature_keypair: pqcrystals_dilithium3_avx2_keypair
++    signature_keypair_from_fseed: pqcrystals_dilithium3_avx2_keypair_from_fseed
++    signature_pubkey_from_privkey: pqcrystals_dilithium3_avx2_pubkey_from_privkey
+     signature_signature: pqcrystals_dilithium3_avx2_signature
+     signature_verify: pqcrystals_dilithium3_avx2_verify
+     sources: ../LICENSE api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-shake.c
+diff --git a/Dilithium5_META.yml b/Dilithium5_META.yml
+index 618b617..71ef0a9 100644
+--- a/Dilithium5_META.yml
++++ b/Dilithium5_META.yml
+@@ -22,6 +22,8 @@ implementations:
+     folder_name: ref
+     compile_opts: -DDILITHIUM_MODE=5 -DDILITHIUM_RANDOMIZED_SIGNING
+     signature_keypair: pqcrystals_dilithium5_ref_keypair
++    signature_keypair_from_fseed: pqcrystals_dilithium5_ref_keypair_from_fseed
++    signature_pubkey_from_privkey: pqcrystals_dilithium5_ref_pubkey_from_privkey
+     signature_signature: pqcrystals_dilithium5_ref_signature
+     signature_verify: pqcrystals_dilithium5_ref_verify
+     sources: ../LICENSE api.h config.h params.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.c ntt.h reduce.c reduce.h rounding.c rounding.h symmetric.h symmetric-shake.c
+@@ -29,6 +31,8 @@ implementations:
+     version: https://github.com/pq-crystals/dilithium/commit/d9c885d3f2e11c05529eeeb7d70d808c972b8409
+     compile_opts: -DDILITHIUM_MODE=5 -DDILITHIUM_RANDOMIZED_SIGNING
+     signature_keypair: pqcrystals_dilithium5_avx2_keypair
++    signature_keypair_from_fseed: pqcrystals_dilithium5_avx2_keypair_from_fseed
++    signature_pubkey_from_privkey: pqcrystals_dilithium5_avx2_pubkey_from_privkey
+     signature_signature: pqcrystals_dilithium5_avx2_signature
+     signature_verify: pqcrystals_dilithium5_avx2_verify
+     sources: ../LICENSE api.h config.h params.h align.h sign.c sign.h packing.c packing.h polyvec.c polyvec.h poly.c poly.h ntt.S invntt.S pointwise.S ntt.h shuffle.S shuffle.inc consts.c consts.h rejsample.c rejsample.h rounding.c rounding.h symmetric.h symmetric-shake.c

--- a/scripts/copy_from_upstream/patches/oldpqclean_dilithium2_aarch64_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
+++ b/scripts/copy_from_upstream/patches/oldpqclean_dilithium2_aarch64_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
@@ -1,0 +1,151 @@
+c17a4b7e354bde46c24a83a65965fdcc524b5243
+diff --git a/crypto_sign/dilithium2/aarch64/api.h b/crypto_sign/dilithium2/aarch64/api.h
+index 2ce4259..b970049 100644
+--- a/crypto_sign/dilithium2/aarch64/api.h
++++ b/crypto_sign/dilithium2/aarch64/api.h
+@@ -19,6 +19,10 @@
+ 
+ int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+ 
++int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_signature(
+     uint8_t *sig, size_t *siglen,
+     const uint8_t *m, size_t mlen, const uint8_t *sk);
+diff --git a/crypto_sign/dilithium2/aarch64/sign.c b/crypto_sign/dilithium2/aarch64/sign.c
+index a299d72..537f5a5 100644
+--- a/crypto_sign/dilithium2/aarch64/sign.c
++++ b/crypto_sign/dilithium2/aarch64/sign.c
+@@ -96,6 +96,113 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
+     return 0;
+ }
+ 
++/*************************************************
++* Name:        crypto_sign_keypair_from_fseed
++*
++* Description: Generates public and private key from fixed seed.
++*
++* Arguments:   - uint8_t *pk: pointer to output public key (allocated
++*                             array of CRYPTO_PUBLICKEYBYTES bytes)
++*              - uint8_t *sk: pointer to output private key (allocated
++*                             array of CRYPTO_SECRETKEYBYTES bytes)
++*              - const uint8_t *seed: Pointer to the input fixed seed. 
++*                                     Must point to an array of SEEDBYTES bytes.
++*                                     The seed provides deterministic randomness 
++*                                     for key generation and must be unique and 
++*                                     securely generated for each keypair to 
++*                                     ensure security.
++*
++* Returns 0 (success)
++**************************************************/
++int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++    uint8_t seedbuf[2 * SEEDBYTES + CRHBYTES];
++    uint8_t tr[SEEDBYTES];
++    const uint8_t *rho, *rhoprime, *key;
++    polyvecl mat[K];
++    polyvecl s1, s1hat;
++    polyveck s2, t1, t0;
++
++    /* Use fixed seed for randomness for rho, rhoprime and key */
++    shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
++    rho = seedbuf;
++    rhoprime = rho + SEEDBYTES;
++    key = rhoprime + CRHBYTES;
++
++    /* Expand matrix */
++    polyvec_matrix_expand(mat, rho);
++
++    /* Sample short vectors s1 and s2 */
++    polyvecl_uniform_eta(&s1, rhoprime, 0);
++    polyveck_uniform_eta(&s2, rhoprime, L);
++
++    /* Matrix-vector multiplication */
++    s1hat = s1;
++    polyvecl_ntt(&s1hat);
++    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
++    polyveck_reduce(&t1);
++    polyveck_invntt_tomont(&t1);
++
++    /* Add error vector s2 */
++    polyveck_add(&t1, &t1, &s2);
++
++    /* Extract t1 and write public key */
++    polyveck_caddq(&t1);
++    polyveck_power2round(&t1, &t0, &t1);
++    pack_pk(pk, rho, &t1);
++
++    /* Compute H(rho, t1) and write secret key */
++    shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
++    pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
++
++    return 0;
++}
++
++/*************************************************
++* Name:        crypto_sign_pubkey_from_privkey
++*
++* Description: Generates public key from exist private key.
++*
++* Arguments:   - uint8_t *pk: pointer to output public key (allocated
++*                             array of CRYPTO_PUBLICKEYBYTES bytes)
++*              - const uint8_t *sk: pointer to the input private key (points
++*                                   to a read-only array of CRYPTO_SECRETKEYBYTES bytes)
++*
++* Returns 0 (success)
++**************************************************/
++int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
++    uint8_t rho[SEEDBYTES];
++    uint8_t tr[SEEDBYTES];
++    uint8_t key[SEEDBYTES];
++    polyvecl s1, s1hat;
++    polyveck s2, t0, t1;
++    polyvecl mat[K];
++    
++    /* unpack privat key */
++    unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
++    
++    /* Expand matrix */
++    polyvec_matrix_expand(mat, rho);
++    
++    /* Matrix-vector multiplication */
++    s1hat = s1;
++    polyvecl_ntt(&s1hat);
++    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
++    polyveck_reduce(&t1);
++    polyveck_invntt_tomont(&t1);
++    
++    /* Add error vector s2 */
++    polyveck_add(&t1, &t1, &s2);
++    
++    /* Extract t1 */
++    polyveck_caddq(&t1);
++    polyveck_power2round(&t1, &t0, &t1);
++    
++    /* Pack public key */
++    pack_pk(pk, rho, &t1);
++    
++    return 0;
++}
++
+ /*************************************************
+ * Name:        crypto_sign_signature
+ *
+diff --git a/crypto_sign/dilithium2/aarch64/sign.h b/crypto_sign/dilithium2/aarch64/sign.h
+index fba1bf1..2388645 100644
+--- a/crypto_sign/dilithium2/aarch64/sign.h
++++ b/crypto_sign/dilithium2/aarch64/sign.h
+@@ -21,6 +21,12 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
+ #define crypto_sign_keypair DILITHIUM_NAMESPACE(crypto_sign_keypair)
+ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+ 
++#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
++int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
++int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ #define crypto_sign_signature DILITHIUM_NAMESPACE(crypto_sign_signature)
+ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
+                           const uint8_t *m, size_t mlen,

--- a/scripts/copy_from_upstream/patches/oldpqclean_dilithium3_aarch64_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
+++ b/scripts/copy_from_upstream/patches/oldpqclean_dilithium3_aarch64_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
@@ -1,0 +1,151 @@
+f7a8ce9e88cfe48deaf559ec8778c17e39042564
+diff --git a/crypto_sign/dilithium3/aarch64/api.h b/crypto_sign/dilithium3/aarch64/api.h
+index 6a05644..3752bc6 100644
+--- a/crypto_sign/dilithium3/aarch64/api.h
++++ b/crypto_sign/dilithium3/aarch64/api.h
+@@ -19,6 +19,10 @@
+ 
+ int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+ 
++int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_signature(
+     uint8_t *sig, size_t *siglen,
+     const uint8_t *m, size_t mlen, const uint8_t *sk);
+diff --git a/crypto_sign/dilithium3/aarch64/sign.c b/crypto_sign/dilithium3/aarch64/sign.c
+index a299d72..537f5a5 100644
+--- a/crypto_sign/dilithium3/aarch64/sign.c
++++ b/crypto_sign/dilithium3/aarch64/sign.c
+@@ -96,6 +96,113 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
+     return 0;
+ }
+ 
++/*************************************************
++* Name:        crypto_sign_keypair_from_fseed
++*
++* Description: Generates public and private key from fixed seed.
++*
++* Arguments:   - uint8_t *pk: pointer to output public key (allocated
++*                             array of CRYPTO_PUBLICKEYBYTES bytes)
++*              - uint8_t *sk: pointer to output private key (allocated
++*                             array of CRYPTO_SECRETKEYBYTES bytes)
++*              - const uint8_t *seed: Pointer to the input fixed seed. 
++*                                     Must point to an array of SEEDBYTES bytes.
++*                                     The seed provides deterministic randomness 
++*                                     for key generation and must be unique and 
++*                                     securely generated for each keypair to 
++*                                     ensure security.
++*
++* Returns 0 (success)
++**************************************************/
++int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++    uint8_t seedbuf[2 * SEEDBYTES + CRHBYTES];
++    uint8_t tr[SEEDBYTES];
++    const uint8_t *rho, *rhoprime, *key;
++    polyvecl mat[K];
++    polyvecl s1, s1hat;
++    polyveck s2, t1, t0;
++
++    /* Use fixed seed for randomness for rho, rhoprime and key */
++    shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
++    rho = seedbuf;
++    rhoprime = rho + SEEDBYTES;
++    key = rhoprime + CRHBYTES;
++
++    /* Expand matrix */
++    polyvec_matrix_expand(mat, rho);
++
++    /* Sample short vectors s1 and s2 */
++    polyvecl_uniform_eta(&s1, rhoprime, 0);
++    polyveck_uniform_eta(&s2, rhoprime, L);
++
++    /* Matrix-vector multiplication */
++    s1hat = s1;
++    polyvecl_ntt(&s1hat);
++    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
++    polyveck_reduce(&t1);
++    polyveck_invntt_tomont(&t1);
++
++    /* Add error vector s2 */
++    polyveck_add(&t1, &t1, &s2);
++
++    /* Extract t1 and write public key */
++    polyveck_caddq(&t1);
++    polyveck_power2round(&t1, &t0, &t1);
++    pack_pk(pk, rho, &t1);
++
++    /* Compute H(rho, t1) and write secret key */
++    shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
++    pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
++
++    return 0;
++}
++
++/*************************************************
++* Name:        crypto_sign_pubkey_from_privkey
++*
++* Description: Generates public key from exist private key.
++*
++* Arguments:   - uint8_t *pk: pointer to output public key (allocated
++*                             array of CRYPTO_PUBLICKEYBYTES bytes)
++*              - const uint8_t *sk: pointer to the input private key (points
++*                                   to a read-only array of CRYPTO_SECRETKEYBYTES bytes)
++*
++* Returns 0 (success)
++**************************************************/
++int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
++    uint8_t rho[SEEDBYTES];
++    uint8_t tr[SEEDBYTES];
++    uint8_t key[SEEDBYTES];
++    polyvecl s1, s1hat;
++    polyveck s2, t0, t1;
++    polyvecl mat[K];
++    
++    /* unpack privat key */
++    unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
++    
++    /* Expand matrix */
++    polyvec_matrix_expand(mat, rho);
++    
++    /* Matrix-vector multiplication */
++    s1hat = s1;
++    polyvecl_ntt(&s1hat);
++    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
++    polyveck_reduce(&t1);
++    polyveck_invntt_tomont(&t1);
++    
++    /* Add error vector s2 */
++    polyveck_add(&t1, &t1, &s2);
++    
++    /* Extract t1 */
++    polyveck_caddq(&t1);
++    polyveck_power2round(&t1, &t0, &t1);
++    
++    /* Pack public key */
++    pack_pk(pk, rho, &t1);
++    
++    return 0;
++}
++
+ /*************************************************
+ * Name:        crypto_sign_signature
+ *
+diff --git a/crypto_sign/dilithium3/aarch64/sign.h b/crypto_sign/dilithium3/aarch64/sign.h
+index fba1bf1..2388645 100644
+--- a/crypto_sign/dilithium3/aarch64/sign.h
++++ b/crypto_sign/dilithium3/aarch64/sign.h
+@@ -21,6 +21,12 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
+ #define crypto_sign_keypair DILITHIUM_NAMESPACE(crypto_sign_keypair)
+ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+ 
++#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
++int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
++int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ #define crypto_sign_signature DILITHIUM_NAMESPACE(crypto_sign_signature)
+ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
+                           const uint8_t *m, size_t mlen,

--- a/scripts/copy_from_upstream/patches/oldpqclean_dilithium5_aarch64_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
+++ b/scripts/copy_from_upstream/patches/oldpqclean_dilithium5_aarch64_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
@@ -1,0 +1,151 @@
+0638e2720240b543a203b9a1aa5fe6e0d487f506
+diff --git a/crypto_sign/dilithium5/aarch64/api.h b/crypto_sign/dilithium5/aarch64/api.h
+index ab5e2c4..69c1ccc 100644
+--- a/crypto_sign/dilithium5/aarch64/api.h
++++ b/crypto_sign/dilithium5/aarch64/api.h
+@@ -20,6 +20,10 @@
+ 
+ int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+ 
++int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_signature(
+     uint8_t *sig, size_t *siglen,
+     const uint8_t *m, size_t mlen, const uint8_t *sk);
+diff --git a/crypto_sign/dilithium5/aarch64/sign.c b/crypto_sign/dilithium5/aarch64/sign.c
+index a299d72..537f5a5 100644
+--- a/crypto_sign/dilithium5/aarch64/sign.c
++++ b/crypto_sign/dilithium5/aarch64/sign.c
+@@ -96,6 +96,113 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
+     return 0;
+ }
+ 
++/*************************************************
++* Name:        crypto_sign_keypair_from_fseed
++*
++* Description: Generates public and private key from fixed seed.
++*
++* Arguments:   - uint8_t *pk: pointer to output public key (allocated
++*                             array of CRYPTO_PUBLICKEYBYTES bytes)
++*              - uint8_t *sk: pointer to output private key (allocated
++*                             array of CRYPTO_SECRETKEYBYTES bytes)
++*              - const uint8_t *seed: Pointer to the input fixed seed. 
++*                                     Must point to an array of SEEDBYTES bytes.
++*                                     The seed provides deterministic randomness 
++*                                     for key generation and must be unique and 
++*                                     securely generated for each keypair to 
++*                                     ensure security.
++*
++* Returns 0 (success)
++**************************************************/
++int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++    uint8_t seedbuf[2 * SEEDBYTES + CRHBYTES];
++    uint8_t tr[SEEDBYTES];
++    const uint8_t *rho, *rhoprime, *key;
++    polyvecl mat[K];
++    polyvecl s1, s1hat;
++    polyveck s2, t1, t0;
++
++    /* Use fixed seed for randomness for rho, rhoprime and key */
++    shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
++    rho = seedbuf;
++    rhoprime = rho + SEEDBYTES;
++    key = rhoprime + CRHBYTES;
++
++    /* Expand matrix */
++    polyvec_matrix_expand(mat, rho);
++
++    /* Sample short vectors s1 and s2 */
++    polyvecl_uniform_eta(&s1, rhoprime, 0);
++    polyveck_uniform_eta(&s2, rhoprime, L);
++
++    /* Matrix-vector multiplication */
++    s1hat = s1;
++    polyvecl_ntt(&s1hat);
++    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
++    polyveck_reduce(&t1);
++    polyveck_invntt_tomont(&t1);
++
++    /* Add error vector s2 */
++    polyveck_add(&t1, &t1, &s2);
++
++    /* Extract t1 and write public key */
++    polyveck_caddq(&t1);
++    polyveck_power2round(&t1, &t0, &t1);
++    pack_pk(pk, rho, &t1);
++
++    /* Compute H(rho, t1) and write secret key */
++    shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
++    pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
++
++    return 0;
++}
++
++/*************************************************
++* Name:        crypto_sign_pubkey_from_privkey
++*
++* Description: Generates public key from exist private key.
++*
++* Arguments:   - uint8_t *pk: pointer to output public key (allocated
++*                             array of CRYPTO_PUBLICKEYBYTES bytes)
++*              - const uint8_t *sk: pointer to the input private key (points
++*                                   to a read-only array of CRYPTO_SECRETKEYBYTES bytes)
++*
++* Returns 0 (success)
++**************************************************/
++int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
++    uint8_t rho[SEEDBYTES];
++    uint8_t tr[SEEDBYTES];
++    uint8_t key[SEEDBYTES];
++    polyvecl s1, s1hat;
++    polyveck s2, t0, t1;
++    polyvecl mat[K];
++    
++    /* unpack privat key */
++    unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
++    
++    /* Expand matrix */
++    polyvec_matrix_expand(mat, rho);
++    
++    /* Matrix-vector multiplication */
++    s1hat = s1;
++    polyvecl_ntt(&s1hat);
++    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
++    polyveck_reduce(&t1);
++    polyveck_invntt_tomont(&t1);
++    
++    /* Add error vector s2 */
++    polyveck_add(&t1, &t1, &s2);
++    
++    /* Extract t1 */
++    polyveck_caddq(&t1);
++    polyveck_power2round(&t1, &t0, &t1);
++    
++    /* Pack public key */
++    pack_pk(pk, rho, &t1);
++    
++    return 0;
++}
++
+ /*************************************************
+ * Name:        crypto_sign_signature
+ *
+diff --git a/crypto_sign/dilithium5/aarch64/sign.h b/crypto_sign/dilithium5/aarch64/sign.h
+index fba1bf1..2388645 100644
+--- a/crypto_sign/dilithium5/aarch64/sign.h
++++ b/crypto_sign/dilithium5/aarch64/sign.h
+@@ -21,6 +21,12 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
+ #define crypto_sign_keypair DILITHIUM_NAMESPACE(crypto_sign_keypair)
+ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+ 
++#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
++int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
++int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ #define crypto_sign_signature DILITHIUM_NAMESPACE(crypto_sign_signature)
+ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
+                           const uint8_t *m, size_t mlen,

--- a/scripts/copy_from_upstream/patches/pqclean_falcon_1024_aarch64_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
+++ b/scripts/copy_from_upstream/patches/pqclean_falcon_1024_aarch64_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
@@ -1,0 +1,185 @@
+2b75c923058f93a2526bc879d5fda17c67b544bf
+diff --git a/crypto_sign/falcon-1024/aarch64/api.h b/crypto_sign/falcon-1024/aarch64/api.h
+index 06787aa..def76c6 100644
+--- a/crypto_sign/falcon-1024/aarch64/api.h
++++ b/crypto_sign/falcon-1024/aarch64/api.h
+@@ -23,6 +23,29 @@
+ int PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair(
+     uint8_t *pk, uint8_t *sk);
+ 
++/*
++ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES
++ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++/*
++ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCON1024_AARCH64_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk);
++
+ /*
+  * Compute a signature on a provided message (m, mlen), with a given
+  * private key (sk). Signature is written in sig[], with length written
+diff --git a/crypto_sign/falcon-1024/aarch64/pqclean.c b/crypto_sign/falcon-1024/aarch64/pqclean.c
+index 7355b07..48b9f99 100644
+--- a/crypto_sign/falcon-1024/aarch64/pqclean.c
++++ b/crypto_sign/falcon-1024/aarch64/pqclean.c
+@@ -108,6 +108,145 @@ PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair(
+     return 0;
+ }
+ 
++/* keypair from fixed seed*/
++int
++PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++    union {
++        uint8_t b[28 * FALCON_N];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
++    uint16_t h[FALCON_N];
++    inner_shake256_context rng;
++    size_t u, v;
++
++    /*
++     * Checking the input seed parameter.
++     * If the seed is NULL, return an error.
++     */
++    if (seed == NULL) {
++        return -1;  // Error: seed is not provided.
++    }
++
++    /*
++     * Initialize the SHAKE256 random number generator using the seed.
++     * We now pass the seed directly to the generator.
++     */
++    inner_shake256_init(&rng);
++    inner_shake256_inject(&rng, seed, 48);
++    inner_shake256_flip(&rng);
++    PQCLEAN_FALCON1024_AARCH64_keygen(&rng, f, g, F, NULL, h, FALCON_LOGN, tmp.b);
++    inner_shake256_ctx_release(&rng);
++
++    /*
++     * Encode private key.
++     */
++    sk[0] = 0x50 + FALCON_LOGN;
++    u = 1;
++    v = PQCLEAN_FALCON1024_AARCH64_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
++            f, PQCLEAN_FALCON1024_AARCH64_max_fg_bits[FALCON_LOGN]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON1024_AARCH64_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
++            g, PQCLEAN_FALCON1024_AARCH64_max_fg_bits[FALCON_LOGN]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON1024_AARCH64_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
++            F, PQCLEAN_FALCON1024_AARCH64_max_FG_bits[FALCON_LOGN]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    if (u != PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + FALCON_LOGN;
++    v = PQCLEAN_FALCON1024_AARCH64_modq_encode(
++            pk + 1, PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
++            h, FALCON_LOGN);
++    if (v != PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
++/*
++ * This function reconstructs the public key from a given private key.
++ * It decodes the private key components (f and g) from the secret key
++ * and uses them to regenerate the corresponding public key (h).
++ * The generated public key is then encoded into the provided pk array.
++ * 
++ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
++ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCON1024_AARCH64_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk) {
++    union {
++        uint8_t b[28 * FALCON_N];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
++    uint16_t h[FALCON_N];
++    size_t u, v;
++
++    /*
++     * Decode the private key.
++     */
++    if (sk[0] != 0x50 + FALCON_LOGN) {
++        return -1;
++    }
++    u = 1;
++    v = PQCLEAN_FALCON1024_AARCH64_trim_i8_decode(
++            f, PQCLEAN_FALCON1024_AARCH64_max_fg_bits[FALCON_LOGN],
++            sk + u, PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON1024_AARCH64_trim_i8_decode(
++            g, PQCLEAN_FALCON1024_AARCH64_max_fg_bits[FALCON_LOGN],
++            sk + u, PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++
++    /*
++     * Reconstruct the public key using f and g by calling the compute_public function.
++     */
++    if (!PQCLEAN_FALCON1024_AARCH64_compute_public(h, f, g, FALCON_LOGN, tmp.b)) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + FALCON_LOGN;
++    v = PQCLEAN_FALCON1024_AARCH64_modq_encode(
++            pk + 1, PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
++            h, FALCON_LOGN);
++    if (v != PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
+ /*
+  * Compute the signature. nonce[] receives the nonce and must have length
+  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/scripts/copy_from_upstream/patches/pqclean_falcon_1024_avx2_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
+++ b/scripts/copy_from_upstream/patches/pqclean_falcon_1024_avx2_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
@@ -1,0 +1,185 @@
+c9682cbd3010153520ec49de0ba0c7b41f711fc0
+diff --git a/crypto_sign/falcon-1024/avx2/api.h b/crypto_sign/falcon-1024/avx2/api.h
+index 85e201f..98b1d19 100644
+--- a/crypto_sign/falcon-1024/avx2/api.h
++++ b/crypto_sign/falcon-1024/avx2/api.h
+@@ -23,6 +23,29 @@
+ int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(
+     uint8_t *pk, uint8_t *sk);
+ 
++/*
++ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES
++ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++/*
++ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCON1024_AVX2_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk);
++
+ /*
+  * Compute a signature on a provided message (m, mlen), with a given
+  * private key (sk). Signature is written in sig[], with length written
+diff --git a/crypto_sign/falcon-1024/avx2/pqclean.c b/crypto_sign/falcon-1024/avx2/pqclean.c
+index ea214a1..951a029 100644
+--- a/crypto_sign/falcon-1024/avx2/pqclean.c
++++ b/crypto_sign/falcon-1024/avx2/pqclean.c
+@@ -108,6 +108,145 @@ PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(
+     return 0;
+ }
+ 
++/* keypair from fixed seed*/
++int
++PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++    union {
++        uint8_t b[FALCON_KEYGEN_TEMP_10];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[1024], g[1024], F[1024];
++    uint16_t h[1024];
++    inner_shake256_context rng;
++    size_t u, v;
++
++    /*
++     * Checking the input seed parameter.
++     * If the seed is NULL, return an error.
++     */
++    if (seed == NULL) {
++        return -1;  // Error: seed is not provided.
++    }
++
++    /*
++     * Initialize the SHAKE256 random number generator using the seed.
++     * We now pass the seed directly to the generator.
++     */
++    inner_shake256_init(&rng);
++    inner_shake256_inject(&rng, seed, 48);
++    inner_shake256_flip(&rng);
++    PQCLEAN_FALCON1024_AVX2_keygen(&rng, f, g, F, NULL, h, 10, tmp.b);
++    inner_shake256_ctx_release(&rng);
++
++    /*
++     * Encode private key.
++     */
++    sk[0] = 0x50 + 10;
++    u = 1;
++    v = PQCLEAN_FALCON1024_AVX2_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
++            f, 10, PQCLEAN_FALCON1024_AVX2_max_fg_bits[10]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON1024_AVX2_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
++            g, 10, PQCLEAN_FALCON1024_AVX2_max_fg_bits[10]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON1024_AVX2_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
++            F, 10, PQCLEAN_FALCON1024_AVX2_max_FG_bits[10]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    if (u != PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + 10;
++    v = PQCLEAN_FALCON1024_AVX2_modq_encode(
++            pk + 1, PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
++            h, 10);
++    if (v != PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
++/*
++ * This function reconstructs the public key from a given private key.
++ * It decodes the private key components (f and g) from the secret key
++ * and uses them to regenerate the corresponding public key (h).
++ * The generated public key is then encoded into the provided pk array.
++ * 
++ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
++ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCON1024_AVX2_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk) {
++    union {
++        uint8_t b[FALCON_KEYGEN_TEMP_10];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[1024], g[1024], F[1024];
++    uint16_t h[1024];
++    size_t u, v;
++
++    /*
++     * Decode the private key.
++     */
++    if (sk[0] != 0x50 + 10) {
++        return -1;
++    }
++    u = 1;
++    v = PQCLEAN_FALCON1024_AVX2_trim_i8_decode(
++            f, 10, PQCLEAN_FALCON1024_AVX2_max_fg_bits[10],
++            sk + u, PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON1024_AVX2_trim_i8_decode(
++            g, 10, PQCLEAN_FALCON1024_AVX2_max_fg_bits[10],
++            sk + u, PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++
++    /*
++     * Reconstruct the public key using f and g by calling the compute_public function.
++     */
++    if (!PQCLEAN_FALCON1024_AVX2_compute_public(h, f, g, 10, tmp.b)) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + 10;
++    v = PQCLEAN_FALCON1024_AVX2_modq_encode(
++            pk + 1, PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
++            h, 10);
++    if (v != PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
+ /*
+  * Compute the signature. nonce[] receives the nonce and must have length
+  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/scripts/copy_from_upstream/patches/pqclean_falcon_1024_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
+++ b/scripts/copy_from_upstream/patches/pqclean_falcon_1024_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
@@ -1,0 +1,186 @@
+db52723d74b24522a3fbb5602a500e0508eb1663
+diff --git a/crypto_sign/falcon-1024/clean/api.h b/crypto_sign/falcon-1024/clean/api.h
+index cc6557f..dbf62e4 100644
+--- a/crypto_sign/falcon-1024/clean/api.h
++++ b/crypto_sign/falcon-1024/clean/api.h
+@@ -23,6 +23,29 @@
+ int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(
+     uint8_t *pk, uint8_t *sk);
+ 
++/*
++ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES
++ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++/*
++ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCON1024_CLEAN_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk);
++
+ /*
+  * Compute a signature on a provided message (m, mlen), with a given
+  * private key (sk). Signature is written in sig[], with length written
+diff --git a/crypto_sign/falcon-1024/clean/pqclean.c b/crypto_sign/falcon-1024/clean/pqclean.c
+index 086d249..fcba2dd 100644
+--- a/crypto_sign/falcon-1024/clean/pqclean.c
++++ b/crypto_sign/falcon-1024/clean/pqclean.c
+@@ -108,6 +108,146 @@ PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(
+     return 0;
+ }
+ 
++/* keypair from fixed seed*/
++int
++PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++    union {
++        uint8_t b[FALCON_KEYGEN_TEMP_10];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[1024], g[1024], F[1024];
++    uint16_t h[1024];
++    inner_shake256_context rng;
++    size_t u, v;
++
++    /*
++     * Checking the input seed parameter.
++     * If the seed is NULL, return an error.
++     */
++    if (seed == NULL) {
++        return -1;  // Error: seed is not provided.
++    }
++
++    /*
++     * Initialize the SHAKE256 random number generator using the seed.
++     * We now pass the seed directly to the generator.
++     */
++    inner_shake256_init(&rng);
++    inner_shake256_inject(&rng, seed, 48);
++    inner_shake256_flip(&rng);
++    PQCLEAN_FALCON1024_CLEAN_keygen(&rng, f, g, F, NULL, h, 10, tmp.b);
++    inner_shake256_ctx_release(&rng);
++
++    /*
++     * Encode private key.
++     */
++    sk[0] = 0x50 + 10;
++    u = 1;
++    v = PQCLEAN_FALCON1024_CLEAN_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
++            f, 10, PQCLEAN_FALCON1024_CLEAN_max_fg_bits[10]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON1024_CLEAN_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
++            g, 10, PQCLEAN_FALCON1024_CLEAN_max_fg_bits[10]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON1024_CLEAN_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
++            F, 10, PQCLEAN_FALCON1024_CLEAN_max_FG_bits[10]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    if (u != PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + 10;
++    v = PQCLEAN_FALCON1024_CLEAN_modq_encode(
++            pk + 1, PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
++            h, 10);
++    if (v != PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
++/*
++ * This function reconstructs the public key from a given private key.
++ * It decodes the private key components (f and g) from the secret key
++ * and uses them to regenerate the corresponding public key (h).
++ * The generated public key is then encoded into the provided pk array.
++ * 
++ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
++ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
++ * Return value: 0 on success, -1 on error.
++ */
++int 
++PQCLEAN_FALCON1024_CLEAN_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk) {
++    union {
++        uint8_t b[FALCON_KEYGEN_TEMP_10];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[1024], g[1024], F[1024];
++    uint16_t h[1024];
++    size_t u, v;
++
++    /*
++     * Decode the private key.
++     */
++    if (sk[0] != 0x50 + 10) {
++        return -1;
++    }
++    u = 1;
++    v = PQCLEAN_FALCON1024_CLEAN_trim_i8_decode(
++            f, 10, PQCLEAN_FALCON1024_CLEAN_max_fg_bits[10],
++            sk + u, PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON1024_CLEAN_trim_i8_decode(
++            g, 10, PQCLEAN_FALCON1024_CLEAN_max_fg_bits[10],
++            sk + u, PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++
++    /*
++     * Reconstruct the public key using f and g by calling the compute_public function.
++     */
++    if (!PQCLEAN_FALCON1024_CLEAN_compute_public(h, f, g, 10, tmp.b)) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + 10;
++    v = PQCLEAN_FALCON1024_CLEAN_modq_encode(
++            pk + 1, PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
++            h, 10);
++    if (v != PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
+ /*
+  * Compute the signature. nonce[] receives the nonce and must have length
+  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/scripts/copy_from_upstream/patches/pqclean_falcon_512_aarch64_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
+++ b/scripts/copy_from_upstream/patches/pqclean_falcon_512_aarch64_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
@@ -1,0 +1,186 @@
+b4943c2bbb8415e3ddfb58ea872cf8077c81fae7
+diff --git a/crypto_sign/falcon-512/aarch64/api.h b/crypto_sign/falcon-512/aarch64/api.h
+index d70db34..eece1b5 100644
+--- a/crypto_sign/falcon-512/aarch64/api.h
++++ b/crypto_sign/falcon-512/aarch64/api.h
+@@ -23,6 +23,29 @@
+ int PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair(
+     uint8_t *pk, uint8_t *sk);
+ 
++/*
++ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES
++ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++/*
++ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCON512_AARCH64_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk);
++
+ /*
+  * Compute a signature on a provided message (m, mlen), with a given
+  * private key (sk). Signature is written in sig[], with length written
+diff --git a/crypto_sign/falcon-512/aarch64/pqclean.c b/crypto_sign/falcon-512/aarch64/pqclean.c
+index b898d74..a163218 100644
+--- a/crypto_sign/falcon-512/aarch64/pqclean.c
++++ b/crypto_sign/falcon-512/aarch64/pqclean.c
+@@ -108,6 +108,146 @@ PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair(
+     return 0;
+ }
+ 
++/* keypair from fixed seed*/
++int
++PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++    union {
++        uint8_t b[28 * FALCON_N];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
++    uint16_t h[FALCON_N];
++    inner_shake256_context rng;
++    size_t u, v;
++
++    /*
++     * Checking the input seed parameter.
++     * If the seed is NULL, return an error.
++     */
++    if (seed == NULL) {
++        return -1;  // Error: seed is not provided.
++    }
++
++    /*
++     * Initialize the SHAKE256 random number generator using the seed.
++     * We now pass the seed directly to the generator.
++     */
++    inner_shake256_init(&rng);
++    inner_shake256_inject(&rng, seed, 48);
++    inner_shake256_flip(&rng);
++    PQCLEAN_FALCON512_AARCH64_keygen(&rng, f, g, F, NULL, h, FALCON_LOGN, tmp.b);
++    inner_shake256_ctx_release(&rng);
++
++    /*
++     * Encode private key.
++     */
++    sk[0] = 0x50 + FALCON_LOGN;
++    u = 1;
++    v = PQCLEAN_FALCON512_AARCH64_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
++            f, PQCLEAN_FALCON512_AARCH64_max_fg_bits[FALCON_LOGN]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON512_AARCH64_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
++            g, PQCLEAN_FALCON512_AARCH64_max_fg_bits[FALCON_LOGN]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON512_AARCH64_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
++            F, PQCLEAN_FALCON512_AARCH64_max_FG_bits[FALCON_LOGN]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    if (u != PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + FALCON_LOGN;
++    v = PQCLEAN_FALCON512_AARCH64_modq_encode(
++            pk + 1, PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
++            h, FALCON_LOGN);
++    if (v != PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
++/*
++ * This function reconstructs the public key from a given private key.
++ * It decodes the private key components (f and g) from the secret key
++ * and uses them to regenerate the corresponding public key (h).
++ * The generated public key is then encoded into the provided pk array.
++ * 
++ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
++ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
++ * Return value: 0 on success, -1 on error.
++ */
++int
++PQCLEAN_FALCON512_AARCH64_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk) {
++    union {
++        uint8_t b[28 * FALCON_N];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
++    uint16_t h[FALCON_N];
++    size_t u, v;
++
++    /*
++     * Decode the private key.
++     */
++    if (sk[0] != 0x50 + FALCON_LOGN) {
++        return -1;
++    }
++    u = 1;
++    v = PQCLEAN_FALCON512_AARCH64_trim_i8_decode(
++            f, PQCLEAN_FALCON512_AARCH64_max_fg_bits[FALCON_LOGN],
++            sk + u, PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON512_AARCH64_trim_i8_decode(
++            g, PQCLEAN_FALCON512_AARCH64_max_fg_bits[FALCON_LOGN],
++            sk + u, PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++
++    /*
++     * Reconstruct the public key using f and g by calling the compute_public function.
++     */
++    if (!PQCLEAN_FALCON512_AARCH64_compute_public(h, f, g, FALCON_LOGN, tmp.b)) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + FALCON_LOGN;
++    v = PQCLEAN_FALCON512_AARCH64_modq_encode(
++            pk + 1, PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
++            h, FALCON_LOGN);
++    if (v != PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
+ /*
+  * Compute the signature. nonce[] receives the nonce and must have length
+  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/scripts/copy_from_upstream/patches/pqclean_falcon_512_avx2_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
+++ b/scripts/copy_from_upstream/patches/pqclean_falcon_512_avx2_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
@@ -1,0 +1,186 @@
+b46875f2b36bbc6850967d1dc44a50eb3b0b4089
+diff --git a/crypto_sign/falcon-512/avx2/api.h b/crypto_sign/falcon-512/avx2/api.h
+index 2f74f26..e918944 100644
+--- a/crypto_sign/falcon-512/avx2/api.h
++++ b/crypto_sign/falcon-512/avx2/api.h
+@@ -23,6 +23,29 @@
+ int PQCLEAN_FALCON512_AVX2_crypto_sign_keypair(
+     uint8_t *pk, uint8_t *sk);
+ 
++/*
++ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
++ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCON512_AVX2_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++/*
++ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCON512_AVX2_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk);
++
+ /*
+  * Compute a signature on a provided message (m, mlen), with a given
+  * private key (sk). Signature is written in sig[], with length written
+diff --git a/crypto_sign/falcon-512/avx2/pqclean.c b/crypto_sign/falcon-512/avx2/pqclean.c
+index 84e393d..6e78c7b 100644
+--- a/crypto_sign/falcon-512/avx2/pqclean.c
++++ b/crypto_sign/falcon-512/avx2/pqclean.c
+@@ -108,6 +108,146 @@ PQCLEAN_FALCON512_AVX2_crypto_sign_keypair(
+     return 0;
+ }
+ 
++/* keypair from fixed seed*/
++int
++PQCLEAN_FALCON512_AVX2_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++    union {
++        uint8_t b[FALCON_KEYGEN_TEMP_9];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[512], g[512], F[512];
++    uint16_t h[512];
++    inner_shake256_context rng;
++    size_t u, v;
++
++    /*
++     * Checking the input seed parameter.
++     * If the seed is NULL, return an error.
++     */
++    if (seed == NULL) {
++        return -1;  // Error: seed is not provided.
++    }
++
++    /*
++     * Initialize the SHAKE256 random number generator using the seed.
++     * We now pass the seed directly to the generator.
++     */
++    inner_shake256_init(&rng);
++    inner_shake256_inject(&rng, seed, 48);
++    inner_shake256_flip(&rng);
++    PQCLEAN_FALCON512_AVX2_keygen(&rng, f, g, F, NULL, h, 9, tmp.b);
++    inner_shake256_ctx_release(&rng);
++
++    /*
++     * Encode private key.
++     */
++    sk[0] = 0x50 + 9;
++    u = 1;
++    v = PQCLEAN_FALCON512_AVX2_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES - u,
++            f, 9, PQCLEAN_FALCON512_AVX2_max_fg_bits[9]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON512_AVX2_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES - u,
++            g, 9, PQCLEAN_FALCON512_AVX2_max_fg_bits[9]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON512_AVX2_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES - u,
++            F, 9, PQCLEAN_FALCON512_AVX2_max_FG_bits[9]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    if (u != PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + 9;
++    v = PQCLEAN_FALCON512_AVX2_modq_encode(
++            pk + 1, PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
++            h, 9);
++    if (v != PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
++/*
++ * This function reconstructs the public key from a given private key.
++ * It decodes the private key components (f and g) from the secret key
++ * and uses them to regenerate the corresponding public key (h).
++ * The generated public key is then encoded into the provided pk array.
++ * 
++ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
++ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
++ * Return value: 0 on success, -1 on error.
++ */
++int
++PQCLEAN_FALCON512_AVX2_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk) {
++    union {
++        uint8_t b[FALCON_KEYGEN_TEMP_9];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[512], g[512], F[512];
++    uint16_t h[512];
++    size_t u, v;
++
++    /*
++     * Decode the private key.
++     */
++    if (sk[0] != 0x50 + 9) {
++        return -1;
++    }
++    u = 1;
++    v = PQCLEAN_FALCON512_AVX2_trim_i8_decode(
++            f, 9, PQCLEAN_FALCON512_AVX2_max_fg_bits[9],
++            sk + u, PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON512_AVX2_trim_i8_decode(
++            g, 9, PQCLEAN_FALCON512_AVX2_max_fg_bits[9],
++            sk + u, PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++
++    /*
++     * Reconstruct the public key using f and g by calling the compute_public function.
++     */
++    if (!PQCLEAN_FALCON512_AVX2_compute_public(h, f, g, 9, tmp.b)) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + 9;
++    v = PQCLEAN_FALCON512_AVX2_modq_encode(
++            pk + 1, PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
++            h, 9);
++    if (v != PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
+ /*
+  * Compute the signature. nonce[] receives the nonce and must have length
+  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/scripts/copy_from_upstream/patches/pqclean_falcon_512_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
+++ b/scripts/copy_from_upstream/patches/pqclean_falcon_512_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
@@ -1,0 +1,186 @@
+0ec3ac2bde9fda44b07fae7df59d473e5563832c
+diff --git a/crypto_sign/falcon-512/clean/api.h b/crypto_sign/falcon-512/clean/api.h
+index 49489d2..b9c1fb9 100644
+--- a/crypto_sign/falcon-512/clean/api.h
++++ b/crypto_sign/falcon-512/clean/api.h
+@@ -23,6 +23,29 @@
+ int PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(
+     uint8_t *pk, uint8_t *sk);
+ 
++/*
++ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES
++ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++/*
++ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCON512_CLEAN_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk);
++
+ /*
+  * Compute a signature on a provided message (m, mlen), with a given
+  * private key (sk). Signature is written in sig[], with length written
+diff --git a/crypto_sign/falcon-512/clean/pqclean.c b/crypto_sign/falcon-512/clean/pqclean.c
+index 80d8cbe..bb8475c 100644
+--- a/crypto_sign/falcon-512/clean/pqclean.c
++++ b/crypto_sign/falcon-512/clean/pqclean.c
+@@ -108,6 +108,146 @@ PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(
+     return 0;
+ }
+ 
++/* keypair from fixed seed*/
++int
++PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++    union {
++        uint8_t b[FALCON_KEYGEN_TEMP_9];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[512], g[512], F[512];
++    uint16_t h[512];
++    inner_shake256_context rng;
++    size_t u, v;
++
++    /*
++     * Checking the input seed parameter.
++     * If the seed is NULL, return an error.
++     */
++    if (seed == NULL) {
++        return -1;  // Error: seed is not provided.
++    }
++
++    /*
++     * Initialize the SHAKE256 random number generator using the seed.
++     * We now pass the seed directly to the generator.
++     */
++    inner_shake256_init(&rng);
++    inner_shake256_inject(&rng, seed, 48);
++    inner_shake256_flip(&rng);
++    PQCLEAN_FALCON512_CLEAN_keygen(&rng, f, g, F, NULL, h, 9, tmp.b);
++    inner_shake256_ctx_release(&rng);
++
++    /*
++     * Encode private key.
++     */
++    sk[0] = 0x50 + 9;
++    u = 1;
++    v = PQCLEAN_FALCON512_CLEAN_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
++            f, 9, PQCLEAN_FALCON512_CLEAN_max_fg_bits[9]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON512_CLEAN_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
++            g, 9, PQCLEAN_FALCON512_CLEAN_max_fg_bits[9]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON512_CLEAN_trim_i8_encode(
++            sk + u, PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
++            F, 9, PQCLEAN_FALCON512_CLEAN_max_FG_bits[9]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    if (u != PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + 9;
++    v = PQCLEAN_FALCON512_CLEAN_modq_encode(
++            pk + 1, PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
++            h, 9);
++    if (v != PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
++/*
++ * This function reconstructs the public key from a given private key.
++ * It decodes the private key components (f and g) from the secret key
++ * and uses them to regenerate the corresponding public key (h).
++ * The generated public key is then encoded into the provided pk array.
++ * 
++ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
++ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
++ * Return value: 0 on success, -1 on error.
++ */
++int
++PQCLEAN_FALCON512_CLEAN_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk) {
++    union {
++        uint8_t b[FALCON_KEYGEN_TEMP_9];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[512], g[512], F[512];
++    uint16_t h[512];
++    size_t u, v;
++
++    /*
++     * Decode the private key.
++     */
++    if (sk[0] != 0x50 + 9) {
++        return -1;
++    }
++    u = 1;
++    v = PQCLEAN_FALCON512_CLEAN_trim_i8_decode(
++            f, 9, PQCLEAN_FALCON512_CLEAN_max_fg_bits[9],
++            sk + u, PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCON512_CLEAN_trim_i8_decode(
++            g, 9, PQCLEAN_FALCON512_CLEAN_max_fg_bits[9],
++            sk + u, PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++
++    /*
++     * Reconstruct the public key using f and g by calling the compute_public function.
++     */
++    if (!PQCLEAN_FALCON512_CLEAN_compute_public(h, f, g, 9, tmp.b)) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + 9;
++    v = PQCLEAN_FALCON512_CLEAN_modq_encode(
++            pk + 1, PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
++            h, 9);
++    if (v != PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
+ /*
+  * Compute the signature. nonce[] receives the nonce and must have length
+  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/scripts/copy_from_upstream/patches/pqclean_falcon_padded_1024_aarch64_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
+++ b/scripts/copy_from_upstream/patches/pqclean_falcon_padded_1024_aarch64_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
@@ -1,0 +1,186 @@
+2469463fe5b3dc6d6d08b141c96487452576db95
+diff --git a/crypto_sign/falcon-padded-1024/aarch64/api.h b/crypto_sign/falcon-padded-1024/aarch64/api.h
+index 9b62998..76ff9a5 100644
+--- a/crypto_sign/falcon-padded-1024/aarch64/api.h
++++ b/crypto_sign/falcon-padded-1024/aarch64/api.h
+@@ -21,6 +21,29 @@
+ int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair(
+     uint8_t *pk, uint8_t *sk);
+ 
++/*
++ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES
++ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++/*
++ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk);
++
+ /*
+  * Compute a signature on a provided message (m, mlen), with a given
+  * private key (sk). Signature is written in sig[], with length written
+diff --git a/crypto_sign/falcon-padded-1024/aarch64/pqclean.c b/crypto_sign/falcon-padded-1024/aarch64/pqclean.c
+index 8cc7563..770563d 100644
+--- a/crypto_sign/falcon-padded-1024/aarch64/pqclean.c
++++ b/crypto_sign/falcon-padded-1024/aarch64/pqclean.c
+@@ -105,6 +105,146 @@ PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair(
+     return 0;
+ }
+ 
++/* keypair from fixed seed*/
++int
++PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++    union {
++        uint8_t b[28 * FALCON_N];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
++    uint16_t h[FALCON_N];
++    inner_shake256_context rng;
++    size_t u, v;
++
++    /*
++     * Checking the input seed parameter.
++     * If the seed is NULL, return an error.
++     */
++    if (seed == NULL) {
++        return -1;  // Error: seed is not provided.
++    }
++
++    /*
++     * Initialize the SHAKE256 random number generator using the seed.
++     * We now pass the seed directly to the generator.
++     */
++    inner_shake256_init(&rng);
++    inner_shake256_inject(&rng, seed, 48);
++    inner_shake256_flip(&rng);
++    PQCLEAN_FALCONPADDED1024_AARCH64_keygen(&rng, f, g, F, NULL, h, FALCON_LOGN, tmp.b);
++    inner_shake256_ctx_release(&rng);
++
++    /*
++     * Encode private key.
++     */
++    sk[0] = 0x50 + FALCON_LOGN;
++    u = 1;
++    v = PQCLEAN_FALCONPADDED1024_AARCH64_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
++            f, PQCLEAN_FALCONPADDED1024_AARCH64_max_fg_bits[FALCON_LOGN]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED1024_AARCH64_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
++            g, PQCLEAN_FALCONPADDED1024_AARCH64_max_fg_bits[FALCON_LOGN]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED1024_AARCH64_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
++            F, PQCLEAN_FALCONPADDED1024_AARCH64_max_FG_bits[FALCON_LOGN]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    if (u != PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + FALCON_LOGN;
++    v = PQCLEAN_FALCONPADDED1024_AARCH64_modq_encode(
++            pk + 1, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
++            h, FALCON_LOGN);
++    if (v != PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
++/*
++ * This function reconstructs the public key from a given private key.
++ * It decodes the private key components (f and g) from the secret key
++ * and uses them to regenerate the corresponding public key (h).
++ * The generated public key is then encoded into the provided pk array.
++ * 
++ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
++ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
++ * Return value: 0 on success, -1 on error.
++ */
++int
++PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk) {
++    union {
++        uint8_t b[28 * FALCON_N];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
++    uint16_t h[FALCON_N];
++    size_t u, v;
++
++    /*
++     * Decode the private key.
++     */
++    if (sk[0] != 0x50 + FALCON_LOGN) {
++        return -1;
++    }
++    u = 1;
++    v = PQCLEAN_FALCONPADDED1024_AARCH64_trim_i8_decode(
++            f, PQCLEAN_FALCONPADDED1024_AARCH64_max_fg_bits[FALCON_LOGN],
++            sk + u, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED1024_AARCH64_trim_i8_decode(
++            g, PQCLEAN_FALCONPADDED1024_AARCH64_max_fg_bits[FALCON_LOGN],
++            sk + u, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++
++    /*
++     * Reconstruct the public key using f and g by calling the compute_public function.
++     */
++    if (!PQCLEAN_FALCONPADDED1024_AARCH64_compute_public(h, f, g, FALCON_LOGN, tmp.b)) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + FALCON_LOGN;
++    v = PQCLEAN_FALCONPADDED1024_AARCH64_modq_encode(
++            pk + 1, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
++            h, FALCON_LOGN);
++    if (v != PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
+ /*
+  * Compute the signature. nonce[] receives the nonce and must have length
+  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/scripts/copy_from_upstream/patches/pqclean_falcon_padded_1024_avx2_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
+++ b/scripts/copy_from_upstream/patches/pqclean_falcon_padded_1024_avx2_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
@@ -1,0 +1,186 @@
+bb71d215ac3de5bce18342152b6a5019e06de374
+diff --git a/crypto_sign/falcon-padded-1024/avx2/api.h b/crypto_sign/falcon-padded-1024/avx2/api.h
+index da61032..9b30dbd 100644
+--- a/crypto_sign/falcon-padded-1024/avx2/api.h
++++ b/crypto_sign/falcon-padded-1024/avx2/api.h
+@@ -21,6 +21,29 @@
+ int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair(
+     uint8_t *pk, uint8_t *sk);
+ 
++/*
++ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES
++ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++/*
++ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk);
++
+ /*
+  * Compute a signature on a provided message (m, mlen), with a given
+  * private key (sk). Signature is written in sig[], with length written
+diff --git a/crypto_sign/falcon-padded-1024/avx2/pqclean.c b/crypto_sign/falcon-padded-1024/avx2/pqclean.c
+index 06560ed..84e366c 100644
+--- a/crypto_sign/falcon-padded-1024/avx2/pqclean.c
++++ b/crypto_sign/falcon-padded-1024/avx2/pqclean.c
+@@ -105,6 +105,146 @@ PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair(
+     return 0;
+ }
+ 
++/* keypair from fixed seed*/
++int
++PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++    union {
++        uint8_t b[FALCON_KEYGEN_TEMP_10];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[1024], g[1024], F[1024];
++    uint16_t h[1024];
++    inner_shake256_context rng;
++    size_t u, v;
++
++    /*
++     * Checking the input seed parameter.
++     * If the seed is NULL, return an error.
++     */
++    if (seed == NULL) {
++        return -1;  // Error: seed is not provided.
++    }
++
++    /*
++     * Initialize the SHAKE256 random number generator using the seed.
++     * We now pass the seed directly to the generator.
++     */
++    inner_shake256_init(&rng);
++    inner_shake256_inject(&rng, seed, 48);
++    inner_shake256_flip(&rng);
++    PQCLEAN_FALCONPADDED1024_AVX2_keygen(&rng, f, g, F, NULL, h, 10, tmp.b);
++    inner_shake256_ctx_release(&rng);
++
++    /*
++     * Encode private key.
++     */
++    sk[0] = 0x50 + 10;
++    u = 1;
++    v = PQCLEAN_FALCONPADDED1024_AVX2_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
++            f, 10, PQCLEAN_FALCONPADDED1024_AVX2_max_fg_bits[10]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED1024_AVX2_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
++            g, 10, PQCLEAN_FALCONPADDED1024_AVX2_max_fg_bits[10]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED1024_AVX2_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
++            F, 10, PQCLEAN_FALCONPADDED1024_AVX2_max_FG_bits[10]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    if (u != PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + 10;
++    v = PQCLEAN_FALCONPADDED1024_AVX2_modq_encode(
++            pk + 1, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
++            h, 10);
++    if (v != PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
++/*
++ * This function reconstructs the public key from a given private key.
++ * It decodes the private key components (f and g) from the secret key
++ * and uses them to regenerate the corresponding public key (h).
++ * The generated public key is then encoded into the provided pk array.
++ * 
++ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
++ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
++ * Return value: 0 on success, -1 on error.
++ */
++int
++PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk) {
++    union {
++        uint8_t b[FALCON_KEYGEN_TEMP_10];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[1024], g[1024], F[1024];
++    uint16_t h[1024];
++    size_t u, v;
++
++    /*
++     * Decode the private key.
++     */
++    if (sk[0] != 0x50 + 10) {
++        return -1;
++    }
++    u = 1;
++    v = PQCLEAN_FALCONPADDED1024_AVX2_trim_i8_decode(
++            f, 10, PQCLEAN_FALCONPADDED1024_AVX2_max_fg_bits[10],
++            sk + u, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED1024_AVX2_trim_i8_decode(
++            g, 10, PQCLEAN_FALCONPADDED1024_AVX2_max_fg_bits[10],
++            sk + u, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++
++    /*
++     * Reconstruct the public key using f and g by calling the compute_public function.
++     */
++    if (!PQCLEAN_FALCONPADDED1024_AVX2_compute_public(h, f, g, 10, tmp.b)) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + 10;
++    v = PQCLEAN_FALCONPADDED1024_AVX2_modq_encode(
++            pk + 1, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
++            h, 10);
++    if (v != PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
+ /*
+  * Compute the signature. nonce[] receives the nonce and must have length
+  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/scripts/copy_from_upstream/patches/pqclean_falcon_padded_1024_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
+++ b/scripts/copy_from_upstream/patches/pqclean_falcon_padded_1024_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
@@ -1,0 +1,186 @@
+cb0a099771b2b0d424abaf38bbb5383d834a174f
+diff --git a/crypto_sign/falcon-padded-1024/clean/api.h b/crypto_sign/falcon-padded-1024/clean/api.h
+index 0d38a55..a3289f4 100644
+--- a/crypto_sign/falcon-padded-1024/clean/api.h
++++ b/crypto_sign/falcon-padded-1024/clean/api.h
+@@ -21,6 +21,29 @@
+ int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair(
+     uint8_t *pk, uint8_t *sk);
+ 
++/*
++ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES
++ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++/*
++ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk);
++
+ /*
+  * Compute a signature on a provided message (m, mlen), with a given
+  * private key (sk). Signature is written in sig[], with length written
+diff --git a/crypto_sign/falcon-padded-1024/clean/pqclean.c b/crypto_sign/falcon-padded-1024/clean/pqclean.c
+index eb6cc85..cf76017 100644
+--- a/crypto_sign/falcon-padded-1024/clean/pqclean.c
++++ b/crypto_sign/falcon-padded-1024/clean/pqclean.c
+@@ -105,6 +105,146 @@ PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair(
+     return 0;
+ }
+ 
++/* keypair from fixed seed*/
++int
++PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++    union {
++        uint8_t b[FALCON_KEYGEN_TEMP_10];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[1024], g[1024], F[1024];
++    uint16_t h[1024];
++    inner_shake256_context rng;
++    size_t u, v;
++
++    /*
++     * Checking the input seed parameter.
++     * If the seed is NULL, return an error.
++     */
++    if (seed == NULL) {
++        return -1;  // Error: seed is not provided.
++    }
++
++    /*
++     * Initialize the SHAKE256 random number generator using the seed.
++     * We now pass the seed directly to the generator.
++     */
++    inner_shake256_init(&rng);
++    inner_shake256_inject(&rng, seed, 48);
++    inner_shake256_flip(&rng);
++    PQCLEAN_FALCONPADDED1024_CLEAN_keygen(&rng, f, g, F, NULL, h, 10, tmp.b);
++    inner_shake256_ctx_release(&rng);
++
++    /*
++     * Encode private key.
++     */
++    sk[0] = 0x50 + 10;
++    u = 1;
++    v = PQCLEAN_FALCONPADDED1024_CLEAN_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
++            f, 10, PQCLEAN_FALCONPADDED1024_CLEAN_max_fg_bits[10]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED1024_CLEAN_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
++            g, 10, PQCLEAN_FALCONPADDED1024_CLEAN_max_fg_bits[10]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED1024_CLEAN_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
++            F, 10, PQCLEAN_FALCONPADDED1024_CLEAN_max_FG_bits[10]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    if (u != PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + 10;
++    v = PQCLEAN_FALCONPADDED1024_CLEAN_modq_encode(
++            pk + 1, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
++            h, 10);
++    if (v != PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
++/*
++ * This function reconstructs the public key from a given private key.
++ * It decodes the private key components (f and g) from the secret key
++ * and uses them to regenerate the corresponding public key (h).
++ * The generated public key is then encoded into the provided pk array.
++ * 
++ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
++ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
++ * Return value: 0 on success, -1 on error.
++ */
++int
++PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk) {
++    union {
++        uint8_t b[FALCON_KEYGEN_TEMP_10];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[1024], g[1024], F[1024];
++    uint16_t h[1024];
++    size_t u, v;
++
++    /*
++     * Decode the private key.
++     */
++    if (sk[0] != 0x50 + 10) {
++        return -1;
++    }
++    u = 1;
++    v = PQCLEAN_FALCONPADDED1024_CLEAN_trim_i8_decode(
++            f, 10, PQCLEAN_FALCONPADDED1024_CLEAN_max_fg_bits[10],
++            sk + u, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED1024_CLEAN_trim_i8_decode(
++            g, 10, PQCLEAN_FALCONPADDED1024_CLEAN_max_fg_bits[10],
++            sk + u, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++
++    /*
++     * Reconstruct the public key using f and g by calling the compute_public function.
++     */
++    if (!PQCLEAN_FALCONPADDED1024_CLEAN_compute_public(h, f, g, 10, tmp.b)) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + 10;
++    v = PQCLEAN_FALCONPADDED1024_CLEAN_modq_encode(
++            pk + 1, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
++            h, 10);
++    if (v != PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
+ /*
+  * Compute the signature. nonce[] receives the nonce and must have length
+  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/scripts/copy_from_upstream/patches/pqclean_falcon_padded_512_aarch64_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
+++ b/scripts/copy_from_upstream/patches/pqclean_falcon_padded_512_aarch64_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
@@ -1,0 +1,186 @@
+778837f3c6110b4202b0e184767ed234f560c8ca
+diff --git a/crypto_sign/falcon-padded-512/aarch64/api.h b/crypto_sign/falcon-padded-512/aarch64/api.h
+index deba20b..c790816 100644
+--- a/crypto_sign/falcon-padded-512/aarch64/api.h
++++ b/crypto_sign/falcon-padded-512/aarch64/api.h
+@@ -21,6 +21,29 @@
+ int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair(
+     uint8_t *pk, uint8_t *sk);
+ 
++/*
++ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES
++ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++/*
++ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk);
++
+ /*
+  * Compute a signature on a provided message (m, mlen), with a given
+  * private key (sk). Signature is written in sig[], with length written
+diff --git a/crypto_sign/falcon-padded-512/aarch64/pqclean.c b/crypto_sign/falcon-padded-512/aarch64/pqclean.c
+index bd6f049..1252e7d 100644
+--- a/crypto_sign/falcon-padded-512/aarch64/pqclean.c
++++ b/crypto_sign/falcon-padded-512/aarch64/pqclean.c
+@@ -105,6 +105,146 @@ PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair(
+     return 0;
+ }
+ 
++/* keypair from fixed seed*/
++int
++PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++    union {
++        uint8_t b[28 * FALCON_N];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
++    uint16_t h[FALCON_N];
++    inner_shake256_context rng;
++    size_t u, v;
++
++    /*
++     * Checking the input seed parameter.
++     * If the seed is NULL, return an error.
++     */
++    if (seed == NULL) {
++        return -1;  // Error: seed is not provided.
++    }
++
++    /*
++     * Initialize the SHAKE256 random number generator using the seed.
++     * We now pass the seed directly to the generator.
++     */
++    inner_shake256_init(&rng);
++    inner_shake256_inject(&rng, seed, 48);
++    inner_shake256_flip(&rng);
++    PQCLEAN_FALCONPADDED512_AARCH64_keygen(&rng, f, g, F, NULL, h, FALCON_LOGN, tmp.b);
++    inner_shake256_ctx_release(&rng);
++
++    /*
++     * Encode private key.
++     */
++    sk[0] = 0x50 + FALCON_LOGN;
++    u = 1;
++    v = PQCLEAN_FALCONPADDED512_AARCH64_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
++            f, PQCLEAN_FALCONPADDED512_AARCH64_max_fg_bits[FALCON_LOGN]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED512_AARCH64_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
++            g, PQCLEAN_FALCONPADDED512_AARCH64_max_fg_bits[FALCON_LOGN]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED512_AARCH64_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
++            F, PQCLEAN_FALCONPADDED512_AARCH64_max_FG_bits[FALCON_LOGN]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    if (u != PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + FALCON_LOGN;
++    v = PQCLEAN_FALCONPADDED512_AARCH64_modq_encode(
++            pk + 1, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
++            h, FALCON_LOGN);
++    if (v != PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
++/*
++ * This function reconstructs the public key from a given private key.
++ * It decodes the private key components (f and g) from the secret key
++ * and uses them to regenerate the corresponding public key (h).
++ * The generated public key is then encoded into the provided pk array.
++ * 
++ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
++ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
++ * Return value: 0 on success, -1 on error.
++ */
++int
++PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk) {
++    union {
++        uint8_t b[28 * FALCON_N];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
++    uint16_t h[FALCON_N];
++    size_t u, v;
++
++    /*
++     * Decode the private key.
++     */
++    if (sk[0] != 0x50 + FALCON_LOGN) {
++        return -1;
++    }
++    u = 1;
++    v = PQCLEAN_FALCONPADDED512_AARCH64_trim_i8_decode(
++            f, PQCLEAN_FALCONPADDED512_AARCH64_max_fg_bits[FALCON_LOGN],
++            sk + u, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED512_AARCH64_trim_i8_decode(
++            g, PQCLEAN_FALCONPADDED512_AARCH64_max_fg_bits[FALCON_LOGN],
++            sk + u, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++
++    /*
++     * Reconstruct the public key using f and g by calling the compute_public function.
++     */
++    if (!PQCLEAN_FALCONPADDED512_AARCH64_compute_public(h, f, g, FALCON_LOGN, tmp.b)) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + FALCON_LOGN;
++    v = PQCLEAN_FALCONPADDED512_AARCH64_modq_encode(
++            pk + 1, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
++            h, FALCON_LOGN);
++    if (v != PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
+ /*
+  * Compute the signature. nonce[] receives the nonce and must have length
+  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/scripts/copy_from_upstream/patches/pqclean_falcon_padded_512_avx2_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
+++ b/scripts/copy_from_upstream/patches/pqclean_falcon_padded_512_avx2_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
@@ -1,0 +1,186 @@
+8c4b4da3cef17d50b2c4008c162176b225e2a192
+diff --git a/crypto_sign/falcon-padded-512/avx2/api.h b/crypto_sign/falcon-padded-512/avx2/api.h
+index c039206..b77c627 100644
+--- a/crypto_sign/falcon-padded-512/avx2/api.h
++++ b/crypto_sign/falcon-padded-512/avx2/api.h
+@@ -21,6 +21,29 @@
+ int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair(
+     uint8_t *pk, uint8_t *sk);
+ 
++/*
++ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES
++ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++/*
++ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk);
++
+ /*
+  * Compute a signature on a provided message (m, mlen), with a given
+  * private key (sk). Signature is written in sig[], with length written
+diff --git a/crypto_sign/falcon-padded-512/avx2/pqclean.c b/crypto_sign/falcon-padded-512/avx2/pqclean.c
+index 1711050..1fc8122 100644
+--- a/crypto_sign/falcon-padded-512/avx2/pqclean.c
++++ b/crypto_sign/falcon-padded-512/avx2/pqclean.c
+@@ -105,6 +105,146 @@ PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair(
+     return 0;
+ }
+ 
++/* keypair from fixed seed*/
++int
++PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++    union {
++        uint8_t b[FALCON_KEYGEN_TEMP_9];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[512], g[512], F[512];
++    uint16_t h[512];
++    inner_shake256_context rng;
++    size_t u, v;
++
++    /*
++     * Checking the input seed parameter.
++     * If the seed is NULL, return an error.
++     */
++    if (seed == NULL) {
++        return -1;  // Error: seed is not provided.
++    }
++
++    /*
++     * Initialize the SHAKE256 random number generator using the seed.
++     * We now pass the seed directly to the generator.
++     */
++    inner_shake256_init(&rng);
++    inner_shake256_inject(&rng, seed, 48);
++    inner_shake256_flip(&rng);
++    PQCLEAN_FALCONPADDED512_AVX2_keygen(&rng, f, g, F, NULL, h, 9, tmp.b);
++    inner_shake256_ctx_release(&rng);
++
++    /*
++     * Encode private key.
++     */
++    sk[0] = 0x50 + 9;
++    u = 1;
++    v = PQCLEAN_FALCONPADDED512_AVX2_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES - u,
++            f, 9, PQCLEAN_FALCONPADDED512_AVX2_max_fg_bits[9]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED512_AVX2_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES - u,
++            g, 9, PQCLEAN_FALCONPADDED512_AVX2_max_fg_bits[9]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED512_AVX2_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES - u,
++            F, 9, PQCLEAN_FALCONPADDED512_AVX2_max_FG_bits[9]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    if (u != PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + 9;
++    v = PQCLEAN_FALCONPADDED512_AVX2_modq_encode(
++            pk + 1, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
++            h, 9);
++    if (v != PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
++/*
++ * This function reconstructs the public key from a given private key.
++ * It decodes the private key components (f and g) from the secret key
++ * and uses them to regenerate the corresponding public key (h).
++ * The generated public key is then encoded into the provided pk array.
++ * 
++ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
++ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
++ * Return value: 0 on success, -1 on error.
++ */
++int
++PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk) {
++    union {
++        uint8_t b[FALCON_KEYGEN_TEMP_9];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[512], g[512], F[512];
++    uint16_t h[512];
++    size_t u, v;
++
++    /*
++     * Decode the private key.
++     */
++    if (sk[0] != 0x50 + 9) {
++        return -1;
++    }
++    u = 1;
++    v = PQCLEAN_FALCONPADDED512_AVX2_trim_i8_decode(
++            f, 9, PQCLEAN_FALCONPADDED512_AVX2_max_fg_bits[9],
++            sk + u, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED512_AVX2_trim_i8_decode(
++            g, 9, PQCLEAN_FALCONPADDED512_AVX2_max_fg_bits[9],
++            sk + u, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++
++    /*
++     * Reconstruct the public key using f and g by calling the compute_public function.
++     */
++    if (!PQCLEAN_FALCONPADDED512_AVX2_compute_public(h, f, g, 9, tmp.b)) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + 9;
++    v = PQCLEAN_FALCONPADDED512_AVX2_modq_encode(
++            pk + 1, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
++            h, 9);
++    if (v != PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
+ /*
+  * Compute the signature. nonce[] receives the nonce and must have length
+  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/scripts/copy_from_upstream/patches/pqclean_falcon_padded_512_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
+++ b/scripts/copy_from_upstream/patches/pqclean_falcon_padded_512_clean_keypair_from_fixed_seed_and_pubkey_from_privkey.patch
@@ -1,0 +1,186 @@
+fa5ffd57839a5ef342a0129b118f5723ed813760
+diff --git a/crypto_sign/falcon-padded-512/clean/api.h b/crypto_sign/falcon-padded-512/clean/api.h
+index 47c1314..2008914 100644
+--- a/crypto_sign/falcon-padded-512/clean/api.h
++++ b/crypto_sign/falcon-padded-512/clean/api.h
+@@ -21,6 +21,29 @@
+ int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair(
+     uint8_t *pk, uint8_t *sk);
+ 
++/*
++ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES
++ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
++
++/*
++ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
++ * Key sizes are exact (in bytes):
++ *   public (pk): PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES
++ *   private (sk): PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES
++ *
++ * Return value: 0 on success, -1 on error.
++ */
++int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk);
++
+ /*
+  * Compute a signature on a provided message (m, mlen), with a given
+  * private key (sk). Signature is written in sig[], with length written
+diff --git a/crypto_sign/falcon-padded-512/clean/pqclean.c b/crypto_sign/falcon-padded-512/clean/pqclean.c
+index 7edf6a8..544a59a 100644
+--- a/crypto_sign/falcon-padded-512/clean/pqclean.c
++++ b/crypto_sign/falcon-padded-512/clean/pqclean.c
+@@ -105,6 +105,146 @@ PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair(
+     return 0;
+ }
+ 
++/* keypair from fixed seed*/
++int
++PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(
++    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++    union {
++        uint8_t b[FALCON_KEYGEN_TEMP_9];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[512], g[512], F[512];
++    uint16_t h[512];
++    inner_shake256_context rng;
++    size_t u, v;
++
++    /*
++     * Checking the input seed parameter.
++     * If the seed is NULL, return an error.
++     */
++    if (seed == NULL) {
++        return -1;  // Error: seed is not provided.
++    }
++
++    /*
++     * Initialize the SHAKE256 random number generator using the seed.
++     * We now pass the seed directly to the generator.
++     */
++    inner_shake256_init(&rng);
++    inner_shake256_inject(&rng, seed, 48);
++    inner_shake256_flip(&rng);
++    PQCLEAN_FALCONPADDED512_CLEAN_keygen(&rng, f, g, F, NULL, h, 9, tmp.b);
++    inner_shake256_ctx_release(&rng);
++
++    /*
++     * Encode private key.
++     */
++    sk[0] = 0x50 + 9;
++    u = 1;
++    v = PQCLEAN_FALCONPADDED512_CLEAN_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
++            f, 9, PQCLEAN_FALCONPADDED512_CLEAN_max_fg_bits[9]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED512_CLEAN_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
++            g, 9, PQCLEAN_FALCONPADDED512_CLEAN_max_fg_bits[9]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED512_CLEAN_trim_i8_encode(
++            sk + u, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
++            F, 9, PQCLEAN_FALCONPADDED512_CLEAN_max_FG_bits[9]);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    if (u != PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + 9;
++    v = PQCLEAN_FALCONPADDED512_CLEAN_modq_encode(
++            pk + 1, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
++            h, 9);
++    if (v != PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
++/*
++ * This function reconstructs the public key from a given private key.
++ * It decodes the private key components (f and g) from the secret key
++ * and uses them to regenerate the corresponding public key (h).
++ * The generated public key is then encoded into the provided pk array.
++ * 
++ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
++ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
++ * Return value: 0 on success, -1 on error.
++ */
++int
++PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_pubkey_from_privkey(
++    uint8_t *pk, const uint8_t *sk) {
++    union {
++        uint8_t b[FALCON_KEYGEN_TEMP_9];
++        uint64_t dummy_u64;
++        fpr dummy_fpr;
++    } tmp;
++    int8_t f[512], g[512], F[512];
++    uint16_t h[512];
++    size_t u, v;
++
++    /*
++     * Decode the private key.
++     */
++    if (sk[0] != 0x50 + 9) {
++        return -1;
++    }
++    u = 1;
++    v = PQCLEAN_FALCONPADDED512_CLEAN_trim_i8_decode(
++            f, 9, PQCLEAN_FALCONPADDED512_CLEAN_max_fg_bits[9],
++            sk + u, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++    u += v;
++    v = PQCLEAN_FALCONPADDED512_CLEAN_trim_i8_decode(
++            g, 9, PQCLEAN_FALCONPADDED512_CLEAN_max_fg_bits[9],
++            sk + u, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES - u);
++    if (v == 0) {
++        return -1;
++    }
++
++    /*
++     * Reconstruct the public key using f and g by calling the compute_public function.
++     */
++    if (!PQCLEAN_FALCONPADDED512_CLEAN_compute_public(h, f, g, 9, tmp.b)) {
++        return -1;
++    }
++
++    /*
++     * Encode public key.
++     */
++    pk[0] = 0x00 + 9;
++    v = PQCLEAN_FALCONPADDED512_CLEAN_modq_encode(
++            pk + 1, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
++            h, 9);
++    if (v != PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
++        return -1;
++    }
++
++    return 0;
++}
++
+ /*
+  * Compute the signature. nonce[] receives the nonce and must have length
+  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/scripts/copy_from_upstream/patches/pqcrystals_dilithium_ref_avx2_2_5_keypair_from_fixed_seed_and_pubkey_from_privkey_function.patch
+++ b/scripts/copy_from_upstream/patches/pqcrystals_dilithium_ref_avx2_2_5_keypair_from_fixed_seed_and_pubkey_from_privkey_function.patch
@@ -1,0 +1,499 @@
+5d234589d707816a1dfd829f4d55f8ee7710b91e
+diff --git a/avx2/api.h b/avx2/api.h
+index d64709d..a4771cb 100644
+--- a/avx2/api.h
++++ b/avx2/api.h
+@@ -14,6 +14,11 @@
+ 
+ int pqcrystals_dilithium2_avx2_keypair(uint8_t *pk, uint8_t *sk);
+ 
++int pqcrystals_dilithium2_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
++                                                  const uint8_t *seed);
++
++int pqcrystals_dilithium2_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ int pqcrystals_dilithium2_avx2_signature(uint8_t *sig, size_t *siglen,
+                                         const uint8_t *m, size_t mlen,
+                                         const uint8_t *sk);
+@@ -36,6 +41,11 @@ int pqcrystals_dilithium2_avx2_open(uint8_t *m, size_t *mlen,
+ 
+ int pqcrystals_dilithium2aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+ 
++int pqcrystals_dilithium2aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
++                                                     const uint8_t *seed);
++
++int pqcrystals_dilithium2aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ int pqcrystals_dilithium2aes_avx2_signature(uint8_t *sig, size_t *siglen,
+                                            const uint8_t *m, size_t mlen,
+                                            const uint8_t *sk);
+@@ -62,6 +72,11 @@ int pqcrystals_dilithium2aes_avx2_open(uint8_t *m, size_t *mlen,
+ 
+ int pqcrystals_dilithium3_avx2_keypair(uint8_t *pk, uint8_t *sk);
+ 
++int pqcrystals_dilithium3_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
++                                                  const uint8_t *seed);
++
++int pqcrystals_dilithium3_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ int pqcrystals_dilithium3_avx2_signature(uint8_t *sig, size_t *siglen,
+                                         const uint8_t *m, size_t mlen,
+                                         const uint8_t *sk);
+@@ -84,6 +99,11 @@ int pqcrystals_dilithium3_avx2_open(uint8_t *m, size_t *mlen,
+ 
+ int pqcrystals_dilithium3aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+ 
++int pqcrystals_dilithium3aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
++                                                     const uint8_t *seed);
++
++int pqcrystals_dilithium3aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ int pqcrystals_dilithium3aes_avx2_signature(uint8_t *sig, size_t *siglen,
+                                            const uint8_t *m, size_t mlen,
+                                            const uint8_t *sk);
+@@ -110,6 +130,11 @@ int pqcrystals_dilithium3aes_avx2_open(uint8_t *m, size_t *mlen,
+ 
+ int pqcrystals_dilithium5_avx2_keypair(uint8_t *pk, uint8_t *sk);
+ 
++int pqcrystals_dilithium5_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
++                                                  const uint8_t *seed);
++
++int pqcrystals_dilithium5_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ int pqcrystals_dilithium5_avx2_signature(uint8_t *sig, size_t *siglen,
+                                         const uint8_t *m, size_t mlen,
+                                         const uint8_t *sk);
+@@ -132,6 +157,11 @@ int pqcrystals_dilithium5_avx2_open(uint8_t *m, size_t *mlen,
+ 
+ int pqcrystals_dilithium5aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+ 
++int pqcrystals_dilithium5aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
++                                                     const uint8_t *seed);
++
++int pqcrystals_dilithium5aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ int pqcrystals_dilithium5aes_avx2_signature(uint8_t *sig, size_t *siglen,
+                                            const uint8_t *m, size_t mlen,
+                                            const uint8_t *sk);
+diff --git a/avx2/sign.c b/avx2/sign.c
+index 448cdd1..bc9fb2d 100644
+--- a/avx2/sign.c
++++ b/avx2/sign.c
+@@ -175,6 +175,205 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
+   return 0;
+ }
+ 
++/*************************************************
++* Name:        crypto_sign_keypair_from_fseed
++*
++* Description: Generates public and private key from fixed seed.
++*
++* Arguments:   - uint8_t *pk: pointer to output public key (allocated
++*                             array of CRYPTO_PUBLICKEYBYTES bytes)
++*              - uint8_t *sk: pointer to output private key (allocated
++*                             array of CRYPTO_SECRETKEYBYTES bytes)
++*              - const uint8_t *seed: Pointer to the input fixed seed.
++*                                     Must point to an array of SEEDBYTES bytes.
++*                                     The seed provides deterministic randomness
++*                                     for key generation and must be unique and
++*                                     securely generated for each keypair to
++*                                     ensure security.
++*
++* Returns 0 (success)
++**************************************************/
++int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++  unsigned int i;
++  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
++  const uint8_t *rho, *rhoprime, *key;
++#ifdef DILITHIUM_USE_AES
++  uint64_t nonce;
++  aes256ctr_ctx aesctx;
++  polyvecl rowbuf[1];
++#else
++  polyvecl rowbuf[2];
++#endif
++  polyvecl s1, *row = rowbuf;
++  polyveck s2;
++  poly t1, t0;
++
++  /* Use fixed seed for randomness for rho, rhoprime and key */
++  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
++  rho = seedbuf;
++  rhoprime = rho + SEEDBYTES;
++  key = rhoprime + CRHBYTES;
++
++  /* Store rho, key */
++  memcpy(pk, rho, SEEDBYTES);
++  memcpy(sk, rho, SEEDBYTES);
++  memcpy(sk + SEEDBYTES, key, SEEDBYTES);
++
++  /* Sample short vectors s1 and s2 */
++#ifdef DILITHIUM_USE_AES
++  aes256ctr_init_u64(&aesctx, rhoprime, 0);
++  for(i = 0; i < L; ++i) {
++    nonce = i;
++    aes256ctr_init_iv_u64(&aesctx, nonce);
++    poly_uniform_eta_preinit(&s1.vec[i], &aesctx);
++  }
++  for(i = 0; i < K; ++i) {
++    nonce = L + i;
++    aes256ctr_init_iv_u64(&aesctx, nonce);
++    poly_uniform_eta_preinit(&s2.vec[i], &aesctx);
++  }
++  aes256_ctx_release(&aesctx);
++#elif K == 4 && L == 4
++  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
++  poly_uniform_eta_4x(&s2.vec[0], &s2.vec[1], &s2.vec[2], &s2.vec[3], rhoprime, 4, 5, 6, 7);
++#elif K == 6 && L == 5
++  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
++  poly_uniform_eta_4x(&s1.vec[4], &s2.vec[0], &s2.vec[1], &s2.vec[2], rhoprime, 4, 5, 6, 7);
++  poly_uniform_eta_4x(&s2.vec[3], &s2.vec[4], &s2.vec[5], &t0, rhoprime, 8, 9, 10, 11);
++#elif K == 8 && L == 7
++  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
++  poly_uniform_eta_4x(&s1.vec[4], &s1.vec[5], &s1.vec[6], &s2.vec[0], rhoprime, 4, 5, 6, 7);
++  poly_uniform_eta_4x(&s2.vec[1], &s2.vec[2], &s2.vec[3], &s2.vec[4], rhoprime, 8, 9, 10, 11);
++  poly_uniform_eta_4x(&s2.vec[5], &s2.vec[6], &s2.vec[7], &t0, rhoprime, 12, 13, 14, 15);
++#else
++#error
++#endif
++
++  /* Pack secret vectors */
++  for(i = 0; i < L; i++)
++    polyeta_pack(sk + 3*SEEDBYTES + i*POLYETA_PACKEDBYTES, &s1.vec[i]);
++  for(i = 0; i < K; i++)
++    polyeta_pack(sk + 3*SEEDBYTES + (L + i)*POLYETA_PACKEDBYTES, &s2.vec[i]);
++
++  /* Transform s1 */
++  polyvecl_ntt(&s1);
++
++#ifdef DILITHIUM_USE_AES
++  aes256ctr_init_u64(&aesctx, rho, 0);
++#endif
++
++  for(i = 0; i < K; i++) {
++    /* Expand matrix row */
++#ifdef DILITHIUM_USE_AES
++    for(unsigned int j = 0; j < L; j++) {
++      nonce = (i << 8) + j;
++      aes256ctr_init_iv_u64(&aesctx, nonce);
++      poly_uniform_preinit(&row->vec[j], &aesctx);
++      poly_nttunpack(&row->vec[j]);
++    }
++#else
++    polyvec_matrix_expand_row(&row, rowbuf, rho, i);
++#endif
++
++    /* Compute inner-product */
++    polyvecl_pointwise_acc_montgomery(&t1, row, &s1);
++    poly_invntt_tomont(&t1);
++
++    /* Add error polynomial */
++    poly_add(&t1, &t1, &s2.vec[i]);
++
++    /* Round t and pack t1, t0 */
++    poly_caddq(&t1);
++    poly_power2round(&t1, &t0, &t1);
++    polyt1_pack(pk + SEEDBYTES + i*POLYT1_PACKEDBYTES, &t1);
++    polyt0_pack(sk + 3*SEEDBYTES + (L+K)*POLYETA_PACKEDBYTES + i*POLYT0_PACKEDBYTES, &t0);
++  }
++
++#ifdef DILITHIUM_USE_AES
++  aes256_ctx_release(&aesctx);
++#endif
++
++  /* Compute H(rho, t1) and store in secret key */
++  shake256(sk + 2*SEEDBYTES, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
++
++  return 0;
++}
++
++/*************************************************
++* Name:        crypto_sign_pubkey_from_privkey
++*
++* Description: Generates public key from existing private key.
++*
++* Arguments:   - uint8_t *pk: pointer to output public key (allocated
++*                             array of CRYPTO_PUBLICKEYBYTES bytes)
++*              - const uint8_t *sk: pointer to input private key (points
++*                                   to array of CRYPTO_SECRETKEYBYTES bytes)
++*
++* Returns 0 (success)
++**************************************************/
++int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
++  unsigned int i;
++  uint8_t rho[SEEDBYTES];
++  uint8_t tr[SEEDBYTES];
++  uint8_t key[SEEDBYTES];
++#ifdef DILITHIUM_USE_AES
++  uint64_t nonce;
++  aes256ctr_ctx aesctx;
++  polyvecl rowbuf[1];
++#else
++  polyvecl rowbuf[2];
++#endif
++  polyvecl s1, *row = rowbuf;
++  polyveck s2;
++  poly t1, t0;
++
++  // Unpack private key
++  unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
++
++  // Store rho in public key
++  memcpy(pk, rho, SEEDBYTES);
++
++  // Transform s1
++  polyvecl_ntt(&s1);
++
++#ifdef DILITHIUM_USE_AES
++  aes256ctr_init_u64(&aesctx, rho, 0);
++#endif
++
++  // Process each row
++  for(i = 0; i < K; i++) {
++    /* Expand matrix row */
++#ifdef DILITHIUM_USE_AES
++    for(unsigned int j = 0; j < L; j++) {
++      nonce = (i << 8) + j;
++      aes256ctr_init_iv_u64(&aesctx, nonce);
++      poly_uniform_preinit(&row->vec[j], &aesctx);
++      poly_nttunpack(&row->vec[j]);
++    }
++#else
++    polyvec_matrix_expand_row(&row, rowbuf, rho, i);
++#endif
++
++    /* Compute inner-product */
++    polyvecl_pointwise_acc_montgomery(&t1, row, &s1);
++    poly_invntt_tomont(&t1);
++
++    /* Add error polynomial */
++    poly_add(&t1, &t1, &s2.vec[i]);
++
++    /* Round t and pack t1 */
++    poly_caddq(&t1);
++    poly_power2round(&t1, &t0, &t1);
++    polyt1_pack(pk + SEEDBYTES + i*POLYT1_PACKEDBYTES, &t1);
++  }
++
++#ifdef DILITHIUM_USE_AES
++  aes256_ctx_release(&aesctx);
++#endif
++
++  return 0;
++}
++
+ /*************************************************
+ * Name:        crypto_sign_signature
+ *
+diff --git a/ref/api.h b/ref/api.h
+index ceeef10..4fd8d93 100644
+--- a/ref/api.h
++++ b/ref/api.h
+@@ -14,6 +14,11 @@
+ 
+ int pqcrystals_dilithium2_ref_keypair(uint8_t *pk, uint8_t *sk);
+ 
++int pqcrystals_dilithium2_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
++                                                 const uint8_t *seed);
++
++int pqcrystals_dilithium2_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ int pqcrystals_dilithium2_ref_signature(uint8_t *sig, size_t *siglen,
+                                         const uint8_t *m, size_t mlen,
+                                         const uint8_t *sk);
+@@ -36,6 +41,11 @@ int pqcrystals_dilithium2_ref_open(uint8_t *m, size_t *mlen,
+ 
+ int pqcrystals_dilithium2aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+ 
++int pqcrystals_dilithium2aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
++                                                    const uint8_t *seed);
++
++int pqcrystals_dilithium2aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ int pqcrystals_dilithium2aes_ref_signature(uint8_t *sig, size_t *siglen,
+                                            const uint8_t *m, size_t mlen,
+                                            const uint8_t *sk);
+@@ -62,6 +72,11 @@ int pqcrystals_dilithium2aes_ref_open(uint8_t *m, size_t *mlen,
+ 
+ int pqcrystals_dilithium3_ref_keypair(uint8_t *pk, uint8_t *sk);
+ 
++int pqcrystals_dilithium3_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
++                                                 const uint8_t *seed);
++
++int pqcrystals_dilithium3_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ int pqcrystals_dilithium3_ref_signature(uint8_t *sig, size_t *siglen,
+                                         const uint8_t *m, size_t mlen,
+                                         const uint8_t *sk);
+@@ -84,6 +99,11 @@ int pqcrystals_dilithium3_ref_open(uint8_t *m, size_t *mlen,
+ 
+ int pqcrystals_dilithium3aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+ 
++int pqcrystals_dilithium3aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
++                                                    const uint8_t *seed);
++
++int pqcrystals_dilithium3aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ int pqcrystals_dilithium3aes_ref_signature(uint8_t *sig, size_t *siglen,
+                                            const uint8_t *m, size_t mlen,
+                                            const uint8_t *sk);
+@@ -110,6 +130,11 @@ int pqcrystals_dilithium3aes_ref_open(uint8_t *m, size_t *mlen,
+ 
+ int pqcrystals_dilithium5_ref_keypair(uint8_t *pk, uint8_t *sk);
+ 
++int pqcrystals_dilithium5_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
++                                                 const uint8_t *seed);
++
++int pqcrystals_dilithium5_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ int pqcrystals_dilithium5_ref_signature(uint8_t *sig, size_t *siglen,
+                                         const uint8_t *m, size_t mlen,
+                                         const uint8_t *sk);
+@@ -132,6 +157,11 @@ int pqcrystals_dilithium5_ref_open(uint8_t *m, size_t *mlen,
+ 
+ int pqcrystals_dilithium5aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+ 
++int pqcrystals_dilithium5aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
++                                                    const uint8_t *seed);
++
++int pqcrystals_dilithium5aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ int pqcrystals_dilithium5aes_ref_signature(uint8_t *sig, size_t *siglen,
+                                            const uint8_t *m, size_t mlen,
+                                            const uint8_t *sk);
+diff --git a/ref/sign.c b/ref/sign.c
+index 16333eb..cdf6ab5 100644
+--- a/ref/sign.c
++++ b/ref/sign.c
+@@ -64,6 +64,113 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
+   return 0;
+ }
+ 
++/*************************************************
++* Name:        crypto_sign_keypair_from_fseed
++*
++* Description: Generates public and private key from fixed seed.
++*
++* Arguments:   - uint8_t *pk: pointer to output public key (allocated
++*                             array of CRYPTO_PUBLICKEYBYTES bytes)
++*              - uint8_t *sk: pointer to output private key (allocated
++*                             array of CRYPTO_SECRETKEYBYTES bytes)
++*              - const uint8_t *seed: Pointer to the input fixed seed.
++*                                     Must point to an array of SEEDBYTES bytes.
++*                                     The seed provides deterministic randomness
++*                                     for key generation and must be unique and
++*                                     securely generated for each keypair to
++*                                     ensure security.
++*
++* Returns 0 (success)
++**************************************************/
++int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
++  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
++  uint8_t tr[SEEDBYTES];
++  const uint8_t *rho, *rhoprime, *key;
++  polyvecl mat[K];
++  polyvecl s1, s1hat;
++  polyveck s2, t1, t0;
++
++  /* Use fixed seed for randomness for rho, rhoprime and key */
++  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
++  rho = seedbuf;
++  rhoprime = rho + SEEDBYTES;
++  key = rhoprime + CRHBYTES;
++
++  /* Expand matrix */
++  polyvec_matrix_expand(mat, rho);
++
++  /* Sample short vectors s1 and s2 */
++  polyvecl_uniform_eta(&s1, rhoprime, 0);
++  polyveck_uniform_eta(&s2, rhoprime, L);
++
++  /* Matrix-vector multiplication */
++  s1hat = s1;
++  polyvecl_ntt(&s1hat);
++  polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
++  polyveck_reduce(&t1);
++  polyveck_invntt_tomont(&t1);
++
++  /* Add error vector s2 */
++  polyveck_add(&t1, &t1, &s2);
++
++  /* Extract t1 and write public key */
++  polyveck_caddq(&t1);
++  polyveck_power2round(&t1, &t0, &t1);
++  pack_pk(pk, rho, &t1);
++
++  /* Compute H(rho, t1) and write secret key */
++  shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
++  pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
++
++  return 0;
++}
++
++/*************************************************
++* Name:        crypto_sign_pubkey_from_privkey
++*
++* Description: Generates public key from exist private key.
++*
++* Arguments:   - uint8_t *pk: pointer to output public key (allocated
++*                             array of CRYPTO_PUBLICKEYBYTES bytes)
++*              - const uint8_t *sk: pointer to the input private key (points
++*                                   to a read-only array of CRYPTO_SECRETKEYBYTES bytes)
++*
++* Returns 0 (success)
++**************************************************/
++int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
++  uint8_t rho[SEEDBYTES];
++  uint8_t tr[SEEDBYTES];
++  uint8_t key[SEEDBYTES];
++  polyvecl s1, s1hat;
++  polyveck s2, t0, t1;
++  polyvecl mat[K];
++
++  /* unpack privat key */
++  unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
++
++  /* Expand matrix */
++  polyvec_matrix_expand(mat, rho);
++
++  /* Matrix-vector multiplication */
++  s1hat = s1;
++  polyvecl_ntt(&s1hat);
++  polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
++  polyveck_reduce(&t1);
++  polyveck_invntt_tomont(&t1);
++
++  /* Add error vector s2 */
++  polyveck_add(&t1, &t1, &s2);
++
++  /* Extract t1 */
++  polyveck_caddq(&t1);
++  polyveck_power2round(&t1, &t0, &t1);
++
++  /* Pack public key */
++  pack_pk(pk, rho, &t1);
++
++  return 0;
++}
++
+ /*************************************************
+ * Name:        crypto_sign_signature
+ *
+diff --git a/ref/sign.h b/ref/sign.h
+index 295f378..a502283 100644
+--- a/ref/sign.h
++++ b/ref/sign.h
+@@ -13,6 +13,13 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
+ #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
+ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+ 
++#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
++int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
++                                   const uint8_t *seed);
++
++#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
++int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
++
+ #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
+ int crypto_sign_signature(uint8_t *sig, size_t *siglen,
+                           const uint8_t *m, size_t mlen,

--- a/scripts/copy_from_upstream/src/sig/family/sig_family.h
+++ b/scripts/copy_from_upstream/src/sig/family/sig_family.h
@@ -14,6 +14,8 @@
 
 OQS_SIG *OQS_SIG_{{ family }}_{{ scheme['scheme'] }}_new(void);
 OQS_API OQS_STATUS OQS_SIG_{{ family }}_{{ scheme['scheme'] }}_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_{{ family }}_{{ scheme['scheme'] }}_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_{{ family }}_{{ scheme['scheme'] }}_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_{{ family }}_{{ scheme['scheme'] }}_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_{{ family }}_{{ scheme['scheme'] }}_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_{{ family }}_{{ scheme['scheme'] }}_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -24,6 +26,8 @@ OQS_API OQS_STATUS OQS_SIG_{{ family }}_{{ scheme['scheme'] }}_verify_with_ctx_s
 #define OQS_SIG_{{ family }}_{{ scheme['alias_scheme'] }}_length_signature OQS_SIG_{{ family }}_{{ scheme['scheme'] }}_length_signature
 OQS_SIG *OQS_SIG_{{ family }}_{{ scheme['alias_scheme'] }}_new(void);
 #define OQS_SIG_{{ family }}_{{ scheme['alias_scheme'] }}_keypair OQS_SIG_{{ family }}_{{ scheme['scheme'] }}_keypair
+#define OQS_SIG_{{ family }}_{{ scheme['alias_scheme'] }}_keypair_from_fseed OQS_SIG_{{ family }}_{{ scheme['scheme'] }}_keypair_from_fseed
+#define OQS_SIG_{{ family }}_{{ scheme['alias_scheme'] }}_pubkey_from_privkey OQS_SIG_{{ family }}_{{ scheme['scheme'] }}_pubkey_from_privkey
 #define OQS_SIG_{{ family }}_{{ scheme['alias_scheme'] }}_sign OQS_SIG_{{ family }}_{{ scheme['scheme'] }}_sign
 #define OQS_SIG_{{ family }}_{{ scheme['alias_scheme'] }}_verify OQS_SIG_{{ family }}_{{ scheme['scheme'] }}_verify
 {%- if 'api-with-context-string' in default_impl and default_impl['api-with-context-string'] %}

--- a/src/sig/cross/sig_cross.h
+++ b/src/sig/cross/sig_cross.h
@@ -12,6 +12,8 @@
 
 OQS_SIG *OQS_SIG_cross_rsdp_128_balanced_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_balanced_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_balanced_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_balanced_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_balanced_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_balanced_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_balanced_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -25,6 +27,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_balanced_verify_with_ctx_str(const uin
 
 OQS_SIG *OQS_SIG_cross_rsdp_128_fast_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_fast_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_fast_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_fast_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_fast_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_fast_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_fast_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -38,6 +42,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_fast_verify_with_ctx_str(const uint8_t
 
 OQS_SIG *OQS_SIG_cross_rsdp_128_small_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_small_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_small_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_small_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_small_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_small_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_small_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -51,6 +57,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_small_verify_with_ctx_str(const uint8_
 
 OQS_SIG *OQS_SIG_cross_rsdp_192_balanced_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_balanced_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_balanced_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_balanced_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_balanced_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_balanced_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_balanced_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -64,6 +72,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_balanced_verify_with_ctx_str(const uin
 
 OQS_SIG *OQS_SIG_cross_rsdp_192_fast_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_fast_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_fast_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_fast_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_fast_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_fast_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_fast_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -77,6 +87,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_fast_verify_with_ctx_str(const uint8_t
 
 OQS_SIG *OQS_SIG_cross_rsdp_192_small_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_small_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_small_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_small_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_small_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_small_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_small_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -90,6 +102,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_small_verify_with_ctx_str(const uint8_
 
 OQS_SIG *OQS_SIG_cross_rsdp_256_balanced_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_balanced_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_balanced_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_balanced_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_balanced_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_balanced_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_balanced_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -103,6 +117,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_balanced_verify_with_ctx_str(const uin
 
 OQS_SIG *OQS_SIG_cross_rsdp_256_fast_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_fast_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_fast_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_fast_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_fast_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_fast_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_fast_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -116,6 +132,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_fast_verify_with_ctx_str(const uint8_t
 
 OQS_SIG *OQS_SIG_cross_rsdp_256_small_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_small_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_small_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_small_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_small_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_small_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_small_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -129,6 +147,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_small_verify_with_ctx_str(const uint8_
 
 OQS_SIG *OQS_SIG_cross_rsdpg_128_balanced_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_balanced_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_balanced_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_balanced_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_balanced_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_balanced_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_balanced_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -142,6 +162,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_balanced_verify_with_ctx_str(const ui
 
 OQS_SIG *OQS_SIG_cross_rsdpg_128_fast_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_fast_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_fast_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_fast_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_fast_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_fast_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_fast_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -155,6 +177,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_fast_verify_with_ctx_str(const uint8_
 
 OQS_SIG *OQS_SIG_cross_rsdpg_128_small_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_small_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_small_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_small_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_small_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_small_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_small_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -168,6 +192,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_small_verify_with_ctx_str(const uint8
 
 OQS_SIG *OQS_SIG_cross_rsdpg_192_balanced_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_balanced_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_balanced_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_balanced_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_balanced_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_balanced_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_balanced_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -181,6 +207,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_balanced_verify_with_ctx_str(const ui
 
 OQS_SIG *OQS_SIG_cross_rsdpg_192_fast_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_fast_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_fast_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_fast_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_fast_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_fast_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_fast_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -194,6 +222,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_fast_verify_with_ctx_str(const uint8_
 
 OQS_SIG *OQS_SIG_cross_rsdpg_192_small_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_small_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_small_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_small_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_small_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_small_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_small_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -207,6 +237,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_small_verify_with_ctx_str(const uint8
 
 OQS_SIG *OQS_SIG_cross_rsdpg_256_balanced_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_balanced_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_balanced_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_balanced_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_balanced_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_balanced_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_balanced_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -220,6 +252,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_balanced_verify_with_ctx_str(const ui
 
 OQS_SIG *OQS_SIG_cross_rsdpg_256_fast_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_fast_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_fast_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_fast_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_fast_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_fast_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_fast_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -233,6 +267,8 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_fast_verify_with_ctx_str(const uint8_
 
 OQS_SIG *OQS_SIG_cross_rsdpg_256_small_new(void);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_small_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_small_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_small_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_small_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_small_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_small_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);

--- a/src/sig/cross/sig_cross_rsdp_128_balanced.c
+++ b/src/sig/cross/sig_cross_rsdp_128_balanced.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdp_128_balanced_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdp_128_balanced_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdp_128_balanced_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdp_128_balanced_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdp_128_balanced_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdp_128_balanced_sign;
 	sig->verify = OQS_SIG_cross_rsdp_128_balanced_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdp_128_balanced_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdp_128_balanced_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDP128BALANCED_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP128BALANCED_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP128BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP128BALANCED_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP128BALANCED_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdp_128_balanced_avx2)
 extern int PQCLEAN_CROSSRSDP128BALANCED_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP128BALANCED_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP128BALANCED_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP128BALANCED_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP128BALANCED_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_balanced_keypair(uint8_t *public_key, 
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDP128BALANCED_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_balanced_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_128_balanced_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP128BALANCED_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP128BALANCED_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP128BALANCED_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_balanced_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_128_balanced_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP128BALANCED_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP128BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP128BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdp_128_fast.c
+++ b/src/sig/cross/sig_cross_rsdp_128_fast.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdp_128_fast_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdp_128_fast_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdp_128_fast_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdp_128_fast_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdp_128_fast_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdp_128_fast_sign;
 	sig->verify = OQS_SIG_cross_rsdp_128_fast_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdp_128_fast_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdp_128_fast_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDP128FAST_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP128FAST_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP128FAST_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP128FAST_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP128FAST_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdp_128_fast_avx2)
 extern int PQCLEAN_CROSSRSDP128FAST_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP128FAST_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP128FAST_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP128FAST_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP128FAST_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_fast_keypair(uint8_t *public_key, uint
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDP128FAST_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_fast_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_128_fast_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP128FAST_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP128FAST_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP128FAST_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_fast_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_128_fast_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP128FAST_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP128FAST_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP128FAST_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdp_128_small.c
+++ b/src/sig/cross/sig_cross_rsdp_128_small.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdp_128_small_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdp_128_small_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdp_128_small_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdp_128_small_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdp_128_small_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdp_128_small_sign;
 	sig->verify = OQS_SIG_cross_rsdp_128_small_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdp_128_small_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdp_128_small_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDP128SMALL_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP128SMALL_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP128SMALL_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP128SMALL_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP128SMALL_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdp_128_small_avx2)
 extern int PQCLEAN_CROSSRSDP128SMALL_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP128SMALL_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP128SMALL_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP128SMALL_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP128SMALL_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_small_keypair(uint8_t *public_key, uin
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDP128SMALL_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_small_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_128_small_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP128SMALL_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP128SMALL_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP128SMALL_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_128_small_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_128_small_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP128SMALL_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP128SMALL_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP128SMALL_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdp_192_balanced.c
+++ b/src/sig/cross/sig_cross_rsdp_192_balanced.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdp_192_balanced_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdp_192_balanced_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdp_192_balanced_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdp_192_balanced_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdp_192_balanced_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdp_192_balanced_sign;
 	sig->verify = OQS_SIG_cross_rsdp_192_balanced_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdp_192_balanced_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdp_192_balanced_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDP192BALANCED_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP192BALANCED_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP192BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP192BALANCED_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP192BALANCED_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdp_192_balanced_avx2)
 extern int PQCLEAN_CROSSRSDP192BALANCED_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP192BALANCED_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP192BALANCED_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP192BALANCED_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP192BALANCED_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_balanced_keypair(uint8_t *public_key, 
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDP192BALANCED_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_balanced_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_192_balanced_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP192BALANCED_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP192BALANCED_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP192BALANCED_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_balanced_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_192_balanced_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP192BALANCED_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP192BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP192BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdp_192_fast.c
+++ b/src/sig/cross/sig_cross_rsdp_192_fast.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdp_192_fast_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdp_192_fast_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdp_192_fast_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdp_192_fast_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdp_192_fast_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdp_192_fast_sign;
 	sig->verify = OQS_SIG_cross_rsdp_192_fast_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdp_192_fast_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdp_192_fast_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDP192FAST_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP192FAST_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP192FAST_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP192FAST_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP192FAST_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdp_192_fast_avx2)
 extern int PQCLEAN_CROSSRSDP192FAST_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP192FAST_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP192FAST_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP192FAST_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP192FAST_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_fast_keypair(uint8_t *public_key, uint
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDP192FAST_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_fast_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_192_fast_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP192FAST_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP192FAST_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP192FAST_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_fast_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_192_fast_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP192FAST_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP192FAST_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP192FAST_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdp_192_small.c
+++ b/src/sig/cross/sig_cross_rsdp_192_small.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdp_192_small_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdp_192_small_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdp_192_small_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdp_192_small_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdp_192_small_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdp_192_small_sign;
 	sig->verify = OQS_SIG_cross_rsdp_192_small_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdp_192_small_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdp_192_small_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDP192SMALL_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP192SMALL_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP192SMALL_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP192SMALL_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP192SMALL_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdp_192_small_avx2)
 extern int PQCLEAN_CROSSRSDP192SMALL_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP192SMALL_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP192SMALL_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP192SMALL_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP192SMALL_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_small_keypair(uint8_t *public_key, uin
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDP192SMALL_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_small_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_192_small_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP192SMALL_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP192SMALL_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP192SMALL_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_192_small_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_192_small_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP192SMALL_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP192SMALL_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP192SMALL_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdp_256_balanced.c
+++ b/src/sig/cross/sig_cross_rsdp_256_balanced.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdp_256_balanced_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdp_256_balanced_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdp_256_balanced_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdp_256_balanced_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdp_256_balanced_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdp_256_balanced_sign;
 	sig->verify = OQS_SIG_cross_rsdp_256_balanced_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdp_256_balanced_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdp_256_balanced_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDP256BALANCED_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP256BALANCED_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP256BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP256BALANCED_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP256BALANCED_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdp_256_balanced_avx2)
 extern int PQCLEAN_CROSSRSDP256BALANCED_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP256BALANCED_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP256BALANCED_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP256BALANCED_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP256BALANCED_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_balanced_keypair(uint8_t *public_key, 
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDP256BALANCED_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_balanced_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_256_balanced_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP256BALANCED_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP256BALANCED_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP256BALANCED_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_balanced_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_256_balanced_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP256BALANCED_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP256BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP256BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdp_256_fast.c
+++ b/src/sig/cross/sig_cross_rsdp_256_fast.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdp_256_fast_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdp_256_fast_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdp_256_fast_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdp_256_fast_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdp_256_fast_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdp_256_fast_sign;
 	sig->verify = OQS_SIG_cross_rsdp_256_fast_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdp_256_fast_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdp_256_fast_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDP256FAST_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP256FAST_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP256FAST_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP256FAST_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP256FAST_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdp_256_fast_avx2)
 extern int PQCLEAN_CROSSRSDP256FAST_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP256FAST_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP256FAST_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP256FAST_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP256FAST_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_fast_keypair(uint8_t *public_key, uint
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDP256FAST_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_fast_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_256_fast_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP256FAST_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP256FAST_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP256FAST_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_fast_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_256_fast_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP256FAST_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP256FAST_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP256FAST_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdp_256_small.c
+++ b/src/sig/cross/sig_cross_rsdp_256_small.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdp_256_small_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdp_256_small_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdp_256_small_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdp_256_small_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdp_256_small_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdp_256_small_sign;
 	sig->verify = OQS_SIG_cross_rsdp_256_small_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdp_256_small_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdp_256_small_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDP256SMALL_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP256SMALL_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP256SMALL_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP256SMALL_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP256SMALL_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdp_256_small_avx2)
 extern int PQCLEAN_CROSSRSDP256SMALL_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDP256SMALL_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDP256SMALL_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP256SMALL_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDP256SMALL_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_small_keypair(uint8_t *public_key, uin
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDP256SMALL_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_small_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_256_small_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP256SMALL_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP256SMALL_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP256SMALL_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdp_256_small_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdp_256_small_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP256SMALL_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDP256SMALL_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDP256SMALL_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdpg_128_balanced.c
+++ b/src/sig/cross/sig_cross_rsdpg_128_balanced.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdpg_128_balanced_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdpg_128_balanced_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdpg_128_balanced_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdpg_128_balanced_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdpg_128_balanced_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdpg_128_balanced_sign;
 	sig->verify = OQS_SIG_cross_rsdpg_128_balanced_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdpg_128_balanced_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdpg_128_balanced_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDPG128BALANCED_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG128BALANCED_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG128BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG128BALANCED_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG128BALANCED_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_128_balanced_avx2)
 extern int PQCLEAN_CROSSRSDPG128BALANCED_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG128BALANCED_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG128BALANCED_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG128BALANCED_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG128BALANCED_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_balanced_keypair(uint8_t *public_key,
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDPG128BALANCED_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_balanced_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_128_balanced_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG128BALANCED_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG128BALANCED_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG128BALANCED_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_balanced_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_128_balanced_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG128BALANCED_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG128BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG128BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdpg_128_fast.c
+++ b/src/sig/cross/sig_cross_rsdpg_128_fast.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdpg_128_fast_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdpg_128_fast_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdpg_128_fast_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdpg_128_fast_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdpg_128_fast_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdpg_128_fast_sign;
 	sig->verify = OQS_SIG_cross_rsdpg_128_fast_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdpg_128_fast_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdpg_128_fast_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDPG128FAST_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG128FAST_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG128FAST_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG128FAST_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG128FAST_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_128_fast_avx2)
 extern int PQCLEAN_CROSSRSDPG128FAST_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG128FAST_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG128FAST_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG128FAST_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG128FAST_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_fast_keypair(uint8_t *public_key, uin
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDPG128FAST_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_fast_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_128_fast_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG128FAST_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG128FAST_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG128FAST_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_fast_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_128_fast_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG128FAST_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG128FAST_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG128FAST_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdpg_128_small.c
+++ b/src/sig/cross/sig_cross_rsdpg_128_small.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdpg_128_small_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdpg_128_small_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdpg_128_small_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdpg_128_small_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdpg_128_small_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdpg_128_small_sign;
 	sig->verify = OQS_SIG_cross_rsdpg_128_small_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdpg_128_small_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdpg_128_small_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDPG128SMALL_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG128SMALL_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG128SMALL_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG128SMALL_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG128SMALL_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_128_small_avx2)
 extern int PQCLEAN_CROSSRSDPG128SMALL_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG128SMALL_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG128SMALL_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG128SMALL_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG128SMALL_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_small_keypair(uint8_t *public_key, ui
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDPG128SMALL_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_small_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_128_small_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG128SMALL_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG128SMALL_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG128SMALL_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_128_small_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_128_small_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG128SMALL_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG128SMALL_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG128SMALL_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdpg_192_balanced.c
+++ b/src/sig/cross/sig_cross_rsdpg_192_balanced.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdpg_192_balanced_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdpg_192_balanced_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdpg_192_balanced_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdpg_192_balanced_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdpg_192_balanced_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdpg_192_balanced_sign;
 	sig->verify = OQS_SIG_cross_rsdpg_192_balanced_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdpg_192_balanced_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdpg_192_balanced_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDPG192BALANCED_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG192BALANCED_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG192BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG192BALANCED_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG192BALANCED_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_192_balanced_avx2)
 extern int PQCLEAN_CROSSRSDPG192BALANCED_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG192BALANCED_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG192BALANCED_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG192BALANCED_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG192BALANCED_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_balanced_keypair(uint8_t *public_key,
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDPG192BALANCED_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_balanced_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_192_balanced_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG192BALANCED_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG192BALANCED_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG192BALANCED_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_balanced_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_192_balanced_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG192BALANCED_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG192BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG192BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdpg_192_fast.c
+++ b/src/sig/cross/sig_cross_rsdpg_192_fast.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdpg_192_fast_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdpg_192_fast_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdpg_192_fast_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdpg_192_fast_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdpg_192_fast_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdpg_192_fast_sign;
 	sig->verify = OQS_SIG_cross_rsdpg_192_fast_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdpg_192_fast_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdpg_192_fast_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDPG192FAST_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG192FAST_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG192FAST_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG192FAST_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG192FAST_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_192_fast_avx2)
 extern int PQCLEAN_CROSSRSDPG192FAST_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG192FAST_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG192FAST_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG192FAST_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG192FAST_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_fast_keypair(uint8_t *public_key, uin
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDPG192FAST_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_fast_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_192_fast_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG192FAST_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG192FAST_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG192FAST_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_fast_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_192_fast_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG192FAST_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG192FAST_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG192FAST_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdpg_192_small.c
+++ b/src/sig/cross/sig_cross_rsdpg_192_small.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdpg_192_small_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdpg_192_small_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdpg_192_small_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdpg_192_small_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdpg_192_small_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdpg_192_small_sign;
 	sig->verify = OQS_SIG_cross_rsdpg_192_small_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdpg_192_small_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdpg_192_small_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDPG192SMALL_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG192SMALL_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG192SMALL_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG192SMALL_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG192SMALL_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_192_small_avx2)
 extern int PQCLEAN_CROSSRSDPG192SMALL_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG192SMALL_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG192SMALL_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG192SMALL_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG192SMALL_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_small_keypair(uint8_t *public_key, ui
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDPG192SMALL_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_small_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_192_small_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG192SMALL_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG192SMALL_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG192SMALL_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_192_small_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_192_small_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG192SMALL_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG192SMALL_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG192SMALL_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdpg_256_balanced.c
+++ b/src/sig/cross/sig_cross_rsdpg_256_balanced.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdpg_256_balanced_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdpg_256_balanced_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdpg_256_balanced_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdpg_256_balanced_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdpg_256_balanced_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdpg_256_balanced_sign;
 	sig->verify = OQS_SIG_cross_rsdpg_256_balanced_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdpg_256_balanced_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdpg_256_balanced_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDPG256BALANCED_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG256BALANCED_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG256BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG256BALANCED_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG256BALANCED_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_256_balanced_avx2)
 extern int PQCLEAN_CROSSRSDPG256BALANCED_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG256BALANCED_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG256BALANCED_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG256BALANCED_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG256BALANCED_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_balanced_keypair(uint8_t *public_key,
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDPG256BALANCED_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_balanced_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_256_balanced_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG256BALANCED_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG256BALANCED_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG256BALANCED_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_balanced_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_256_balanced_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG256BALANCED_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG256BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG256BALANCED_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdpg_256_fast.c
+++ b/src/sig/cross/sig_cross_rsdpg_256_fast.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdpg_256_fast_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdpg_256_fast_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdpg_256_fast_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdpg_256_fast_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdpg_256_fast_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdpg_256_fast_sign;
 	sig->verify = OQS_SIG_cross_rsdpg_256_fast_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdpg_256_fast_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdpg_256_fast_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDPG256FAST_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG256FAST_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG256FAST_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG256FAST_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG256FAST_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_256_fast_avx2)
 extern int PQCLEAN_CROSSRSDPG256FAST_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG256FAST_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG256FAST_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG256FAST_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG256FAST_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_fast_keypair(uint8_t *public_key, uin
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDPG256FAST_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_fast_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_256_fast_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG256FAST_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG256FAST_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG256FAST_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_fast_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_256_fast_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG256FAST_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG256FAST_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG256FAST_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/cross/sig_cross_rsdpg_256_small.c
+++ b/src/sig/cross/sig_cross_rsdpg_256_small.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_cross_rsdpg_256_small_new(void) {
 	sig->length_signature = OQS_SIG_cross_rsdpg_256_small_length_signature;
 
 	sig->keypair = OQS_SIG_cross_rsdpg_256_small_keypair;
+	sig->keypair_from_fseed = OQS_SIG_cross_rsdpg_256_small_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_cross_rsdpg_256_small_pubkey_from_privkey;
 	sig->sign = OQS_SIG_cross_rsdpg_256_small_sign;
 	sig->verify = OQS_SIG_cross_rsdpg_256_small_verify;
 	sig->sign_with_ctx_str = OQS_SIG_cross_rsdpg_256_small_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_cross_rsdpg_256_small_new(void) {
 }
 
 extern int PQCLEAN_CROSSRSDPG256SMALL_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG256SMALL_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG256SMALL_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG256SMALL_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG256SMALL_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_256_small_avx2)
 extern int PQCLEAN_CROSSRSDPG256SMALL_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_CROSSRSDPG256SMALL_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_CROSSRSDPG256SMALL_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG256SMALL_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_CROSSRSDPG256SMALL_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_small_keypair(uint8_t *public_key, ui
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_CROSSRSDPG256SMALL_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_small_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_256_small_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG256SMALL_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG256SMALL_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG256SMALL_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_cross_rsdpg_256_small_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_cross_rsdpg_256_small_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG256SMALL_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_CROSSRSDPG256SMALL_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_CROSSRSDPG256SMALL_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/dilithium/oldpqclean_dilithium2_aarch64/api.h
+++ b/src/sig/dilithium/oldpqclean_dilithium2_aarch64/api.h
@@ -19,6 +19,10 @@
 
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_signature(
     uint8_t *sig, size_t *siglen,
     const uint8_t *m, size_t mlen, const uint8_t *sk);

--- a/src/sig/dilithium/oldpqclean_dilithium2_aarch64/sign.c
+++ b/src/sig/dilithium/oldpqclean_dilithium2_aarch64/sign.c
@@ -97,6 +97,113 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair_from_fseed
+*
+* Description: Generates public and private key from fixed seed.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*              - const uint8_t *seed: Pointer to the input fixed seed.
+*                                     Must point to an array of SEEDBYTES bytes.
+*                                     The seed provides deterministic randomness
+*                                     for key generation and must be unique and
+*                                     securely generated for each keypair to
+*                                     ensure security.
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    uint8_t seedbuf[2 * SEEDBYTES + CRHBYTES];
+    uint8_t tr[SEEDBYTES];
+    const uint8_t *rho, *rhoprime, *key;
+    polyvecl mat[K];
+    polyvecl s1, s1hat;
+    polyveck s2, t1, t0;
+
+    /* Use fixed seed for randomness for rho, rhoprime and key */
+    shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+    rho = seedbuf;
+    rhoprime = rho + SEEDBYTES;
+    key = rhoprime + CRHBYTES;
+
+    /* Expand matrix */
+    polyvec_matrix_expand(mat, rho);
+
+    /* Sample short vectors s1 and s2 */
+    polyvecl_uniform_eta(&s1, rhoprime, 0);
+    polyveck_uniform_eta(&s2, rhoprime, L);
+
+    /* Matrix-vector multiplication */
+    s1hat = s1;
+    polyvecl_ntt(&s1hat);
+    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+    polyveck_reduce(&t1);
+    polyveck_invntt_tomont(&t1);
+
+    /* Add error vector s2 */
+    polyveck_add(&t1, &t1, &s2);
+
+    /* Extract t1 and write public key */
+    polyveck_caddq(&t1);
+    polyveck_power2round(&t1, &t0, &t1);
+    pack_pk(pk, rho, &t1);
+
+    /* Compute H(rho, t1) and write secret key */
+    shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+    pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
+
+    return 0;
+}
+
+/*************************************************
+* Name:        crypto_sign_pubkey_from_privkey
+*
+* Description: Generates public key from exist private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - const uint8_t *sk: pointer to the input private key (points
+*                                   to a read-only array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
+    uint8_t rho[SEEDBYTES];
+    uint8_t tr[SEEDBYTES];
+    uint8_t key[SEEDBYTES];
+    polyvecl s1, s1hat;
+    polyveck s2, t0, t1;
+    polyvecl mat[K];
+
+    /* unpack privat key */
+    unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
+
+    /* Expand matrix */
+    polyvec_matrix_expand(mat, rho);
+
+    /* Matrix-vector multiplication */
+    s1hat = s1;
+    polyvecl_ntt(&s1hat);
+    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+    polyveck_reduce(&t1);
+    polyveck_invntt_tomont(&t1);
+
+    /* Add error vector s2 */
+    polyveck_add(&t1, &t1, &s2);
+
+    /* Extract t1 */
+    polyveck_caddq(&t1);
+    polyveck_power2round(&t1, &t0, &t1);
+
+    /* Pack public key */
+    pack_pk(pk, rho, &t1);
+
+    return 0;
+}
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/oldpqclean_dilithium2_aarch64/sign.h
+++ b/src/sig/dilithium/oldpqclean_dilithium2_aarch64/sign.h
@@ -21,6 +21,12 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(crypto_sign_keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(crypto_sign_signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/oldpqclean_dilithium3_aarch64/api.h
+++ b/src/sig/dilithium/oldpqclean_dilithium3_aarch64/api.h
@@ -19,6 +19,10 @@
 
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_signature(
     uint8_t *sig, size_t *siglen,
     const uint8_t *m, size_t mlen, const uint8_t *sk);

--- a/src/sig/dilithium/oldpqclean_dilithium3_aarch64/sign.c
+++ b/src/sig/dilithium/oldpqclean_dilithium3_aarch64/sign.c
@@ -97,6 +97,113 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair_from_fseed
+*
+* Description: Generates public and private key from fixed seed.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*              - const uint8_t *seed: Pointer to the input fixed seed.
+*                                     Must point to an array of SEEDBYTES bytes.
+*                                     The seed provides deterministic randomness
+*                                     for key generation and must be unique and
+*                                     securely generated for each keypair to
+*                                     ensure security.
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    uint8_t seedbuf[2 * SEEDBYTES + CRHBYTES];
+    uint8_t tr[SEEDBYTES];
+    const uint8_t *rho, *rhoprime, *key;
+    polyvecl mat[K];
+    polyvecl s1, s1hat;
+    polyveck s2, t1, t0;
+
+    /* Use fixed seed for randomness for rho, rhoprime and key */
+    shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+    rho = seedbuf;
+    rhoprime = rho + SEEDBYTES;
+    key = rhoprime + CRHBYTES;
+
+    /* Expand matrix */
+    polyvec_matrix_expand(mat, rho);
+
+    /* Sample short vectors s1 and s2 */
+    polyvecl_uniform_eta(&s1, rhoprime, 0);
+    polyveck_uniform_eta(&s2, rhoprime, L);
+
+    /* Matrix-vector multiplication */
+    s1hat = s1;
+    polyvecl_ntt(&s1hat);
+    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+    polyveck_reduce(&t1);
+    polyveck_invntt_tomont(&t1);
+
+    /* Add error vector s2 */
+    polyveck_add(&t1, &t1, &s2);
+
+    /* Extract t1 and write public key */
+    polyveck_caddq(&t1);
+    polyveck_power2round(&t1, &t0, &t1);
+    pack_pk(pk, rho, &t1);
+
+    /* Compute H(rho, t1) and write secret key */
+    shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+    pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
+
+    return 0;
+}
+
+/*************************************************
+* Name:        crypto_sign_pubkey_from_privkey
+*
+* Description: Generates public key from exist private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - const uint8_t *sk: pointer to the input private key (points
+*                                   to a read-only array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
+    uint8_t rho[SEEDBYTES];
+    uint8_t tr[SEEDBYTES];
+    uint8_t key[SEEDBYTES];
+    polyvecl s1, s1hat;
+    polyveck s2, t0, t1;
+    polyvecl mat[K];
+
+    /* unpack privat key */
+    unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
+
+    /* Expand matrix */
+    polyvec_matrix_expand(mat, rho);
+
+    /* Matrix-vector multiplication */
+    s1hat = s1;
+    polyvecl_ntt(&s1hat);
+    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+    polyveck_reduce(&t1);
+    polyveck_invntt_tomont(&t1);
+
+    /* Add error vector s2 */
+    polyveck_add(&t1, &t1, &s2);
+
+    /* Extract t1 */
+    polyveck_caddq(&t1);
+    polyveck_power2round(&t1, &t0, &t1);
+
+    /* Pack public key */
+    pack_pk(pk, rho, &t1);
+
+    return 0;
+}
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/oldpqclean_dilithium3_aarch64/sign.h
+++ b/src/sig/dilithium/oldpqclean_dilithium3_aarch64/sign.h
@@ -21,6 +21,12 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(crypto_sign_keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(crypto_sign_signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/oldpqclean_dilithium5_aarch64/api.h
+++ b/src/sig/dilithium/oldpqclean_dilithium5_aarch64/api.h
@@ -20,6 +20,10 @@
 
 int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_signature(
     uint8_t *sig, size_t *siglen,
     const uint8_t *m, size_t mlen, const uint8_t *sk);

--- a/src/sig/dilithium/oldpqclean_dilithium5_aarch64/sign.c
+++ b/src/sig/dilithium/oldpqclean_dilithium5_aarch64/sign.c
@@ -97,6 +97,113 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair_from_fseed
+*
+* Description: Generates public and private key from fixed seed.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*              - const uint8_t *seed: Pointer to the input fixed seed.
+*                                     Must point to an array of SEEDBYTES bytes.
+*                                     The seed provides deterministic randomness
+*                                     for key generation and must be unique and
+*                                     securely generated for each keypair to
+*                                     ensure security.
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    uint8_t seedbuf[2 * SEEDBYTES + CRHBYTES];
+    uint8_t tr[SEEDBYTES];
+    const uint8_t *rho, *rhoprime, *key;
+    polyvecl mat[K];
+    polyvecl s1, s1hat;
+    polyveck s2, t1, t0;
+
+    /* Use fixed seed for randomness for rho, rhoprime and key */
+    shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+    rho = seedbuf;
+    rhoprime = rho + SEEDBYTES;
+    key = rhoprime + CRHBYTES;
+
+    /* Expand matrix */
+    polyvec_matrix_expand(mat, rho);
+
+    /* Sample short vectors s1 and s2 */
+    polyvecl_uniform_eta(&s1, rhoprime, 0);
+    polyveck_uniform_eta(&s2, rhoprime, L);
+
+    /* Matrix-vector multiplication */
+    s1hat = s1;
+    polyvecl_ntt(&s1hat);
+    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+    polyveck_reduce(&t1);
+    polyveck_invntt_tomont(&t1);
+
+    /* Add error vector s2 */
+    polyveck_add(&t1, &t1, &s2);
+
+    /* Extract t1 and write public key */
+    polyveck_caddq(&t1);
+    polyveck_power2round(&t1, &t0, &t1);
+    pack_pk(pk, rho, &t1);
+
+    /* Compute H(rho, t1) and write secret key */
+    shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+    pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
+
+    return 0;
+}
+
+/*************************************************
+* Name:        crypto_sign_pubkey_from_privkey
+*
+* Description: Generates public key from exist private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - const uint8_t *sk: pointer to the input private key (points
+*                                   to a read-only array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
+    uint8_t rho[SEEDBYTES];
+    uint8_t tr[SEEDBYTES];
+    uint8_t key[SEEDBYTES];
+    polyvecl s1, s1hat;
+    polyveck s2, t0, t1;
+    polyvecl mat[K];
+
+    /* unpack privat key */
+    unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
+
+    /* Expand matrix */
+    polyvec_matrix_expand(mat, rho);
+
+    /* Matrix-vector multiplication */
+    s1hat = s1;
+    polyvecl_ntt(&s1hat);
+    polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+    polyveck_reduce(&t1);
+    polyveck_invntt_tomont(&t1);
+
+    /* Add error vector s2 */
+    polyveck_add(&t1, &t1, &s2);
+
+    /* Extract t1 */
+    polyveck_caddq(&t1);
+    polyveck_power2round(&t1, &t0, &t1);
+
+    /* Pack public key */
+    pack_pk(pk, rho, &t1);
+
+    return 0;
+}
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/oldpqclean_dilithium5_aarch64/sign.h
+++ b/src/sig/dilithium/oldpqclean_dilithium5_aarch64/sign.h
@@ -21,6 +21,12 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(crypto_sign_keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(crypto_sign_signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/api.h
@@ -14,6 +14,11 @@
 
 int pqcrystals_dilithium2_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium2_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                  const uint8_t *seed);
+
+int pqcrystals_dilithium2_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium2_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -35,6 +40,11 @@ int pqcrystals_dilithium2_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium2aes_avx2_BYTES pqcrystals_dilithium2_avx2_BYTES
 
 int pqcrystals_dilithium2aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium2aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                     const uint8_t *seed);
+
+int pqcrystals_dilithium2aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium2aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -62,6 +72,11 @@ int pqcrystals_dilithium2aes_avx2_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium3_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium3_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                  const uint8_t *seed);
+
+int pqcrystals_dilithium3_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium3_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -83,6 +98,11 @@ int pqcrystals_dilithium3_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium3aes_avx2_BYTES pqcrystals_dilithium3_avx2_BYTES
 
 int pqcrystals_dilithium3aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium3aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                     const uint8_t *seed);
+
+int pqcrystals_dilithium3aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium3aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -110,6 +130,11 @@ int pqcrystals_dilithium3aes_avx2_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium5_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium5_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                  const uint8_t *seed);
+
+int pqcrystals_dilithium5_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium5_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -131,6 +156,11 @@ int pqcrystals_dilithium5_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium5aes_avx2_BYTES pqcrystals_dilithium5_avx2_BYTES
 
 int pqcrystals_dilithium5aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium5aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                     const uint8_t *seed);
+
+int pqcrystals_dilithium5aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium5aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/sign.c
@@ -176,6 +176,205 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair_from_fseed
+*
+* Description: Generates public and private key from fixed seed.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*              - const uint8_t *seed: Pointer to the input fixed seed.
+*                                     Must point to an array of SEEDBYTES bytes.
+*                                     The seed provides deterministic randomness
+*                                     for key generation and must be unique and
+*                                     securely generated for each keypair to
+*                                     ensure security.
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+  unsigned int i;
+  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
+  const uint8_t *rho, *rhoprime, *key;
+#ifdef DILITHIUM_USE_AES
+  uint64_t nonce;
+  aes256ctr_ctx aesctx;
+  polyvecl rowbuf[1];
+#else
+  polyvecl rowbuf[2];
+#endif
+  polyvecl s1, *row = rowbuf;
+  polyveck s2;
+  poly t1, t0;
+
+  /* Use fixed seed for randomness for rho, rhoprime and key */
+  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+  rho = seedbuf;
+  rhoprime = rho + SEEDBYTES;
+  key = rhoprime + CRHBYTES;
+
+  /* Store rho, key */
+  memcpy(pk, rho, SEEDBYTES);
+  memcpy(sk, rho, SEEDBYTES);
+  memcpy(sk + SEEDBYTES, key, SEEDBYTES);
+
+  /* Sample short vectors s1 and s2 */
+#ifdef DILITHIUM_USE_AES
+  aes256ctr_init_u64(&aesctx, rhoprime, 0);
+  for(i = 0; i < L; ++i) {
+    nonce = i;
+    aes256ctr_init_iv_u64(&aesctx, nonce);
+    poly_uniform_eta_preinit(&s1.vec[i], &aesctx);
+  }
+  for(i = 0; i < K; ++i) {
+    nonce = L + i;
+    aes256ctr_init_iv_u64(&aesctx, nonce);
+    poly_uniform_eta_preinit(&s2.vec[i], &aesctx);
+  }
+  aes256_ctx_release(&aesctx);
+#elif K == 4 && L == 4
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s2.vec[0], &s2.vec[1], &s2.vec[2], &s2.vec[3], rhoprime, 4, 5, 6, 7);
+#elif K == 6 && L == 5
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s1.vec[4], &s2.vec[0], &s2.vec[1], &s2.vec[2], rhoprime, 4, 5, 6, 7);
+  poly_uniform_eta_4x(&s2.vec[3], &s2.vec[4], &s2.vec[5], &t0, rhoprime, 8, 9, 10, 11);
+#elif K == 8 && L == 7
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s1.vec[4], &s1.vec[5], &s1.vec[6], &s2.vec[0], rhoprime, 4, 5, 6, 7);
+  poly_uniform_eta_4x(&s2.vec[1], &s2.vec[2], &s2.vec[3], &s2.vec[4], rhoprime, 8, 9, 10, 11);
+  poly_uniform_eta_4x(&s2.vec[5], &s2.vec[6], &s2.vec[7], &t0, rhoprime, 12, 13, 14, 15);
+#else
+#error
+#endif
+
+  /* Pack secret vectors */
+  for(i = 0; i < L; i++)
+    polyeta_pack(sk + 3*SEEDBYTES + i*POLYETA_PACKEDBYTES, &s1.vec[i]);
+  for(i = 0; i < K; i++)
+    polyeta_pack(sk + 3*SEEDBYTES + (L + i)*POLYETA_PACKEDBYTES, &s2.vec[i]);
+
+  /* Transform s1 */
+  polyvecl_ntt(&s1);
+
+#ifdef DILITHIUM_USE_AES
+  aes256ctr_init_u64(&aesctx, rho, 0);
+#endif
+
+  for(i = 0; i < K; i++) {
+    /* Expand matrix row */
+#ifdef DILITHIUM_USE_AES
+    for(unsigned int j = 0; j < L; j++) {
+      nonce = (i << 8) + j;
+      aes256ctr_init_iv_u64(&aesctx, nonce);
+      poly_uniform_preinit(&row->vec[j], &aesctx);
+      poly_nttunpack(&row->vec[j]);
+    }
+#else
+    polyvec_matrix_expand_row(&row, rowbuf, rho, i);
+#endif
+
+    /* Compute inner-product */
+    polyvecl_pointwise_acc_montgomery(&t1, row, &s1);
+    poly_invntt_tomont(&t1);
+
+    /* Add error polynomial */
+    poly_add(&t1, &t1, &s2.vec[i]);
+
+    /* Round t and pack t1, t0 */
+    poly_caddq(&t1);
+    poly_power2round(&t1, &t0, &t1);
+    polyt1_pack(pk + SEEDBYTES + i*POLYT1_PACKEDBYTES, &t1);
+    polyt0_pack(sk + 3*SEEDBYTES + (L+K)*POLYETA_PACKEDBYTES + i*POLYT0_PACKEDBYTES, &t0);
+  }
+
+#ifdef DILITHIUM_USE_AES
+  aes256_ctx_release(&aesctx);
+#endif
+
+  /* Compute H(rho, t1) and store in secret key */
+  shake256(sk + 2*SEEDBYTES, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+
+  return 0;
+}
+
+/*************************************************
+* Name:        crypto_sign_pubkey_from_privkey
+*
+* Description: Generates public key from existing private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - const uint8_t *sk: pointer to input private key (points
+*                                   to array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
+  unsigned int i;
+  uint8_t rho[SEEDBYTES];
+  uint8_t tr[SEEDBYTES];
+  uint8_t key[SEEDBYTES];
+#ifdef DILITHIUM_USE_AES
+  uint64_t nonce;
+  aes256ctr_ctx aesctx;
+  polyvecl rowbuf[1];
+#else
+  polyvecl rowbuf[2];
+#endif
+  polyvecl s1, *row = rowbuf;
+  polyveck s2;
+  poly t1, t0;
+
+  // Unpack private key
+  unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
+
+  // Store rho in public key
+  memcpy(pk, rho, SEEDBYTES);
+
+  // Transform s1
+  polyvecl_ntt(&s1);
+
+#ifdef DILITHIUM_USE_AES
+  aes256ctr_init_u64(&aesctx, rho, 0);
+#endif
+
+  // Process each row
+  for(i = 0; i < K; i++) {
+    /* Expand matrix row */
+#ifdef DILITHIUM_USE_AES
+    for(unsigned int j = 0; j < L; j++) {
+      nonce = (i << 8) + j;
+      aes256ctr_init_iv_u64(&aesctx, nonce);
+      poly_uniform_preinit(&row->vec[j], &aesctx);
+      poly_nttunpack(&row->vec[j]);
+    }
+#else
+    polyvec_matrix_expand_row(&row, rowbuf, rho, i);
+#endif
+
+    /* Compute inner-product */
+    polyvecl_pointwise_acc_montgomery(&t1, row, &s1);
+    poly_invntt_tomont(&t1);
+
+    /* Add error polynomial */
+    poly_add(&t1, &t1, &s2.vec[i]);
+
+    /* Round t and pack t1 */
+    poly_caddq(&t1);
+    poly_power2round(&t1, &t0, &t1);
+    polyt1_pack(pk + SEEDBYTES + i*POLYT1_PACKEDBYTES, &t1);
+  }
+
+#ifdef DILITHIUM_USE_AES
+  aes256_ctx_release(&aesctx);
+#endif
+
+  return 0;
+}
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_avx2/sign.h
@@ -13,6 +13,13 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                   const uint8_t *seed);
+
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_ref/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_ref/api.h
@@ -14,6 +14,11 @@
 
 int pqcrystals_dilithium2_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium2_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                 const uint8_t *seed);
+
+int pqcrystals_dilithium2_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium2_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -35,6 +40,11 @@ int pqcrystals_dilithium2_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium2aes_ref_BYTES pqcrystals_dilithium2_ref_BYTES
 
 int pqcrystals_dilithium2aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium2aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                    const uint8_t *seed);
+
+int pqcrystals_dilithium2aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium2aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -62,6 +72,11 @@ int pqcrystals_dilithium2aes_ref_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium3_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium3_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                 const uint8_t *seed);
+
+int pqcrystals_dilithium3_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium3_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -83,6 +98,11 @@ int pqcrystals_dilithium3_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium3aes_ref_BYTES pqcrystals_dilithium3_ref_BYTES
 
 int pqcrystals_dilithium3aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium3aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                    const uint8_t *seed);
+
+int pqcrystals_dilithium3aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium3aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -110,6 +130,11 @@ int pqcrystals_dilithium3aes_ref_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium5_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium5_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                 const uint8_t *seed);
+
+int pqcrystals_dilithium5_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium5_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -131,6 +156,11 @@ int pqcrystals_dilithium5_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium5aes_ref_BYTES pqcrystals_dilithium5_ref_BYTES
 
 int pqcrystals_dilithium5aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium5aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                    const uint8_t *seed);
+
+int pqcrystals_dilithium5aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium5aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_ref/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_ref/sign.c
@@ -65,6 +65,113 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair_from_fseed
+*
+* Description: Generates public and private key from fixed seed.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*              - const uint8_t *seed: Pointer to the input fixed seed.
+*                                     Must point to an array of SEEDBYTES bytes.
+*                                     The seed provides deterministic randomness
+*                                     for key generation and must be unique and
+*                                     securely generated for each keypair to
+*                                     ensure security.
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
+  uint8_t tr[SEEDBYTES];
+  const uint8_t *rho, *rhoprime, *key;
+  polyvecl mat[K];
+  polyvecl s1, s1hat;
+  polyveck s2, t1, t0;
+
+  /* Use fixed seed for randomness for rho, rhoprime and key */
+  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+  rho = seedbuf;
+  rhoprime = rho + SEEDBYTES;
+  key = rhoprime + CRHBYTES;
+
+  /* Expand matrix */
+  polyvec_matrix_expand(mat, rho);
+
+  /* Sample short vectors s1 and s2 */
+  polyvecl_uniform_eta(&s1, rhoprime, 0);
+  polyveck_uniform_eta(&s2, rhoprime, L);
+
+  /* Matrix-vector multiplication */
+  s1hat = s1;
+  polyvecl_ntt(&s1hat);
+  polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+  polyveck_reduce(&t1);
+  polyveck_invntt_tomont(&t1);
+
+  /* Add error vector s2 */
+  polyveck_add(&t1, &t1, &s2);
+
+  /* Extract t1 and write public key */
+  polyveck_caddq(&t1);
+  polyveck_power2round(&t1, &t0, &t1);
+  pack_pk(pk, rho, &t1);
+
+  /* Compute H(rho, t1) and write secret key */
+  shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+  pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
+
+  return 0;
+}
+
+/*************************************************
+* Name:        crypto_sign_pubkey_from_privkey
+*
+* Description: Generates public key from exist private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - const uint8_t *sk: pointer to the input private key (points
+*                                   to a read-only array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
+  uint8_t rho[SEEDBYTES];
+  uint8_t tr[SEEDBYTES];
+  uint8_t key[SEEDBYTES];
+  polyvecl s1, s1hat;
+  polyveck s2, t0, t1;
+  polyvecl mat[K];
+
+  /* unpack privat key */
+  unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
+
+  /* Expand matrix */
+  polyvec_matrix_expand(mat, rho);
+
+  /* Matrix-vector multiplication */
+  s1hat = s1;
+  polyvecl_ntt(&s1hat);
+  polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+  polyveck_reduce(&t1);
+  polyveck_invntt_tomont(&t1);
+
+  /* Add error vector s2 */
+  polyveck_add(&t1, &t1, &s2);
+
+  /* Extract t1 */
+  polyveck_caddq(&t1);
+  polyveck_power2round(&t1, &t0, &t1);
+
+  /* Pack public key */
+  pack_pk(pk, rho, &t1);
+
+  return 0;
+}
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium2_ref/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium2_ref/sign.h
@@ -13,6 +13,13 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                   const uint8_t *seed);
+
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/api.h
@@ -14,6 +14,11 @@
 
 int pqcrystals_dilithium2_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium2_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                  const uint8_t *seed);
+
+int pqcrystals_dilithium2_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium2_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -35,6 +40,11 @@ int pqcrystals_dilithium2_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium2aes_avx2_BYTES pqcrystals_dilithium2_avx2_BYTES
 
 int pqcrystals_dilithium2aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium2aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                     const uint8_t *seed);
+
+int pqcrystals_dilithium2aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium2aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -62,6 +72,11 @@ int pqcrystals_dilithium2aes_avx2_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium3_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium3_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                  const uint8_t *seed);
+
+int pqcrystals_dilithium3_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium3_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -83,6 +98,11 @@ int pqcrystals_dilithium3_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium3aes_avx2_BYTES pqcrystals_dilithium3_avx2_BYTES
 
 int pqcrystals_dilithium3aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium3aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                     const uint8_t *seed);
+
+int pqcrystals_dilithium3aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium3aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -110,6 +130,11 @@ int pqcrystals_dilithium3aes_avx2_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium5_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium5_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                  const uint8_t *seed);
+
+int pqcrystals_dilithium5_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium5_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -131,6 +156,11 @@ int pqcrystals_dilithium5_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium5aes_avx2_BYTES pqcrystals_dilithium5_avx2_BYTES
 
 int pqcrystals_dilithium5aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium5aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                     const uint8_t *seed);
+
+int pqcrystals_dilithium5aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium5aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/sign.c
@@ -176,6 +176,205 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair_from_fseed
+*
+* Description: Generates public and private key from fixed seed.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*              - const uint8_t *seed: Pointer to the input fixed seed.
+*                                     Must point to an array of SEEDBYTES bytes.
+*                                     The seed provides deterministic randomness
+*                                     for key generation and must be unique and
+*                                     securely generated for each keypair to
+*                                     ensure security.
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+  unsigned int i;
+  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
+  const uint8_t *rho, *rhoprime, *key;
+#ifdef DILITHIUM_USE_AES
+  uint64_t nonce;
+  aes256ctr_ctx aesctx;
+  polyvecl rowbuf[1];
+#else
+  polyvecl rowbuf[2];
+#endif
+  polyvecl s1, *row = rowbuf;
+  polyveck s2;
+  poly t1, t0;
+
+  /* Use fixed seed for randomness for rho, rhoprime and key */
+  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+  rho = seedbuf;
+  rhoprime = rho + SEEDBYTES;
+  key = rhoprime + CRHBYTES;
+
+  /* Store rho, key */
+  memcpy(pk, rho, SEEDBYTES);
+  memcpy(sk, rho, SEEDBYTES);
+  memcpy(sk + SEEDBYTES, key, SEEDBYTES);
+
+  /* Sample short vectors s1 and s2 */
+#ifdef DILITHIUM_USE_AES
+  aes256ctr_init_u64(&aesctx, rhoprime, 0);
+  for(i = 0; i < L; ++i) {
+    nonce = i;
+    aes256ctr_init_iv_u64(&aesctx, nonce);
+    poly_uniform_eta_preinit(&s1.vec[i], &aesctx);
+  }
+  for(i = 0; i < K; ++i) {
+    nonce = L + i;
+    aes256ctr_init_iv_u64(&aesctx, nonce);
+    poly_uniform_eta_preinit(&s2.vec[i], &aesctx);
+  }
+  aes256_ctx_release(&aesctx);
+#elif K == 4 && L == 4
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s2.vec[0], &s2.vec[1], &s2.vec[2], &s2.vec[3], rhoprime, 4, 5, 6, 7);
+#elif K == 6 && L == 5
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s1.vec[4], &s2.vec[0], &s2.vec[1], &s2.vec[2], rhoprime, 4, 5, 6, 7);
+  poly_uniform_eta_4x(&s2.vec[3], &s2.vec[4], &s2.vec[5], &t0, rhoprime, 8, 9, 10, 11);
+#elif K == 8 && L == 7
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s1.vec[4], &s1.vec[5], &s1.vec[6], &s2.vec[0], rhoprime, 4, 5, 6, 7);
+  poly_uniform_eta_4x(&s2.vec[1], &s2.vec[2], &s2.vec[3], &s2.vec[4], rhoprime, 8, 9, 10, 11);
+  poly_uniform_eta_4x(&s2.vec[5], &s2.vec[6], &s2.vec[7], &t0, rhoprime, 12, 13, 14, 15);
+#else
+#error
+#endif
+
+  /* Pack secret vectors */
+  for(i = 0; i < L; i++)
+    polyeta_pack(sk + 3*SEEDBYTES + i*POLYETA_PACKEDBYTES, &s1.vec[i]);
+  for(i = 0; i < K; i++)
+    polyeta_pack(sk + 3*SEEDBYTES + (L + i)*POLYETA_PACKEDBYTES, &s2.vec[i]);
+
+  /* Transform s1 */
+  polyvecl_ntt(&s1);
+
+#ifdef DILITHIUM_USE_AES
+  aes256ctr_init_u64(&aesctx, rho, 0);
+#endif
+
+  for(i = 0; i < K; i++) {
+    /* Expand matrix row */
+#ifdef DILITHIUM_USE_AES
+    for(unsigned int j = 0; j < L; j++) {
+      nonce = (i << 8) + j;
+      aes256ctr_init_iv_u64(&aesctx, nonce);
+      poly_uniform_preinit(&row->vec[j], &aesctx);
+      poly_nttunpack(&row->vec[j]);
+    }
+#else
+    polyvec_matrix_expand_row(&row, rowbuf, rho, i);
+#endif
+
+    /* Compute inner-product */
+    polyvecl_pointwise_acc_montgomery(&t1, row, &s1);
+    poly_invntt_tomont(&t1);
+
+    /* Add error polynomial */
+    poly_add(&t1, &t1, &s2.vec[i]);
+
+    /* Round t and pack t1, t0 */
+    poly_caddq(&t1);
+    poly_power2round(&t1, &t0, &t1);
+    polyt1_pack(pk + SEEDBYTES + i*POLYT1_PACKEDBYTES, &t1);
+    polyt0_pack(sk + 3*SEEDBYTES + (L+K)*POLYETA_PACKEDBYTES + i*POLYT0_PACKEDBYTES, &t0);
+  }
+
+#ifdef DILITHIUM_USE_AES
+  aes256_ctx_release(&aesctx);
+#endif
+
+  /* Compute H(rho, t1) and store in secret key */
+  shake256(sk + 2*SEEDBYTES, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+
+  return 0;
+}
+
+/*************************************************
+* Name:        crypto_sign_pubkey_from_privkey
+*
+* Description: Generates public key from existing private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - const uint8_t *sk: pointer to input private key (points
+*                                   to array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
+  unsigned int i;
+  uint8_t rho[SEEDBYTES];
+  uint8_t tr[SEEDBYTES];
+  uint8_t key[SEEDBYTES];
+#ifdef DILITHIUM_USE_AES
+  uint64_t nonce;
+  aes256ctr_ctx aesctx;
+  polyvecl rowbuf[1];
+#else
+  polyvecl rowbuf[2];
+#endif
+  polyvecl s1, *row = rowbuf;
+  polyveck s2;
+  poly t1, t0;
+
+  // Unpack private key
+  unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
+
+  // Store rho in public key
+  memcpy(pk, rho, SEEDBYTES);
+
+  // Transform s1
+  polyvecl_ntt(&s1);
+
+#ifdef DILITHIUM_USE_AES
+  aes256ctr_init_u64(&aesctx, rho, 0);
+#endif
+
+  // Process each row
+  for(i = 0; i < K; i++) {
+    /* Expand matrix row */
+#ifdef DILITHIUM_USE_AES
+    for(unsigned int j = 0; j < L; j++) {
+      nonce = (i << 8) + j;
+      aes256ctr_init_iv_u64(&aesctx, nonce);
+      poly_uniform_preinit(&row->vec[j], &aesctx);
+      poly_nttunpack(&row->vec[j]);
+    }
+#else
+    polyvec_matrix_expand_row(&row, rowbuf, rho, i);
+#endif
+
+    /* Compute inner-product */
+    polyvecl_pointwise_acc_montgomery(&t1, row, &s1);
+    poly_invntt_tomont(&t1);
+
+    /* Add error polynomial */
+    poly_add(&t1, &t1, &s2.vec[i]);
+
+    /* Round t and pack t1 */
+    poly_caddq(&t1);
+    poly_power2round(&t1, &t0, &t1);
+    polyt1_pack(pk + SEEDBYTES + i*POLYT1_PACKEDBYTES, &t1);
+  }
+
+#ifdef DILITHIUM_USE_AES
+  aes256_ctx_release(&aesctx);
+#endif
+
+  return 0;
+}
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/sign.h
@@ -13,6 +13,13 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                   const uint8_t *seed);
+
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/api.h
@@ -14,6 +14,11 @@
 
 int pqcrystals_dilithium2_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium2_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                 const uint8_t *seed);
+
+int pqcrystals_dilithium2_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium2_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -35,6 +40,11 @@ int pqcrystals_dilithium2_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium2aes_ref_BYTES pqcrystals_dilithium2_ref_BYTES
 
 int pqcrystals_dilithium2aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium2aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                    const uint8_t *seed);
+
+int pqcrystals_dilithium2aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium2aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -62,6 +72,11 @@ int pqcrystals_dilithium2aes_ref_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium3_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium3_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                 const uint8_t *seed);
+
+int pqcrystals_dilithium3_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium3_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -83,6 +98,11 @@ int pqcrystals_dilithium3_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium3aes_ref_BYTES pqcrystals_dilithium3_ref_BYTES
 
 int pqcrystals_dilithium3aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium3aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                    const uint8_t *seed);
+
+int pqcrystals_dilithium3aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium3aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -110,6 +130,11 @@ int pqcrystals_dilithium3aes_ref_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium5_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium5_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                 const uint8_t *seed);
+
+int pqcrystals_dilithium5_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium5_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -131,6 +156,11 @@ int pqcrystals_dilithium5_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium5aes_ref_BYTES pqcrystals_dilithium5_ref_BYTES
 
 int pqcrystals_dilithium5aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium5aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                    const uint8_t *seed);
+
+int pqcrystals_dilithium5aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium5aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/sign.c
@@ -65,6 +65,113 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair_from_fseed
+*
+* Description: Generates public and private key from fixed seed.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*              - const uint8_t *seed: Pointer to the input fixed seed.
+*                                     Must point to an array of SEEDBYTES bytes.
+*                                     The seed provides deterministic randomness
+*                                     for key generation and must be unique and
+*                                     securely generated for each keypair to
+*                                     ensure security.
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
+  uint8_t tr[SEEDBYTES];
+  const uint8_t *rho, *rhoprime, *key;
+  polyvecl mat[K];
+  polyvecl s1, s1hat;
+  polyveck s2, t1, t0;
+
+  /* Use fixed seed for randomness for rho, rhoprime and key */
+  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+  rho = seedbuf;
+  rhoprime = rho + SEEDBYTES;
+  key = rhoprime + CRHBYTES;
+
+  /* Expand matrix */
+  polyvec_matrix_expand(mat, rho);
+
+  /* Sample short vectors s1 and s2 */
+  polyvecl_uniform_eta(&s1, rhoprime, 0);
+  polyveck_uniform_eta(&s2, rhoprime, L);
+
+  /* Matrix-vector multiplication */
+  s1hat = s1;
+  polyvecl_ntt(&s1hat);
+  polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+  polyveck_reduce(&t1);
+  polyveck_invntt_tomont(&t1);
+
+  /* Add error vector s2 */
+  polyveck_add(&t1, &t1, &s2);
+
+  /* Extract t1 and write public key */
+  polyveck_caddq(&t1);
+  polyveck_power2round(&t1, &t0, &t1);
+  pack_pk(pk, rho, &t1);
+
+  /* Compute H(rho, t1) and write secret key */
+  shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+  pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
+
+  return 0;
+}
+
+/*************************************************
+* Name:        crypto_sign_pubkey_from_privkey
+*
+* Description: Generates public key from exist private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - const uint8_t *sk: pointer to the input private key (points
+*                                   to a read-only array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
+  uint8_t rho[SEEDBYTES];
+  uint8_t tr[SEEDBYTES];
+  uint8_t key[SEEDBYTES];
+  polyvecl s1, s1hat;
+  polyveck s2, t0, t1;
+  polyvecl mat[K];
+
+  /* unpack privat key */
+  unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
+
+  /* Expand matrix */
+  polyvec_matrix_expand(mat, rho);
+
+  /* Matrix-vector multiplication */
+  s1hat = s1;
+  polyvecl_ntt(&s1hat);
+  polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+  polyveck_reduce(&t1);
+  polyveck_invntt_tomont(&t1);
+
+  /* Add error vector s2 */
+  polyveck_add(&t1, &t1, &s2);
+
+  /* Extract t1 */
+  polyveck_caddq(&t1);
+  polyveck_power2round(&t1, &t0, &t1);
+
+  /* Pack public key */
+  pack_pk(pk, rho, &t1);
+
+  return 0;
+}
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/sign.h
@@ -13,6 +13,13 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                   const uint8_t *seed);
+
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/api.h
@@ -14,6 +14,11 @@
 
 int pqcrystals_dilithium2_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium2_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                  const uint8_t *seed);
+
+int pqcrystals_dilithium2_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium2_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -35,6 +40,11 @@ int pqcrystals_dilithium2_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium2aes_avx2_BYTES pqcrystals_dilithium2_avx2_BYTES
 
 int pqcrystals_dilithium2aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium2aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                     const uint8_t *seed);
+
+int pqcrystals_dilithium2aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium2aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -62,6 +72,11 @@ int pqcrystals_dilithium2aes_avx2_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium3_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium3_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                  const uint8_t *seed);
+
+int pqcrystals_dilithium3_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium3_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -83,6 +98,11 @@ int pqcrystals_dilithium3_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium3aes_avx2_BYTES pqcrystals_dilithium3_avx2_BYTES
 
 int pqcrystals_dilithium3aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium3aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                     const uint8_t *seed);
+
+int pqcrystals_dilithium3aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium3aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -110,6 +130,11 @@ int pqcrystals_dilithium3aes_avx2_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium5_avx2_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium5_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                  const uint8_t *seed);
+
+int pqcrystals_dilithium5_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium5_avx2_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -131,6 +156,11 @@ int pqcrystals_dilithium5_avx2_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium5aes_avx2_BYTES pqcrystals_dilithium5_avx2_BYTES
 
 int pqcrystals_dilithium5aes_avx2_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium5aes_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                     const uint8_t *seed);
+
+int pqcrystals_dilithium5aes_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium5aes_avx2_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/sign.c
@@ -176,6 +176,205 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair_from_fseed
+*
+* Description: Generates public and private key from fixed seed.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*              - const uint8_t *seed: Pointer to the input fixed seed.
+*                                     Must point to an array of SEEDBYTES bytes.
+*                                     The seed provides deterministic randomness
+*                                     for key generation and must be unique and
+*                                     securely generated for each keypair to
+*                                     ensure security.
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+  unsigned int i;
+  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
+  const uint8_t *rho, *rhoprime, *key;
+#ifdef DILITHIUM_USE_AES
+  uint64_t nonce;
+  aes256ctr_ctx aesctx;
+  polyvecl rowbuf[1];
+#else
+  polyvecl rowbuf[2];
+#endif
+  polyvecl s1, *row = rowbuf;
+  polyveck s2;
+  poly t1, t0;
+
+  /* Use fixed seed for randomness for rho, rhoprime and key */
+  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+  rho = seedbuf;
+  rhoprime = rho + SEEDBYTES;
+  key = rhoprime + CRHBYTES;
+
+  /* Store rho, key */
+  memcpy(pk, rho, SEEDBYTES);
+  memcpy(sk, rho, SEEDBYTES);
+  memcpy(sk + SEEDBYTES, key, SEEDBYTES);
+
+  /* Sample short vectors s1 and s2 */
+#ifdef DILITHIUM_USE_AES
+  aes256ctr_init_u64(&aesctx, rhoprime, 0);
+  for(i = 0; i < L; ++i) {
+    nonce = i;
+    aes256ctr_init_iv_u64(&aesctx, nonce);
+    poly_uniform_eta_preinit(&s1.vec[i], &aesctx);
+  }
+  for(i = 0; i < K; ++i) {
+    nonce = L + i;
+    aes256ctr_init_iv_u64(&aesctx, nonce);
+    poly_uniform_eta_preinit(&s2.vec[i], &aesctx);
+  }
+  aes256_ctx_release(&aesctx);
+#elif K == 4 && L == 4
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s2.vec[0], &s2.vec[1], &s2.vec[2], &s2.vec[3], rhoprime, 4, 5, 6, 7);
+#elif K == 6 && L == 5
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s1.vec[4], &s2.vec[0], &s2.vec[1], &s2.vec[2], rhoprime, 4, 5, 6, 7);
+  poly_uniform_eta_4x(&s2.vec[3], &s2.vec[4], &s2.vec[5], &t0, rhoprime, 8, 9, 10, 11);
+#elif K == 8 && L == 7
+  poly_uniform_eta_4x(&s1.vec[0], &s1.vec[1], &s1.vec[2], &s1.vec[3], rhoprime, 0, 1, 2, 3);
+  poly_uniform_eta_4x(&s1.vec[4], &s1.vec[5], &s1.vec[6], &s2.vec[0], rhoprime, 4, 5, 6, 7);
+  poly_uniform_eta_4x(&s2.vec[1], &s2.vec[2], &s2.vec[3], &s2.vec[4], rhoprime, 8, 9, 10, 11);
+  poly_uniform_eta_4x(&s2.vec[5], &s2.vec[6], &s2.vec[7], &t0, rhoprime, 12, 13, 14, 15);
+#else
+#error
+#endif
+
+  /* Pack secret vectors */
+  for(i = 0; i < L; i++)
+    polyeta_pack(sk + 3*SEEDBYTES + i*POLYETA_PACKEDBYTES, &s1.vec[i]);
+  for(i = 0; i < K; i++)
+    polyeta_pack(sk + 3*SEEDBYTES + (L + i)*POLYETA_PACKEDBYTES, &s2.vec[i]);
+
+  /* Transform s1 */
+  polyvecl_ntt(&s1);
+
+#ifdef DILITHIUM_USE_AES
+  aes256ctr_init_u64(&aesctx, rho, 0);
+#endif
+
+  for(i = 0; i < K; i++) {
+    /* Expand matrix row */
+#ifdef DILITHIUM_USE_AES
+    for(unsigned int j = 0; j < L; j++) {
+      nonce = (i << 8) + j;
+      aes256ctr_init_iv_u64(&aesctx, nonce);
+      poly_uniform_preinit(&row->vec[j], &aesctx);
+      poly_nttunpack(&row->vec[j]);
+    }
+#else
+    polyvec_matrix_expand_row(&row, rowbuf, rho, i);
+#endif
+
+    /* Compute inner-product */
+    polyvecl_pointwise_acc_montgomery(&t1, row, &s1);
+    poly_invntt_tomont(&t1);
+
+    /* Add error polynomial */
+    poly_add(&t1, &t1, &s2.vec[i]);
+
+    /* Round t and pack t1, t0 */
+    poly_caddq(&t1);
+    poly_power2round(&t1, &t0, &t1);
+    polyt1_pack(pk + SEEDBYTES + i*POLYT1_PACKEDBYTES, &t1);
+    polyt0_pack(sk + 3*SEEDBYTES + (L+K)*POLYETA_PACKEDBYTES + i*POLYT0_PACKEDBYTES, &t0);
+  }
+
+#ifdef DILITHIUM_USE_AES
+  aes256_ctx_release(&aesctx);
+#endif
+
+  /* Compute H(rho, t1) and store in secret key */
+  shake256(sk + 2*SEEDBYTES, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+
+  return 0;
+}
+
+/*************************************************
+* Name:        crypto_sign_pubkey_from_privkey
+*
+* Description: Generates public key from existing private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - const uint8_t *sk: pointer to input private key (points
+*                                   to array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
+  unsigned int i;
+  uint8_t rho[SEEDBYTES];
+  uint8_t tr[SEEDBYTES];
+  uint8_t key[SEEDBYTES];
+#ifdef DILITHIUM_USE_AES
+  uint64_t nonce;
+  aes256ctr_ctx aesctx;
+  polyvecl rowbuf[1];
+#else
+  polyvecl rowbuf[2];
+#endif
+  polyvecl s1, *row = rowbuf;
+  polyveck s2;
+  poly t1, t0;
+
+  // Unpack private key
+  unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
+
+  // Store rho in public key
+  memcpy(pk, rho, SEEDBYTES);
+
+  // Transform s1
+  polyvecl_ntt(&s1);
+
+#ifdef DILITHIUM_USE_AES
+  aes256ctr_init_u64(&aesctx, rho, 0);
+#endif
+
+  // Process each row
+  for(i = 0; i < K; i++) {
+    /* Expand matrix row */
+#ifdef DILITHIUM_USE_AES
+    for(unsigned int j = 0; j < L; j++) {
+      nonce = (i << 8) + j;
+      aes256ctr_init_iv_u64(&aesctx, nonce);
+      poly_uniform_preinit(&row->vec[j], &aesctx);
+      poly_nttunpack(&row->vec[j]);
+    }
+#else
+    polyvec_matrix_expand_row(&row, rowbuf, rho, i);
+#endif
+
+    /* Compute inner-product */
+    polyvecl_pointwise_acc_montgomery(&t1, row, &s1);
+    poly_invntt_tomont(&t1);
+
+    /* Add error polynomial */
+    poly_add(&t1, &t1, &s2.vec[i]);
+
+    /* Round t and pack t1 */
+    poly_caddq(&t1);
+    poly_power2round(&t1, &t0, &t1);
+    polyt1_pack(pk + SEEDBYTES + i*POLYT1_PACKEDBYTES, &t1);
+  }
+
+#ifdef DILITHIUM_USE_AES
+  aes256_ctx_release(&aesctx);
+#endif
+
+  return 0;
+}
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_avx2/sign.h
@@ -13,6 +13,13 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                   const uint8_t *seed);
+
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_ref/api.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_ref/api.h
@@ -14,6 +14,11 @@
 
 int pqcrystals_dilithium2_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium2_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                 const uint8_t *seed);
+
+int pqcrystals_dilithium2_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium2_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -35,6 +40,11 @@ int pqcrystals_dilithium2_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium2aes_ref_BYTES pqcrystals_dilithium2_ref_BYTES
 
 int pqcrystals_dilithium2aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium2aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                    const uint8_t *seed);
+
+int pqcrystals_dilithium2aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium2aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -62,6 +72,11 @@ int pqcrystals_dilithium2aes_ref_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium3_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium3_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                 const uint8_t *seed);
+
+int pqcrystals_dilithium3_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium3_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -83,6 +98,11 @@ int pqcrystals_dilithium3_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium3aes_ref_BYTES pqcrystals_dilithium3_ref_BYTES
 
 int pqcrystals_dilithium3aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium3aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                    const uint8_t *seed);
+
+int pqcrystals_dilithium3aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium3aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,
@@ -110,6 +130,11 @@ int pqcrystals_dilithium3aes_ref_open(uint8_t *m, size_t *mlen,
 
 int pqcrystals_dilithium5_ref_keypair(uint8_t *pk, uint8_t *sk);
 
+int pqcrystals_dilithium5_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                 const uint8_t *seed);
+
+int pqcrystals_dilithium5_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 int pqcrystals_dilithium5_ref_signature(uint8_t *sig, size_t *siglen,
                                         const uint8_t *m, size_t mlen,
                                         const uint8_t *sk);
@@ -131,6 +156,11 @@ int pqcrystals_dilithium5_ref_open(uint8_t *m, size_t *mlen,
 #define pqcrystals_dilithium5aes_ref_BYTES pqcrystals_dilithium5_ref_BYTES
 
 int pqcrystals_dilithium5aes_ref_keypair(uint8_t *pk, uint8_t *sk);
+
+int pqcrystals_dilithium5aes_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                                    const uint8_t *seed);
+
+int pqcrystals_dilithium5aes_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 
 int pqcrystals_dilithium5aes_ref_signature(uint8_t *sig, size_t *siglen,
                                            const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_ref/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_ref/sign.c
@@ -65,6 +65,113 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 }
 
 /*************************************************
+* Name:        crypto_sign_keypair_from_fseed
+*
+* Description: Generates public and private key from fixed seed.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*              - const uint8_t *seed: Pointer to the input fixed seed.
+*                                     Must point to an array of SEEDBYTES bytes.
+*                                     The seed provides deterministic randomness
+*                                     for key generation and must be unique and
+*                                     securely generated for each keypair to
+*                                     ensure security.
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
+  uint8_t tr[SEEDBYTES];
+  const uint8_t *rho, *rhoprime, *key;
+  polyvecl mat[K];
+  polyvecl s1, s1hat;
+  polyveck s2, t1, t0;
+
+  /* Use fixed seed for randomness for rho, rhoprime and key */
+  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+  rho = seedbuf;
+  rhoprime = rho + SEEDBYTES;
+  key = rhoprime + CRHBYTES;
+
+  /* Expand matrix */
+  polyvec_matrix_expand(mat, rho);
+
+  /* Sample short vectors s1 and s2 */
+  polyvecl_uniform_eta(&s1, rhoprime, 0);
+  polyveck_uniform_eta(&s2, rhoprime, L);
+
+  /* Matrix-vector multiplication */
+  s1hat = s1;
+  polyvecl_ntt(&s1hat);
+  polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+  polyveck_reduce(&t1);
+  polyveck_invntt_tomont(&t1);
+
+  /* Add error vector s2 */
+  polyveck_add(&t1, &t1, &s2);
+
+  /* Extract t1 and write public key */
+  polyveck_caddq(&t1);
+  polyveck_power2round(&t1, &t0, &t1);
+  pack_pk(pk, rho, &t1);
+
+  /* Compute H(rho, t1) and write secret key */
+  shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
+  pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
+
+  return 0;
+}
+
+/*************************************************
+* Name:        crypto_sign_pubkey_from_privkey
+*
+* Description: Generates public key from exist private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - const uint8_t *sk: pointer to the input private key (points
+*                                   to a read-only array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk) {
+  uint8_t rho[SEEDBYTES];
+  uint8_t tr[SEEDBYTES];
+  uint8_t key[SEEDBYTES];
+  polyvecl s1, s1hat;
+  polyveck s2, t0, t1;
+  polyvecl mat[K];
+
+  /* unpack privat key */
+  unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
+
+  /* Expand matrix */
+  polyvec_matrix_expand(mat, rho);
+
+  /* Matrix-vector multiplication */
+  s1hat = s1;
+  polyvecl_ntt(&s1hat);
+  polyvec_matrix_pointwise_montgomery(&t1, mat, &s1hat);
+  polyveck_reduce(&t1);
+  polyveck_invntt_tomont(&t1);
+
+  /* Add error vector s2 */
+  polyveck_add(&t1, &t1, &s2);
+
+  /* Extract t1 */
+  polyveck_caddq(&t1);
+  polyveck_power2round(&t1, &t0, &t1);
+
+  /* Pack public key */
+  pack_pk(pk, rho, &t1);
+
+  return 0;
+}
+
+/*************************************************
 * Name:        crypto_sign_signature
 *
 * Description: Computes signature.

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium5_ref/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium5_ref/sign.h
@@ -13,6 +13,13 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_keypair_from_fseed DILITHIUM_NAMESPACE(keypair_from_fseed)
+int crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk,
+                                   const uint8_t *seed);
+
+#define crypto_sign_pubkey_from_privkey DILITHIUM_NAMESPACE(pubkey_from_privkey)
+int crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/sig_dilithium.h
+++ b/src/sig/dilithium/sig_dilithium.h
@@ -12,6 +12,8 @@
 
 OQS_SIG *OQS_SIG_dilithium_2_new(void);
 OQS_API OQS_STATUS OQS_SIG_dilithium_2_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_dilithium_2_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_dilithium_2_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_2_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_2_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_2_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -25,6 +27,8 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_2_verify_with_ctx_str(const uint8_t *messag
 
 OQS_SIG *OQS_SIG_dilithium_3_new(void);
 OQS_API OQS_STATUS OQS_SIG_dilithium_3_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_dilithium_3_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_dilithium_3_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_3_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_3_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_3_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -38,6 +42,8 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_3_verify_with_ctx_str(const uint8_t *messag
 
 OQS_SIG *OQS_SIG_dilithium_5_new(void);
 OQS_API OQS_STATUS OQS_SIG_dilithium_5_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_dilithium_5_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_dilithium_5_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_5_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_5_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_5_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);

--- a/src/sig/dilithium/sig_dilithium_2.c
+++ b/src/sig/dilithium/sig_dilithium_2.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_dilithium_2_new(void) {
 	sig->length_signature = OQS_SIG_dilithium_2_length_signature;
 
 	sig->keypair = OQS_SIG_dilithium_2_keypair;
+	sig->keypair_from_fseed = OQS_SIG_dilithium_2_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_dilithium_2_pubkey_from_privkey;
 	sig->sign = OQS_SIG_dilithium_2_sign;
 	sig->verify = OQS_SIG_dilithium_2_verify;
 	sig->sign_with_ctx_str = OQS_SIG_dilithium_2_sign_with_ctx_str;
@@ -32,17 +34,23 @@ OQS_SIG *OQS_SIG_dilithium_2_new(void) {
 }
 
 extern int pqcrystals_dilithium2_ref_keypair(uint8_t *pk, uint8_t *sk);
+extern int pqcrystals_dilithium2_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int pqcrystals_dilithium2_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_dilithium2_ref_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium2_ref_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_dilithium_2_avx2)
 extern int pqcrystals_dilithium2_avx2_keypair(uint8_t *pk, uint8_t *sk);
+extern int pqcrystals_dilithium2_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int pqcrystals_dilithium2_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_dilithium2_avx2_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium2_avx2_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
 
 #if defined(OQS_ENABLE_SIG_dilithium_2_aarch64)
 extern int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -70,6 +78,58 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_2_keypair(uint8_t *public_key, uint8_t *sec
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) pqcrystals_dilithium2_ref_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_dilithium_2_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_dilithium_2_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) pqcrystals_dilithium2_avx2_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium2_ref_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_dilithium_2_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium2_ref_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) pqcrystals_dilithium2_ref_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_dilithium_2_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_dilithium_2_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) pqcrystals_dilithium2_avx2_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium2_ref_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_dilithium_2_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_DILITHIUM2_AARCH64_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium2_ref_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) pqcrystals_dilithium2_ref_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/dilithium/sig_dilithium_3.c
+++ b/src/sig/dilithium/sig_dilithium_3.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_dilithium_3_new(void) {
 	sig->length_signature = OQS_SIG_dilithium_3_length_signature;
 
 	sig->keypair = OQS_SIG_dilithium_3_keypair;
+	sig->keypair_from_fseed = OQS_SIG_dilithium_3_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_dilithium_3_pubkey_from_privkey;
 	sig->sign = OQS_SIG_dilithium_3_sign;
 	sig->verify = OQS_SIG_dilithium_3_verify;
 	sig->sign_with_ctx_str = OQS_SIG_dilithium_3_sign_with_ctx_str;
@@ -32,17 +34,23 @@ OQS_SIG *OQS_SIG_dilithium_3_new(void) {
 }
 
 extern int pqcrystals_dilithium3_ref_keypair(uint8_t *pk, uint8_t *sk);
+extern int pqcrystals_dilithium3_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int pqcrystals_dilithium3_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_dilithium3_ref_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium3_ref_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_dilithium_3_avx2)
 extern int pqcrystals_dilithium3_avx2_keypair(uint8_t *pk, uint8_t *sk);
+extern int pqcrystals_dilithium3_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int pqcrystals_dilithium3_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_dilithium3_avx2_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium3_avx2_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
 
 #if defined(OQS_ENABLE_SIG_dilithium_3_aarch64)
 extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -70,6 +78,58 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_3_keypair(uint8_t *public_key, uint8_t *sec
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) pqcrystals_dilithium3_ref_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_dilithium_3_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_dilithium_3_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) pqcrystals_dilithium3_avx2_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium3_ref_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_dilithium_3_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium3_ref_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) pqcrystals_dilithium3_ref_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_dilithium_3_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_dilithium_3_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) pqcrystals_dilithium3_avx2_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium3_ref_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_dilithium_3_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium3_ref_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) pqcrystals_dilithium3_ref_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/dilithium/sig_dilithium_5.c
+++ b/src/sig/dilithium/sig_dilithium_5.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_dilithium_5_new(void) {
 	sig->length_signature = OQS_SIG_dilithium_5_length_signature;
 
 	sig->keypair = OQS_SIG_dilithium_5_keypair;
+	sig->keypair_from_fseed = OQS_SIG_dilithium_5_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_dilithium_5_pubkey_from_privkey;
 	sig->sign = OQS_SIG_dilithium_5_sign;
 	sig->verify = OQS_SIG_dilithium_5_verify;
 	sig->sign_with_ctx_str = OQS_SIG_dilithium_5_sign_with_ctx_str;
@@ -32,17 +34,23 @@ OQS_SIG *OQS_SIG_dilithium_5_new(void) {
 }
 
 extern int pqcrystals_dilithium5_ref_keypair(uint8_t *pk, uint8_t *sk);
+extern int pqcrystals_dilithium5_ref_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int pqcrystals_dilithium5_ref_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_dilithium5_ref_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium5_ref_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_dilithium_5_avx2)
 extern int pqcrystals_dilithium5_avx2_keypair(uint8_t *pk, uint8_t *sk);
+extern int pqcrystals_dilithium5_avx2_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int pqcrystals_dilithium5_avx2_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_dilithium5_avx2_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium5_avx2_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
 
 #if defined(OQS_ENABLE_SIG_dilithium_5_aarch64)
 extern int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -70,6 +78,58 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_5_keypair(uint8_t *public_key, uint8_t *sec
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) pqcrystals_dilithium5_ref_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_dilithium_5_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_dilithium_5_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) pqcrystals_dilithium5_avx2_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium5_ref_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_dilithium_5_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium5_ref_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) pqcrystals_dilithium5_ref_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_dilithium_5_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_dilithium_5_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) pqcrystals_dilithium5_avx2_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium5_ref_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_dilithium_5_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_DILITHIUM5_AARCH64_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium5_ref_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) pqcrystals_dilithium5_ref_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/falcon/pqclean_falcon-1024_aarch64/api.h
+++ b/src/sig/falcon/pqclean_falcon-1024_aarch64/api.h
@@ -24,6 +24,29 @@ int PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES
+ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
+ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON1024_AARCH64_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-1024_aarch64/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-1024_aarch64/pqclean.c
@@ -108,6 +108,145 @@ PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[28 * FALCON_N];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
+    uint16_t h[FALCON_N];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCON1024_AARCH64_keygen(&rng, f, g, F, NULL, h, FALCON_LOGN, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + FALCON_LOGN;
+    u = 1;
+    v = PQCLEAN_FALCON1024_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            f, PQCLEAN_FALCON1024_AARCH64_max_fg_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            g, PQCLEAN_FALCON1024_AARCH64_max_fg_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            F, PQCLEAN_FALCON1024_AARCH64_max_FG_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + FALCON_LOGN;
+    v = PQCLEAN_FALCON1024_AARCH64_modq_encode(
+            pk + 1, PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
+            h, FALCON_LOGN);
+    if (v != PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f and g) from the secret key
+ * and uses them to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ *
+ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON1024_AARCH64_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[28 * FALCON_N];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
+    uint16_t h[FALCON_N];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + FALCON_LOGN) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCON1024_AARCH64_trim_i8_decode(
+            f, PQCLEAN_FALCON1024_AARCH64_max_fg_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_AARCH64_trim_i8_decode(
+            g, PQCLEAN_FALCON1024_AARCH64_max_fg_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCON1024_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCON1024_AARCH64_compute_public(h, f, g, FALCON_LOGN, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + FALCON_LOGN;
+    v = PQCLEAN_FALCON1024_AARCH64_modq_encode(
+            pk + 1, PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
+            h, FALCON_LOGN);
+    if (v != PQCLEAN_FALCON1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-1024_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-1024_avx2/api.h
@@ -24,6 +24,29 @@ int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES
+ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
+ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON1024_AVX2_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-1024_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-1024_avx2/pqclean.c
@@ -108,6 +108,145 @@ PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_10];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[1024], g[1024], F[1024];
+    uint16_t h[1024];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCON1024_AVX2_keygen(&rng, f, g, F, NULL, h, 10, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + 10;
+    u = 1;
+    v = PQCLEAN_FALCON1024_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            f, 10, PQCLEAN_FALCON1024_AVX2_max_fg_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            g, 10, PQCLEAN_FALCON1024_AVX2_max_fg_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            F, 10, PQCLEAN_FALCON1024_AVX2_max_FG_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 10;
+    v = PQCLEAN_FALCON1024_AVX2_modq_encode(
+            pk + 1, PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 10);
+    if (v != PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f and g) from the secret key
+ * and uses them to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ *
+ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON1024_AVX2_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_10];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[1024], g[1024], F[1024];
+    uint16_t h[1024];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + 10) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCON1024_AVX2_trim_i8_decode(
+            f, 10, PQCLEAN_FALCON1024_AVX2_max_fg_bits[10],
+            sk + u, PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_AVX2_trim_i8_decode(
+            g, 10, PQCLEAN_FALCON1024_AVX2_max_fg_bits[10],
+            sk + u, PQCLEAN_FALCON1024_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCON1024_AVX2_compute_public(h, f, g, 10, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 10;
+    v = PQCLEAN_FALCON1024_AVX2_modq_encode(
+            pk + 1, PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 10);
+    if (v != PQCLEAN_FALCON1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-1024_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-1024_clean/api.h
@@ -24,6 +24,29 @@ int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES
+ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
+ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON1024_CLEAN_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-1024_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-1024_clean/pqclean.c
@@ -108,6 +108,146 @@ PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_10];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[1024], g[1024], F[1024];
+    uint16_t h[1024];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCON1024_CLEAN_keygen(&rng, f, g, F, NULL, h, 10, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + 10;
+    u = 1;
+    v = PQCLEAN_FALCON1024_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            f, 10, PQCLEAN_FALCON1024_CLEAN_max_fg_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            g, 10, PQCLEAN_FALCON1024_CLEAN_max_fg_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            F, 10, PQCLEAN_FALCON1024_CLEAN_max_FG_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 10;
+    v = PQCLEAN_FALCON1024_CLEAN_modq_encode(
+            pk + 1, PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 10);
+    if (v != PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f and g) from the secret key
+ * and uses them to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ *
+ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * Return value: 0 on success, -1 on error.
+ */
+int
+PQCLEAN_FALCON1024_CLEAN_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_10];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[1024], g[1024], F[1024];
+    uint16_t h[1024];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + 10) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCON1024_CLEAN_trim_i8_decode(
+            f, 10, PQCLEAN_FALCON1024_CLEAN_max_fg_bits[10],
+            sk + u, PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON1024_CLEAN_trim_i8_decode(
+            g, 10, PQCLEAN_FALCON1024_CLEAN_max_fg_bits[10],
+            sk + u, PQCLEAN_FALCON1024_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCON1024_CLEAN_compute_public(h, f, g, 10, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 10;
+    v = PQCLEAN_FALCON1024_CLEAN_modq_encode(
+            pk + 1, PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 10);
+    if (v != PQCLEAN_FALCON1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-512_aarch64/api.h
+++ b/src/sig/falcon/pqclean_falcon-512_aarch64/api.h
@@ -24,6 +24,29 @@ int PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES
+ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
+ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON512_AARCH64_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-512_aarch64/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-512_aarch64/pqclean.c
@@ -108,6 +108,146 @@ PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[28 * FALCON_N];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
+    uint16_t h[FALCON_N];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCON512_AARCH64_keygen(&rng, f, g, F, NULL, h, FALCON_LOGN, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + FALCON_LOGN;
+    u = 1;
+    v = PQCLEAN_FALCON512_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            f, PQCLEAN_FALCON512_AARCH64_max_fg_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            g, PQCLEAN_FALCON512_AARCH64_max_fg_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            F, PQCLEAN_FALCON512_AARCH64_max_FG_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + FALCON_LOGN;
+    v = PQCLEAN_FALCON512_AARCH64_modq_encode(
+            pk + 1, PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
+            h, FALCON_LOGN);
+    if (v != PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f and g) from the secret key
+ * and uses them to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ *
+ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * Return value: 0 on success, -1 on error.
+ */
+int
+PQCLEAN_FALCON512_AARCH64_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[28 * FALCON_N];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
+    uint16_t h[FALCON_N];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + FALCON_LOGN) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCON512_AARCH64_trim_i8_decode(
+            f, PQCLEAN_FALCON512_AARCH64_max_fg_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_AARCH64_trim_i8_decode(
+            g, PQCLEAN_FALCON512_AARCH64_max_fg_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCON512_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCON512_AARCH64_compute_public(h, f, g, FALCON_LOGN, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + FALCON_LOGN;
+    v = PQCLEAN_FALCON512_AARCH64_modq_encode(
+            pk + 1, PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
+            h, FALCON_LOGN);
+    if (v != PQCLEAN_FALCON512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-512_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-512_avx2/api.h
@@ -24,6 +24,29 @@ int PQCLEAN_FALCON512_AVX2_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON512_AVX2_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
+ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON512_AVX2_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-512_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-512_avx2/pqclean.c
@@ -108,6 +108,146 @@ PQCLEAN_FALCON512_AVX2_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCON512_AVX2_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_9];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[512], g[512], F[512];
+    uint16_t h[512];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCON512_AVX2_keygen(&rng, f, g, F, NULL, h, 9, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + 9;
+    u = 1;
+    v = PQCLEAN_FALCON512_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            f, 9, PQCLEAN_FALCON512_AVX2_max_fg_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            g, 9, PQCLEAN_FALCON512_AVX2_max_fg_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            F, 9, PQCLEAN_FALCON512_AVX2_max_FG_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 9;
+    v = PQCLEAN_FALCON512_AVX2_modq_encode(
+            pk + 1, PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 9);
+    if (v != PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f and g) from the secret key
+ * and uses them to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ *
+ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * Return value: 0 on success, -1 on error.
+ */
+int
+PQCLEAN_FALCON512_AVX2_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_9];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[512], g[512], F[512];
+    uint16_t h[512];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + 9) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCON512_AVX2_trim_i8_decode(
+            f, 9, PQCLEAN_FALCON512_AVX2_max_fg_bits[9],
+            sk + u, PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_AVX2_trim_i8_decode(
+            g, 9, PQCLEAN_FALCON512_AVX2_max_fg_bits[9],
+            sk + u, PQCLEAN_FALCON512_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCON512_AVX2_compute_public(h, f, g, 9, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 9;
+    v = PQCLEAN_FALCON512_AVX2_modq_encode(
+            pk + 1, PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 9);
+    if (v != PQCLEAN_FALCON512_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-512_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-512_clean/api.h
@@ -24,6 +24,29 @@ int PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES
+ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
+ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCON512_CLEAN_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-512_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-512_clean/pqclean.c
@@ -108,6 +108,146 @@ PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_9];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[512], g[512], F[512];
+    uint16_t h[512];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCON512_CLEAN_keygen(&rng, f, g, F, NULL, h, 9, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + 9;
+    u = 1;
+    v = PQCLEAN_FALCON512_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            f, 9, PQCLEAN_FALCON512_CLEAN_max_fg_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            g, 9, PQCLEAN_FALCON512_CLEAN_max_fg_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            F, 9, PQCLEAN_FALCON512_CLEAN_max_FG_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 9;
+    v = PQCLEAN_FALCON512_CLEAN_modq_encode(
+            pk + 1, PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 9);
+    if (v != PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f and g) from the secret key
+ * and uses them to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ *
+ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * Return value: 0 on success, -1 on error.
+ */
+int
+PQCLEAN_FALCON512_CLEAN_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_9];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[512], g[512], F[512];
+    uint16_t h[512];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + 9) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCON512_CLEAN_trim_i8_decode(
+            f, 9, PQCLEAN_FALCON512_CLEAN_max_fg_bits[9],
+            sk + u, PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCON512_CLEAN_trim_i8_decode(
+            g, 9, PQCLEAN_FALCON512_CLEAN_max_fg_bits[9],
+            sk + u, PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCON512_CLEAN_compute_public(h, f, g, 9, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 9;
+    v = PQCLEAN_FALCON512_CLEAN_modq_encode(
+            pk + 1, PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 9);
+    if (v != PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-padded-1024_aarch64/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_aarch64/api.h
@@ -22,6 +22,29 @@ int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES
+ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
+ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-1024_aarch64/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_aarch64/pqclean.c
@@ -105,6 +105,146 @@ PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[28 * FALCON_N];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
+    uint16_t h[FALCON_N];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCONPADDED1024_AARCH64_keygen(&rng, f, g, F, NULL, h, FALCON_LOGN, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + FALCON_LOGN;
+    u = 1;
+    v = PQCLEAN_FALCONPADDED1024_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            f, PQCLEAN_FALCONPADDED1024_AARCH64_max_fg_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            g, PQCLEAN_FALCONPADDED1024_AARCH64_max_fg_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            F, PQCLEAN_FALCONPADDED1024_AARCH64_max_FG_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + FALCON_LOGN;
+    v = PQCLEAN_FALCONPADDED1024_AARCH64_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
+            h, FALCON_LOGN);
+    if (v != PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f and g) from the secret key
+ * and uses them to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ *
+ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * Return value: 0 on success, -1 on error.
+ */
+int
+PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[28 * FALCON_N];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
+    uint16_t h[FALCON_N];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + FALCON_LOGN) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCONPADDED1024_AARCH64_trim_i8_decode(
+            f, PQCLEAN_FALCONPADDED1024_AARCH64_max_fg_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_AARCH64_trim_i8_decode(
+            g, PQCLEAN_FALCONPADDED1024_AARCH64_max_fg_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCONPADDED1024_AARCH64_compute_public(h, f, g, FALCON_LOGN, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + FALCON_LOGN;
+    v = PQCLEAN_FALCONPADDED1024_AARCH64_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
+            h, FALCON_LOGN);
+    if (v != PQCLEAN_FALCONPADDED1024_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-padded-1024_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_avx2/api.h
@@ -22,6 +22,29 @@ int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES
+ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
+ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-1024_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_avx2/pqclean.c
@@ -105,6 +105,146 @@ PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_10];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[1024], g[1024], F[1024];
+    uint16_t h[1024];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCONPADDED1024_AVX2_keygen(&rng, f, g, F, NULL, h, 10, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + 10;
+    u = 1;
+    v = PQCLEAN_FALCONPADDED1024_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            f, 10, PQCLEAN_FALCONPADDED1024_AVX2_max_fg_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            g, 10, PQCLEAN_FALCONPADDED1024_AVX2_max_fg_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            F, 10, PQCLEAN_FALCONPADDED1024_AVX2_max_FG_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 10;
+    v = PQCLEAN_FALCONPADDED1024_AVX2_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 10);
+    if (v != PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f and g) from the secret key
+ * and uses them to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ *
+ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * Return value: 0 on success, -1 on error.
+ */
+int
+PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_10];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[1024], g[1024], F[1024];
+    uint16_t h[1024];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + 10) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCONPADDED1024_AVX2_trim_i8_decode(
+            f, 10, PQCLEAN_FALCONPADDED1024_AVX2_max_fg_bits[10],
+            sk + u, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_AVX2_trim_i8_decode(
+            g, 10, PQCLEAN_FALCONPADDED1024_AVX2_max_fg_bits[10],
+            sk + u, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCONPADDED1024_AVX2_compute_public(h, f, g, 10, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 10;
+    v = PQCLEAN_FALCONPADDED1024_AVX2_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 10);
+    if (v != PQCLEAN_FALCONPADDED1024_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-padded-1024_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_clean/api.h
@@ -22,6 +22,29 @@ int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES
+ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
+ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-1024_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-1024_clean/pqclean.c
@@ -105,6 +105,146 @@ PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_10];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[1024], g[1024], F[1024];
+    uint16_t h[1024];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCONPADDED1024_CLEAN_keygen(&rng, f, g, F, NULL, h, 10, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + 10;
+    u = 1;
+    v = PQCLEAN_FALCONPADDED1024_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            f, 10, PQCLEAN_FALCONPADDED1024_CLEAN_max_fg_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            g, 10, PQCLEAN_FALCONPADDED1024_CLEAN_max_fg_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            F, 10, PQCLEAN_FALCONPADDED1024_CLEAN_max_FG_bits[10]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 10;
+    v = PQCLEAN_FALCONPADDED1024_CLEAN_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 10);
+    if (v != PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f and g) from the secret key
+ * and uses them to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ *
+ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * Return value: 0 on success, -1 on error.
+ */
+int
+PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_10];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[1024], g[1024], F[1024];
+    uint16_t h[1024];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + 10) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCONPADDED1024_CLEAN_trim_i8_decode(
+            f, 10, PQCLEAN_FALCONPADDED1024_CLEAN_max_fg_bits[10],
+            sk + u, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED1024_CLEAN_trim_i8_decode(
+            g, 10, PQCLEAN_FALCONPADDED1024_CLEAN_max_fg_bits[10],
+            sk + u, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCONPADDED1024_CLEAN_compute_public(h, f, g, 10, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 10;
+    v = PQCLEAN_FALCONPADDED1024_CLEAN_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 10);
+    if (v != PQCLEAN_FALCONPADDED1024_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-padded-512_aarch64/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-512_aarch64/api.h
@@ -22,6 +22,29 @@ int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES
+ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
+ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-512_aarch64/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-512_aarch64/pqclean.c
@@ -105,6 +105,146 @@ PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[28 * FALCON_N];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
+    uint16_t h[FALCON_N];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCONPADDED512_AARCH64_keygen(&rng, f, g, F, NULL, h, FALCON_LOGN, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + FALCON_LOGN;
+    u = 1;
+    v = PQCLEAN_FALCONPADDED512_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            f, PQCLEAN_FALCONPADDED512_AARCH64_max_fg_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            g, PQCLEAN_FALCONPADDED512_AARCH64_max_fg_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_AARCH64_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES - u,
+            F, PQCLEAN_FALCONPADDED512_AARCH64_max_FG_bits[FALCON_LOGN]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + FALCON_LOGN;
+    v = PQCLEAN_FALCONPADDED512_AARCH64_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
+            h, FALCON_LOGN);
+    if (v != PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f and g) from the secret key
+ * and uses them to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ *
+ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * Return value: 0 on success, -1 on error.
+ */
+int
+PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[28 * FALCON_N];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[FALCON_N], g[FALCON_N], F[FALCON_N];
+    uint16_t h[FALCON_N];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + FALCON_LOGN) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCONPADDED512_AARCH64_trim_i8_decode(
+            f, PQCLEAN_FALCONPADDED512_AARCH64_max_fg_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_AARCH64_trim_i8_decode(
+            g, PQCLEAN_FALCONPADDED512_AARCH64_max_fg_bits[FALCON_LOGN],
+            sk + u, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCONPADDED512_AARCH64_compute_public(h, f, g, FALCON_LOGN, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + FALCON_LOGN;
+    v = PQCLEAN_FALCONPADDED512_AARCH64_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1,
+            h, FALCON_LOGN);
+    if (v != PQCLEAN_FALCONPADDED512_AARCH64_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-padded-512_avx2/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-512_avx2/api.h
@@ -22,6 +22,29 @@ int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES
+ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
+ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-512_avx2/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-512_avx2/pqclean.c
@@ -105,6 +105,146 @@ PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_9];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[512], g[512], F[512];
+    uint16_t h[512];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCONPADDED512_AVX2_keygen(&rng, f, g, F, NULL, h, 9, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + 9;
+    u = 1;
+    v = PQCLEAN_FALCONPADDED512_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            f, 9, PQCLEAN_FALCONPADDED512_AVX2_max_fg_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            g, 9, PQCLEAN_FALCONPADDED512_AVX2_max_fg_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_AVX2_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES - u,
+            F, 9, PQCLEAN_FALCONPADDED512_AVX2_max_FG_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 9;
+    v = PQCLEAN_FALCONPADDED512_AVX2_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 9);
+    if (v != PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f and g) from the secret key
+ * and uses them to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ *
+ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * Return value: 0 on success, -1 on error.
+ */
+int
+PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_9];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[512], g[512], F[512];
+    uint16_t h[512];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + 9) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCONPADDED512_AVX2_trim_i8_decode(
+            f, 9, PQCLEAN_FALCONPADDED512_AVX2_max_fg_bits[9],
+            sk + u, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_AVX2_trim_i8_decode(
+            g, 9, PQCLEAN_FALCONPADDED512_AVX2_max_fg_bits[9],
+            sk + u, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCONPADDED512_AVX2_compute_public(h, f, g, 9, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 9;
+    v = PQCLEAN_FALCONPADDED512_AVX2_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 9);
+    if (v != PQCLEAN_FALCONPADDED512_AVX2_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/pqclean_falcon-padded-512_clean/api.h
+++ b/src/sig/falcon/pqclean_falcon-padded-512_clean/api.h
@@ -22,6 +22,29 @@ int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair(
     uint8_t *pk, uint8_t *sk);
 
 /*
+ * Generate a new key pair from fixed seed. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES
+ *   seed (seed): Input buffer containing the fixed seed (size: dependent on algorithm settings, for Falcon standard setting = 48 bytes)
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+/*
+ * Generate a public key from a private key. Public key goes into pk[], private key in sk[].
+ * Key sizes are exact (in bytes):
+ *   public (pk): PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES
+ *   private (sk): PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES
+ *
+ * Return value: 0 on success, -1 on error.
+ */
+int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk);
+
+/*
  * Compute a signature on a provided message (m, mlen), with a given
  * private key (sk). Signature is written in sig[], with length written
  * into *siglen. Signature length is variable; maximum signature length

--- a/src/sig/falcon/pqclean_falcon-padded-512_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-padded-512_clean/pqclean.c
@@ -105,6 +105,146 @@ PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair(
     return 0;
 }
 
+/* keypair from fixed seed*/
+int
+PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(
+    uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_9];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[512], g[512], F[512];
+    uint16_t h[512];
+    inner_shake256_context rng;
+    size_t u, v;
+
+    /*
+     * Checking the input seed parameter.
+     * If the seed is NULL, return an error.
+     */
+    if (seed == NULL) {
+        return -1;  // Error: seed is not provided.
+    }
+
+    /*
+     * Initialize the SHAKE256 random number generator using the seed.
+     * We now pass the seed directly to the generator.
+     */
+    inner_shake256_init(&rng);
+    inner_shake256_inject(&rng, seed, 48);
+    inner_shake256_flip(&rng);
+    PQCLEAN_FALCONPADDED512_CLEAN_keygen(&rng, f, g, F, NULL, h, 9, tmp.b);
+    inner_shake256_ctx_release(&rng);
+
+    /*
+     * Encode private key.
+     */
+    sk[0] = 0x50 + 9;
+    u = 1;
+    v = PQCLEAN_FALCONPADDED512_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            f, 9, PQCLEAN_FALCONPADDED512_CLEAN_max_fg_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            g, 9, PQCLEAN_FALCONPADDED512_CLEAN_max_fg_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_CLEAN_trim_i8_encode(
+            sk + u, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES - u,
+            F, 9, PQCLEAN_FALCONPADDED512_CLEAN_max_FG_bits[9]);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    if (u != PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 9;
+    v = PQCLEAN_FALCONPADDED512_CLEAN_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 9);
+    if (v != PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * This function reconstructs the public key from a given private key.
+ * It decodes the private key components (f and g) from the secret key
+ * and uses them to regenerate the corresponding public key (h).
+ * The generated public key is then encoded into the provided pk array.
+ *
+ * public (pk):  The output buffer where the public key will be stored (must be at least PQCLEAN_FALCON512_CLEAN_CRYPTO_PUBLICKEYBYTES in size).
+ * private (sk):  The input secret key (private key) in byte array format (must be PQCLEAN_FALCON512_CLEAN_CRYPTO_SECRETKEYBYTES in size).
+ * Return value: 0 on success, -1 on error.
+ */
+int
+PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_pubkey_from_privkey(
+    uint8_t *pk, const uint8_t *sk) {
+    union {
+        uint8_t b[FALCON_KEYGEN_TEMP_9];
+        uint64_t dummy_u64;
+        fpr dummy_fpr;
+    } tmp;
+    int8_t f[512], g[512], F[512];
+    uint16_t h[512];
+    size_t u, v;
+
+    /*
+     * Decode the private key.
+     */
+    if (sk[0] != 0x50 + 9) {
+        return -1;
+    }
+    u = 1;
+    v = PQCLEAN_FALCONPADDED512_CLEAN_trim_i8_decode(
+            f, 9, PQCLEAN_FALCONPADDED512_CLEAN_max_fg_bits[9],
+            sk + u, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+    u += v;
+    v = PQCLEAN_FALCONPADDED512_CLEAN_trim_i8_decode(
+            g, 9, PQCLEAN_FALCONPADDED512_CLEAN_max_fg_bits[9],
+            sk + u, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_SECRETKEYBYTES - u);
+    if (v == 0) {
+        return -1;
+    }
+
+    /*
+     * Reconstruct the public key using f and g by calling the compute_public function.
+     */
+    if (!PQCLEAN_FALCONPADDED512_CLEAN_compute_public(h, f, g, 9, tmp.b)) {
+        return -1;
+    }
+
+    /*
+     * Encode public key.
+     */
+    pk[0] = 0x00 + 9;
+    v = PQCLEAN_FALCONPADDED512_CLEAN_modq_encode(
+            pk + 1, PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1,
+            h, 9);
+    if (v != PQCLEAN_FALCONPADDED512_CLEAN_CRYPTO_PUBLICKEYBYTES - 1) {
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Compute the signature. nonce[] receives the nonce and must have length
  * NONCELEN bytes. sigbuf[] receives the signature value (without nonce

--- a/src/sig/falcon/sig_falcon.h
+++ b/src/sig/falcon/sig_falcon.h
@@ -12,6 +12,8 @@
 
 OQS_SIG *OQS_SIG_falcon_512_new(void);
 OQS_API OQS_STATUS OQS_SIG_falcon_512_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_falcon_512_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_falcon_512_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_512_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_512_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_512_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -25,6 +27,8 @@ OQS_API OQS_STATUS OQS_SIG_falcon_512_verify_with_ctx_str(const uint8_t *message
 
 OQS_SIG *OQS_SIG_falcon_1024_new(void);
 OQS_API OQS_STATUS OQS_SIG_falcon_1024_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_falcon_1024_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_falcon_1024_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_1024_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_1024_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_1024_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -38,6 +42,8 @@ OQS_API OQS_STATUS OQS_SIG_falcon_1024_verify_with_ctx_str(const uint8_t *messag
 
 OQS_SIG *OQS_SIG_falcon_padded_512_new(void);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -51,6 +57,8 @@ OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_verify_with_ctx_str(const uint8_t *
 
 OQS_SIG *OQS_SIG_falcon_padded_1024_new(void);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);

--- a/src/sig/falcon/sig_falcon_1024.c
+++ b/src/sig/falcon/sig_falcon_1024.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_falcon_1024_new(void) {
 	sig->length_signature = OQS_SIG_falcon_1024_length_signature;
 
 	sig->keypair = OQS_SIG_falcon_1024_keypair;
+	sig->keypair_from_fseed = OQS_SIG_falcon_1024_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_falcon_1024_pubkey_from_privkey;
 	sig->sign = OQS_SIG_falcon_1024_sign;
 	sig->verify = OQS_SIG_falcon_1024_verify;
 	sig->sign_with_ctx_str = OQS_SIG_falcon_1024_sign_with_ctx_str;
@@ -32,17 +34,23 @@ OQS_SIG *OQS_SIG_falcon_1024_new(void) {
 }
 
 extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_falcon_1024_avx2)
 extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
 
 #if defined(OQS_ENABLE_SIG_falcon_1024_aarch64)
 extern int PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCON1024_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON1024_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -70,6 +78,58 @@ OQS_API OQS_STATUS OQS_SIG_falcon_1024_keypair(uint8_t *public_key, uint8_t *sec
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_falcon_1024_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_falcon_1024_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCON1024_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_falcon_1024_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCON1024_AARCH64_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_falcon_1024_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_falcon_1024_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCON1024_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_falcon_1024_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCON1024_AARCH64_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_FALCON1024_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/falcon/sig_falcon_512.c
+++ b/src/sig/falcon/sig_falcon_512.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_falcon_512_new(void) {
 	sig->length_signature = OQS_SIG_falcon_512_length_signature;
 
 	sig->keypair = OQS_SIG_falcon_512_keypair;
+	sig->keypair_from_fseed = OQS_SIG_falcon_512_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_falcon_512_pubkey_from_privkey;
 	sig->sign = OQS_SIG_falcon_512_sign;
 	sig->verify = OQS_SIG_falcon_512_verify;
 	sig->sign_with_ctx_str = OQS_SIG_falcon_512_sign_with_ctx_str;
@@ -32,17 +34,23 @@ OQS_SIG *OQS_SIG_falcon_512_new(void) {
 }
 
 extern int PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCON512_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCON512_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON512_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_falcon_512_avx2)
 extern int PQCLEAN_FALCON512_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCON512_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCON512_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCON512_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON512_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
 
 #if defined(OQS_ENABLE_SIG_falcon_512_aarch64)
 extern int PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCON512_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCON512_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCON512_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -70,6 +78,58 @@ OQS_API OQS_STATUS OQS_SIG_falcon_512_keypair(uint8_t *public_key, uint8_t *secr
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_falcon_512_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_falcon_512_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCON512_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_falcon_512_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCON512_AARCH64_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_falcon_512_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_falcon_512_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCON512_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCON512_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_falcon_512_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCON512_AARCH64_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCON512_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_FALCON512_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/falcon/sig_falcon_padded_1024.c
+++ b/src/sig/falcon/sig_falcon_padded_1024.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_falcon_padded_1024_new(void) {
 	sig->length_signature = OQS_SIG_falcon_padded_1024_length_signature;
 
 	sig->keypair = OQS_SIG_falcon_padded_1024_keypair;
+	sig->keypair_from_fseed = OQS_SIG_falcon_padded_1024_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_falcon_padded_1024_pubkey_from_privkey;
 	sig->sign = OQS_SIG_falcon_padded_1024_sign;
 	sig->verify = OQS_SIG_falcon_padded_1024_verify;
 	sig->sign_with_ctx_str = OQS_SIG_falcon_padded_1024_sign_with_ctx_str;
@@ -32,17 +34,23 @@ OQS_SIG *OQS_SIG_falcon_padded_1024_new(void) {
 }
 
 extern int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_falcon_padded_1024_avx2)
 extern int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
 
 #if defined(OQS_ENABLE_SIG_falcon_padded_1024_aarch64)
 extern int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -70,6 +78,58 @@ OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_keypair(uint8_t *public_key, uint8
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_falcon_padded_1024_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_falcon_padded_1024_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_falcon_padded_1024_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_falcon_padded_1024_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_falcon_padded_1024_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_AARCH64_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_FALCONPADDED1024_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/falcon/sig_falcon_padded_512.c
+++ b/src/sig/falcon/sig_falcon_padded_512.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_falcon_padded_512_new(void) {
 	sig->length_signature = OQS_SIG_falcon_padded_512_length_signature;
 
 	sig->keypair = OQS_SIG_falcon_padded_512_keypair;
+	sig->keypair_from_fseed = OQS_SIG_falcon_padded_512_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_falcon_padded_512_pubkey_from_privkey;
 	sig->sign = OQS_SIG_falcon_padded_512_sign;
 	sig->verify = OQS_SIG_falcon_padded_512_verify;
 	sig->sign_with_ctx_str = OQS_SIG_falcon_padded_512_sign_with_ctx_str;
@@ -32,17 +34,23 @@ OQS_SIG *OQS_SIG_falcon_padded_512_new(void) {
 }
 
 extern int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_falcon_padded_512_avx2)
 extern int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
 
 #if defined(OQS_ENABLE_SIG_falcon_padded_512_aarch64)
 extern int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -70,6 +78,58 @@ OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_keypair(uint8_t *public_key, uint8_
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_falcon_padded_512_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_falcon_padded_512_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_falcon_padded_512_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_falcon_padded_512_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED512_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_falcon_padded_512_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED512_AARCH64_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_FALCONPADDED512_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/mayo/sig_mayo.h
+++ b/src/sig/mayo/sig_mayo.h
@@ -12,6 +12,8 @@
 
 OQS_SIG *OQS_SIG_mayo_1_new(void);
 OQS_API OQS_STATUS OQS_SIG_mayo_1_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_mayo_1_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_mayo_1_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_mayo_1_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_mayo_1_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_mayo_1_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -25,6 +27,8 @@ OQS_API OQS_STATUS OQS_SIG_mayo_1_verify_with_ctx_str(const uint8_t *message, si
 
 OQS_SIG *OQS_SIG_mayo_2_new(void);
 OQS_API OQS_STATUS OQS_SIG_mayo_2_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_mayo_2_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_mayo_2_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_mayo_2_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_mayo_2_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_mayo_2_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -38,6 +42,8 @@ OQS_API OQS_STATUS OQS_SIG_mayo_2_verify_with_ctx_str(const uint8_t *message, si
 
 OQS_SIG *OQS_SIG_mayo_3_new(void);
 OQS_API OQS_STATUS OQS_SIG_mayo_3_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_mayo_3_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_mayo_3_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_mayo_3_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_mayo_3_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_mayo_3_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -51,6 +57,8 @@ OQS_API OQS_STATUS OQS_SIG_mayo_3_verify_with_ctx_str(const uint8_t *message, si
 
 OQS_SIG *OQS_SIG_mayo_5_new(void);
 OQS_API OQS_STATUS OQS_SIG_mayo_5_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_mayo_5_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_mayo_5_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_mayo_5_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_mayo_5_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_mayo_5_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);

--- a/src/sig/mayo/sig_mayo_1.c
+++ b/src/sig/mayo/sig_mayo_1.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_mayo_1_new(void) {
 	sig->length_signature = OQS_SIG_mayo_1_length_signature;
 
 	sig->keypair = OQS_SIG_mayo_1_keypair;
+	sig->keypair_from_fseed = OQS_SIG_mayo_1_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_mayo_1_pubkey_from_privkey;
 	sig->sign = OQS_SIG_mayo_1_sign;
 	sig->verify = OQS_SIG_mayo_1_verify;
 	sig->sign_with_ctx_str = OQS_SIG_mayo_1_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_mayo_1_new(void) {
 }
 
 extern int pqmayo_MAYO_1_opt_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_MAYO1_OPT_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_MAYO1_OPT_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqmayo_MAYO_1_opt_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqmayo_MAYO_1_opt_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_mayo_1_avx2)
 extern int pqmayo_MAYO_1_avx2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_MAYO1_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_MAYO1_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqmayo_MAYO_1_avx2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqmayo_MAYO_1_avx2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_mayo_1_keypair(uint8_t *public_key, uint8_t *secret_k
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) pqmayo_MAYO_1_opt_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_mayo_1_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_mayo_1_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_MAYO1_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_MAYO1_OPT_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_MAYO1_OPT_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_mayo_1_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_mayo_1_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_MAYO1_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_MAYO1_OPT_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_MAYO1_OPT_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/mayo/sig_mayo_2.c
+++ b/src/sig/mayo/sig_mayo_2.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_mayo_2_new(void) {
 	sig->length_signature = OQS_SIG_mayo_2_length_signature;
 
 	sig->keypair = OQS_SIG_mayo_2_keypair;
+	sig->keypair_from_fseed = OQS_SIG_mayo_2_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_mayo_2_pubkey_from_privkey;
 	sig->sign = OQS_SIG_mayo_2_sign;
 	sig->verify = OQS_SIG_mayo_2_verify;
 	sig->sign_with_ctx_str = OQS_SIG_mayo_2_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_mayo_2_new(void) {
 }
 
 extern int pqmayo_MAYO_2_opt_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_MAYO2_OPT_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_MAYO2_OPT_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqmayo_MAYO_2_opt_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqmayo_MAYO_2_opt_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_mayo_2_avx2)
 extern int pqmayo_MAYO_2_avx2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_MAYO2_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_MAYO2_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqmayo_MAYO_2_avx2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqmayo_MAYO_2_avx2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_mayo_2_keypair(uint8_t *public_key, uint8_t *secret_k
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) pqmayo_MAYO_2_opt_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_mayo_2_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_mayo_2_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_MAYO2_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_MAYO2_OPT_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_MAYO2_OPT_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_mayo_2_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_mayo_2_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_MAYO2_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_MAYO2_OPT_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_MAYO2_OPT_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/mayo/sig_mayo_3.c
+++ b/src/sig/mayo/sig_mayo_3.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_mayo_3_new(void) {
 	sig->length_signature = OQS_SIG_mayo_3_length_signature;
 
 	sig->keypair = OQS_SIG_mayo_3_keypair;
+	sig->keypair_from_fseed = OQS_SIG_mayo_3_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_mayo_3_pubkey_from_privkey;
 	sig->sign = OQS_SIG_mayo_3_sign;
 	sig->verify = OQS_SIG_mayo_3_verify;
 	sig->sign_with_ctx_str = OQS_SIG_mayo_3_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_mayo_3_new(void) {
 }
 
 extern int pqmayo_MAYO_3_opt_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_MAYO3_OPT_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_MAYO3_OPT_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqmayo_MAYO_3_opt_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqmayo_MAYO_3_opt_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_mayo_3_avx2)
 extern int pqmayo_MAYO_3_avx2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_MAYO3_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_MAYO3_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqmayo_MAYO_3_avx2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqmayo_MAYO_3_avx2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_mayo_3_keypair(uint8_t *public_key, uint8_t *secret_k
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) pqmayo_MAYO_3_opt_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_mayo_3_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_mayo_3_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_MAYO3_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_MAYO3_OPT_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_MAYO3_OPT_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_mayo_3_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_mayo_3_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_MAYO3_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_MAYO3_OPT_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_MAYO3_OPT_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/mayo/sig_mayo_5.c
+++ b/src/sig/mayo/sig_mayo_5.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_mayo_5_new(void) {
 	sig->length_signature = OQS_SIG_mayo_5_length_signature;
 
 	sig->keypair = OQS_SIG_mayo_5_keypair;
+	sig->keypair_from_fseed = OQS_SIG_mayo_5_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_mayo_5_pubkey_from_privkey;
 	sig->sign = OQS_SIG_mayo_5_sign;
 	sig->verify = OQS_SIG_mayo_5_verify;
 	sig->sign_with_ctx_str = OQS_SIG_mayo_5_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_mayo_5_new(void) {
 }
 
 extern int pqmayo_MAYO_5_opt_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_MAYO5_OPT_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_MAYO5_OPT_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqmayo_MAYO_5_opt_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqmayo_MAYO_5_opt_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_mayo_5_avx2)
 extern int pqmayo_MAYO_5_avx2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_MAYO5_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_MAYO5_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqmayo_MAYO_5_avx2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqmayo_MAYO_5_avx2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_mayo_5_keypair(uint8_t *public_key, uint8_t *secret_k
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) pqmayo_MAYO_5_opt_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_mayo_5_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_mayo_5_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_MAYO5_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_MAYO5_OPT_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_MAYO5_OPT_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_mayo_5_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_mayo_5_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_MAYO5_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_MAYO5_OPT_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_MAYO5_OPT_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/ml_dsa/sig_ml_dsa.h
+++ b/src/sig/ml_dsa/sig_ml_dsa.h
@@ -12,6 +12,8 @@
 
 OQS_SIG *OQS_SIG_ml_dsa_44_new(void);
 OQS_API OQS_STATUS OQS_SIG_ml_dsa_44_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_ml_dsa_44_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_ml_dsa_44_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_ml_dsa_44_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_ml_dsa_44_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_ml_dsa_44_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -25,6 +27,8 @@ OQS_API OQS_STATUS OQS_SIG_ml_dsa_44_verify_with_ctx_str(const uint8_t *message,
 
 OQS_SIG *OQS_SIG_ml_dsa_65_new(void);
 OQS_API OQS_STATUS OQS_SIG_ml_dsa_65_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_ml_dsa_65_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_ml_dsa_65_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_ml_dsa_65_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_ml_dsa_65_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_ml_dsa_65_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -38,6 +42,8 @@ OQS_API OQS_STATUS OQS_SIG_ml_dsa_65_verify_with_ctx_str(const uint8_t *message,
 
 OQS_SIG *OQS_SIG_ml_dsa_87_new(void);
 OQS_API OQS_STATUS OQS_SIG_ml_dsa_87_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_ml_dsa_87_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_ml_dsa_87_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_ml_dsa_87_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_ml_dsa_87_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_ml_dsa_87_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);

--- a/src/sig/ml_dsa/sig_ml_dsa_44.c
+++ b/src/sig/ml_dsa/sig_ml_dsa_44.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_ml_dsa_44_new(void) {
 	sig->length_signature = OQS_SIG_ml_dsa_44_length_signature;
 
 	sig->keypair = OQS_SIG_ml_dsa_44_keypair;
+	sig->keypair_from_fseed = OQS_SIG_ml_dsa_44_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_ml_dsa_44_pubkey_from_privkey;
 	sig->sign = OQS_SIG_ml_dsa_44_sign;
 	sig->verify = OQS_SIG_ml_dsa_44_verify;
 	sig->sign_with_ctx_str = OQS_SIG_ml_dsa_44_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_ml_dsa_44_new(void) {
 }
 
 extern int pqcrystals_ml_dsa_44_ref_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_MLDSA44_REF_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_MLDSA44_REF_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_ml_dsa_44_ref_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *sk);
 extern int pqcrystals_ml_dsa_44_ref_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_ml_dsa_44_avx2)
 extern int pqcrystals_ml_dsa_44_avx2_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_MLDSA44_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_MLDSA44_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_ml_dsa_44_avx2_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *sk);
 extern int pqcrystals_ml_dsa_44_avx2_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_ml_dsa_44_keypair(uint8_t *public_key, uint8_t *secre
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) pqcrystals_ml_dsa_44_ref_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_ml_dsa_44_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_ml_dsa_44_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_MLDSA44_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_MLDSA44_REF_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_MLDSA44_REF_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_ml_dsa_44_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_ml_dsa_44_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_MLDSA44_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_MLDSA44_REF_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_MLDSA44_REF_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/ml_dsa/sig_ml_dsa_65.c
+++ b/src/sig/ml_dsa/sig_ml_dsa_65.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_ml_dsa_65_new(void) {
 	sig->length_signature = OQS_SIG_ml_dsa_65_length_signature;
 
 	sig->keypair = OQS_SIG_ml_dsa_65_keypair;
+	sig->keypair_from_fseed = OQS_SIG_ml_dsa_65_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_ml_dsa_65_pubkey_from_privkey;
 	sig->sign = OQS_SIG_ml_dsa_65_sign;
 	sig->verify = OQS_SIG_ml_dsa_65_verify;
 	sig->sign_with_ctx_str = OQS_SIG_ml_dsa_65_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_ml_dsa_65_new(void) {
 }
 
 extern int pqcrystals_ml_dsa_65_ref_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_MLDSA65_REF_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_MLDSA65_REF_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_ml_dsa_65_ref_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *sk);
 extern int pqcrystals_ml_dsa_65_ref_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_ml_dsa_65_avx2)
 extern int pqcrystals_ml_dsa_65_avx2_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_MLDSA65_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_MLDSA65_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_ml_dsa_65_avx2_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *sk);
 extern int pqcrystals_ml_dsa_65_avx2_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_ml_dsa_65_keypair(uint8_t *public_key, uint8_t *secre
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) pqcrystals_ml_dsa_65_ref_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_ml_dsa_65_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_ml_dsa_65_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_MLDSA65_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_MLDSA65_REF_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_MLDSA65_REF_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_ml_dsa_65_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_ml_dsa_65_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_MLDSA65_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_MLDSA65_REF_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_MLDSA65_REF_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/ml_dsa/sig_ml_dsa_87.c
+++ b/src/sig/ml_dsa/sig_ml_dsa_87.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_ml_dsa_87_new(void) {
 	sig->length_signature = OQS_SIG_ml_dsa_87_length_signature;
 
 	sig->keypair = OQS_SIG_ml_dsa_87_keypair;
+	sig->keypair_from_fseed = OQS_SIG_ml_dsa_87_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_ml_dsa_87_pubkey_from_privkey;
 	sig->sign = OQS_SIG_ml_dsa_87_sign;
 	sig->verify = OQS_SIG_ml_dsa_87_verify;
 	sig->sign_with_ctx_str = OQS_SIG_ml_dsa_87_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_ml_dsa_87_new(void) {
 }
 
 extern int pqcrystals_ml_dsa_87_ref_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_MLDSA87_REF_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_MLDSA87_REF_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_ml_dsa_87_ref_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *sk);
 extern int pqcrystals_ml_dsa_87_ref_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_ml_dsa_87_avx2)
 extern int pqcrystals_ml_dsa_87_avx2_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_MLDSA87_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_MLDSA87_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int pqcrystals_ml_dsa_87_avx2_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *sk);
 extern int pqcrystals_ml_dsa_87_avx2_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *ctx, size_t ctxlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_ml_dsa_87_keypair(uint8_t *public_key, uint8_t *secre
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) pqcrystals_ml_dsa_87_ref_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_ml_dsa_87_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_ml_dsa_87_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_MLDSA87_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_MLDSA87_REF_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_MLDSA87_REF_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_ml_dsa_87_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_ml_dsa_87_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_MLDSA87_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_MLDSA87_REF_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_MLDSA87_REF_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/sig.c
+++ b/src/sig/sig.c
@@ -718,6 +718,22 @@ OQS_API OQS_STATUS OQS_SIG_keypair(const OQS_SIG *sig, uint8_t *public_key, uint
 	}
 }
 
+OQS_API OQS_STATUS OQS_SIG_keypair_from_fseed(const OQS_SIG *sig, uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+	if (sig == NULL || sig->keypair_from_fseed(public_key, secret_key, seed) != OQS_SUCCESS) {
+		return OQS_ERROR;
+	} else {
+		return OQS_SUCCESS;
+	}
+}
+
+OQS_API OQS_STATUS OQS_SIG_pubkey_from_privkey(const OQS_SIG *sig, uint8_t *public_key, const uint8_t *secret_key) {
+	if (sig == NULL || sig->pubkey_from_privkey(public_key, secret_key) != OQS_SUCCESS) {
+		return OQS_ERROR;
+	} else {
+		return OQS_SUCCESS;
+	}
+}
+
 OQS_API OQS_STATUS OQS_SIG_sign(const OQS_SIG *sig, uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key) {
 	if (sig == NULL || sig->sign(signature, signature_len, message, message_len, secret_key) != OQS_SUCCESS) {
 		return OQS_ERROR;

--- a/src/sig/sig.h
+++ b/src/sig/sig.h
@@ -203,6 +203,16 @@ typedef struct OQS_SIG {
 	OQS_STATUS (*keypair)(uint8_t *public_key, uint8_t *secret_key);
 
 	/**
+	 * Keypair generation algorithm but can generate keypair from fixed seed or other random source.
+	 */
+	OQS_STATUS (*keypair_from_fseed)(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+
+	/**
+	* Public key generation from exist private key.
+	*/
+	OQS_STATUS (*pubkey_from_privkey)(uint8_t *public_key, const uint8_t *secret_key);
+
+	/**
 	 * Signature generation algorithm.
 	 *
 	 * Caller is responsible for allocating sufficient memory for `signature`,
@@ -289,6 +299,16 @@ OQS_API OQS_SIG *OQS_SIG_new(const char *method_name);
  * @return OQS_SUCCESS or OQS_ERROR
  */
 OQS_API OQS_STATUS OQS_SIG_keypair(const OQS_SIG *sig, uint8_t *public_key, uint8_t *secret_key);
+
+/**
+ * Keypair generation algorithm but can generate keypair from fixed seed or other random source.
+ */
+OQS_API OQS_STATUS OQS_SIG_keypair_from_fseed(const OQS_SIG *sig, uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+
+/**
+ * Public key generation from exist private key.
+ */
+OQS_API OQS_STATUS OQS_SIG_pubkey_from_privkey(const OQS_SIG *sig, uint8_t *public_key, const uint8_t *secret_key);
 
 /**
  * Signature generation algorithm.

--- a/src/sig/sphincs/sig_sphincs.h
+++ b/src/sig/sphincs/sig_sphincs.h
@@ -12,6 +12,8 @@
 
 OQS_SIG *OQS_SIG_sphincs_sha2_128f_simple_new(void);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128f_simple_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128f_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128f_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128f_simple_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128f_simple_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128f_simple_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -25,6 +27,8 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128f_simple_verify_with_ctx_str(const ui
 
 OQS_SIG *OQS_SIG_sphincs_sha2_128s_simple_new(void);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128s_simple_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128s_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128s_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128s_simple_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128s_simple_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128s_simple_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -38,6 +42,8 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128s_simple_verify_with_ctx_str(const ui
 
 OQS_SIG *OQS_SIG_sphincs_sha2_192f_simple_new(void);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192f_simple_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192f_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192f_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192f_simple_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192f_simple_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192f_simple_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -51,6 +57,8 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192f_simple_verify_with_ctx_str(const ui
 
 OQS_SIG *OQS_SIG_sphincs_sha2_192s_simple_new(void);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192s_simple_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192s_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192s_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192s_simple_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192s_simple_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192s_simple_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -64,6 +72,8 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192s_simple_verify_with_ctx_str(const ui
 
 OQS_SIG *OQS_SIG_sphincs_sha2_256f_simple_new(void);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256f_simple_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256f_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256f_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256f_simple_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256f_simple_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256f_simple_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -77,6 +87,8 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256f_simple_verify_with_ctx_str(const ui
 
 OQS_SIG *OQS_SIG_sphincs_sha2_256s_simple_new(void);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256s_simple_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256s_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256s_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256s_simple_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256s_simple_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256s_simple_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -90,6 +102,8 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256s_simple_verify_with_ctx_str(const ui
 
 OQS_SIG *OQS_SIG_sphincs_shake_128f_simple_new(void);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128f_simple_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128f_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128f_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128f_simple_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128f_simple_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128f_simple_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -103,6 +117,8 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128f_simple_verify_with_ctx_str(const u
 
 OQS_SIG *OQS_SIG_sphincs_shake_128s_simple_new(void);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128s_simple_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128s_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128s_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128s_simple_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128s_simple_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128s_simple_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -116,6 +132,8 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128s_simple_verify_with_ctx_str(const u
 
 OQS_SIG *OQS_SIG_sphincs_shake_192f_simple_new(void);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192f_simple_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192f_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192f_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192f_simple_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192f_simple_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192f_simple_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -129,6 +147,8 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192f_simple_verify_with_ctx_str(const u
 
 OQS_SIG *OQS_SIG_sphincs_shake_192s_simple_new(void);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192s_simple_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192s_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192s_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192s_simple_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192s_simple_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192s_simple_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -142,6 +162,8 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192s_simple_verify_with_ctx_str(const u
 
 OQS_SIG *OQS_SIG_sphincs_shake_256f_simple_new(void);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256f_simple_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256f_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256f_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256f_simple_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256f_simple_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256f_simple_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);
@@ -155,6 +177,8 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256f_simple_verify_with_ctx_str(const u
 
 OQS_SIG *OQS_SIG_sphincs_shake_256s_simple_new(void);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256s_simple_keypair(uint8_t *public_key, uint8_t *secret_key);
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256s_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256s_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256s_simple_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256s_simple_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);
 OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256s_simple_sign_with_ctx_str(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx, size_t ctxlen, const uint8_t *secret_key);

--- a/src/sig/sphincs/sig_sphincs_sha2_128f_simple.c
+++ b/src/sig/sphincs/sig_sphincs_sha2_128f_simple.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_sphincs_sha2_128f_simple_new(void) {
 	sig->length_signature = OQS_SIG_sphincs_sha2_128f_simple_length_signature;
 
 	sig->keypair = OQS_SIG_sphincs_sha2_128f_simple_keypair;
+	sig->keypair_from_fseed = OQS_SIG_sphincs_sha2_128f_simple_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_sphincs_sha2_128f_simple_pubkey_from_privkey;
 	sig->sign = OQS_SIG_sphincs_sha2_128f_simple_sign;
 	sig->verify = OQS_SIG_sphincs_sha2_128f_simple_verify;
 	sig->sign_with_ctx_str = OQS_SIG_sphincs_sha2_128f_simple_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_sphincs_sha2_128f_simple_new(void) {
 }
 
 extern int PQCLEAN_SPHINCSSHA2128FSIMPLE_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHA2128FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHA2128FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2128FSIMPLE_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2128FSIMPLE_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_sphincs_sha2_128f_simple_avx2)
 extern int PQCLEAN_SPHINCSSHA2128FSIMPLE_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHA2128FSIMPLE_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHA2128FSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2128FSIMPLE_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2128FSIMPLE_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128f_simple_keypair(uint8_t *public_key,
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2128FSIMPLE_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128f_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_sphincs_sha2_128f_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2128FSIMPLE_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2128FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2128FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128f_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_sphincs_sha2_128f_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2128FSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2128FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2128FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/sphincs/sig_sphincs_sha2_128s_simple.c
+++ b/src/sig/sphincs/sig_sphincs_sha2_128s_simple.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_sphincs_sha2_128s_simple_new(void) {
 	sig->length_signature = OQS_SIG_sphincs_sha2_128s_simple_length_signature;
 
 	sig->keypair = OQS_SIG_sphincs_sha2_128s_simple_keypair;
+	sig->keypair_from_fseed = OQS_SIG_sphincs_sha2_128s_simple_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_sphincs_sha2_128s_simple_pubkey_from_privkey;
 	sig->sign = OQS_SIG_sphincs_sha2_128s_simple_sign;
 	sig->verify = OQS_SIG_sphincs_sha2_128s_simple_verify;
 	sig->sign_with_ctx_str = OQS_SIG_sphincs_sha2_128s_simple_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_sphincs_sha2_128s_simple_new(void) {
 }
 
 extern int PQCLEAN_SPHINCSSHA2128SSIMPLE_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHA2128SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHA2128SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2128SSIMPLE_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2128SSIMPLE_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_sphincs_sha2_128s_simple_avx2)
 extern int PQCLEAN_SPHINCSSHA2128SSIMPLE_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHA2128SSIMPLE_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHA2128SSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2128SSIMPLE_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2128SSIMPLE_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128s_simple_keypair(uint8_t *public_key,
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2128SSIMPLE_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128s_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_sphincs_sha2_128s_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2128SSIMPLE_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2128SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2128SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_128s_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_sphincs_sha2_128s_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2128SSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2128SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2128SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/sphincs/sig_sphincs_sha2_192f_simple.c
+++ b/src/sig/sphincs/sig_sphincs_sha2_192f_simple.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_sphincs_sha2_192f_simple_new(void) {
 	sig->length_signature = OQS_SIG_sphincs_sha2_192f_simple_length_signature;
 
 	sig->keypair = OQS_SIG_sphincs_sha2_192f_simple_keypair;
+	sig->keypair_from_fseed = OQS_SIG_sphincs_sha2_192f_simple_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_sphincs_sha2_192f_simple_pubkey_from_privkey;
 	sig->sign = OQS_SIG_sphincs_sha2_192f_simple_sign;
 	sig->verify = OQS_SIG_sphincs_sha2_192f_simple_verify;
 	sig->sign_with_ctx_str = OQS_SIG_sphincs_sha2_192f_simple_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_sphincs_sha2_192f_simple_new(void) {
 }
 
 extern int PQCLEAN_SPHINCSSHA2192FSIMPLE_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHA2192FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHA2192FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2192FSIMPLE_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2192FSIMPLE_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_sphincs_sha2_192f_simple_avx2)
 extern int PQCLEAN_SPHINCSSHA2192FSIMPLE_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHA2192FSIMPLE_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHA2192FSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2192FSIMPLE_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2192FSIMPLE_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192f_simple_keypair(uint8_t *public_key,
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2192FSIMPLE_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192f_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_sphincs_sha2_192f_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2192FSIMPLE_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2192FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2192FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192f_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_sphincs_sha2_192f_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2192FSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2192FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2192FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/sphincs/sig_sphincs_sha2_192s_simple.c
+++ b/src/sig/sphincs/sig_sphincs_sha2_192s_simple.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_sphincs_sha2_192s_simple_new(void) {
 	sig->length_signature = OQS_SIG_sphincs_sha2_192s_simple_length_signature;
 
 	sig->keypair = OQS_SIG_sphincs_sha2_192s_simple_keypair;
+	sig->keypair_from_fseed = OQS_SIG_sphincs_sha2_192s_simple_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_sphincs_sha2_192s_simple_pubkey_from_privkey;
 	sig->sign = OQS_SIG_sphincs_sha2_192s_simple_sign;
 	sig->verify = OQS_SIG_sphincs_sha2_192s_simple_verify;
 	sig->sign_with_ctx_str = OQS_SIG_sphincs_sha2_192s_simple_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_sphincs_sha2_192s_simple_new(void) {
 }
 
 extern int PQCLEAN_SPHINCSSHA2192SSIMPLE_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHA2192SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHA2192SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2192SSIMPLE_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2192SSIMPLE_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_sphincs_sha2_192s_simple_avx2)
 extern int PQCLEAN_SPHINCSSHA2192SSIMPLE_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHA2192SSIMPLE_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHA2192SSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2192SSIMPLE_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2192SSIMPLE_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192s_simple_keypair(uint8_t *public_key,
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2192SSIMPLE_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192s_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_sphincs_sha2_192s_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2192SSIMPLE_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2192SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2192SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_192s_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_sphincs_sha2_192s_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2192SSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2192SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2192SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/sphincs/sig_sphincs_sha2_256f_simple.c
+++ b/src/sig/sphincs/sig_sphincs_sha2_256f_simple.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_sphincs_sha2_256f_simple_new(void) {
 	sig->length_signature = OQS_SIG_sphincs_sha2_256f_simple_length_signature;
 
 	sig->keypair = OQS_SIG_sphincs_sha2_256f_simple_keypair;
+	sig->keypair_from_fseed = OQS_SIG_sphincs_sha2_256f_simple_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_sphincs_sha2_256f_simple_pubkey_from_privkey;
 	sig->sign = OQS_SIG_sphincs_sha2_256f_simple_sign;
 	sig->verify = OQS_SIG_sphincs_sha2_256f_simple_verify;
 	sig->sign_with_ctx_str = OQS_SIG_sphincs_sha2_256f_simple_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_sphincs_sha2_256f_simple_new(void) {
 }
 
 extern int PQCLEAN_SPHINCSSHA2256FSIMPLE_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHA2256FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHA2256FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2256FSIMPLE_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2256FSIMPLE_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_sphincs_sha2_256f_simple_avx2)
 extern int PQCLEAN_SPHINCSSHA2256FSIMPLE_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHA2256FSIMPLE_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHA2256FSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2256FSIMPLE_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2256FSIMPLE_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256f_simple_keypair(uint8_t *public_key,
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2256FSIMPLE_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256f_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_sphincs_sha2_256f_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2256FSIMPLE_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2256FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2256FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256f_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_sphincs_sha2_256f_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2256FSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2256FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2256FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/sphincs/sig_sphincs_sha2_256s_simple.c
+++ b/src/sig/sphincs/sig_sphincs_sha2_256s_simple.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_sphincs_sha2_256s_simple_new(void) {
 	sig->length_signature = OQS_SIG_sphincs_sha2_256s_simple_length_signature;
 
 	sig->keypair = OQS_SIG_sphincs_sha2_256s_simple_keypair;
+	sig->keypair_from_fseed = OQS_SIG_sphincs_sha2_256s_simple_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_sphincs_sha2_256s_simple_pubkey_from_privkey;
 	sig->sign = OQS_SIG_sphincs_sha2_256s_simple_sign;
 	sig->verify = OQS_SIG_sphincs_sha2_256s_simple_verify;
 	sig->sign_with_ctx_str = OQS_SIG_sphincs_sha2_256s_simple_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_sphincs_sha2_256s_simple_new(void) {
 }
 
 extern int PQCLEAN_SPHINCSSHA2256SSIMPLE_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHA2256SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHA2256SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2256SSIMPLE_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2256SSIMPLE_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_sphincs_sha2_256s_simple_avx2)
 extern int PQCLEAN_SPHINCSSHA2256SSIMPLE_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHA2256SSIMPLE_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHA2256SSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2256SSIMPLE_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHA2256SSIMPLE_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256s_simple_keypair(uint8_t *public_key,
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2256SSIMPLE_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256s_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_sphincs_sha2_256s_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2256SSIMPLE_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2256SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2256SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_sha2_256s_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_sphincs_sha2_256s_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2256SSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHA2256SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHA2256SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/sphincs/sig_sphincs_shake_128f_simple.c
+++ b/src/sig/sphincs/sig_sphincs_shake_128f_simple.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_sphincs_shake_128f_simple_new(void) {
 	sig->length_signature = OQS_SIG_sphincs_shake_128f_simple_length_signature;
 
 	sig->keypair = OQS_SIG_sphincs_shake_128f_simple_keypair;
+	sig->keypair_from_fseed = OQS_SIG_sphincs_shake_128f_simple_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_sphincs_shake_128f_simple_pubkey_from_privkey;
 	sig->sign = OQS_SIG_sphincs_shake_128f_simple_sign;
 	sig->verify = OQS_SIG_sphincs_shake_128f_simple_verify;
 	sig->sign_with_ctx_str = OQS_SIG_sphincs_shake_128f_simple_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_sphincs_shake_128f_simple_new(void) {
 }
 
 extern int PQCLEAN_SPHINCSSHAKE128FSIMPLE_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHAKE128FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHAKE128FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE128FSIMPLE_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE128FSIMPLE_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_sphincs_shake_128f_simple_avx2)
 extern int PQCLEAN_SPHINCSSHAKE128FSIMPLE_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHAKE128FSIMPLE_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHAKE128FSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE128FSIMPLE_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE128FSIMPLE_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128f_simple_keypair(uint8_t *public_key
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE128FSIMPLE_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128f_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_sphincs_shake_128f_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE128FSIMPLE_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE128FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE128FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128f_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_sphincs_shake_128f_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE128FSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE128FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE128FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/sphincs/sig_sphincs_shake_128s_simple.c
+++ b/src/sig/sphincs/sig_sphincs_shake_128s_simple.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_sphincs_shake_128s_simple_new(void) {
 	sig->length_signature = OQS_SIG_sphincs_shake_128s_simple_length_signature;
 
 	sig->keypair = OQS_SIG_sphincs_shake_128s_simple_keypair;
+	sig->keypair_from_fseed = OQS_SIG_sphincs_shake_128s_simple_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_sphincs_shake_128s_simple_pubkey_from_privkey;
 	sig->sign = OQS_SIG_sphincs_shake_128s_simple_sign;
 	sig->verify = OQS_SIG_sphincs_shake_128s_simple_verify;
 	sig->sign_with_ctx_str = OQS_SIG_sphincs_shake_128s_simple_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_sphincs_shake_128s_simple_new(void) {
 }
 
 extern int PQCLEAN_SPHINCSSHAKE128SSIMPLE_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHAKE128SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHAKE128SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE128SSIMPLE_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE128SSIMPLE_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_sphincs_shake_128s_simple_avx2)
 extern int PQCLEAN_SPHINCSSHAKE128SSIMPLE_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHAKE128SSIMPLE_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHAKE128SSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE128SSIMPLE_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE128SSIMPLE_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128s_simple_keypair(uint8_t *public_key
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE128SSIMPLE_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128s_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_sphincs_shake_128s_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE128SSIMPLE_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE128SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE128SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_128s_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_sphincs_shake_128s_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE128SSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE128SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE128SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/sphincs/sig_sphincs_shake_192f_simple.c
+++ b/src/sig/sphincs/sig_sphincs_shake_192f_simple.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_sphincs_shake_192f_simple_new(void) {
 	sig->length_signature = OQS_SIG_sphincs_shake_192f_simple_length_signature;
 
 	sig->keypair = OQS_SIG_sphincs_shake_192f_simple_keypair;
+	sig->keypair_from_fseed = OQS_SIG_sphincs_shake_192f_simple_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_sphincs_shake_192f_simple_pubkey_from_privkey;
 	sig->sign = OQS_SIG_sphincs_shake_192f_simple_sign;
 	sig->verify = OQS_SIG_sphincs_shake_192f_simple_verify;
 	sig->sign_with_ctx_str = OQS_SIG_sphincs_shake_192f_simple_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_sphincs_shake_192f_simple_new(void) {
 }
 
 extern int PQCLEAN_SPHINCSSHAKE192FSIMPLE_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHAKE192FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHAKE192FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE192FSIMPLE_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE192FSIMPLE_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_sphincs_shake_192f_simple_avx2)
 extern int PQCLEAN_SPHINCSSHAKE192FSIMPLE_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHAKE192FSIMPLE_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHAKE192FSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE192FSIMPLE_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE192FSIMPLE_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192f_simple_keypair(uint8_t *public_key
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE192FSIMPLE_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192f_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_sphincs_shake_192f_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE192FSIMPLE_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE192FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE192FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192f_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_sphincs_shake_192f_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE192FSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE192FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE192FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/sphincs/sig_sphincs_shake_192s_simple.c
+++ b/src/sig/sphincs/sig_sphincs_shake_192s_simple.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_sphincs_shake_192s_simple_new(void) {
 	sig->length_signature = OQS_SIG_sphincs_shake_192s_simple_length_signature;
 
 	sig->keypair = OQS_SIG_sphincs_shake_192s_simple_keypair;
+	sig->keypair_from_fseed = OQS_SIG_sphincs_shake_192s_simple_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_sphincs_shake_192s_simple_pubkey_from_privkey;
 	sig->sign = OQS_SIG_sphincs_shake_192s_simple_sign;
 	sig->verify = OQS_SIG_sphincs_shake_192s_simple_verify;
 	sig->sign_with_ctx_str = OQS_SIG_sphincs_shake_192s_simple_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_sphincs_shake_192s_simple_new(void) {
 }
 
 extern int PQCLEAN_SPHINCSSHAKE192SSIMPLE_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHAKE192SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHAKE192SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE192SSIMPLE_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE192SSIMPLE_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_sphincs_shake_192s_simple_avx2)
 extern int PQCLEAN_SPHINCSSHAKE192SSIMPLE_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHAKE192SSIMPLE_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHAKE192SSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE192SSIMPLE_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE192SSIMPLE_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192s_simple_keypair(uint8_t *public_key
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE192SSIMPLE_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192s_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_sphincs_shake_192s_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE192SSIMPLE_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE192SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE192SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_192s_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_sphincs_shake_192s_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE192SSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE192SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE192SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/sphincs/sig_sphincs_shake_256f_simple.c
+++ b/src/sig/sphincs/sig_sphincs_shake_256f_simple.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_sphincs_shake_256f_simple_new(void) {
 	sig->length_signature = OQS_SIG_sphincs_shake_256f_simple_length_signature;
 
 	sig->keypair = OQS_SIG_sphincs_shake_256f_simple_keypair;
+	sig->keypair_from_fseed = OQS_SIG_sphincs_shake_256f_simple_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_sphincs_shake_256f_simple_pubkey_from_privkey;
 	sig->sign = OQS_SIG_sphincs_shake_256f_simple_sign;
 	sig->verify = OQS_SIG_sphincs_shake_256f_simple_verify;
 	sig->sign_with_ctx_str = OQS_SIG_sphincs_shake_256f_simple_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_sphincs_shake_256f_simple_new(void) {
 }
 
 extern int PQCLEAN_SPHINCSSHAKE256FSIMPLE_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHAKE256FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHAKE256FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE256FSIMPLE_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE256FSIMPLE_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_sphincs_shake_256f_simple_avx2)
 extern int PQCLEAN_SPHINCSSHAKE256FSIMPLE_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHAKE256FSIMPLE_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHAKE256FSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE256FSIMPLE_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE256FSIMPLE_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256f_simple_keypair(uint8_t *public_key
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE256FSIMPLE_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256f_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_sphincs_shake_256f_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE256FSIMPLE_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE256FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE256FSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256f_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_sphincs_shake_256f_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE256FSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE256FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE256FSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 

--- a/src/sig/sphincs/sig_sphincs_shake_256s_simple.c
+++ b/src/sig/sphincs/sig_sphincs_shake_256s_simple.c
@@ -23,6 +23,8 @@ OQS_SIG *OQS_SIG_sphincs_shake_256s_simple_new(void) {
 	sig->length_signature = OQS_SIG_sphincs_shake_256s_simple_length_signature;
 
 	sig->keypair = OQS_SIG_sphincs_shake_256s_simple_keypair;
+	sig->keypair_from_fseed = OQS_SIG_sphincs_shake_256s_simple_keypair_from_fseed;
+	sig->pubkey_from_privkey = OQS_SIG_sphincs_shake_256s_simple_pubkey_from_privkey;
 	sig->sign = OQS_SIG_sphincs_shake_256s_simple_sign;
 	sig->verify = OQS_SIG_sphincs_shake_256s_simple_verify;
 	sig->sign_with_ctx_str = OQS_SIG_sphincs_shake_256s_simple_sign_with_ctx_str;
@@ -32,11 +34,15 @@ OQS_SIG *OQS_SIG_sphincs_shake_256s_simple_new(void) {
 }
 
 extern int PQCLEAN_SPHINCSSHAKE256SSIMPLE_CLEAN_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHAKE256SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHAKE256SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE256SSIMPLE_CLEAN_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE256SSIMPLE_CLEAN_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_sphincs_shake_256s_simple_avx2)
 extern int PQCLEAN_SPHINCSSHAKE256SSIMPLE_AVX2_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_SPHINCSSHAKE256SSIMPLE_AVX2_crypto_sign_keypair_from_fseed(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+extern int PQCLEAN_SPHINCSSHAKE256SSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(uint8_t *pk, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE256SSIMPLE_AVX2_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_SPHINCSSHAKE256SSIMPLE_AVX2_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -54,6 +60,38 @@ OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256s_simple_keypair(uint8_t *public_key
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE256SSIMPLE_CLEAN_crypto_sign_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256s_simple_keypair_from_fseed(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_sphincs_shake_256s_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE256SSIMPLE_AVX2_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE256SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE256SSIMPLE_CLEAN_crypto_sign_keypair_from_fseed(public_key, secret_key, seed);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_sphincs_shake_256s_simple_pubkey_from_privkey(uint8_t *public_key, const uint8_t *secret_key) {
+#if defined(OQS_ENABLE_SIG_sphincs_shake_256s_simple_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE256SSIMPLE_AVX2_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE256SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) PQCLEAN_SPHINCSSHAKE256SSIMPLE_CLEAN_crypto_sign_pubkey_from_privkey(public_key, secret_key);
 #endif
 }
 


### PR DESCRIPTION
extended api for allow use fixed seed for generate key pair and generate public key from private key in Signature schemes

in this case we pass the seed as a parame.

`OQS_SIG_keypair_from_fseed(const OQS_SIG *sig, uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);`

in this case we pass the private key as a param.

`OQS_SIG_pubkey_from_privkey(const OQS_SIG *sig, uint8_t *public_key, const uint8_t *secret_key);`

falcon and dilithium at this moment - all versions. But can be done for other algos to.

"issue #2030"

old pull request  https://github.com/open-quantum-safe/liboqs/pull/2027 , recreated for with correct style.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [x] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

it's extended api , but not affect native support old functions.

