### PR TITLE
Skip failing CI test

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,6 +36,11 @@ jobs:
           # No point in testing stateful sigs with minimal libjade build
           - libjade-build: -DOQS_LIBJADE_BUILD=ON -DOQS_MINIMAL_BUILD="${{ vars.LIBJADE_ALG_LIST }}"
             CMAKE_ARGS: -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+          # Failing configuration on Github actions; see https://github.com/open-quantum-safe/liboqs/pull/2148
+          - os: macos-15
+            CMAKE_ARGS: -DCMAKE_C_COMPILER=gcc-14
+            libjade-build: -DOQS_LIBJADE_BUILD=ON
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Python

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,7 +39,7 @@ jobs:
           # Failing configuration on Github actions; see https://github.com/open-quantum-safe/liboqs/pull/2148
           - os: macos-15
             CMAKE_ARGS: -DCMAKE_C_COMPILER=gcc-14
-            libjade-build: -DOQS_LIBJADE_BUILD=ON
+            libjade-build: -DOQS_LIBJADE_BUILD=OFF
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
One Github Actions workflow has been failing (macos-15, gcc-14), seemingly not related to a change we've made. This PR temporarily disables it.

See discussion in https://github.com/open-quantum-safe/liboqs/pull/2148