### PR TITLE
Add a function to check if context string is supported

### DIFF
--- a/src/sig/sig.c
+++ b/src/sig/sig.c
@@ -1110,6 +1110,16 @@ OQS_API OQS_STATUS OQS_SIG_verify_with_ctx_str(const OQS_SIG *sig, const uint8_t
 	}
 }
 
+OQS_API bool OQS_SIG_supports_ctx_str(const char *alg_name) {
+	OQS_SIG *sig = OQS_SIG_new(alg_name);
+	if (sig == NULL) {
+		return false;
+	}
+	bool result = sig->sig_with_ctx_support;
+	OQS_SIG_free(sig);
+	return result;
+}
+
 OQS_API void OQS_SIG_free(OQS_SIG *sig) {
 	OQS_MEM_insecure_free(sig);
 }

--- a/src/sig/sig.h
+++ b/src/sig/sig.h
@@ -412,6 +412,14 @@ OQS_API OQS_STATUS OQS_SIG_verify_with_ctx_str(const OQS_SIG *sig, const uint8_t
  */
 OQS_API void OQS_SIG_free(OQS_SIG *sig);
 
+/**
+ * Indicates whether the specified signature algorithm supports signing with a context string.
+ *
+ * @param[in] alg_name Name of the desired algorithm; one of the names in `OQS_SIG_algs`.
+ * @return true if the algorithm supports context string signing, false otherwise.
+ */
+OQS_API bool OQS_SIG_supports_ctx_str(const char *alg_name);
+
 ///// OQS_COPY_FROM_UPSTREAM_FRAGMENT_INCLUDE_START
 #ifdef OQS_ENABLE_SIG_DILITHIUM
 #include <oqs/sig_dilithium.h>


### PR DESCRIPTION
Hi, this PR introduces a new API function:

```c
OQS_API bool OQS_SIG_supports_ctx_str(const char *alg_name);
``` 
- This allows for projects like liboqs-python to be able to check whether a given siguature algorithm supports context strings or not, without relying on internal structures.

<br>

This was done because I noticed liboqs-python's CI [kept failing](https://github.com/open-quantum-safe/liboqs-python/actions/runs/14085054590/job/39446808787), due to context string-related tests running on algorithms that don't support them, there was a work-around in the pytest but that became a bit convoluted (at least more than if liboqs itself had a feature like this).

<details><summary>I was able to have a C-side test to check API and struct consistency for all enabled signature algorithms, I can add this in to the PR if needed, I kept it back as I'm not totally sure if there needs to be a specific test-case for this.</summary>
<p>
./build/tests/test_sig Dilithium2<br>
OQS_SIG_supports_ctx_str API test passed for all enabled algorithms. <br>
Testing signature algorithms using liboqs version 0.13.1-dev <br>
... <br>
Sample computation for signature Dilithium2 <br>
verification passes as expected <br>
</p>
</details>