### PR TITLE
Adjust constant-time test exception for mlkem-native

### DIFF
--- a/tests/constant_time/kem/passes/ml_kem
+++ b/tests/constant_time/kem/passes/ml_kem
@@ -1,14 +1,14 @@
 {
    The parts of sk being hashed and compared here are public.
    Memcheck:Cond
-   fun:PQCP_MLKEM_NATIVE_MLKEM*_check_sk
+   fun:mlk_check_sk
    fun:PQCP_MLKEM_NATIVE_MLKEM*_dec
 }
 {
    The parts of sk being hashed and compared here are public.
    Memcheck:Cond
    fun:bcmp
-   fun:PQCP_MLKEM_NATIVE_MLKEM*_check_sk
+   fun:mlk_check_sk
    fun:PQCP_MLKEM_NATIVE_MLKEM*_dec
 }
 {


### PR DESCRIPTION
- Resolves #2161 

The constant-time tests have been failing for mlkem-native as check_sk changed it's name and is no no longer recognized as an exception. This function processes exclusively public data in the secret key and it's, hence, okay to branch both inside the function and depending on the return value.

This commit renames the function in the constant_time exceptions file.
