### PR TITLE
Use OQS_MEM_cleanse() instead of memset()

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,6 +36,11 @@ jobs:
           # No point in testing stateful sigs with minimal libjade build
           - libjade-build: -DOQS_LIBJADE_BUILD=ON -DOQS_MINIMAL_BUILD="${{ vars.LIBJADE_ALG_LIST }}"
             CMAKE_ARGS: -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
+          # Failing configuration on Github actions; see https://github.com/open-quantum-safe/liboqs/pull/2148
+          - os: macos-15
+            CMAKE_ARGS: -DCMAKE_C_COMPILER=gcc-14
+            libjade-build: -DOQS_LIBJADE_BUILD=OFF
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Python

--- a/src/common/rand/rand_nist.c
+++ b/src/common/rand/rand_nist.c
@@ -67,7 +67,7 @@ void OQS_randombytes_nist_kat_init_256bit(const uint8_t *entropy_input, const ui
 		for (int i = 0; i < 48; i++) {
 			seed_material[i] ^= personalization_string[i];
 		}
-	memset(DRBG_ctx.Key, 0x00, 32);
+	OQS_MEM_cleanse(DRBG_ctx.Key, 32);
 	memset(DRBG_ctx.V, 0x00, 16);
 	AES256_CTR_DRBG_Update(seed_material, DRBG_ctx.Key, DRBG_ctx.V);
 	DRBG_ctx.reseed_counter = 1;

--- a/src/sig_stfl/lms/external/hss_reserve.c
+++ b/src/sig_stfl/lms/external/hss_reserve.c
@@ -55,7 +55,7 @@ bool hss_advance_count(struct hss_working_key *w, sequence_t cur_count,
                 /* We can trash the copy in secure storage, though */
         if (update_private_key) {
             unsigned char private_key[PRIVATE_KEY_LEN];
-            memset( private_key, PARM_SET_END, PRIVATE_KEY_LEN );
+            OQS_MEM_cleanse(private_key, PRIVATE_KEY_LEN);
             if (!update_private_key(private_key, PRIVATE_KEY_LEN, context)) {
                 info->error_code = hss_error_private_key_write_failed;
                 return false;

--- a/src/sig_stfl/lms/external/hss_sign.c
+++ b/src/sig_stfl/lms/external/hss_sign.c
@@ -184,7 +184,7 @@ static int generate_merkle_signature(
     if (message == NULL) {
         /* Internal interface: if message = NULL, we're supposed to */
         /* generate everything *except* the OTS signature */
-        memset( signature, 0, ots_sig_size );
+        OQS_MEM_cleanse( signature, ots_sig_size );
     } else {
         struct seed_derive derive;
         if (!hss_seed_derive_init( &derive,
@@ -701,7 +701,7 @@ done_advancing:
     /* And we've set things up for the next signature... */
 
     if (trash_private_key) {
-        memset( w->private_key, PARM_SET_END, PRIVATE_KEY_LEN );
+        OQS_MEM_cleanse( w->private_key, PRIVATE_KEY_LEN );
     }
 
     return true;
@@ -709,12 +709,12 @@ done_advancing:
 failed:
 
     if (trash_private_key) {
-        memset( w->private_key, PARM_SET_END, PRIVATE_KEY_LEN );
+        OQS_MEM_cleanse( w->private_key, PRIVATE_KEY_LEN );
     }
 
     /* On failure, make sure that we don't return anything that might be */
     /* misconstrued as a real signature */
-    memset( signature, 0, signature_buf_len );
+    OQS_MEM_cleanse( signature, signature_buf_len );
     return false;
 }
 

--- a/src/sig_stfl/lms/sig_stfl_lms.c
+++ b/src/sig_stfl/lms/sig_stfl_lms.c
@@ -108,7 +108,7 @@ OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_LMS_##LMS_VARIANT##_new(void) {\
         if (sk == NULL) {\
                 return NULL;\
         }\
-        memset(sk, 0, sizeof(OQS_SIG_STFL_SECRET_KEY));\
+        OQS_MEM_cleanse(sk, sizeof(OQS_SIG_STFL_SECRET_KEY));\
 \
         sk->length_secret_key = OQS_SIG_STFL_alg_lms_length_private_key;\
 \

--- a/src/sig_stfl/lms/sig_stfl_lms_functions.c
+++ b/src/sig_stfl/lms/sig_stfl_lms_functions.c
@@ -260,7 +260,7 @@ int oqs_sig_stfl_lms_keypair(uint8_t *pk, OQS_SIG_STFL_SECRET_KEY *sk, const uin
 		return -1;
 	}
 
-	memset(oqs_key_data, 0, sizeof(oqs_lms_key_data));
+	OQS_MEM_cleanse(oqs_key_data, sizeof(oqs_lms_key_data));
 	if (sk->length_secret_key == 0) {
 		OQS_MEM_insecure_free(oqs_key_data);
 		oqs_key_data = NULL;
@@ -276,7 +276,7 @@ int oqs_sig_stfl_lms_keypair(uint8_t *pk, OQS_SIG_STFL_SECRET_KEY *sk, const uin
 		return -1;
 	}
 
-	memset(oqs_key_data->sec_key, 0, sk->length_secret_key);
+	OQS_MEM_cleanse(oqs_key_data->sec_key, sk->length_secret_key);
 
 	//Aux Data
 	size_t len_aux_data = DEFAULT_AUX_DATA;

--- a/src/sig_stfl/xmss/external/xmss_core_fast.c
+++ b/src/sig_stfl/xmss/external/xmss_core_fast.c
@@ -679,8 +679,8 @@ int xmss_core_sign(const xmss_params *params,
     if (idx >= ((1ULL << params->full_height) - 1)) {
         // Delete secret key here. We only do this in memory, production code
         // has to make sure that this happens on disk.
-        memset(sk, 0xFF, params->index_bytes);
-        memset(sk + params->index_bytes, 0, (size_t)(params->sk_bytes - params->index_bytes));
+        OQS_MEM_cleanse(sk, params->index_bytes);
+        OQS_MEM_cleanse(sk + params->index_bytes, (size_t)(params->sk_bytes - params->index_bytes));
         if (idx > ((1ULL << params->full_height) - 1)) {
             ret = -2; // We already used all one-time keys
             goto cleanup;
@@ -952,8 +952,8 @@ int xmssmt_core_sign(const xmss_params *params,
     if (idx >= ((1ULL << params->full_height) - 1)) {
         // Delete secret key here. We only do this in memory, production code
         // has to make sure that this happens on disk.
-        memset(sk, 0xFF, params->index_bytes);
-        memset(sk + params->index_bytes, 0, (size_t)(params->sk_bytes - params->index_bytes));
+        OQS_MEM_cleanse(sk, params->index_bytes);
+        OQS_MEM_cleanse(sk + params->index_bytes, (size_t)(params->sk_bytes - params->index_bytes));
         if (idx > ((1ULL << params->full_height) - 1)) {
             // We already used all one-time keys
             ret = -2;

--- a/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
@@ -18,7 +18,7 @@ extern inline OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_new(size_t length_sec
 	if (sk == NULL) {
 		return NULL;
 	}
-	memset(sk, 0, sizeof(OQS_SIG_STFL_SECRET_KEY));
+	OQS_MEM_cleanse(sk, sizeof(OQS_SIG_STFL_SECRET_KEY));
 
 	sk->length_secret_key = length_secret_key;
 
@@ -34,7 +34,7 @@ extern inline OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_new(size_t length_sec
 		return NULL;
 	}
 
-	memset(sk->secret_key_data, 0, sk->length_secret_key);
+	OQS_MEM_cleanse(sk->secret_key_data, sk->length_secret_key);
 
 	// Set application specific context
 	sk->context = NULL;

--- a/tests/kat_sig_stfl.c
+++ b/tests/kat_sig_stfl.c
@@ -98,7 +98,7 @@ size_t ReadHex(FILE *infile, unsigned char *a, unsigned long Length, const char 
 		a[0] = 0x00;
 		return 1;
 	}
-	memset(a, 0x00, Length);
+	OQS_MEM_cleanse(a, Length);
 	started = 0;
 	if (FindMarker(infile, str))
 		while ((ch = fgetc(infile)) != EOF) {

--- a/tests/test_kem.c
+++ b/tests/test_kem.c
@@ -72,7 +72,7 @@ static bool mlkem_rej_testcase(OQS_KEM *kem, uint8_t *ciphertext, uint8_t *secre
 		goto cleanup;
 	}
 	secret_key[0] -= 1; // Restore private key
-	memset(buff_z_c, 0, length_z_c); // Reset buffer
+	OQS_MEM_cleanse(buff_z_c, length_z_c); // Reset buffer
 
 	// Scenario 2: Test rejection key by corrupting the ciphertext
 	ciphertext[0] += 1;

--- a/tests/test_sig_stfl.c
+++ b/tests/test_sig_stfl.c
@@ -94,7 +94,7 @@ int ReadHex(FILE *infile, unsigned char *a, unsigned long Length, char *str) {
 		a[0] = 0x00;
 		return 1;
 	}
-	memset(a, 0x00, Length);
+	OQS_MEM_cleanse(a, Length);
 	started = 0;
 	if (FindMarker(infile, str))
 		while ((ch = fgetc(infile)) != EOF) {


### PR DESCRIPTION
This is needed for secret objects as memset
maybe optimized out by the compiler.

Fixes https://github.com/open-quantum-safe/liboqs/issues/1864
