### PR TITLE
Added Custom Timeout to CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,6 +118,8 @@ jobs:
             CMAKE_ARGS: -DOQS_USE_SHA3_AVX512VL=OFF
             PYTEST_ARGS: --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 85 # max + 3*std over the last thousands of successful runs
+
     container:
       image: ${{ matrix.container }}
     steps:
@@ -154,6 +156,7 @@ jobs:
 
   linux_arm_emulated:
     runs-on: ubuntu-latest
+    timeout-minutes: 85 # max + 3*std over the last thousands of successful runs
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,6 +42,7 @@ jobs:
             libjade-build: -DOQS_LIBJADE_BUILD=OFF
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 85 # max + 3*std over the last thousands of successful runs
     steps:
       - name: Install Python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # pin@v5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,6 @@ jobs:
   platform-tests:
     needs: basic-checks
     uses: ./.github/workflows/platforms.yml
-    timeout-minutes: 85 # max + 3*std over the last 20,000 successful runs
 
   code-coverage:
     needs: basic-checks

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
   platform-tests:
     needs: basic-checks
     uses: ./.github/workflows/platforms.yml
-    timeout-minutes: 85 # minutes, max + 3*std over the last 20,000 successful runs
+    timeout-minutes: 85 # max + 3*std over the last 20,000 successful runs
 
   code-coverage:
     needs: basic-checks

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,7 @@ jobs:
   platform-tests:
     needs: basic-checks
     uses: ./.github/workflows/platforms.yml
+    timeout-minutes: 85 # minutes, max + 3*std over the last 20,000 successful runs
 
   code-coverage:
     needs: basic-checks

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,7 +4,6 @@ permissions:
   contents: read
 
 on: [workflow_call, workflow_dispatch]
-
 jobs:
 
   windows-arm64:
@@ -13,6 +12,7 @@ jobs:
         runner: [windows-2022, windows-2025]
         stfl_opt: [ON, OFF]
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 85 # max + 3*std over the last thousands of successful runs
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
       - name: Generate Project
@@ -28,6 +28,7 @@ jobs:
         toolchain: [.CMake/toolchain_windows_x86.cmake, .CMake/toolchain_windows_amd64.cmake]
         stfl_opt: [ON, OFF]
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 85 # max + 3*std over the last thousands of successful runs
     steps:
       - name: Install Python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # pin@v5


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
### Change Summary
Added custom timeout for `platform-tests` job of the `Pull request tests` workflow based on historical data that could lead to resource savings and faster CI for the project.

### More details
Over the last 20670 successful runs, the `platform-tests` job has a maximum runtime of 61 minutes (mean=7, std=8) across all matrix combinations that arise from the called actions.

However, there are failed runs that fail after reaching the threshold of 6 hours that GitHub imposes. In other words, these jobs seem to get stuck, possibly for external or random reasons. 

One such example is [this](https://github.com/open-quantum-safe/liboqs/actions/runs/13566979003/job/37922797116) job run, that failed after 6 hours. More stuck jobs have been observed over the last months, the first one on 17-Oct-2024 and the last one one on 27-Feb-2025, while more recent occurences are also possible because our dataset has a cutoff date around late May. With the proposed changes, a total of **65 hours would have been saved** over the last six months retrospectively, clearing the queue for other workflows and **speeding up the CI** of the project, while also **saving resources** in general 🌱.

The idea is to set a timeout to stop jobs that run much longer than their historical maximum, because such jobs are probably stuck and will simply fail with a timeout at 6 hours.

Our PR proposes to set the timeout to `max + 3*std = 85 minutes` where `max` and `std` (standard deviation) are derived from the history of 20670 successful runs. This will provide sufficient margin if the workflow gets naturally slower in the future, but if you would prefer lower/higher threshold we would be happy to do it.

Note that the timeout applies to all the matrix jobs, and not to their sum, overriding the default 6-hour timeout of github.

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Thanks for your time on this.

Feel free to let us know (here or in the email below) if you have any questions, and thanks for putting in the time to read this.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch

### Questions
<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.) => No
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.) => No

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

