### PR TITLE
Add references to security response process

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -10,6 +10,8 @@ This classification is roughly based on the [rust platform support tier classifi
 
 Tier 1 targets can be thought of as "guaranteed to work". The CI system builds and tests binary versions for each tier 1 target to make sure any change does not negatively affect those platforms. Platform-specific build documentation must exist. Tier 1 targets marked with a dagger (†) are additionally tested for constant-time behaviour. The CI system contains automated constant-time testing for each of these starred targets, and all failures are documented in the `tests/constant_time` directory. IMPORTANT: This does not mean that constant-time behaviour is guaranteed on these targets, or that non-constant-time behaviour is limited to documented exceptions. It does, however, mean that `liboqs` developers should track constant-time issues on these platforms.
 
+Tier 1 platforms are also prioritized for security support, as per the [OQS security response process](https://github.com/open-quantum-safe/tsc/blob/main/security/response-process.md).
+
 ### Tier 2
 
 Tier 2 targets can be thought of as "guaranteed to build". The `liboqs` CI system contains builds for each tier 2 target; testing may or may not be available (typically depending on CI system platform availability). Therefore, tier 2 targets often work to quite a good degree and patches are always welcome! Tier 2 targets may also have known deficiencies caused by a lack of expertise to fix those on a given platform. Again, help and PRs to move platforms from tier 2 to tier 1 are always welcome.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ We realize some parties may want to deploy quantum-safe cryptography prior to th
 
 **WE DO NOT CURRENTLY RECOMMEND RELYING ON THIS LIBRARY IN A PRODUCTION ENVIRONMENT OR TO PROTECT ANY SENSITIVE DATA.** This library is meant to help with research and prototyping.  While we make a best-effort approach to avoid security bugs, this library has not received the level of auditing and analysis that would be necessary to rely on it for high security use.
 
+Please see [SECURITY.md](SECURITY.md) for details on how to report a vulnerability and the OQS vulnerability response process.
+
 #### Platform limitations
 
 In order to optimize support effort,

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ We realize some parties may want to deploy quantum-safe cryptography prior to th
 
 **WE DO NOT CURRENTLY RECOMMEND RELYING ON THIS LIBRARY IN A PRODUCTION ENVIRONMENT OR TO PROTECT ANY SENSITIVE DATA.** This library is meant to help with research and prototyping.  While we make a best-effort approach to avoid security bugs, this library has not received the level of auditing and analysis that would be necessary to rely on it for high security use.
 
-Please see [SECURITY.md](SECURITY.md) for details on how to report a vulnerability and the OQS vulnerability response process.
+Please see [SECURITY.md](SECURITY.md#security-policy) for details on how to report a vulnerability and the OQS vulnerability response process.
 
 #### Platform limitations
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 We only support the most recent release.
 
-Using any code prior to 0.10.1 is strongly discouraged due to a [known security vulnerability in Kyber](https://github.com/open-quantum-safe/liboqs/releases/tag/0.10.1).
+Using any code prior to 0.12.0 is strongly discouraged due to a [known security vulnerability in HQC](https://github.com/open-quantum-safe/liboqs/security/advisories/GHSA-gpf4-vrrw-r8v7).
 
 | Version | Supported          |
 | ------- | ------------------ |
@@ -29,3 +29,7 @@ The following types of attacks are outside the scope of our threat model:
 Mitigations for security issues outside the stated threat model may still be applied depending on the nature of the issue and the mitigation.
 
 (Based in part on https://openssl-library.org/policies/general/security-policy/index.html)
+
+## Security Response Process
+
+Security reports for liboqs will be handled in accordance with the [OQS security response process](https://github.com/open-quantum-safe/tsc/blob/main/security/response-process.md).

--- a/docs/.Doxyfile
+++ b/docs/.Doxyfile
@@ -960,6 +960,7 @@ INPUT                  = src/common/aes/aes_ops.h \
                          src/sig_stfl/sig_stfl.h \
                          README.md \
                          CONFIGURE.md \
+                         SECURITY.md \
                          CONTRIBUTORS
 
 # This tag can be used to specify the character encoding of the source files

--- a/scripts/run_doxygen.sh
+++ b/scripts/run_doxygen.sh
@@ -8,10 +8,11 @@ if [ "$#" -ne 3 ]; then
 fi
 
 # Doxygen can't handle Github Markdown so we temporarily reformat it
-cp README.md README.md-orig
-python3 scripts/doxyfy.py README.md-orig README.md
-cp CONFIGURE.md CONFIGURE.md-orig
-python3 scripts/doxyfy.py CONFIGURE.md-orig CONFIGURE.md
+for file in README.md CONFIGURE.md SECURITY.md
+do
+	cp $file $file-orig
+	python3 scripts/doxyfy.py $file-orig $file
+done
 
 # run doxygen:
 mkdir -p "$3/docs"
@@ -19,7 +20,9 @@ env DOXYGEN_DESTIONATION_DIR="$3/docs" "$1" "$2"
 EXITCODE=$?
 
 # undo the Github Markdown reformatting
-mv README.md-orig README.md
-mv CONFIGURE.md-orig CONFIGURE.md
+for file in README.md CONFIGURE.md SECURITY.md
+do
+	mv $file-orig $file
+done
 
 exit ${EXITCODE}


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

- Adds references to the future OQS security response process document in README.md and SECURITY.md.
- Updates SECURITY.md to discourage releases below 0.12.0 due to the HQC vulnerability.

Not to be merged until https://github.com/open-quantum-safe/tsc/pull/124 lands.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

