### PR TITLE
GitHub runner updates

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,13 +1,6 @@
-# Labels of self-hosted runner in array of strings.
-
-# NB. ubuntu-24.04-arm is not self-hosted but this configuration
-#     is required for liboqs to lint correctly with actionlint v1.7.1
-
-self-hosted-runner:
-  # Labels of self-hosted runner in array of string
-  labels:
-    - ubuntu-24.04-arm
 # Configuration variables in array of strings defined in your repository or organization
+# From https://github.com/rhysd/actionlint/blob/v1.7.7/docs/config.md:
+# "When an array is set, actionlint will check vars properties strictly. An empty array means no variable is allowed."
 config-variables:
   # - DEFAULT_RUNNER
   # - JOB_NAME

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ jobs:
           - macos-15
         CMAKE_ARGS:
           - -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-          - -DCMAKE_C_COMPILER=gcc
+          - -DCMAKE_C_COMPILER=gcc-14
           - -DOQS_USE_OPENSSL=OFF
           - -DBUILD_SHARED_LIBS=ON -DOQS_DIST_BUILD=OFF
         libjade-build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,12 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # macos-14 runs on aarch64; the others run on x64
+          # macos-13 runs on x64; the others run on aarch64
           - macos-13
           - macos-14
+          - macos-15
         CMAKE_ARGS:
           - -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-          - -DCMAKE_C_COMPILER=gcc-13
+          - -DCMAKE_C_COMPILER=gcc-14
           - -DOQS_USE_OPENSSL=OFF
           - -DBUILD_SHARED_LIBS=ON -DOQS_DIST_BUILD=OFF
         libjade-build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ jobs:
           - macos-15
         CMAKE_ARGS:
           - -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-          - -DCMAKE_C_COMPILER=gcc-14
+          - -DCMAKE_C_COMPILER=gcc
           - -DOQS_USE_OPENSSL=OFF
           - -DBUILD_SHARED_LIBS=ON -DOQS_DIST_BUILD=OFF
         libjade-build:
@@ -27,9 +27,11 @@ jobs:
           # libjade to minimise repeated tests
           - -DOQS_LIBJADE_BUILD=ON -DOQS_MINIMAL_BUILD="${{ vars.LIBJADE_ALG_LIST }}"
         exclude:
-          # macos-14 runs on aarch64, libjade targets x86
+          # macos-14 and macos-15 run on aarch64, libjade targets x86
           # Skip testing libjade on macos-14
           - os: macos-14
+            libjade-build: -DOQS_LIBJADE_BUILD=ON -DOQS_MINIMAL_BUILD="${{ vars.LIBJADE_ALG_LIST }}"
+          - os: macos-15
             libjade-build: -DOQS_LIBJADE_BUILD=ON -DOQS_MINIMAL_BUILD="${{ vars.LIBJADE_ALG_LIST }}"
           # No point in testing stateful sigs with minimal libjade build
           - libjade-build: -DOQS_LIBJADE_BUILD=ON -DOQS_MINIMAL_BUILD="${{ vars.LIBJADE_ALG_LIST }}"
@@ -44,8 +46,6 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
       - name: Install dependencies
         run: env HOMEBREW_NO_AUTO_UPDATE=1 brew install ninja && pip3 install --require-hashes --break-system-packages -r .github/workflows/requirements.txt
-      - name: Patch GCC
-        run: env HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall --ignore-dependencies gcc@13 && wget https://raw.githubusercontent.com/Homebrew/homebrew-core/eb6dd225d093b66054e18e07d56509cf670793b1/Formula/g/gcc%4013.rb && env HOMEBREW_NO_AUTO_UPDATE=1 brew install --ignore-dependencies --formula gcc@13.rb
       - name: Get system information
         run: sysctl -a | grep machdep.cpu
       - name: Configure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ on: [workflow_call, workflow_dispatch]
 jobs:
 
   windows-arm64:
-    runs-on: windows-2022
+    runs-on: [windows-2022, windows-2025]
     strategy:
       matrix:
         stfl_opt: [ON, OFF]
@@ -20,7 +20,7 @@ jobs:
         run: cmake --build build
 
   windows-x86:
-    runs-on: windows-2022
+    runs-on: [windows-2022, windows-2025]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,10 +8,11 @@ on: [workflow_call, workflow_dispatch]
 jobs:
 
   windows-arm64:
-    runs-on: [windows-2022, windows-2025]
     strategy:
       matrix:
+        runner: [windows-2022, windows-2025]
         stfl_opt: [ON, OFF]
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
       - name: Generate Project
@@ -20,12 +21,13 @@ jobs:
         run: cmake --build build
 
   windows-x86:
-    runs-on: [windows-2022, windows-2025]
     strategy:
       fail-fast: false
       matrix:
+        runner: [windows-2022, windows-2025]
         toolchain: [.CMake/toolchain_windows_x86.cmake, .CMake/toolchain_windows_amd64.cmake]
         stfl_opt: [ON, OFF]
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Install Python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # pin@v5

--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -45,14 +45,14 @@ In this policy, the words "must" and "must not" specify absolute requirements th
 ### Tier 1
 
 - x86_64/amd64/x64 for Ubuntu Linux (Noble)†
-- x86_64/amd64/x64 for MacOS (XCode 14 and 15)
+- x86_64/amd64/x64 for MacOS (XCode 15)
 - aarch64 for Ubuntu (Noble)
-- aarch64 for MacOS (XCode 15)
+- aarch64 for MacOS (XCode 15 and 16)
 - armhf/ARM7 and aarch64 emulation on Ubuntu
 
 ### Tier 2
 
-- x86_64/amd64/x64 for Windows (Visual Studio Toolchain) 2022
+- x86_64/amd64/x64 for Windows (Visual Studio Toolchain) 2022 and 2025
 - armeabi-v7a, arm64-v8a, x86, x86_64 for Android
 - aarch64 for Apple iOS and tvOS (CMake `-DPLATFORM=OS64` and `TVOS`)
 - arm64, arm (32 bit), x86, x86_64, riscv32, riscv64 for Zephyr


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
This PR does the following:
- Adds the new (beta) GitHub runners for Windows 2025 and macOS 15.
- Updates PLATFORMS.md accordingly.
- Sets macOS runners to use gcc-14 (now supported by all runners) instead of gcc-13.
- Removes the GCC 13 patching logic from CI.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

Closes #1804.

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

