### PR TITLE
Added dilithium3 derand keypair from seed

### DIFF
--- a/src/sig/dilithium/oldpqclean_dilithium3_aarch64/sign.c
+++ b/src/sig/dilithium/oldpqclean_dilithium3_aarch64/sign.c
@@ -41,29 +41,29 @@
 #include <stdint.h>
 
 /*************************************************
-* Name:        crypto_sign_keypair
+* Name:        crypto_sign_seed_keypair
 *
-* Description: Generates public and private key.
+* Description: Generates public and private key from a seed.
 *
 * Arguments:   - uint8_t *pk: pointer to output public key (allocated
 *                             array of CRYPTO_PUBLICKEYBYTES bytes)
 *              - uint8_t *sk: pointer to output private key (allocated
 *                             array of CRYPTO_SECRETKEYBYTES bytes)
+*              - const uint8_t *seed: pointer to input seed
 *
 * Returns 0 (success)
 **************************************************/
-int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
-    uint8_t seedbuf[2 * SEEDBYTES + CRHBYTES];
+int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+    uint8_t expanded_seedbuf[2 * SEEDBYTES + CRHBYTES];
     uint8_t tr[SEEDBYTES];
     const uint8_t *rho, *rhoprime, *key;
     polyvecl mat[K];
     polyvecl s1, s1hat;
     polyveck s2, t1, t0;
 
-    /* Get randomness for rho, rhoprime and key */
-    randombytes(seedbuf, SEEDBYTES);
-    shake256(seedbuf, 2 * SEEDBYTES + CRHBYTES, seedbuf, SEEDBYTES);
-    rho = seedbuf;
+    /* Expand seed which is randomness for rho, rhoprime and key */
+    shake256(expanded_seedbuf, 2 * SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+    rho = expanded_seedbuf;
     rhoprime = rho + SEEDBYTES;
     key = rhoprime + CRHBYTES;
 
@@ -94,6 +94,24 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
     pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
 
     return 0;
+}
+
+/*************************************************
+* Name:        crypto_sign_keypair
+*
+* Description: Generates public and private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
+    uint8_t seedbuf[2 * SEEDBYTES + CRHBYTES];
+    randombytes(seedbuf, SEEDBYTES);
+    return crypto_sign_seed_keypair(pk, sk, seedbuf);
 }
 
 /*************************************************

--- a/src/sig/dilithium/oldpqclean_dilithium3_aarch64/sign.h
+++ b/src/sig/dilithium/oldpqclean_dilithium3_aarch64/sign.h
@@ -21,6 +21,9 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(crypto_sign_keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_seed_keypair DILITHIUM_NAMESPACE(crypto_sign_seed_keypair)
+int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(crypto_sign_signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_avx2/sign.h
@@ -13,6 +13,9 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_seed_keypair DILITHIUM_NAMESPACE(seed_keypair)
+int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/sign.c
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/sign.c
@@ -8,30 +8,31 @@
 #include "symmetric.h"
 #include "fips202.h"
 
+
 /*************************************************
-* Name:        crypto_sign_keypair
+* Name:        crypto_sign_seed_keypair
 *
-* Description: Generates public and private key.
+* Description: Generates public and private key from a seed.
 *
 * Arguments:   - uint8_t *pk: pointer to output public key (allocated
 *                             array of CRYPTO_PUBLICKEYBYTES bytes)
 *              - uint8_t *sk: pointer to output private key (allocated
 *                             array of CRYPTO_SECRETKEYBYTES bytes)
+*              - const uint8_t *seed: pointer to input seed
 *
 * Returns 0 (success)
 **************************************************/
-int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
-  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
+int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk, const uint8_t *seed) {
+  uint8_t expanded_seedbuf[2*SEEDBYTES + CRHBYTES];
   uint8_t tr[SEEDBYTES];
   const uint8_t *rho, *rhoprime, *key;
   polyvecl mat[K];
   polyvecl s1, s1hat;
   polyveck s2, t1, t0;
 
-  /* Get randomness for rho, rhoprime and key */
-  randombytes(seedbuf, SEEDBYTES);
-  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seedbuf, SEEDBYTES);
-  rho = seedbuf;
+  /* Expanding seed, which is randomness for rho, rhoprime and key */
+  shake256(expanded_seedbuf, 2*SEEDBYTES + CRHBYTES, seed, SEEDBYTES);
+  rho = expanded_seedbuf;
   rhoprime = rho + SEEDBYTES;
   key = rhoprime + CRHBYTES;
 
@@ -63,6 +64,25 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 
   return 0;
 }
