### PR TITLE
Restrict -Wno-maybe-uninitialized to GCC and fix stack size typo

### DIFF
--- a/.CMake/compiler_opts.cmake
+++ b/.CMake/compiler_opts.cmake
@@ -207,11 +207,14 @@ endif()
 
 if(MINGW OR MSYS OR CYGWIN)
     set(OQS_USE_PTHREADS OFF)
-    add_compile_options(-Wno-maybe-uninitialized)
+    # Apply -Wno-maybe-uninitialized only for GCC
+    if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+        add_compile_options(-Wno-maybe-uninitialized)
+    endif()
     if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.13.0")
         add_link_options(-Wl,--stack,16777216)
     else()
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--stack,1677216")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--stack,16777216")
     endif()
 endif()
 


### PR DESCRIPTION
This PR:
1. Restricts `-Wno-maybe-uninitialized` to GCC, fixing Clang warnings on Windows (e.g., MSYS2).
2. Fixes stack size typo from `1677216` to `16777216` (16MB) for consistency.

Fixes #2108


### Changes
- Restricted `-Wno-maybe-uninitialized` to GCC with `CMAKE_C_COMPILER_ID STREQUAL "GNU"`.
- Corrected stack size in `CMAKE_EXE_LINKER_FLAGS` to `16777216`.
