### PR TITLE
Remove armel comment

### DIFF
--- a/.CMake/toolchain_armel.cmake
+++ b/.CMake/toolchain_armel.cmake
@@ -1,8 +1,0 @@
-# SPDX-License-Identifier: MIT
-
-set(CMAKE_SYSTEM_NAME Linux)
-set(CMAKE_SYSTEM_PROCESSOR arm32v7)
-set(CMAKE_CROSSCOMPILING ON)
-
-set(CMAKE_C_COMPILER arm-linux-gnueabi-gcc)
-set(CMAKE_CROSSCOMPILING_EMULATOR "qemu-arm-static;-L;/usr/arm-linux-gnueabi/")

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -169,10 +169,7 @@ jobs:
             ARCH: armhf
             CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=generic -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
             PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
-          # no longer supporting armel
-          # - name: armel
-          #   ARCH: armel
-          #   CMAKE_ARGS: -DOQS_ENABLE_SIG_SPHINCS=OFF -DOQS_USE_OPENSSL=OFF -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=generic
+
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4


### PR DESCRIPTION
Since armel is no longer a supported platform, the commented out workflow in `linux.yml` can be removed.