### PR TITLE
Temporarily disable HQC

### DIFF
--- a/.CMake/alg_support.cmake
+++ b/.CMake/alg_support.cmake
@@ -117,7 +117,7 @@ cmake_dependent_option(OQS_ENABLE_KEM_classic_mceliece_6960119f "" ON "OQS_ENABL
 cmake_dependent_option(OQS_ENABLE_KEM_classic_mceliece_8192128 "" ON "OQS_ENABLE_KEM_CLASSIC_MCELIECE" OFF)
 cmake_dependent_option(OQS_ENABLE_KEM_classic_mceliece_8192128f "" ON "OQS_ENABLE_KEM_CLASSIC_MCELIECE" OFF)
 
-option(OQS_ENABLE_KEM_HQC "Enable hqc algorithm family" ON)
+option(OQS_ENABLE_KEM_HQC "Enable hqc algorithm family" OFF)
 cmake_dependent_option(OQS_ENABLE_KEM_hqc_128 "" ON "OQS_ENABLE_KEM_HQC" OFF)
 cmake_dependent_option(OQS_ENABLE_KEM_hqc_192 "" ON "OQS_ENABLE_KEM_HQC" OFF)
 cmake_dependent_option(OQS_ENABLE_KEM_hqc_256 "" ON "OQS_ENABLE_KEM_HQC" OFF)

--- a/scripts/copy_from_upstream/.CMake/alg_support.cmake/add_enable_by_alg.fragment
+++ b/scripts/copy_from_upstream/.CMake/alg_support.cmake/add_enable_by_alg.fragment
@@ -1,5 +1,9 @@
 {% for family in instructions['kems'] %}
+{%- if 'disable_by_default' in family and family['disable_by_default'] %}
+option(OQS_ENABLE_KEM_{{ family['name']|upper }} "Enable {{ family['name'] }} algorithm family" OFF)
+{%- else %}
 option(OQS_ENABLE_KEM_{{ family['name']|upper }} "Enable {{ family['name'] }} algorithm family" ON)
+{%- endif %}
     {%- for scheme in family['schemes'] %}
 cmake_dependent_option(OQS_ENABLE_KEM_{{ family['name'] }}_{{ scheme['scheme'] }} "" ON "OQS_ENABLE_KEM_{{ family['name']|upper }}" OFF)
 {%- if 'alias_scheme' in scheme %}
@@ -9,7 +13,11 @@ cmake_dependent_option(OQS_ENABLE_KEM_{{ family['name'] }}_{{ scheme['alias_sche
 {% endfor -%}
 
 {% for family in instructions['sigs'] %}
+{%- if 'disable_by_default' in family and family['disable_by_default'] %}
+option(OQS_ENABLE_SIG_{{ family['name']|upper }} "Enable {{ family['name'] }} algorithm family" OFF)
+{%- else %}
 option(OQS_ENABLE_SIG_{{ family['name']|upper }} "Enable {{ family['name'] }} algorithm family" ON)
+{%- endif %}
     {%- for scheme in family['schemes'] %}
 cmake_dependent_option(OQS_ENABLE_SIG_{{ family['name'] }}_{{ scheme['scheme'] }} "" ON "OQS_ENABLE_SIG_{{ family['name']|upper }}" OFF)
 {%- if 'alias_scheme' in scheme %}

--- a/scripts/copy_from_upstream/copy_from_upstream.yml
+++ b/scripts/copy_from_upstream/copy_from_upstream.yml
@@ -135,6 +135,7 @@ kems:
     name: hqc
     default_implementation: clean
     upstream_location: pqclean
+    disable_by_default: True
     schemes:
       -
         scheme: "128"


### PR DESCRIPTION
Recently a [security flaw in the IND-CCA2 security of HQC](https://groups.google.com/a/list.nist.gov/g/pqc-forum/c/Wiu4ZQo3fP8) was announced. A fix from the HQC is forthcoming.  This PR proposes disabling HQC from the default build for the liboqs 0.13.0 release.

Note that copy_from_upstream consistency checks will fail since I have manually overridden a CMakeLists variable to disable the algorithm.

The following text can be included in the liboqs 0.13.0 release notes:

> - HQC: Due to a [recently announced security flaw in the IND-CCA2 security of HQC](https://groups.google.com/a/list.nist.gov/g/pqc-forum/c/Wiu4ZQo3fP8), the HQC code in liboqs has been disabled by default. It will be re-enabled in a future release when a revised version of HQC is available.


* [No] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [No] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)
