### PR TITLE
Adjust HTML file for the continuous benchamarking page

### DIFF
--- a/dev/bench/index.html
+++ b/dev/bench/index.html
@@ -82,12 +82,23 @@
       .benchmark-chart {
         max-width: 1000px;
       }
+      .benchmark-extra {
+        margin-top: -10px;
+        margin-bottom: 20px;
+        text-align: center;
+        max-width: 1000px;
+        margin-left: auto;
+        margin-right: auto;
+      }
     </style>
-    <title>Benchmarks</title>
+    <title> liboqs benchmarking</title>
   </head>
 
   <body>
     <header id="header">
+      <div class="header-item">
+        <div class="header-label"><strong>This page contains continuous benchmarking information about the available KEM and signature algorithms within liboqs.<br> The benchmarking tests show the mean CPU cycles performed by the operation in 3 seconds of execution.<br> The portrayed data was gathered using the speed_kem and speed_sig tests.</strong></div><br> 
+      </div>
       <div class="header-item">
         <strong class="header-label">Last Update:</strong>
         <span id="last-update"></span>
@@ -96,10 +107,25 @@
         <strong class="header-label">Repository:</strong>
         <a id="repository-link" rel="noopener"></a>
       </div>
+      <div class="header-item">
+        <strong class="header-label">Latest commit build information:</strong>
+        <span id="build-info"></span>
+      </div>
+      <br>
+      <div class="header-item">
+        <strong class="header-label">Filter:</strong>
+        <select id="filter-select">
+          <option value="all">All</option>
+        </select>
+      </div>
+      <br>
+      <div class="header-item">
+        <button id="dl-button">Download data as JSON</button>
+      </div>
     </header>
     <main id="main"></main>
     <footer>
-      <button id="dl-button">Download data as JSON</button>
+
       <div class="spacer"></div>
       <div class="small">Powered by <a rel="noopener" href="https://github.com/marketplace/actions/continuous-benchmark">github-action-benchmark</a></div>
     </footer>
@@ -151,6 +177,16 @@
           const repoLink = document.getElementById('repository-link');
           repoLink.href = data.repoUrl;
           repoLink.textContent = data.repoUrl;
+          // Find the latest 'extra' info from all entries and show it in the header entry
+          let lastExtra = null;
+          for (const entryList of Object.values(data.entries)) {
+            for (const entry of entryList) {
+              for (const bench of entry.benches) {
+                if (bench.extra) lastExtra = bench.extra;
+              }
+            }
+          }
+          document.getElementById('build-info').textContent = lastExtra || '';
 
           // Render footer
           document.getElementById('dl-button').onclick = () => {
@@ -166,6 +202,91 @@
             name,
             dataSet: collectBenchesPerTestCase(data.entries[name]),
           }));
