### PR TITLE
Fix PR workflow runs

### DIFF
--- a/.github/workflows/commit-to-main.yml
+++ b/.github/workflows/commit-to-main.yml
@@ -15,24 +15,9 @@ jobs:
   scorecard:
     uses: ./.github/workflows/scorecard.yml
     secrets: inherit
-    # complete list of permissions keys as per
-    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#defining-access-for-the-github_token-permissions
-    # accessed September 4, 2024
     permissions:
-      actions: read
-      attestations: read
-      checks: read
-      contents: read
-      deployments: read
       id-token: write
-      issues: read
-      discussions: read
-      packages: read
-      pages: read
-      pull-requests: read
-      repository-projects: read
       security-events: write
-      statuses: read
 
   basic-downstream:
     uses: ./.github/workflows/downstream-basic.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,9 @@ jobs:
     # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#defining-access-for-the-github_token-permissions
     # accessed September 4, 2024
     # 'models' is an undocumented option that was added April 10, 2025 to address CI failure
-    #    permissions:
+    permissions:
+      id-token: write
+      security-events: write
     #      actions: read
     #      attestations: read
     #      checks: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,19 +26,19 @@ jobs:
     # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#defining-access-for-the-github_token-permissions
     # accessed September 4, 2024
     # 'models' is an undocumented option that was added April 10, 2025 to address CI failure
-    permissions:
-      actions: read
-      attestations: read
-      checks: read
-      contents: read
-      deployments: read
-      id-token: write
-      issues: read
-      discussions: read
-      packages: read
-      pages: read
-      pull-requests: read
-      repository-projects: read
-      security-events: write
-      statuses: read
-      models: read
+    #    permissions:
+    #      actions: read
+    #      attestations: read
+    #      checks: read
+    #      contents: read
+    #      deployments: read
+    #      id-token: write
+    #      issues: read
+    #      discussions: read
+    #      packages: read
+    #      pages: read
+    #      pull-requests: read
+    #      repository-projects: read
+    #      security-events: write
+    #      statuses: read
+    #      models: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,25 +22,6 @@ jobs:
     needs: basic-checks
     uses: ./.github/workflows/scorecard.yml
     secrets: inherit
-    # complete list of permissions keys as per
-    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#defining-access-for-the-github_token-permissions
-    # accessed September 4, 2024
-    # 'models' is an undocumented option that was added April 10, 2025 to address CI failure
     permissions:
       id-token: write
       security-events: write
-    #      actions: read
-    #      attestations: read
-    #      checks: read
-    #      contents: read
-    #      deployments: read
-    #      id-token: write
-    #      issues: read
-    #      discussions: read
-    #      packages: read
-    #      pages: read
-    #      pull-requests: read
-    #      repository-projects: read
-    #      security-events: write
-    #      statuses: read
-    #      models: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,6 +25,7 @@ jobs:
     # complete list of permissions keys as per
     # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#defining-access-for-the-github_token-permissions
     # accessed September 4, 2024
+    # 'models' is an undocumented option that was added April 10, 2025 to address CI failure
     permissions:
       actions: read
       attestations: read
@@ -40,3 +41,4 @@ jobs:
       repository-projects: read
       security-events: write
       statuses: read
+      models: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,6 +1,6 @@
 name: Scorecard supply-chain security
 
-permissions: read-all
+permissions: {}
 
 on:
   # For Branch-Protection check. Only the default branch is supported. See

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -14,24 +14,9 @@ jobs:
   scorecard:
     uses: ./.github/workflows/scorecard.yml
     secrets: inherit
-    # complete list of permissions keys as per
-    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#defining-access-for-the-github_token-permissions
-    # accessed September 4, 2024
     permissions:
-      actions: read
-      attestations: read
-      checks: read
-      contents: read
-      deployments: read
       id-token: write
-      issues: read
-      discussions: read
-      packages: read
-      pages: read
-      pull-requests: read
-      repository-projects: read
       security-events: write
-      statuses: read
 
   extended-tests:
     uses: ./.github/workflows/extended.yml


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
PR workflow runs (specifically, the OpenSSF scorecard runs) are failing at startup due to an issue with the GitHub Actions configuration. It looks like GitHub has added a new `models` option that needs to be given a value.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

