### PR TITLE
Increase alert threshold for continuous benchmarking

### DIFF
--- a/.github/workflows/kem-bench.yml
+++ b/.github/workflows/kem-bench.yml
@@ -117,5 +117,5 @@ jobs:
           auto-push: true
           comment-on-alert: true
           summary-always: true
-          alert-threshold: 50%
+          alert-threshold: 105%
           comment-always: true

--- a/.github/workflows/sig-bench.yml
+++ b/.github/workflows/sig-bench.yml
@@ -147,5 +147,5 @@ jobs:
           auto-push: true
           comment-on-alert: true
           summary-always: true
-          alert-threshold: 50%
+          alert-threshold: 105%
           comment-always: true


### PR DESCRIPTION
This PR updates the alert threshold suggested in the conversation of the continuous benchmarking PR #2134, as suggested by @SWilson4.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)
