### PR TITLE
Added Kyber implementation details to test_kem.c

### DIFF
--- a/tests/test_kem.c
+++ b/tests/test_kem.c
@@ -149,8 +149,68 @@ static OQS_STATUS kem_test_correctness(const char *method_name) {
 		goto err;
 	}
 
+	// Check KEM implementation
+	const char *implementation = NULL;
+
+#if defined(OQS_ENABLE_LIBJADE_KEM_kyber_512_avx2)
+	if (strcasecmp(method_name, OQS_KEM_alg_kyber_512) == 0) {
+		implementation = "src/kem/kyber/libjade_kyber512_avx2";
+	}
+#elif defined(OQS_ENABLE_LIBJADE_KEM_kyber_512)
+	if (strcasecmp(method_name, OQS_KEM_alg_kyber_512) == 0) {
+		implementation = "src/kem/kyber/libjade_kyber512_ref";
+	}
+#elif defined(OQS_ENABLE_KEM_kyber_512_avx2)
+	if (strcasecmp(method_name, OQS_KEM_alg_kyber_512) == 0) {
+		implementation = "src/kem/kyber/pqcrystals-kyber_kyber512_avx2";
+	}
+#elif defined(OQS_ENABLE_KEM_kyber_512_aarch64)
+	if (strcasecmp(method_name, OQS_KEM_alg_kyber_512) == 0) {
+		implementation = "src/kem/kyber/oldpqclean_kyber512_aarch64";
+	}
+#endif
+
+#if defined(OQS_ENABLE_LIBJADE_KEM_kyber_768_avx2)
+	if (strcasecmp(method_name, OQS_KEM_alg_kyber_768) == 0) {
+		implementation = "src/kem/kyber/libjade_kyber768_avx2";
+	}
+#elif defined(OQS_ENABLE_LIBJADE_KEM_kyber_768)
+	if (strcasecmp(method_name, OQS_KEM_alg_kyber_768) == 0) {
+		implementation = "src/kem/kyber/libjade_kyber768_ref";
+	}
+#elif defined(OQS_ENABLE_KEM_kyber_768_avx2)
+	if (strcasecmp(method_name, OQS_KEM_alg_kyber_768) == 0) {
+		implementation = "src/kem/kyber/pqcrystals-kyber_kyber768_avx2";
+	}
+#elif defined(OQS_ENABLE_KEM_kyber_768)
+	if (strcasecmp(method_name, OQS_KEM_alg_kyber_768) == 0) {
+		implementation = "src/kem/kyber/pqcrystals-kyber_kyber768_ref";
+	}
+#elif defined(OQS_ENABLE_KEM_kyber_768_aarch64)
+	if (strcasecmp(method_name, OQS_KEM_alg_kyber_768) == 0) {
+		implementation = "src/kem/kyber/oldpqclean_kyber768_aarch64";
+	}
+#endif
+
+#if defined(OQS_ENABLE_KEM_kyber_1024_avx2)
+	if (strcasecmp(method_name, OQS_KEM_alg_kyber_1024) == 0) {
+		implementation = "src/kem/kyber/pqcrystals-kyber_kyber1024_avx2";
+	}
+#elif defined(OQS_ENABLE_KEM_kyber_1024_aarch64)
+	if (strcasecmp(method_name, OQS_KEM_alg_kyber_1024) == 0) {
+		implementation = "src/kem/kyber/oldpqclean_kyber1024_aarch64";
+	}
+#elif defined(OQS_ENABLE_KEM_kyber_1024)
+	if (strcasecmp(method_name, OQS_KEM_alg_kyber_1024) == 0) {
+		implementation = "src/kem/kyber/pqcrystals-kyber_kyber1024_ref";
+	}
+#else
+	implementation = "Unknown";
+#endif
+
 	printf("================================================================================\n");
 	printf("Sample computation for KEM %s\n", kem->method_name);
+	printf("Implementation source: %s\n", implementation);
 	printf("================================================================================\n");
 
 	public_key = OQS_MEM_malloc(kem->length_public_key + 2 * sizeof(magic_t));


### PR DESCRIPTION
This PR aims to fix #1786 by including the implementation path in the test_kem.c file for Kyber implementations. Before moving forward with other algorithms, I would like to confirm if this approach is correct and if the referenced implementation path aligns with the information requested in the issue.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)