### PR TITLE
Check for NULL dereference before using secure free

### DIFF
--- a/src/sig_stfl/lms/sig_stfl_lms_functions.c
+++ b/src/sig_stfl/lms/sig_stfl_lms_functions.c
@@ -660,7 +660,7 @@ void oqs_secret_lms_key_free(OQS_SIG_STFL_SECRET_KEY *sk) {
 
 	if (sk->secret_key_data) {
 		oqs_lms_key_data *key_data = (oqs_lms_key_data *)sk->secret_key_data;
-		if (key_data) {
+		if (key_data != NULL) {
 			OQS_MEM_secure_free(key_data->sec_key, key_data->len_sec_key);
 			key_data->sec_key = NULL;
 

--- a/tests/test_kem.c
+++ b/tests/test_kem.c
@@ -279,13 +279,13 @@ err:
 	ret = OQS_ERROR;
 
 cleanup:
-	if (secret_key) {
+	if ((secret_key) && (kem != NULL)) {
 		OQS_MEM_secure_free(secret_key - sizeof(magic_t), kem->length_secret_key + 2 * sizeof(magic_t));
 	}
-	if (shared_secret_e) {
+	if ((shared_secret_e) && (kem != NULL)) {
 		OQS_MEM_secure_free(shared_secret_e - sizeof(magic_t), kem->length_shared_secret + 2 * sizeof(magic_t));
 	}
-	if (shared_secret_d) {
+	if ((shared_secret_d) && (kem != NULL)) {
 		OQS_MEM_secure_free(shared_secret_d - sizeof(magic_t), kem->length_shared_secret + 2 * sizeof(magic_t));
 	}
 	if (public_key) {
@@ -294,7 +294,7 @@ cleanup:
 	if (ciphertext) {
 		OQS_MEM_insecure_free(ciphertext - sizeof(magic_t));
 	}
-	if (seed) {
+	if ((seed) && (kem != NULL)) {
 		OQS_MEM_secure_free(seed - sizeof(magic_t), kem->length_keypair_seed + 2 * sizeof(magic_t));
 	}
 	OQS_KEM_free(kem);

--- a/tests/test_sig.c
+++ b/tests/test_sig.c
@@ -211,7 +211,7 @@ err:
 	ret = OQS_ERROR;
 
 cleanup:
-	if (secret_key) {
+	if ((secret_key) && (sig != NULL)) {
 		OQS_MEM_secure_free(secret_key - sizeof(magic_t), sig->length_secret_key + 2 * sizeof(magic_t));
 	}
 	if (public_key) {

--- a/zephyr/samples/KEMs/src/main.c
+++ b/zephyr/samples/KEMs/src/main.c
@@ -152,13 +152,13 @@ err:
 	ret = OQS_ERROR;
 
 cleanup:
-	if (secret_key) {
+	if ((secret_key) && (kem != NULL)) {
 		OQS_MEM_secure_free(secret_key - sizeof(magic_t), kem->length_secret_key + 2 * sizeof(magic_t));
 	}
-	if (shared_secret_e) {
+	if ((shared_secret_e) && (kem != NULL)) {
 		OQS_MEM_secure_free(shared_secret_e - sizeof(magic_t), kem->length_shared_secret + 2 * sizeof(magic_t));
 	}
-	if (shared_secret_d) {
+	if ((shared_secret_d) && (kem != NULL)) {
 		OQS_MEM_secure_free(shared_secret_d - sizeof(magic_t), kem->length_shared_secret + 2 * sizeof(magic_t));
 	}
 	if (public_key) {

--- a/zephyr/samples/Signatures/src/main.c
+++ b/zephyr/samples/Signatures/src/main.c
@@ -132,7 +132,7 @@ err:
 	ret = OQS_ERROR;
 
 cleanup:
-	if (secret_key) {
+	if ((secret_key) && (sig != NULL)) {
 		OQS_MEM_secure_free(secret_key - sizeof(magic_t), sig->length_secret_key + 2 * sizeof(magic_t));
 	}
 	if (public_key) {


### PR DESCRIPTION
Added as a safety check before dereferencing a pointer
