### PR TITLE
Update to public Ubuntu 24.04 ARM runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,12 +1,12 @@
 # Labels of self-hosted runner in array of strings.
 
-# NB. oqs-arm64 is not self-hosted but this configuration
+# NB. ubuntu-24.04-arm is not self-hosted but this configuration
 #     is required for liboqs to lint correctly with actionlint v1.7.1
 
 self-hosted-runner:
   # Labels of self-hosted runner in array of string
   labels:
-    - oqs-arm64
+    - ubuntu-24.04-arm
 # Configuration variables in array of strings defined in your repository or organization
 config-variables:
   # - DEFAULT_RUNNER

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - name: arm64
-            runner: oqs-arm64
+            runner: ubuntu-24.04-arm
             container: openquantumsafe/ci-ubuntu-latest:latest
             PYTEST_ARGS: --maxprocesses=10 --ignore=tests/test_kat_all.py
             CMAKE_ARGS: -DOQS_ENABLE_SIG_STFL_LMS=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

The GitHub ARM runners are now available to the general public.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

Related: https://github.com/open-quantum-safe/oqs-demos/issues/332.

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

