### PR TITLE
Promote @SWilson4 from Committer to Maintainer [skip ci]

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -108,6 +108,7 @@ Votes are to be executed by way of open GitHub discussions. No quorum is needed 
 @dstebila
 @Martyrshot
 @praveksharma
+@SWilson4
 @vsoftco
 
 ## Former Maintainers and Committers

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -106,10 +106,17 @@ Votes are to be executed by way of open GitHub discussions. No quorum is needed 
 @bhess
 @christianpaquin
 @dstebila
-@jschanck
 @Martyrshot
 @praveksharma
 @vsoftco
+
+## Former Maintainers and Committers
+
+OQS is grateful to the following individuals who have previously served as Maintainers or Committers for liboqs.
+
+### Former Committers
+
+@jschanck
 
 ## Afterword
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -96,13 +96,13 @@ Votes are to be executed by way of open GitHub discussions. No quorum is needed 
 
 ### Maintainers
 
-@baentsch
+@baentsch (on leave of absence as of March 11, 2025)
 @dstebila
 @SWilson4
 
 ### Committers
 
-@baentsch
+@baentsch (on leave of absence as of March 11, 2025)
 @bhess
 @christianpaquin
 @dstebila

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -98,6 +98,7 @@ Votes are to be executed by way of open GitHub discussions. No quorum is needed 
 
 @baentsch
 @dstebila
+@SWilson4
 
 ### Committers
 
@@ -108,7 +109,6 @@ Votes are to be executed by way of open GitHub discussions. No quorum is needed 
 @jschanck
 @Martyrshot
 @praveksharma
-@swilson4
 @vsoftco
 
 ## Afterword


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

As per the April 1 TSC meeting, I've offered to step up as a maintainer for liboqs. Per GOVERNANCE.md, this appointment requires a majority approval from the current group of committers and can be vetoed by any maintainer.

When reading through the GOVERNANCE.md file, I saw a couple of opportunities for updates:
- Michael's leave of absence has now been documented.
- John Schanck has now been removed from the list of Committers as per https://github.com/open-quantum-safe/tsc/pull/126.

I've added a "Former Committers" section to the document to acknowledge John's contributions.

With that, I believe the list of voting committers is
- @bhess 
- @christianpaquin 
- @dstebila 
- @Martyrshot 
- @praveksharma 
- @SWilson4 
- @vsoftco 

Not sure if I count as a voting member here? :laughing: I will leave as draft to prevent merge until the 0.13.0 release is out the door.