### PR TITLE
Fix failing zephyr CI workflows, pinning v0.27.4

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -9,7 +9,7 @@ jobs:
 
   zephyr_test:
     runs-on: ubuntu-22.04
-    container: ghcr.io/zephyrproject-rtos/ci:latest
+    container: ghcr.io/zephyrproject-rtos/ci:v0.27.4
     env:
         CMAKE_PREFIX_PATH: /opt/toolchains
     strategy:


### PR DESCRIPTION
The Zephyr build has been failing for the past week during CI [initialization of the container](https://github.com/open-quantum-safe/liboqs/actions/runs/13038661455/job/36375179162).

The failure seems to correlate with the "latest" update to the Zephyr container that occurred 6 days ago: https://github.com/zephyrproject-rtos/docker-image/pkgs/container/ci.

The PR fixes the failing zephyr worflow by pinning the Zephyr container to the latest release 0.27.4, which would bring CI to a better state. However, CI overall is still failing due to https://github.com/open-quantum-safe/liboqs/issues/2056.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

