### PR TITLE
Ensure that building against liboqs build directory works

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -190,6 +190,6 @@ install(FILES ${PUBLIC_HEADERS}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/oqs)
 
 export(EXPORT liboqsTargets
-       FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/liboqsTargets.cmake"
+       FILE "${CMAKE_CURRENT_BINARY_DIR}/liboqsTargets.cmake"
        NAMESPACE OQS::
 )


### PR DESCRIPTION
liboqsTargets.cmake is supposed to be adjacent liboqsConfig.cmake for the
latter to be functional.  This change ensure that this condition is met in
the build directory, allowing other CMake projects to build against a liboqs
build directory (as should be possible, implied by the use of 'export()').
