### PR TITLE
Update nist-round in UOV and MAYO data sheet

### DIFF
--- a/docs/algorithms/sig/mayo.yml
+++ b/docs/algorithms/sig/mayo.yml
@@ -8,7 +8,7 @@ principal-submitters:
 - Matthias J. Kannwischer
 crypto-assumption: multivariable quadratic equations, oil and vinegar
 website: https://pqmayo.org
-nist-round: 1
+nist-round: 2
 spec-version: NIST Round 2 (February 2025)
 primary-upstream:
   source: https://github.com/PQCMayo/MAYO-C/commit/4b7cd94c96b9522864efe40c6ad1fa269584a807

--- a/docs/algorithms/sig/uov.yml
+++ b/docs/algorithms/sig/uov.yml
@@ -14,7 +14,7 @@ principal-submitters:
 - Bo-Yin Yang
 crypto-assumption: multivariable quadratic equations, oil and vinegar
 website: https://www.uovsig.org/
-nist-round: 1
+nist-round: 2
 spec-version: NIST Round 2 (February 2025)
 primary-upstream:
   source: https://github.com/pqov/pqov/commit/7e0832b6732a476119742c4acabd11b7c767aefb


### PR DESCRIPTION
Fix in UOV and MAYO data sheet: nist-round should be 2