+
+/*************************************************
+* Name:        crypto_sign_keypair
+*
+* Description: Generates public and private key.
+*
+* Arguments:   - uint8_t *pk: pointer to output public key (allocated
+*                             array of CRYPTO_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key (allocated
+*                             array of CRYPTO_SECRETKEYBYTES bytes)
+*
+* Returns 0 (success)
+**************************************************/
+int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
+  uint8_t seed[SEEDBYTES];
+  randombytes(seed, SEEDBYTES);
+  return crypto_sign_seed_keypair(pk, sk, seed);
+}
+
 
 /*************************************************
 * Name:        crypto_sign_signature

--- a/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/sign.h
+++ b/src/sig/dilithium/pqcrystals-dilithium_dilithium3_ref/sign.h
@@ -13,6 +13,9 @@ void challenge(poly *c, const uint8_t seed[SEEDBYTES]);
 #define crypto_sign_keypair DILITHIUM_NAMESPACE(keypair)
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
 
+#define crypto_sign_seed_keypair DILITHIUM_NAMESPACE(seed_keypair)
+int crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
 #define crypto_sign_signature DILITHIUM_NAMESPACE(signature)
 int crypto_sign_signature(uint8_t *sig, size_t *siglen,
                           const uint8_t *m, size_t mlen,

--- a/src/sig/dilithium/sig_dilithium.h
+++ b/src/sig/dilithium/sig_dilithium.h
@@ -24,6 +24,7 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_2_verify_with_ctx_str(const uint8_t *messag
 #define OQS_SIG_dilithium_3_length_signature 3293
 
 OQS_SIG *OQS_SIG_dilithium_3_new(void);
+OQS_API OQS_STATUS OQS_SIG_dilithium_3_seed_keypair(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_SIG_dilithium_3_keypair(uint8_t *public_key, uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_3_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_SIG_dilithium_3_verify(const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key);

--- a/src/sig/dilithium/sig_dilithium_3.c
+++ b/src/sig/dilithium/sig_dilithium_3.c
@@ -33,17 +33,20 @@ OQS_SIG *OQS_SIG_dilithium_3_new(void) {
 }
 
 extern int pqcrystals_dilithium3_ref_keypair(uint8_t *pk, uint8_t *sk);
+extern int pqcrystals_dilithium3_ref_seed_keypair(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int pqcrystals_dilithium3_ref_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium3_ref_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 
 #if defined(OQS_ENABLE_SIG_dilithium_3_avx2)
 extern int pqcrystals_dilithium3_avx2_keypair(uint8_t *pk, uint8_t *sk);
+extern int pqcrystals_dilithium3_avx2_seed_keypair(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int pqcrystals_dilithium3_avx2_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int pqcrystals_dilithium3_avx2_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
 
 #if defined(OQS_ENABLE_SIG_dilithium_3_aarch64)
 extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
 extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_signature(uint8_t *sig, size_t *siglen, const uint8_t *m, size_t mlen, const uint8_t *sk);
 extern int PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_verify(const uint8_t *sig, size_t siglen, const uint8_t *m, size_t mlen, const uint8_t *pk);
 #endif
@@ -71,6 +74,32 @@ OQS_API OQS_STATUS OQS_SIG_dilithium_3_keypair(uint8_t *public_key, uint8_t *sec
 #endif /* OQS_DIST_BUILD */
 #else
 	return (OQS_STATUS) pqcrystals_dilithium3_ref_keypair(public_key, secret_key);
+#endif
+}
+
+OQS_API OQS_STATUS OQS_SIG_dilithium_3_seed_keypair(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
+#if defined(OQS_ENABLE_SIG_dilithium_3_avx2)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) pqcrystals_dilithium3_avx2_seed_keypair(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium3_ref_seed_keypair(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#elif defined(OQS_ENABLE_SIG_dilithium_3_aarch64)
+#if defined(OQS_DIST_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_ARM_NEON)) {
+#endif /* OQS_DIST_BUILD */
+		return (OQS_STATUS) PQCLEAN_DILITHIUM3_AARCH64_crypto_sign_seed_keypair(public_key, secret_key, seed);
+#if defined(OQS_DIST_BUILD)
+	} else {
+		return (OQS_STATUS) pqcrystals_dilithium3_ref_seed_keypair(public_key, secret_key, seed);
+	}
+#endif /* OQS_DIST_BUILD */
+#else
+	return (OQS_STATUS) pqcrystals_dilithium3_ref_seed_keypair(public_key, secret_key, seed);
 #endif
 }
 

--- a/test_sig.Dockerfile
+++ b/test_sig.Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y \
+    cmake gcc g++ ninja-build libssl-dev git \
+    python3-pytest python3-pytest-xdist python3-yaml
+WORKDIR /liboqs
+COPY . .
+RUN mkdir build && cd build && cmake -GNinja .. && ninja
+CMD ["./build/tests/test_sig", "Dilithium3"]

--- a/test_sig.sh
+++ b/test_sig.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Building Docker image for OQS sigs test...${NC}"
+docker build --progress=plain \
+    -f test_sig.Dockerfile -t liboqs-sig-test .
+    # --platform=linux/amd64 \
+
+if [ $? -ne 0 ]; then
+    echo -e "${RED}Docker build failed!${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}Running OQS sigs test in container...${NC}"
+docker run --rm liboqs-sig-test
+
+# Optional: Run with interactive shell for debugging
+if [ "$1" == "--debug" ]; then
+    echo -e "${GREEN}Starting interactive debugging session...${NC}"
+    docker run --rm -it liboqs-sigs-test /bin/bash
+fi
+
+# Optional: Clean up the image after testing
+if [ "$1" == "--clean" ]; then
+    echo -e "${GREEN}Cleaning up Docker image...${NC}"
+    docker rmi liboqs-sig-test
+fi


### PR DESCRIPTION
Added dilithium3 implementation for deterministic keypair generation from seed (please review for security correctness) with enhancement to test suite mirroring the way other algos test deterministic generation

Included Docker runner for test

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [N] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [N] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