+        }
+
+        function populateFilterOptions() {
+          const filterSelect = document.getElementById('filter-select');
+          const kems = [
+            "BIKE-L1", "BIKE-L3", "BIKE-L5",
+            "Classic-McEliece-348864", "Classic-McEliece-348864f",
+            "Classic-McEliece-460896", "Classic-McEliece-460896f",
+            "Classic-McEliece-6688128", "Classic-McEliece-6688128f",
+            "Classic-McEliece-6960119", "Classic-McEliece-6960119f",
+            "Classic-McEliece-8192128", "Classic-McEliece-8192128f",
+            "Kyber512", "Kyber768", "Kyber1024",
+            "ML-KEM-512", "ML-KEM-768", "ML-KEM-1024",
+            "sntrup761",
+            "FrodoKEM-640-AES", "FrodoKEM-640-SHAKE",
+            "FrodoKEM-976-AES", "FrodoKEM-976-SHAKE",
+            "FrodoKEM-1344-AES", "FrodoKEM-1344-SHAKE"
+          ];
+
+          const signatures = [
+            "Dilithium2", "Dilithium3", "Dilithium5",
+            "ML-DSA-44", "ML-DSA-65", "ML-DSA-87",
+            "Falcon-512", "Falcon-1024", "Falcon-padded-512", "Falcon-padded-1024",
+            "SPHINCS+-SHA2-128f-simple", "SPHINCS+-SHA2-128s-simple",
+            "SPHINCS+-SHA2-192f-simple", "SPHINCS+-SHA2-192s-simple",
+            "SPHINCS+-SHA2-256f-simple", "SPHINCS+-SHA2-256s-simple",
+            "SPHINCS+-SHAKE-128f-simple", "SPHINCS+-SHAKE-128s-simple",
+            "SPHINCS+-SHAKE-192f-simple", "SPHINCS+-SHAKE-192s-simple",
+            "SPHINCS+-SHAKE-256f-simple", "SPHINCS+-SHAKE-256s-simple",
+            "MAYO-1", "MAYO-2", "MAYO-3", "MAYO-5",
+            "cross-rsdp-128-balanced", "cross-rsdp-128-fast", "cross-rsdp-128-small",
+            "cross-rsdp-192-balanced", "cross-rsdp-192-fast", "cross-rsdp-192-small",
+            "cross-rsdp-256-balanced", "cross-rsdp-256-fast", "cross-rsdp-256-small",
+            "cross-rsdpg-128-balanced", "cross-rsdpg-128-fast", "cross-rsdpg-128-small",
+            "cross-rsdpg-192-balanced", "cross-rsdpg-192-fast", "cross-rsdpg-192-small",
+            "cross-rsdpg-256-balanced", "cross-rsdpg-256-fast", "cross-rsdpg-256-small",
+            "OV-Is", "OV-Ip", "OV-III", "OV-V",
+            "OV-Is-pkc", "OV-Ip-pkc", "OV-III-pkc", "OV-V-pkc",
+            "OV-Is-pkc-skc", "OV-Ip-pkc-skc", "OV-III-pkc-skc", "OV-V-pkc-skc"
+          ];
+
+          // Add KEMs to the filter
+          const kemGroup = document.createElement('optgroup');
+          kemGroup.label = "KEMs";
+          kems.forEach(kem => {
+            const option = document.createElement('option');
+            option.value = kem;
+            option.textContent = kem;
+            kemGroup.appendChild(option);
+          });
+          filterSelect.appendChild(kemGroup);
+
+          // Add Signatures to the filter
+          const signatureGroup = document.createElement('optgroup');
+          signatureGroup.label = "Signatures";
+          signatures.forEach(signature => {
+            const option = document.createElement('option');
+            option.value = signature;
+            option.textContent = signature;
+            signatureGroup.appendChild(option);
+          });
+          filterSelect.appendChild(signatureGroup);
+        }
+
+        function filterData(dataSets, filter) {
+          if (filter === 'all') {
+            return dataSets;
+          }
+
+          return dataSets.filter(({ name }) => name === filter);
+        }
+
+        function attachFilterListener(dataSets) {
+          const filterSelect = document.getElementById('filter-select');
+          filterSelect.addEventListener('change', () => {
+            const filter = filterSelect.value;
+            const filteredDataSets = filterData(dataSets, filter);
+
+            // Clear existing graphs
+            const main = document.getElementById('main');
+            main.innerHTML = '';
+
+            // Re-render graphs with filtered data
+            renderAllChars(filteredDataSets);
+          });
         }
 
         function renderAllChars(dataSets) {
@@ -225,10 +346,10 @@
                     }
                     return label;
                   },
-                  afterLabel: item => {
-                    const { extra } = dataset[item.index].bench;
-                    return extra ? '\n' + extra : '';
-                  }
+                  // afterLabel: item => {
+                  //   const { extra } = dataset[item.index].bench;
+                  //   return extra ? '\n' + extra : '';
+                  // }
                 }
               },
               onClick: (_mouseEvent, activeElems) => {
@@ -249,7 +370,7 @@
             });
           }
 
-          function renderBenchSet(name, benchSet, main) {
+          function renderBenchSet(name, extra, benchSet, main) {
             const setElem = document.createElement('div');
             setElem.className = 'benchmark-set';
             main.appendChild(setElem);
@@ -259,22 +380,27 @@
             nameElem.textContent = name;
             setElem.appendChild(nameElem);
 
+
+
             const graphsElem = document.createElement('div');
             graphsElem.className = 'benchmark-graphs';
             setElem.appendChild(graphsElem);
 
             for (const [benchName, benches] of benchSet.entries()) {
-              renderGraph(graphsElem, benchName, benches)
+              renderGraph(graphsElem, benchName, benches);
             }
           }
 
           const main = document.getElementById('main');
-          for (const {name, dataSet} of dataSets) {
-            renderBenchSet(name, dataSet, main);
+          for (const {name, extra, dataSet} of dataSets) {
+            renderBenchSet(name, extra, dataSet, main);
           }
         }
 
-        renderAllChars(init()); // Start
+        const dataSets = init(); // Initialize data
+        populateFilterOptions(); // Populate filter dropdown
+        attachFilterListener(dataSets); // Attach filter logic
+        renderAllChars(dataSets); // Start rendering
       })();
     </script>
   </body>


### PR DESCRIPTION
This PR is a continuation of #2134, which aims to adjust some details of the generated html file so the layout shows as in https://pablo-gf.github.io/liboqs/dev/bench/ . I could not include these changes to the previous PR because the file was not yet generated.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

