### PR TITLE
Benchmarking comments only on alerts

### DIFF
--- a/.github/workflows/kem-bench.yml
+++ b/.github/workflows/kem-bench.yml
@@ -118,4 +118,4 @@ jobs:
           comment-on-alert: true
           summary-always: true
           alert-threshold: 105%
-          comment-always: true
+          comment-always: false

--- a/.github/workflows/sig-bench.yml
+++ b/.github/workflows/sig-bench.yml
@@ -148,4 +148,4 @@ jobs:
           comment-on-alert: true
           summary-always: true
           alert-threshold: 105%
-          comment-always: true
+          comment-always: false


### PR DESCRIPTION
Reduce the number of comments posted/emailed by benchmark regression testing.