### PR TITLE
Adding poutine SAST

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
       - name: Ensure GitHub actions are valid
         run: actionlint -shellcheck "" # run *without* shellcheck
+      - name: poutine - Static Application Security Testing
+        uses: boostsecurityio/poutine-action@main 
 
   stylecheck:
     name: Check code formatting

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -17,6 +17,10 @@ jobs:
         run: actionlint -shellcheck "" # run *without* shellcheck
       - name: poutine - Static Application Security Testing
         uses: boostsecurityio/poutine-action@main 
+      - name: Upload poutine SARIF file
+      uses: github/codeql-action/upload-sarif@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # v3.24.10
+      with:
+        sarif_file: results.sarif
 
   stylecheck:
     name: Check code formatting

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -18,9 +18,9 @@ jobs:
       - name: poutine - Static Application Security Testing
         uses: boostsecurityio/poutine-action@main 
       - name: Upload poutine SARIF file
-      uses: github/codeql-action/upload-sarif@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # v3.24.10
-      with:
-        sarif_file: results.sarif
+        uses: github/codeql-action/upload-sarif@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # v3.24.10
+        with:
+          sarif_file: results.sarif
 
   stylecheck:
     name: Check code formatting

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Upload poutine SARIF file
         uses: github/codeql-action/upload-sarif@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # v3.24.10
         with:
-          sarif_file: results.sarif
+          format: sarif
+          output: poutine_results.sarif
 
   stylecheck:
     name: Check code formatting

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
       - name: Ensure GitHub actions are valid
         run: actionlint -shellcheck "" # run *without* shellcheck
+      - name: Configure as safe directory
+        run: git config --global --add safe.directory /__w/liboqs/liboqs
       - name: poutine - Static Application Security Testing
         uses: boostsecurityio/poutine-action@main 
       - name: Upload poutine SARIF file

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -19,11 +19,13 @@ jobs:
         run: git config --global --add safe.directory /__w/liboqs/liboqs
       - name: poutine - Static Application Security Testing
         uses: boostsecurityio/poutine-action@main 
-      - name: Upload poutine SARIF file
-        uses: github/codeql-action/upload-sarif@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # v3.24.10
         with:
           format: sarif
           output: poutine_results.sarif
+      - name: Upload poutine SARIF file
+        uses: github/codeql-action/upload-sarif@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # v3.24.10
+        with:
+          sarif_file: poutine_results.sarif
 
   stylecheck:
     name: Check code formatting

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -10,6 +10,8 @@ jobs:
     name: Check validity of GitHub workflows
     runs-on: ubuntu-latest
     container: openquantumsafe/ci-ubuntu-latest:latest
+    permissions:
+      security-events: write
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4


### PR DESCRIPTION
This PR adds poutine to CI for static application security testing

This PR addresses issue #1866

When this feature was pushed it was observed that poutine ran as part of the CI routine which shows that the feature works

This PR does NOT change input/output behaviour of a cryptographic algorithm and does not change the list of algorithms available
