### PR TITLE
Fix typo in PLATFORMS.md

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -50,7 +50,7 @@ In this policy, the words "must" and "must not" specify absolute requirements th
 - x86_64/amd64/x64 for MacOS (XCode 15)
 - aarch64 for Ubuntu (Noble)
 - aarch64 for MacOS (XCode 15 and 16)
-- armhf/ARM7 and aarch64 emulation on Ubuntu
+- armhf/ARM7 emulation on Ubuntu
 
 ### Tier 2
 
@@ -62,7 +62,7 @@ In this policy, the words "must" and "must not" specify absolute requirements th
 ### Tier 3
 
 - x86 for Windows (Visual Studio Toolchain)
-- ppc641e for Ubuntu (Focal)
+- ppc64le for Ubuntu (Focal)
 - s390x for Ubuntu (Focal)
 - loongarch64 for Debian Linux (trixie)
 - NVIDIA GPU architectures 70, 75, 80, 86, 89, and 90 with a x86_64 CPU for Linux


### PR DESCRIPTION
* armel is no longer supported, so I've removed reference to it
* Fixed a typo with ppc64le