### PR TITLE
Update CROSS to version 2.2

### DIFF
--- a/docs/algorithms/sig/cross.md
+++ b/docs/algorithms/sig/cross.md
@@ -7,7 +7,7 @@
 - **Authors' website**: https://www.cross-crypto.com/
 - **Specification version**: 2.2 + PQClean and OQS patches.
 - **Primary Source**<a name="primary-source"></a>:
-  - **Source**: https://github.com/CROSS-signature/CROSS-lib-oqs/commit/ca50b43df8d676a5814007bbe94e6df379c4005a
+  - **Source**: https://github.com/CROSS-signature/CROSS-lib-oqs/commit/cc9047e3967e79bd5708493803726c1138f593e0
   - **Implementation license (SPDX-Identifier)**: CC0-1.0
 
 

--- a/docs/algorithms/sig/cross.md
+++ b/docs/algorithms/sig/cross.md
@@ -7,7 +7,7 @@
 - **Authors' website**: https://www.cross-crypto.com/
 - **Specification version**: 2.2 + PQClean and OQS patches.
 - **Primary Source**<a name="primary-source"></a>:
-  - **Source**: https://github.com/CROSS-signature/CROSS-lib-oqs/commit/cc9047e3967e79bd5708493803726c1138f593e0
+  - **Source**: https://github.com/CROSS-signature/CROSS-lib-oqs/commit/c8f7411fed136f0e37600973fa3dbed53465e54f
   - **Implementation license (SPDX-Identifier)**: CC0-1.0
 
 

--- a/docs/algorithms/sig/cross.md
+++ b/docs/algorithms/sig/cross.md
@@ -2,12 +2,12 @@
 
 - **Algorithm type**: Digital signature scheme.
 - **Main cryptographic assumption**: hardness of the restricted syndrome decoding problem for random linear codes on a finite field.
-- **Principal submitters**: Marco Baldi, Alessandro Barenghi, Michele Battagliola, Sebastian Bitzer, Patrick Karl, Felice Manganiello, Alessio Pavoni, Gerardo Pelosi, Paolo Santini, Jonas Schupp, Edoardo Signorini, Freeman Slaughter, Antonia Wachter-Zeh, Violetta Weger.
+- **Principal submitters**: Marco Baldi, Alessandro Barenghi, Michele Battagliola, Sebastian Bitzer, Patrick Karl, Felice Manganiello, Alessio Pavoni, Gerardo Pelosi, Federico Pintore, Paolo Santini, Jonas Schupp, Edoardo Signorini, Freeman Slaughter, Antonia Wachter-Zeh, Violetta Weger.
 - **Auxiliary submitters**: Marco Gianvecchio.
 - **Authors' website**: https://www.cross-crypto.com/
-- **Specification version**: 2.0 + PQClean and OQS patches.
+- **Specification version**: 2.2 + PQClean and OQS patches.
 - **Primary Source**<a name="primary-source"></a>:
-  - **Source**: https://github.com/CROSS-signature/CROSS-lib-oqs/commit/efd17279e75308b000bda7c7f58866620d652bc1
+  - **Source**: https://github.com/CROSS-signature/CROSS-lib-oqs/commit/ca50b43df8d676a5814007bbe94e6df379c4005a
   - **Implementation license (SPDX-Identifier)**: CC0-1.0
 
 

--- a/docs/algorithms/sig/cross.yml
+++ b/docs/algorithms/sig/cross.yml
@@ -9,6 +9,7 @@ principal-submitters:
 - Felice Manganiello
 - Alessio Pavoni
 - Gerardo Pelosi
+- Federico Pintore
 - Paolo Santini
 - Jonas Schupp
 - Edoardo Signorini
@@ -21,9 +22,9 @@ crypto-assumption: hardness of the restricted syndrome decoding problem for rand
   linear codes on a finite field
 website: https://www.cross-crypto.com/
 nist-round: 2
-spec-version: 2.0 + PQClean and OQS patches
+spec-version: 2.2 + PQClean and OQS patches
 primary-upstream:
-  source: https://github.com/CROSS-signature/CROSS-lib-oqs/commit/efd17279e75308b000bda7c7f58866620d652bc1
+  source: https://github.com/CROSS-signature/CROSS-lib-oqs/commit/ca50b43df8d676a5814007bbe94e6df379c4005a
   spdx-license-identifier: CC0-1.0
 parameter-sets:
 - name: cross-rsdp-128-balanced

--- a/docs/algorithms/sig/cross.yml
+++ b/docs/algorithms/sig/cross.yml
@@ -24,7 +24,7 @@ website: https://www.cross-crypto.com/
 nist-round: 2
 spec-version: 2.2 + PQClean and OQS patches
 primary-upstream:
-  source: https://github.com/CROSS-signature/CROSS-lib-oqs/commit/cc9047e3967e79bd5708493803726c1138f593e0
+  source: https://github.com/CROSS-signature/CROSS-lib-oqs/commit/c8f7411fed136f0e37600973fa3dbed53465e54f
   spdx-license-identifier: CC0-1.0
 parameter-sets:
 - name: cross-rsdp-128-balanced

--- a/docs/algorithms/sig/cross.yml
+++ b/docs/algorithms/sig/cross.yml
@@ -24,7 +24,7 @@ website: https://www.cross-crypto.com/
 nist-round: 2
 spec-version: 2.2 + PQClean and OQS patches
 primary-upstream:
-  source: https://github.com/CROSS-signature/CROSS-lib-oqs/commit/ca50b43df8d676a5814007bbe94e6df379c4005a
+  source: https://github.com/CROSS-signature/CROSS-lib-oqs/commit/cc9047e3967e79bd5708493803726c1138f593e0
   spdx-license-identifier: CC0-1.0
 parameter-sets:
 - name: cross-rsdp-128-balanced

--- a/scripts/copy_from_upstream/copy_from_upstream.yml
+++ b/scripts/copy_from_upstream/copy_from_upstream.yml
@@ -82,7 +82,7 @@ upstreams:
     name: upcross
     git_url: https://github.com/CROSS-signature/CROSS-lib-oqs.git
     git_branch: master
-    git_commit: efd17279e75308b000bda7c7f58866620d652bc1
+    git_commit: ca50b43df8d676a5814007bbe94e6df379c4005a
     sig_meta_path: 'generate/crypto_sign/{pqclean_scheme}/META.yml'
     sig_scheme_path: 'generate/crypto_sign/{pqclean_scheme}'
   -

--- a/scripts/copy_from_upstream/copy_from_upstream.yml
+++ b/scripts/copy_from_upstream/copy_from_upstream.yml
@@ -82,7 +82,7 @@ upstreams:
     name: upcross
     git_url: https://github.com/CROSS-signature/CROSS-lib-oqs.git
     git_branch: master
-    git_commit: cc9047e3967e79bd5708493803726c1138f593e0
+    git_commit: c8f7411fed136f0e37600973fa3dbed53465e54f
     sig_meta_path: 'generate/crypto_sign/{pqclean_scheme}/META.yml'
     sig_scheme_path: 'generate/crypto_sign/{pqclean_scheme}'
   -

--- a/scripts/copy_from_upstream/copy_from_upstream.yml
+++ b/scripts/copy_from_upstream/copy_from_upstream.yml
@@ -82,7 +82,7 @@ upstreams:
     name: upcross
     git_url: https://github.com/CROSS-signature/CROSS-lib-oqs.git
     git_branch: master
-    git_commit: ca50b43df8d676a5814007bbe94e6df379c4005a
+    git_commit: cc9047e3967e79bd5708493803726c1138f593e0
     sig_meta_path: 'generate/crypto_sign/{pqclean_scheme}/META.yml'
     sig_scheme_path: 'generate/crypto_sign/{pqclean_scheme}'
   -

--- a/src/sig/cross/sig_cross_rsdp_128_balanced.c
+++ b/src/sig/cross/sig_cross_rsdp_128_balanced.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdp_128_balanced_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdp_128_balanced;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdp_128_fast.c
+++ b/src/sig/cross/sig_cross_rsdp_128_fast.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdp_128_fast_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdp_128_fast;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdp_128_small.c
+++ b/src/sig/cross/sig_cross_rsdp_128_small.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdp_128_small_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdp_128_small;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdp_192_balanced.c
+++ b/src/sig/cross/sig_cross_rsdp_192_balanced.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdp_192_balanced_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdp_192_balanced;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdp_192_fast.c
+++ b/src/sig/cross/sig_cross_rsdp_192_fast.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdp_192_fast_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdp_192_fast;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdp_192_small.c
+++ b/src/sig/cross/sig_cross_rsdp_192_small.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdp_192_small_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdp_192_small;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdp_256_balanced.c
+++ b/src/sig/cross/sig_cross_rsdp_256_balanced.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdp_256_balanced_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdp_256_balanced;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdp_256_fast.c
+++ b/src/sig/cross/sig_cross_rsdp_256_fast.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdp_256_fast_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdp_256_fast;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdp_256_small.c
+++ b/src/sig/cross/sig_cross_rsdp_256_small.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdp_256_small_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdp_256_small;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdpg_128_balanced.c
+++ b/src/sig/cross/sig_cross_rsdpg_128_balanced.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdpg_128_balanced_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdpg_128_balanced;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdpg_128_fast.c
+++ b/src/sig/cross/sig_cross_rsdpg_128_fast.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdpg_128_fast_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdpg_128_fast;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdpg_128_small.c
+++ b/src/sig/cross/sig_cross_rsdpg_128_small.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdpg_128_small_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdpg_128_small;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 1;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdpg_192_balanced.c
+++ b/src/sig/cross/sig_cross_rsdpg_192_balanced.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdpg_192_balanced_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdpg_192_balanced;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdpg_192_fast.c
+++ b/src/sig/cross/sig_cross_rsdpg_192_fast.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdpg_192_fast_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdpg_192_fast;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdpg_192_small.c
+++ b/src/sig/cross/sig_cross_rsdpg_192_small.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdpg_192_small_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdpg_192_small;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 3;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdpg_256_balanced.c
+++ b/src/sig/cross/sig_cross_rsdpg_256_balanced.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdpg_256_balanced_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdpg_256_balanced;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdpg_256_fast.c
+++ b/src/sig/cross/sig_cross_rsdpg_256_fast.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdpg_256_fast_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdpg_256_fast;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;

--- a/src/sig/cross/sig_cross_rsdpg_256_small.c
+++ b/src/sig/cross/sig_cross_rsdpg_256_small.c
@@ -12,7 +12,7 @@ OQS_SIG *OQS_SIG_cross_rsdpg_256_small_new(void) {
 		return NULL;
 	}
 	sig->method_name = OQS_SIG_alg_cross_rsdpg_256_small;
-	sig->alg_version = "2.0 + PQClean and OQS patches";
+	sig->alg_version = "2.2 + PQClean and OQS patches";
 
 	sig->claimed_nist_level = 5;
 	sig->euf_cma = true;

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -56,6 +56,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -543,6 +545,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -554,6 +557,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -563,6 +567,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP128BALANCED_AVX2_CRYPTO_RANDOMBYTES 16
+
 
 int PQCLEAN_CROSSRSDP128BALANCED_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,113 @@
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
 
+
+/* AVX2 utility functions */
+
+/* reduce modulo 509 eigth 32-bit integers packed into a 256-bit vector, using Barrett's method
+ * each 32-bit integer sould be in the range [0, 508*508] i.e. the result of a mul in FP
+ * however, the function actually works for integers in the wider range [0, 8339743] */
+static inline __m256i mm256_mod509_epu32(__m256i a) {
+	int b_shift = 18; // ceil(log2(509))*2
+	int b_mul = (((uint64_t)1U << b_shift) / P);
+	/* r = a - ((B_MUL * a) >> B_SHIFT) * P) */
+	__m256i b_mul_32 = _mm256_set1_epi32(b_mul);
+	__m256i p_32 = _mm256_set1_epi32(P);
+	__m256i r = _mm256_mullo_epi32(a, b_mul_32);
+	r = _mm256_srli_epi32(r, b_shift);
+	r = _mm256_mullo_epi32(r, p_32);
+	r = _mm256_sub_epi32(a, r);
+	/* r = min(r, r - P) */
+	__m256i rs = _mm256_sub_epi32(r, p_32);
+	r = _mm256_min_epu32(r, rs);
+	return r;
+}
+
+/* reduce modulo 509 sixteen 16-bit integers packed into a 256-bit vector
+ * each 16-bit integer sould be in the range [0, 508*2] */
+static inline __m256i mm256_mod509_epu16(__m256i a) {
+	/* r = min(r, r - P) */
+	__m256i p_256 = _mm256_set1_epi16(509);
+	__m256i as = _mm256_sub_epi16(a, p_256);
+	return _mm256_min_epu16(a, as);
+}
+
+/* shuffle sixteen 16-bit integers packed into a 256-bit vector:
+ * shuffle(a[], b[]) returns c[] where c[i]=a[b[i]]
+ * operates within 128-bit lanes, so b[i] must be in the range [0,7] */
+static inline __m256i mm256_shuffle_epi16(__m256i a, __m256i b) {
+	__m256i x1 = _mm256_setr_epi8(0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14, 0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14);
+	__m256i x2 = _mm256_setr_epi8(0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1);
+	b = _mm256_adds_epu16(b, b);
+	b = _mm256_shuffle_epi8(b, x1);
+	b = _mm256_adds_epu8(b, x2);
+	b = _mm256_shuffle_epi8(a, b);
+	return b;
+}
+
+/* for each 16-bit integer packed into a 256-bit vector, select one of two
+ * values based on a boolean condition, without using if-else statements:
+ * cmov(cond[], true_val[], false_val[]) returns r[] where r[i]=true_val[i]
+ * if cond[i]==1, and r[i]=false_val[i] if cond[i]==0 */
+static inline __m256i mm256_cmov_epu16(__m256i c, __m256i t, __m256i f) {
+	__m256i zeros  = _mm256_setzero_si256();
+	__m256i cmask  = _mm256_sub_epi16(zeros, c);
+	__m256i cmaskn = _mm256_xor_si256(cmask, _mm256_set1_epi16(-1));
+	__m256i tval   = _mm256_and_si256(cmask, t);
+	__m256i fval   = _mm256_and_si256(cmaskn, f);
+	__m256i r      = _mm256_or_si256(tval, fval);
+	return r;
+}
+
+/* multiply 16-bit integers packed into 256-bit vectors and reduce the result
+ * modulo 509: mulmod509(a[], b[]) returns c[] where c[i]=(a[i]*b[i])%509 */
+static inline __m256i mm256_mulmod509_epu16(__m256i a, __m256i b) {
+	/* multiply */
+	__m256i l = _mm256_mullo_epi16(a, b);
+	__m256i h = _mm256_mulhi_epu16(a, b);
+	/* unpack 16-bit to 32-bit */
+	__m256i u0 = _mm256_unpacklo_epi16(l, h);
+	__m256i u1 = _mm256_unpackhi_epi16(l, h);
+	/* reduce */
+	u0 = mm256_mod509_epu32(u0);
+	u1 = mm256_mod509_epu32(u1);
+	/* pack 32-bit to 16-bit */
+	__m256i r = _mm256_packs_epi32(u0, u1);
+	return r;
+}
+
+/* for each 16-bit integer x packed into a 256-bit vector, with x in [1, 127],
+ * compute: (16^x) mod 509 */
+static inline __m256i mm256_exp16mod509_epu16(__m256i a) {
+	/* high 3 bits */
+	__m256i h3 = _mm256_srli_epi16(a, 4);
+	__m256i pre_h3 = _mm256_setr_epi16(
+	                     1, 302, 93, 91, 505, 319, 137, 145,
+	                     1, 302, 93, 91, 505, 319, 137, 145);
+	__m256i h3_shu = mm256_shuffle_epi16(pre_h3, h3);
+	/* low 4 bits */
+	__m256i mask_l4 = _mm256_set1_epi16(0x0F); //0b1111
+	__m256i l4 = _mm256_and_si256(a, mask_l4);
+	__m256i mask_l4_bit4 = _mm256_set1_epi16(0x8); //0b1000
+	__m256i l4_bit4 = _mm256_and_si256(a, mask_l4_bit4);
+	l4_bit4 = _mm256_srli_epi16(l4_bit4, 3);
+	__m256i l4_sub8 = _mm256_sub_epi16(l4, _mm256_set1_epi16(8));
+	__m256i pre_l4_0 = _mm256_setr_epi16(
+	                       1, 16, 256, 24, 384, 36, 67, 54,
+	                       1, 16, 256, 24, 384, 36, 67, 54);
+	__m256i l4_shu_0 = mm256_shuffle_epi16(pre_l4_0, l4);
+	__m256i pre_l4_1 = _mm256_setr_epi16(
+	                       355, 81, 278, 376, 417, 55, 371, 337,
+	                       355, 81, 278, 376, 417, 55, 371, 337);
+	__m256i l4_shu_1 = mm256_shuffle_epi16(pre_l4_1, l4_sub8);
+	__m256i l4_shu = mm256_cmov_epu16(l4_bit4, l4_shu_1, l4_shu_0);
+	/* multiply */
+	__m256i r = mm256_mulmod509_epu16(h3_shu, l4_shu);
+	return r;
+}
+
+
+
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
 void fp_dz_norm_synd(FP_ELEM v[N - K]) {
@@ -92,6 +199,7 @@ void restr_vec_by_fp_matrix(FP_ELEM res[N - K],
 	}
 }
 
+
 /* Computes e * [I_k V]^T, V is already in transposed form
  * since  */
 static
@@ -127,6 +235,7 @@ void fp_vec_by_fp_matrix(FP_ELEM res[N - K],
 		res[i] = FPRED_DOUBLE(res_dprec[i]);
 	}
 }
+
 
 static inline
 void fp_vec_by_fp_vec_pointwise(FP_ELEM res[N],
@@ -209,6 +318,8 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 	}
 	memcpy(res, res_align, N);
 }
+
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,9 @@
 #define   W (215)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +120,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 128, 256}
@@ -130,3 +134,4 @@
 #define BITS_V_CT_RNG 28028
 #define BITS_N_FZ_CT_RNG 717
 #define BITS_CWSTR_RNG 4776
+

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,11 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x07) + ((x) >> 3))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
+
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -63,3 +66,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -208,6 +208,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -224,6 +225,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake128_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -55,6 +55,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -154,14 +156,14 @@ void CROSS_sign(const sk_t *const SK,
 	FP_ELEM s_prime[N - K];
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -324,8 +326,8 @@ int CROSS_verify(const pk_t *const PK,
 	seed_leaves(round_seeds, seed_tree);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -416,6 +418,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -437,9 +440,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP128BALANCED_CLEAN_CRYPTO_RANDOMBYTES 16
+
 
 int PQCLEAN_CROSSRSDP128BALANCED_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -45,6 +45,8 @@
 #define FPRED_OPPOSITE(x) ((x) ^ 0x7F)
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -126,6 +128,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,9 @@
 #define   W (215)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +120,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 128, 256}
@@ -130,3 +134,4 @@
 #define BITS_V_CT_RNG 28028
 #define BITS_N_FZ_CT_RNG 717
 #define BITS_CWSTR_RNG 4776
+

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,8 @@
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
 
+
+
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
 	for (int i = 0; i < N; i++) {
@@ -63,3 +65,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -174,6 +174,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -190,6 +191,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-balanced_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -56,6 +56,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -537,6 +539,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -548,6 +551,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -557,6 +561,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -64,6 +64,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP128FAST_AVX2_CRYPTO_RANDOMBYTES 16
+
 
 int PQCLEAN_CROSSRSDP128FAST_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,113 @@
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
 
+
+/* AVX2 utility functions */
+
+/* reduce modulo 509 eigth 32-bit integers packed into a 256-bit vector, using Barrett's method
+ * each 32-bit integer sould be in the range [0, 508*508] i.e. the result of a mul in FP
+ * however, the function actually works for integers in the wider range [0, 8339743] */
+static inline __m256i mm256_mod509_epu32(__m256i a) {
+	int b_shift = 18; // ceil(log2(509))*2
+	int b_mul = (((uint64_t)1U << b_shift) / P);
+	/* r = a - ((B_MUL * a) >> B_SHIFT) * P) */
+	__m256i b_mul_32 = _mm256_set1_epi32(b_mul);
+	__m256i p_32 = _mm256_set1_epi32(P);
+	__m256i r = _mm256_mullo_epi32(a, b_mul_32);
+	r = _mm256_srli_epi32(r, b_shift);
+	r = _mm256_mullo_epi32(r, p_32);
+	r = _mm256_sub_epi32(a, r);
+	/* r = min(r, r - P) */
+	__m256i rs = _mm256_sub_epi32(r, p_32);
+	r = _mm256_min_epu32(r, rs);
+	return r;
+}
+
+/* reduce modulo 509 sixteen 16-bit integers packed into a 256-bit vector
+ * each 16-bit integer sould be in the range [0, 508*2] */
+static inline __m256i mm256_mod509_epu16(__m256i a) {
+	/* r = min(r, r - P) */
+	__m256i p_256 = _mm256_set1_epi16(509);
+	__m256i as = _mm256_sub_epi16(a, p_256);
+	return _mm256_min_epu16(a, as);
+}
+
+/* shuffle sixteen 16-bit integers packed into a 256-bit vector:
+ * shuffle(a[], b[]) returns c[] where c[i]=a[b[i]]
+ * operates within 128-bit lanes, so b[i] must be in the range [0,7] */
+static inline __m256i mm256_shuffle_epi16(__m256i a, __m256i b) {
+	__m256i x1 = _mm256_setr_epi8(0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14, 0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14);
+	__m256i x2 = _mm256_setr_epi8(0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1);
+	b = _mm256_adds_epu16(b, b);
+	b = _mm256_shuffle_epi8(b, x1);
+	b = _mm256_adds_epu8(b, x2);
+	b = _mm256_shuffle_epi8(a, b);
+	return b;
+}
+
+/* for each 16-bit integer packed into a 256-bit vector, select one of two
+ * values based on a boolean condition, without using if-else statements:
+ * cmov(cond[], true_val[], false_val[]) returns r[] where r[i]=true_val[i]
+ * if cond[i]==1, and r[i]=false_val[i] if cond[i]==0 */
+static inline __m256i mm256_cmov_epu16(__m256i c, __m256i t, __m256i f) {
+	__m256i zeros  = _mm256_setzero_si256();
+	__m256i cmask  = _mm256_sub_epi16(zeros, c);
+	__m256i cmaskn = _mm256_xor_si256(cmask, _mm256_set1_epi16(-1));
+	__m256i tval   = _mm256_and_si256(cmask, t);
+	__m256i fval   = _mm256_and_si256(cmaskn, f);
+	__m256i r      = _mm256_or_si256(tval, fval);
+	return r;
+}
+
+/* multiply 16-bit integers packed into 256-bit vectors and reduce the result
+ * modulo 509: mulmod509(a[], b[]) returns c[] where c[i]=(a[i]*b[i])%509 */
+static inline __m256i mm256_mulmod509_epu16(__m256i a, __m256i b) {
+	/* multiply */
+	__m256i l = _mm256_mullo_epi16(a, b);
+	__m256i h = _mm256_mulhi_epu16(a, b);
+	/* unpack 16-bit to 32-bit */
+	__m256i u0 = _mm256_unpacklo_epi16(l, h);
+	__m256i u1 = _mm256_unpackhi_epi16(l, h);
+	/* reduce */
+	u0 = mm256_mod509_epu32(u0);
+	u1 = mm256_mod509_epu32(u1);
+	/* pack 32-bit to 16-bit */
+	__m256i r = _mm256_packs_epi32(u0, u1);
+	return r;
+}
+
+/* for each 16-bit integer x packed into a 256-bit vector, with x in [1, 127],
+ * compute: (16^x) mod 509 */
+static inline __m256i mm256_exp16mod509_epu16(__m256i a) {
+	/* high 3 bits */
+	__m256i h3 = _mm256_srli_epi16(a, 4);
+	__m256i pre_h3 = _mm256_setr_epi16(
+	                     1, 302, 93, 91, 505, 319, 137, 145,
+	                     1, 302, 93, 91, 505, 319, 137, 145);
+	__m256i h3_shu = mm256_shuffle_epi16(pre_h3, h3);
+	/* low 4 bits */
+	__m256i mask_l4 = _mm256_set1_epi16(0x0F); //0b1111
+	__m256i l4 = _mm256_and_si256(a, mask_l4);
+	__m256i mask_l4_bit4 = _mm256_set1_epi16(0x8); //0b1000
+	__m256i l4_bit4 = _mm256_and_si256(a, mask_l4_bit4);
+	l4_bit4 = _mm256_srli_epi16(l4_bit4, 3);
+	__m256i l4_sub8 = _mm256_sub_epi16(l4, _mm256_set1_epi16(8));
+	__m256i pre_l4_0 = _mm256_setr_epi16(
+	                       1, 16, 256, 24, 384, 36, 67, 54,
+	                       1, 16, 256, 24, 384, 36, 67, 54);
+	__m256i l4_shu_0 = mm256_shuffle_epi16(pre_l4_0, l4);
+	__m256i pre_l4_1 = _mm256_setr_epi16(
+	                       355, 81, 278, 376, 417, 55, 371, 337,
+	                       355, 81, 278, 376, 417, 55, 371, 337);
+	__m256i l4_shu_1 = mm256_shuffle_epi16(pre_l4_1, l4_sub8);
+	__m256i l4_shu = mm256_cmov_epu16(l4_bit4, l4_shu_1, l4_shu_0);
+	/* multiply */
+	__m256i r = mm256_mulmod509_epu16(h3_shu, l4_shu);
+	return r;
+}
+
+
+
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
 void fp_dz_norm_synd(FP_ELEM v[N - K]) {
@@ -92,6 +199,7 @@ void restr_vec_by_fp_matrix(FP_ELEM res[N - K],
 	}
 }
 
+
 /* Computes e * [I_k V]^T, V is already in transposed form
  * since  */
 static
@@ -127,6 +235,7 @@ void fp_vec_by_fp_matrix(FP_ELEM res[N - K],
 		res[i] = FPRED_DOUBLE(res_dprec[i]);
 	}
 }
+
 
 static inline
 void fp_vec_by_fp_vec_pointwise(FP_ELEM res[N],
@@ -209,6 +318,8 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 	}
 	memcpy(res, res_align, N);
 }
+
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "csprng_hash.h"
 #include "merkle_tree.h"
 #include "parameters.h"
+
 
 #define TO_PUBLISH 1
 #define NOT_TO_PUBLISH 0
@@ -95,3 +96,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
 	tree_root(root, recomputed_leaves);
 	return 1;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -33,6 +33,7 @@
 
 #include "namespace.h"
 
+
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],
                uint8_t leaves[T][HASH_DIGEST_LENGTH]);
 
@@ -44,3 +45,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
                        uint8_t recomputed_leaves[T][HASH_DIGEST_LENGTH],
                        const uint8_t mtp[W * HASH_DIGEST_LENGTH],
                        const uint8_t leaves_to_reveal[T]);
+

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,9 @@
 #define   W ( 82)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +120,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 2, 2, 58, 58}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 30, 60, 64, 128}
@@ -130,3 +134,4 @@
 #define BITS_V_CT_RNG 28028
 #define BITS_N_FZ_CT_RNG 717
 #define BITS_CWSTR_RNG 3656
+

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,11 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x07) + ((x) >> 3))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
+
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -63,3 +66,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake128_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -55,6 +55,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -152,14 +154,14 @@ void CROSS_sign(const sk_t *const SK,
 	FP_ELEM s_prime[N - K];
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -318,8 +320,8 @@ int CROSS_verify(const pk_t *const PK,
 	is_stree_padding_ok = rebuild_leaves(round_seeds, chall_2, sig->path);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -410,6 +412,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -431,9 +434,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -64,6 +64,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP128FAST_CLEAN_CRYPTO_RANDOMBYTES 16
+
 
 int PQCLEAN_CROSSRSDP128FAST_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -45,6 +45,8 @@
 #define FPRED_OPPOSITE(x) ((x) ^ 0x7F)
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -126,6 +128,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "csprng_hash.h"
 #include "merkle_tree.h"
 #include "parameters.h"
+
 
 #define TO_PUBLISH 1
 #define NOT_TO_PUBLISH 0
@@ -95,3 +96,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
 	tree_root(root, recomputed_leaves);
 	return 1;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -33,6 +33,7 @@
 
 #include "namespace.h"
 
+
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],
                uint8_t leaves[T][HASH_DIGEST_LENGTH]);
 
@@ -44,3 +45,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
                        uint8_t recomputed_leaves[T][HASH_DIGEST_LENGTH],
                        const uint8_t mtp[W * HASH_DIGEST_LENGTH],
                        const uint8_t leaves_to_reveal[T]);
+

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,9 @@
 #define   W ( 82)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +120,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 2, 2, 58, 58}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 30, 60, 64, 128}
@@ -130,3 +134,4 @@
 #define BITS_V_CT_RNG 28028
 #define BITS_N_FZ_CT_RNG 717
 #define BITS_CWSTR_RNG 3656
+

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,8 @@
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
 
+
+
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
 	for (int i = 0; i < N; i++) {
@@ -63,3 +65,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-fast_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-fast_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -56,6 +56,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -543,6 +545,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -554,6 +557,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -563,6 +567,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP128SMALL_AVX2_CRYPTO_RANDOMBYTES 16
+
 
 int PQCLEAN_CROSSRSDP128SMALL_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,113 @@
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
 
+
+/* AVX2 utility functions */
+
+/* reduce modulo 509 eigth 32-bit integers packed into a 256-bit vector, using Barrett's method
+ * each 32-bit integer sould be in the range [0, 508*508] i.e. the result of a mul in FP
+ * however, the function actually works for integers in the wider range [0, 8339743] */
+static inline __m256i mm256_mod509_epu32(__m256i a) {
+	int b_shift = 18; // ceil(log2(509))*2
+	int b_mul = (((uint64_t)1U << b_shift) / P);
+	/* r = a - ((B_MUL * a) >> B_SHIFT) * P) */
+	__m256i b_mul_32 = _mm256_set1_epi32(b_mul);
+	__m256i p_32 = _mm256_set1_epi32(P);
+	__m256i r = _mm256_mullo_epi32(a, b_mul_32);
+	r = _mm256_srli_epi32(r, b_shift);
+	r = _mm256_mullo_epi32(r, p_32);
+	r = _mm256_sub_epi32(a, r);
+	/* r = min(r, r - P) */
+	__m256i rs = _mm256_sub_epi32(r, p_32);
+	r = _mm256_min_epu32(r, rs);
+	return r;
+}
+
+/* reduce modulo 509 sixteen 16-bit integers packed into a 256-bit vector
+ * each 16-bit integer sould be in the range [0, 508*2] */
+static inline __m256i mm256_mod509_epu16(__m256i a) {
+	/* r = min(r, r - P) */
+	__m256i p_256 = _mm256_set1_epi16(509);
+	__m256i as = _mm256_sub_epi16(a, p_256);
+	return _mm256_min_epu16(a, as);
+}
+
+/* shuffle sixteen 16-bit integers packed into a 256-bit vector:
+ * shuffle(a[], b[]) returns c[] where c[i]=a[b[i]]
+ * operates within 128-bit lanes, so b[i] must be in the range [0,7] */
+static inline __m256i mm256_shuffle_epi16(__m256i a, __m256i b) {
+	__m256i x1 = _mm256_setr_epi8(0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14, 0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14);
+	__m256i x2 = _mm256_setr_epi8(0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1);
+	b = _mm256_adds_epu16(b, b);
+	b = _mm256_shuffle_epi8(b, x1);
+	b = _mm256_adds_epu8(b, x2);
+	b = _mm256_shuffle_epi8(a, b);
+	return b;
+}
+
+/* for each 16-bit integer packed into a 256-bit vector, select one of two
+ * values based on a boolean condition, without using if-else statements:
+ * cmov(cond[], true_val[], false_val[]) returns r[] where r[i]=true_val[i]
+ * if cond[i]==1, and r[i]=false_val[i] if cond[i]==0 */
+static inline __m256i mm256_cmov_epu16(__m256i c, __m256i t, __m256i f) {
+	__m256i zeros  = _mm256_setzero_si256();
+	__m256i cmask  = _mm256_sub_epi16(zeros, c);
+	__m256i cmaskn = _mm256_xor_si256(cmask, _mm256_set1_epi16(-1));
+	__m256i tval   = _mm256_and_si256(cmask, t);
+	__m256i fval   = _mm256_and_si256(cmaskn, f);
+	__m256i r      = _mm256_or_si256(tval, fval);
+	return r;
+}
+
+/* multiply 16-bit integers packed into 256-bit vectors and reduce the result
+ * modulo 509: mulmod509(a[], b[]) returns c[] where c[i]=(a[i]*b[i])%509 */
+static inline __m256i mm256_mulmod509_epu16(__m256i a, __m256i b) {
+	/* multiply */
+	__m256i l = _mm256_mullo_epi16(a, b);
+	__m256i h = _mm256_mulhi_epu16(a, b);
+	/* unpack 16-bit to 32-bit */
+	__m256i u0 = _mm256_unpacklo_epi16(l, h);
+	__m256i u1 = _mm256_unpackhi_epi16(l, h);
+	/* reduce */
+	u0 = mm256_mod509_epu32(u0);
+	u1 = mm256_mod509_epu32(u1);
+	/* pack 32-bit to 16-bit */
+	__m256i r = _mm256_packs_epi32(u0, u1);
+	return r;
+}
+
+/* for each 16-bit integer x packed into a 256-bit vector, with x in [1, 127],
+ * compute: (16^x) mod 509 */
+static inline __m256i mm256_exp16mod509_epu16(__m256i a) {
+	/* high 3 bits */
+	__m256i h3 = _mm256_srli_epi16(a, 4);
+	__m256i pre_h3 = _mm256_setr_epi16(
+	                     1, 302, 93, 91, 505, 319, 137, 145,
+	                     1, 302, 93, 91, 505, 319, 137, 145);
+	__m256i h3_shu = mm256_shuffle_epi16(pre_h3, h3);
+	/* low 4 bits */
+	__m256i mask_l4 = _mm256_set1_epi16(0x0F); //0b1111
+	__m256i l4 = _mm256_and_si256(a, mask_l4);
+	__m256i mask_l4_bit4 = _mm256_set1_epi16(0x8); //0b1000
+	__m256i l4_bit4 = _mm256_and_si256(a, mask_l4_bit4);
+	l4_bit4 = _mm256_srli_epi16(l4_bit4, 3);
+	__m256i l4_sub8 = _mm256_sub_epi16(l4, _mm256_set1_epi16(8));
+	__m256i pre_l4_0 = _mm256_setr_epi16(
+	                       1, 16, 256, 24, 384, 36, 67, 54,
+	                       1, 16, 256, 24, 384, 36, 67, 54);
+	__m256i l4_shu_0 = mm256_shuffle_epi16(pre_l4_0, l4);
+	__m256i pre_l4_1 = _mm256_setr_epi16(
+	                       355, 81, 278, 376, 417, 55, 371, 337,
+	                       355, 81, 278, 376, 417, 55, 371, 337);
+	__m256i l4_shu_1 = mm256_shuffle_epi16(pre_l4_1, l4_sub8);
+	__m256i l4_shu = mm256_cmov_epu16(l4_bit4, l4_shu_1, l4_shu_0);
+	/* multiply */
+	__m256i r = mm256_mulmod509_epu16(h3_shu, l4_shu);
+	return r;
+}
+
+
+
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
 void fp_dz_norm_synd(FP_ELEM v[N - K]) {
@@ -92,6 +199,7 @@ void restr_vec_by_fp_matrix(FP_ELEM res[N - K],
 	}
 }
 
+
 /* Computes e * [I_k V]^T, V is already in transposed form
  * since  */
 static
@@ -127,6 +235,7 @@ void fp_vec_by_fp_matrix(FP_ELEM res[N - K],
 		res[i] = FPRED_DOUBLE(res_dprec[i]);
 	}
 }
+
 
 static inline
 void fp_vec_by_fp_vec_pointwise(FP_ELEM res[N],
@@ -209,6 +318,8 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 	}
 	memcpy(res, res_align, N);
 }
+
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,10 @@
 #define   W (488)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +121,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 16, 16, 16, 16, 16, 16}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 16, 32, 64, 128, 256, 512}
@@ -130,3 +135,4 @@
 #define BITS_V_CT_RNG 28028
 #define BITS_N_FZ_CT_RNG 717
 #define BITS_CWSTR_RNG 10390
+

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,11 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x07) + ((x) >> 3))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
+
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -63,3 +66,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -208,6 +208,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -224,6 +225,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake128_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdp-128-small_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-128-small_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -55,6 +55,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -154,14 +156,14 @@ void CROSS_sign(const sk_t *const SK,
 	FP_ELEM s_prime[N - K];
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -324,8 +326,8 @@ int CROSS_verify(const pk_t *const PK,
 	seed_leaves(round_seeds, seed_tree);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -416,6 +418,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -437,9 +440,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdp-128-small_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-128-small_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP128SMALL_CLEAN_CRYPTO_RANDOMBYTES 16
+
 
 int PQCLEAN_CROSSRSDP128SMALL_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-128-small_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-small_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-small_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -45,6 +45,8 @@
 #define FPRED_OPPOSITE(x) ((x) ^ 0x7F)
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -126,6 +128,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-128-small_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdp-128-small_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdp-128-small_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-small_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-128-small_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,10 @@
 #define   W (488)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +121,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 16, 16, 16, 16, 16, 16}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 16, 32, 64, 128, 256, 512}
@@ -130,3 +135,4 @@
 #define BITS_V_CT_RNG 28028
 #define BITS_N_FZ_CT_RNG 717
 #define BITS_CWSTR_RNG 10390
+

--- a/src/sig/cross/upcross_cross-rsdp-128-small_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,8 @@
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
 
+
+
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
 	for (int i = 0; i < N; i++) {
@@ -63,3 +65,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-128-small_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -174,6 +174,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -190,6 +191,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdp-128-small_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdp-128-small_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-128-small_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-128-small_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -56,6 +56,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -543,6 +545,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -554,6 +557,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -563,6 +567,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP192BALANCED_AVX2_CRYPTO_RANDOMBYTES 24
+
 
 int PQCLEAN_CROSSRSDP192BALANCED_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,113 @@
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
 
+
+/* AVX2 utility functions */
+
+/* reduce modulo 509 eigth 32-bit integers packed into a 256-bit vector, using Barrett's method
+ * each 32-bit integer sould be in the range [0, 508*508] i.e. the result of a mul in FP
+ * however, the function actually works for integers in the wider range [0, 8339743] */
+static inline __m256i mm256_mod509_epu32(__m256i a) {
+	int b_shift = 18; // ceil(log2(509))*2
+	int b_mul = (((uint64_t)1U << b_shift) / P);
+	/* r = a - ((B_MUL * a) >> B_SHIFT) * P) */
+	__m256i b_mul_32 = _mm256_set1_epi32(b_mul);
+	__m256i p_32 = _mm256_set1_epi32(P);
+	__m256i r = _mm256_mullo_epi32(a, b_mul_32);
+	r = _mm256_srli_epi32(r, b_shift);
+	r = _mm256_mullo_epi32(r, p_32);
+	r = _mm256_sub_epi32(a, r);
+	/* r = min(r, r - P) */
+	__m256i rs = _mm256_sub_epi32(r, p_32);
+	r = _mm256_min_epu32(r, rs);
+	return r;
+}
+
+/* reduce modulo 509 sixteen 16-bit integers packed into a 256-bit vector
+ * each 16-bit integer sould be in the range [0, 508*2] */
+static inline __m256i mm256_mod509_epu16(__m256i a) {
+	/* r = min(r, r - P) */
+	__m256i p_256 = _mm256_set1_epi16(509);
+	__m256i as = _mm256_sub_epi16(a, p_256);
+	return _mm256_min_epu16(a, as);
+}
+
+/* shuffle sixteen 16-bit integers packed into a 256-bit vector:
+ * shuffle(a[], b[]) returns c[] where c[i]=a[b[i]]
+ * operates within 128-bit lanes, so b[i] must be in the range [0,7] */
+static inline __m256i mm256_shuffle_epi16(__m256i a, __m256i b) {
+	__m256i x1 = _mm256_setr_epi8(0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14, 0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14);
+	__m256i x2 = _mm256_setr_epi8(0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1);
+	b = _mm256_adds_epu16(b, b);
+	b = _mm256_shuffle_epi8(b, x1);
+	b = _mm256_adds_epu8(b, x2);
+	b = _mm256_shuffle_epi8(a, b);
+	return b;
+}
+
+/* for each 16-bit integer packed into a 256-bit vector, select one of two
+ * values based on a boolean condition, without using if-else statements:
+ * cmov(cond[], true_val[], false_val[]) returns r[] where r[i]=true_val[i]
+ * if cond[i]==1, and r[i]=false_val[i] if cond[i]==0 */
+static inline __m256i mm256_cmov_epu16(__m256i c, __m256i t, __m256i f) {
+	__m256i zeros  = _mm256_setzero_si256();
+	__m256i cmask  = _mm256_sub_epi16(zeros, c);
+	__m256i cmaskn = _mm256_xor_si256(cmask, _mm256_set1_epi16(-1));
+	__m256i tval   = _mm256_and_si256(cmask, t);
+	__m256i fval   = _mm256_and_si256(cmaskn, f);
+	__m256i r      = _mm256_or_si256(tval, fval);
+	return r;
+}
+
+/* multiply 16-bit integers packed into 256-bit vectors and reduce the result
+ * modulo 509: mulmod509(a[], b[]) returns c[] where c[i]=(a[i]*b[i])%509 */
+static inline __m256i mm256_mulmod509_epu16(__m256i a, __m256i b) {
+	/* multiply */
+	__m256i l = _mm256_mullo_epi16(a, b);
+	__m256i h = _mm256_mulhi_epu16(a, b);
+	/* unpack 16-bit to 32-bit */
+	__m256i u0 = _mm256_unpacklo_epi16(l, h);
+	__m256i u1 = _mm256_unpackhi_epi16(l, h);
+	/* reduce */
+	u0 = mm256_mod509_epu32(u0);
+	u1 = mm256_mod509_epu32(u1);
+	/* pack 32-bit to 16-bit */
+	__m256i r = _mm256_packs_epi32(u0, u1);
+	return r;
+}
+
+/* for each 16-bit integer x packed into a 256-bit vector, with x in [1, 127],
+ * compute: (16^x) mod 509 */
+static inline __m256i mm256_exp16mod509_epu16(__m256i a) {
+	/* high 3 bits */
+	__m256i h3 = _mm256_srli_epi16(a, 4);
+	__m256i pre_h3 = _mm256_setr_epi16(
+	                     1, 302, 93, 91, 505, 319, 137, 145,
+	                     1, 302, 93, 91, 505, 319, 137, 145);
+	__m256i h3_shu = mm256_shuffle_epi16(pre_h3, h3);
+	/* low 4 bits */
+	__m256i mask_l4 = _mm256_set1_epi16(0x0F); //0b1111
+	__m256i l4 = _mm256_and_si256(a, mask_l4);
+	__m256i mask_l4_bit4 = _mm256_set1_epi16(0x8); //0b1000
+	__m256i l4_bit4 = _mm256_and_si256(a, mask_l4_bit4);
+	l4_bit4 = _mm256_srli_epi16(l4_bit4, 3);
+	__m256i l4_sub8 = _mm256_sub_epi16(l4, _mm256_set1_epi16(8));
+	__m256i pre_l4_0 = _mm256_setr_epi16(
+	                       1, 16, 256, 24, 384, 36, 67, 54,
+	                       1, 16, 256, 24, 384, 36, 67, 54);
+	__m256i l4_shu_0 = mm256_shuffle_epi16(pre_l4_0, l4);
+	__m256i pre_l4_1 = _mm256_setr_epi16(
+	                       355, 81, 278, 376, 417, 55, 371, 337,
+	                       355, 81, 278, 376, 417, 55, 371, 337);
+	__m256i l4_shu_1 = mm256_shuffle_epi16(pre_l4_1, l4_sub8);
+	__m256i l4_shu = mm256_cmov_epu16(l4_bit4, l4_shu_1, l4_shu_0);
+	/* multiply */
+	__m256i r = mm256_mulmod509_epu16(h3_shu, l4_shu);
+	return r;
+}
+
+
+
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
 void fp_dz_norm_synd(FP_ELEM v[N - K]) {
@@ -92,6 +199,7 @@ void restr_vec_by_fp_matrix(FP_ELEM res[N - K],
 	}
 }
 
+
 /* Computes e * [I_k V]^T, V is already in transposed form
  * since  */
 static
@@ -127,6 +235,7 @@ void fp_vec_by_fp_matrix(FP_ELEM res[N - K],
 		res[i] = FPRED_DOUBLE(res_dprec[i]);
 	}
 }
+
 
 static inline
 void fp_vec_by_fp_vec_pointwise(FP_ELEM res[N],
@@ -209,6 +318,8 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 	}
 	memcpy(res, res_align, N);
 }
+
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,9 @@
 #define   W (321)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +120,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 0, 0, 256}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 128, 256, 256}
@@ -130,3 +134,4 @@
 #define BITS_V_CT_RNG 60711
 #define BITS_N_FZ_CT_RNG 1065
 #define BITS_CWSTR_RNG 8586
+

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,11 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x07) + ((x) >> 3))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
+
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -63,3 +66,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -208,6 +208,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -224,6 +225,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake256_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -55,6 +55,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -154,14 +156,14 @@ void CROSS_sign(const sk_t *const SK,
 	FP_ELEM s_prime[N - K];
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -324,8 +326,8 @@ int CROSS_verify(const pk_t *const PK,
 	seed_leaves(round_seeds, seed_tree);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -416,6 +418,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -437,9 +440,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP192BALANCED_CLEAN_CRYPTO_RANDOMBYTES 24
+
 
 int PQCLEAN_CROSSRSDP192BALANCED_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -45,6 +45,8 @@
 #define FPRED_OPPOSITE(x) ((x) ^ 0x7F)
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -126,6 +128,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,9 @@
 #define   W (321)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +120,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 0, 0, 256}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 128, 256, 256}
@@ -130,3 +134,4 @@
 #define BITS_V_CT_RNG 60711
 #define BITS_N_FZ_CT_RNG 1065
 #define BITS_CWSTR_RNG 8586
+

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,8 @@
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
 
+
+
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
 	for (int i = 0; i < N; i++) {
@@ -63,3 +65,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -174,6 +174,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -190,6 +191,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-balanced_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -56,6 +56,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -537,6 +539,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -548,6 +551,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -557,6 +561,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -64,6 +64,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP192FAST_AVX2_CRYPTO_RANDOMBYTES 24
+
 
 int PQCLEAN_CROSSRSDP192FAST_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,113 @@
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
 
+
+/* AVX2 utility functions */
+
+/* reduce modulo 509 eigth 32-bit integers packed into a 256-bit vector, using Barrett's method
+ * each 32-bit integer sould be in the range [0, 508*508] i.e. the result of a mul in FP
+ * however, the function actually works for integers in the wider range [0, 8339743] */
+static inline __m256i mm256_mod509_epu32(__m256i a) {
+	int b_shift = 18; // ceil(log2(509))*2
+	int b_mul = (((uint64_t)1U << b_shift) / P);
+	/* r = a - ((B_MUL * a) >> B_SHIFT) * P) */
+	__m256i b_mul_32 = _mm256_set1_epi32(b_mul);
+	__m256i p_32 = _mm256_set1_epi32(P);
+	__m256i r = _mm256_mullo_epi32(a, b_mul_32);
+	r = _mm256_srli_epi32(r, b_shift);
+	r = _mm256_mullo_epi32(r, p_32);
+	r = _mm256_sub_epi32(a, r);
+	/* r = min(r, r - P) */
+	__m256i rs = _mm256_sub_epi32(r, p_32);
+	r = _mm256_min_epu32(r, rs);
+	return r;
+}
+
+/* reduce modulo 509 sixteen 16-bit integers packed into a 256-bit vector
+ * each 16-bit integer sould be in the range [0, 508*2] */
+static inline __m256i mm256_mod509_epu16(__m256i a) {
+	/* r = min(r, r - P) */
+	__m256i p_256 = _mm256_set1_epi16(509);
+	__m256i as = _mm256_sub_epi16(a, p_256);
+	return _mm256_min_epu16(a, as);
+}
+
+/* shuffle sixteen 16-bit integers packed into a 256-bit vector:
+ * shuffle(a[], b[]) returns c[] where c[i]=a[b[i]]
+ * operates within 128-bit lanes, so b[i] must be in the range [0,7] */
+static inline __m256i mm256_shuffle_epi16(__m256i a, __m256i b) {
+	__m256i x1 = _mm256_setr_epi8(0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14, 0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14);
+	__m256i x2 = _mm256_setr_epi8(0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1);
+	b = _mm256_adds_epu16(b, b);
+	b = _mm256_shuffle_epi8(b, x1);
+	b = _mm256_adds_epu8(b, x2);
+	b = _mm256_shuffle_epi8(a, b);
+	return b;
+}
+
+/* for each 16-bit integer packed into a 256-bit vector, select one of two
+ * values based on a boolean condition, without using if-else statements:
+ * cmov(cond[], true_val[], false_val[]) returns r[] where r[i]=true_val[i]
+ * if cond[i]==1, and r[i]=false_val[i] if cond[i]==0 */
+static inline __m256i mm256_cmov_epu16(__m256i c, __m256i t, __m256i f) {
+	__m256i zeros  = _mm256_setzero_si256();
+	__m256i cmask  = _mm256_sub_epi16(zeros, c);
+	__m256i cmaskn = _mm256_xor_si256(cmask, _mm256_set1_epi16(-1));
+	__m256i tval   = _mm256_and_si256(cmask, t);
+	__m256i fval   = _mm256_and_si256(cmaskn, f);
+	__m256i r      = _mm256_or_si256(tval, fval);
+	return r;
+}
+
+/* multiply 16-bit integers packed into 256-bit vectors and reduce the result
+ * modulo 509: mulmod509(a[], b[]) returns c[] where c[i]=(a[i]*b[i])%509 */
+static inline __m256i mm256_mulmod509_epu16(__m256i a, __m256i b) {
+	/* multiply */
+	__m256i l = _mm256_mullo_epi16(a, b);
+	__m256i h = _mm256_mulhi_epu16(a, b);
+	/* unpack 16-bit to 32-bit */
+	__m256i u0 = _mm256_unpacklo_epi16(l, h);
+	__m256i u1 = _mm256_unpackhi_epi16(l, h);
+	/* reduce */
+	u0 = mm256_mod509_epu32(u0);
+	u1 = mm256_mod509_epu32(u1);
+	/* pack 32-bit to 16-bit */
+	__m256i r = _mm256_packs_epi32(u0, u1);
+	return r;
+}
+
+/* for each 16-bit integer x packed into a 256-bit vector, with x in [1, 127],
+ * compute: (16^x) mod 509 */
+static inline __m256i mm256_exp16mod509_epu16(__m256i a) {
+	/* high 3 bits */
+	__m256i h3 = _mm256_srli_epi16(a, 4);
+	__m256i pre_h3 = _mm256_setr_epi16(
+	                     1, 302, 93, 91, 505, 319, 137, 145,
+	                     1, 302, 93, 91, 505, 319, 137, 145);
+	__m256i h3_shu = mm256_shuffle_epi16(pre_h3, h3);
+	/* low 4 bits */
+	__m256i mask_l4 = _mm256_set1_epi16(0x0F); //0b1111
+	__m256i l4 = _mm256_and_si256(a, mask_l4);
+	__m256i mask_l4_bit4 = _mm256_set1_epi16(0x8); //0b1000
+	__m256i l4_bit4 = _mm256_and_si256(a, mask_l4_bit4);
+	l4_bit4 = _mm256_srli_epi16(l4_bit4, 3);
+	__m256i l4_sub8 = _mm256_sub_epi16(l4, _mm256_set1_epi16(8));
+	__m256i pre_l4_0 = _mm256_setr_epi16(
+	                       1, 16, 256, 24, 384, 36, 67, 54,
+	                       1, 16, 256, 24, 384, 36, 67, 54);
+	__m256i l4_shu_0 = mm256_shuffle_epi16(pre_l4_0, l4);
+	__m256i pre_l4_1 = _mm256_setr_epi16(
+	                       355, 81, 278, 376, 417, 55, 371, 337,
+	                       355, 81, 278, 376, 417, 55, 371, 337);
+	__m256i l4_shu_1 = mm256_shuffle_epi16(pre_l4_1, l4_sub8);
+	__m256i l4_shu = mm256_cmov_epu16(l4_bit4, l4_shu_1, l4_shu_0);
+	/* multiply */
+	__m256i r = mm256_mulmod509_epu16(h3_shu, l4_shu);
+	return r;
+}
+
+
+
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
 void fp_dz_norm_synd(FP_ELEM v[N - K]) {
@@ -92,6 +199,7 @@ void restr_vec_by_fp_matrix(FP_ELEM res[N - K],
 	}
 }
 
+
 /* Computes e * [I_k V]^T, V is already in transposed form
  * since  */
 static
@@ -127,6 +235,7 @@ void fp_vec_by_fp_matrix(FP_ELEM res[N - K],
 		res[i] = FPRED_DOUBLE(res_dprec[i]);
 	}
 }
+
 
 static inline
 void fp_vec_by_fp_vec_pointwise(FP_ELEM res[N],
@@ -209,6 +318,8 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 	}
 	memcpy(res, res_align, N);
 }
+
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "csprng_hash.h"
 #include "merkle_tree.h"
 #include "parameters.h"
+
 
 #define TO_PUBLISH 1
 #define NOT_TO_PUBLISH 0
@@ -95,3 +96,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
 	tree_root(root, recomputed_leaves);
 	return 1;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -33,6 +33,7 @@
 
 #include "namespace.h"
 
+
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],
                uint8_t leaves[T][HASH_DIGEST_LENGTH]);
 
@@ -44,3 +45,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
                        uint8_t recomputed_leaves[T][HASH_DIGEST_LENGTH],
                        const uint8_t mtp[W * HASH_DIGEST_LENGTH],
                        const uint8_t leaves_to_reveal[T]);
+

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,9 @@
 #define   W (125)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +120,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 2, 30}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 126, 224}
@@ -130,3 +134,4 @@
 #define BITS_V_CT_RNG 60711
 #define BITS_N_FZ_CT_RNG 1065
 #define BITS_CWSTR_RNG 5264
+

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,11 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x07) + ((x) >> 3))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
+
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -63,3 +66,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake256_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -55,6 +55,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -152,14 +154,14 @@ void CROSS_sign(const sk_t *const SK,
 	FP_ELEM s_prime[N - K];
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -318,8 +320,8 @@ int CROSS_verify(const pk_t *const PK,
 	is_stree_padding_ok = rebuild_leaves(round_seeds, chall_2, sig->path);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -410,6 +412,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -431,9 +434,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -64,6 +64,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP192FAST_CLEAN_CRYPTO_RANDOMBYTES 24
+
 
 int PQCLEAN_CROSSRSDP192FAST_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -45,6 +45,8 @@
 #define FPRED_OPPOSITE(x) ((x) ^ 0x7F)
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -126,6 +128,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "csprng_hash.h"
 #include "merkle_tree.h"
 #include "parameters.h"
+
 
 #define TO_PUBLISH 1
 #define NOT_TO_PUBLISH 0
@@ -95,3 +96,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
 	tree_root(root, recomputed_leaves);
 	return 1;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -33,6 +33,7 @@
 
 #include "namespace.h"
 
+
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],
                uint8_t leaves[T][HASH_DIGEST_LENGTH]);
 
@@ -44,3 +45,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
                        uint8_t recomputed_leaves[T][HASH_DIGEST_LENGTH],
                        const uint8_t mtp[W * HASH_DIGEST_LENGTH],
                        const uint8_t leaves_to_reveal[T]);
+

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,9 @@
 #define   W (125)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +120,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 2, 30}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 126, 224}
@@ -130,3 +134,4 @@
 #define BITS_V_CT_RNG 60711
 #define BITS_N_FZ_CT_RNG 1065
 #define BITS_CWSTR_RNG 5264
+

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,8 @@
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
 
+
+
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
 	for (int i = 0; i < N; i++) {
@@ -63,3 +65,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-fast_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-fast_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -56,6 +56,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -543,6 +545,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -554,6 +557,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -563,6 +567,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP192SMALL_AVX2_CRYPTO_RANDOMBYTES 24
+
 
 int PQCLEAN_CROSSRSDP192SMALL_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,113 @@
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
 
+
+/* AVX2 utility functions */
+
+/* reduce modulo 509 eigth 32-bit integers packed into a 256-bit vector, using Barrett's method
+ * each 32-bit integer sould be in the range [0, 508*508] i.e. the result of a mul in FP
+ * however, the function actually works for integers in the wider range [0, 8339743] */
+static inline __m256i mm256_mod509_epu32(__m256i a) {
+	int b_shift = 18; // ceil(log2(509))*2
+	int b_mul = (((uint64_t)1U << b_shift) / P);
+	/* r = a - ((B_MUL * a) >> B_SHIFT) * P) */
+	__m256i b_mul_32 = _mm256_set1_epi32(b_mul);
+	__m256i p_32 = _mm256_set1_epi32(P);
+	__m256i r = _mm256_mullo_epi32(a, b_mul_32);
+	r = _mm256_srli_epi32(r, b_shift);
+	r = _mm256_mullo_epi32(r, p_32);
+	r = _mm256_sub_epi32(a, r);
+	/* r = min(r, r - P) */
+	__m256i rs = _mm256_sub_epi32(r, p_32);
+	r = _mm256_min_epu32(r, rs);
+	return r;
+}
+
+/* reduce modulo 509 sixteen 16-bit integers packed into a 256-bit vector
+ * each 16-bit integer sould be in the range [0, 508*2] */
+static inline __m256i mm256_mod509_epu16(__m256i a) {
+	/* r = min(r, r - P) */
+	__m256i p_256 = _mm256_set1_epi16(509);
+	__m256i as = _mm256_sub_epi16(a, p_256);
+	return _mm256_min_epu16(a, as);
+}
+
+/* shuffle sixteen 16-bit integers packed into a 256-bit vector:
+ * shuffle(a[], b[]) returns c[] where c[i]=a[b[i]]
+ * operates within 128-bit lanes, so b[i] must be in the range [0,7] */
+static inline __m256i mm256_shuffle_epi16(__m256i a, __m256i b) {
+	__m256i x1 = _mm256_setr_epi8(0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14, 0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14);
+	__m256i x2 = _mm256_setr_epi8(0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1);
+	b = _mm256_adds_epu16(b, b);
+	b = _mm256_shuffle_epi8(b, x1);
+	b = _mm256_adds_epu8(b, x2);
+	b = _mm256_shuffle_epi8(a, b);
+	return b;
+}
+
+/* for each 16-bit integer packed into a 256-bit vector, select one of two
+ * values based on a boolean condition, without using if-else statements:
+ * cmov(cond[], true_val[], false_val[]) returns r[] where r[i]=true_val[i]
+ * if cond[i]==1, and r[i]=false_val[i] if cond[i]==0 */
+static inline __m256i mm256_cmov_epu16(__m256i c, __m256i t, __m256i f) {
+	__m256i zeros  = _mm256_setzero_si256();
+	__m256i cmask  = _mm256_sub_epi16(zeros, c);
+	__m256i cmaskn = _mm256_xor_si256(cmask, _mm256_set1_epi16(-1));
+	__m256i tval   = _mm256_and_si256(cmask, t);
+	__m256i fval   = _mm256_and_si256(cmaskn, f);
+	__m256i r      = _mm256_or_si256(tval, fval);
+	return r;
+}
+
+/* multiply 16-bit integers packed into 256-bit vectors and reduce the result
+ * modulo 509: mulmod509(a[], b[]) returns c[] where c[i]=(a[i]*b[i])%509 */
+static inline __m256i mm256_mulmod509_epu16(__m256i a, __m256i b) {
+	/* multiply */
+	__m256i l = _mm256_mullo_epi16(a, b);
+	__m256i h = _mm256_mulhi_epu16(a, b);
+	/* unpack 16-bit to 32-bit */
+	__m256i u0 = _mm256_unpacklo_epi16(l, h);
+	__m256i u1 = _mm256_unpackhi_epi16(l, h);
+	/* reduce */
+	u0 = mm256_mod509_epu32(u0);
+	u1 = mm256_mod509_epu32(u1);
+	/* pack 32-bit to 16-bit */
+	__m256i r = _mm256_packs_epi32(u0, u1);
+	return r;
+}
+
+/* for each 16-bit integer x packed into a 256-bit vector, with x in [1, 127],
+ * compute: (16^x) mod 509 */
+static inline __m256i mm256_exp16mod509_epu16(__m256i a) {
+	/* high 3 bits */
+	__m256i h3 = _mm256_srli_epi16(a, 4);
+	__m256i pre_h3 = _mm256_setr_epi16(
+	                     1, 302, 93, 91, 505, 319, 137, 145,
+	                     1, 302, 93, 91, 505, 319, 137, 145);
+	__m256i h3_shu = mm256_shuffle_epi16(pre_h3, h3);
+	/* low 4 bits */
+	__m256i mask_l4 = _mm256_set1_epi16(0x0F); //0b1111
+	__m256i l4 = _mm256_and_si256(a, mask_l4);
+	__m256i mask_l4_bit4 = _mm256_set1_epi16(0x8); //0b1000
+	__m256i l4_bit4 = _mm256_and_si256(a, mask_l4_bit4);
+	l4_bit4 = _mm256_srli_epi16(l4_bit4, 3);
+	__m256i l4_sub8 = _mm256_sub_epi16(l4, _mm256_set1_epi16(8));
+	__m256i pre_l4_0 = _mm256_setr_epi16(
+	                       1, 16, 256, 24, 384, 36, 67, 54,
+	                       1, 16, 256, 24, 384, 36, 67, 54);
+	__m256i l4_shu_0 = mm256_shuffle_epi16(pre_l4_0, l4);
+	__m256i pre_l4_1 = _mm256_setr_epi16(
+	                       355, 81, 278, 376, 417, 55, 371, 337,
+	                       355, 81, 278, 376, 417, 55, 371, 337);
+	__m256i l4_shu_1 = mm256_shuffle_epi16(pre_l4_1, l4_sub8);
+	__m256i l4_shu = mm256_cmov_epu16(l4_bit4, l4_shu_1, l4_shu_0);
+	/* multiply */
+	__m256i r = mm256_mulmod509_epu16(h3_shu, l4_shu);
+	return r;
+}
+
+
+
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
 void fp_dz_norm_synd(FP_ELEM v[N - K]) {
@@ -92,6 +199,7 @@ void restr_vec_by_fp_matrix(FP_ELEM res[N - K],
 	}
 }
 
+
 /* Computes e * [I_k V]^T, V is already in transposed form
  * since  */
 static
@@ -127,6 +235,7 @@ void fp_vec_by_fp_matrix(FP_ELEM res[N - K],
 		res[i] = FPRED_DOUBLE(res_dprec[i]);
 	}
 }
+
 
 static inline
 void fp_vec_by_fp_vec_pointwise(FP_ELEM res[N],
@@ -209,6 +318,8 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 	}
 	memcpy(res, res_align, N);
 }
+
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,10 @@
 #define   W (527)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +121,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 8, 8, 8, 8, 136, 136}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 24, 48, 96, 192, 256, 512}
@@ -130,3 +135,4 @@
 #define BITS_V_CT_RNG 60711
 #define BITS_N_FZ_CT_RNG 1065
 #define BITS_CWSTR_RNG 12880
+

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,11 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x07) + ((x) >> 3))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
+
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -63,3 +66,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -208,6 +208,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -224,6 +225,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake256_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdp-192-small_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-192-small_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -55,6 +55,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -154,14 +156,14 @@ void CROSS_sign(const sk_t *const SK,
 	FP_ELEM s_prime[N - K];
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -324,8 +326,8 @@ int CROSS_verify(const pk_t *const PK,
 	seed_leaves(round_seeds, seed_tree);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -416,6 +418,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -437,9 +440,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdp-192-small_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-192-small_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP192SMALL_CLEAN_CRYPTO_RANDOMBYTES 24
+
 
 int PQCLEAN_CROSSRSDP192SMALL_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-192-small_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-small_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-small_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -45,6 +45,8 @@
 #define FPRED_OPPOSITE(x) ((x) ^ 0x7F)
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -126,6 +128,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-192-small_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdp-192-small_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdp-192-small_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-small_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-192-small_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,10 @@
 #define   W (527)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +121,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 8, 8, 8, 8, 136, 136}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 24, 48, 96, 192, 256, 512}
@@ -130,3 +135,4 @@
 #define BITS_V_CT_RNG 60711
 #define BITS_N_FZ_CT_RNG 1065
 #define BITS_CWSTR_RNG 12880
+

--- a/src/sig/cross/upcross_cross-rsdp-192-small_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,8 @@
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
 
+
+
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
 	for (int i = 0; i < N; i++) {
@@ -63,3 +65,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-192-small_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -174,6 +174,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -190,6 +191,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdp-192-small_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdp-192-small_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-192-small_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-192-small_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -56,6 +56,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -543,6 +545,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -554,6 +557,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -563,6 +567,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP256BALANCED_AVX2_CRYPTO_RANDOMBYTES 32
+
 
 int PQCLEAN_CROSSRSDP256BALANCED_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,113 @@
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
 
+
+/* AVX2 utility functions */
+
+/* reduce modulo 509 eigth 32-bit integers packed into a 256-bit vector, using Barrett's method
+ * each 32-bit integer sould be in the range [0, 508*508] i.e. the result of a mul in FP
+ * however, the function actually works for integers in the wider range [0, 8339743] */
+static inline __m256i mm256_mod509_epu32(__m256i a) {
+	int b_shift = 18; // ceil(log2(509))*2
+	int b_mul = (((uint64_t)1U << b_shift) / P);
+	/* r = a - ((B_MUL * a) >> B_SHIFT) * P) */
+	__m256i b_mul_32 = _mm256_set1_epi32(b_mul);
+	__m256i p_32 = _mm256_set1_epi32(P);
+	__m256i r = _mm256_mullo_epi32(a, b_mul_32);
+	r = _mm256_srli_epi32(r, b_shift);
+	r = _mm256_mullo_epi32(r, p_32);
+	r = _mm256_sub_epi32(a, r);
+	/* r = min(r, r - P) */
+	__m256i rs = _mm256_sub_epi32(r, p_32);
+	r = _mm256_min_epu32(r, rs);
+	return r;
+}
+
+/* reduce modulo 509 sixteen 16-bit integers packed into a 256-bit vector
+ * each 16-bit integer sould be in the range [0, 508*2] */
+static inline __m256i mm256_mod509_epu16(__m256i a) {
+	/* r = min(r, r - P) */
+	__m256i p_256 = _mm256_set1_epi16(509);
+	__m256i as = _mm256_sub_epi16(a, p_256);
+	return _mm256_min_epu16(a, as);
+}
+
+/* shuffle sixteen 16-bit integers packed into a 256-bit vector:
+ * shuffle(a[], b[]) returns c[] where c[i]=a[b[i]]
+ * operates within 128-bit lanes, so b[i] must be in the range [0,7] */
+static inline __m256i mm256_shuffle_epi16(__m256i a, __m256i b) {
+	__m256i x1 = _mm256_setr_epi8(0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14, 0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14);
+	__m256i x2 = _mm256_setr_epi8(0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1);
+	b = _mm256_adds_epu16(b, b);
+	b = _mm256_shuffle_epi8(b, x1);
+	b = _mm256_adds_epu8(b, x2);
+	b = _mm256_shuffle_epi8(a, b);
+	return b;
+}
+
+/* for each 16-bit integer packed into a 256-bit vector, select one of two
+ * values based on a boolean condition, without using if-else statements:
+ * cmov(cond[], true_val[], false_val[]) returns r[] where r[i]=true_val[i]
+ * if cond[i]==1, and r[i]=false_val[i] if cond[i]==0 */
+static inline __m256i mm256_cmov_epu16(__m256i c, __m256i t, __m256i f) {
+	__m256i zeros  = _mm256_setzero_si256();
+	__m256i cmask  = _mm256_sub_epi16(zeros, c);
+	__m256i cmaskn = _mm256_xor_si256(cmask, _mm256_set1_epi16(-1));
+	__m256i tval   = _mm256_and_si256(cmask, t);
+	__m256i fval   = _mm256_and_si256(cmaskn, f);
+	__m256i r      = _mm256_or_si256(tval, fval);
+	return r;
+}
+
+/* multiply 16-bit integers packed into 256-bit vectors and reduce the result
+ * modulo 509: mulmod509(a[], b[]) returns c[] where c[i]=(a[i]*b[i])%509 */
+static inline __m256i mm256_mulmod509_epu16(__m256i a, __m256i b) {
+	/* multiply */
+	__m256i l = _mm256_mullo_epi16(a, b);
+	__m256i h = _mm256_mulhi_epu16(a, b);
+	/* unpack 16-bit to 32-bit */
+	__m256i u0 = _mm256_unpacklo_epi16(l, h);
+	__m256i u1 = _mm256_unpackhi_epi16(l, h);
+	/* reduce */
+	u0 = mm256_mod509_epu32(u0);
+	u1 = mm256_mod509_epu32(u1);
+	/* pack 32-bit to 16-bit */
+	__m256i r = _mm256_packs_epi32(u0, u1);
+	return r;
+}
+
+/* for each 16-bit integer x packed into a 256-bit vector, with x in [1, 127],
+ * compute: (16^x) mod 509 */
+static inline __m256i mm256_exp16mod509_epu16(__m256i a) {
+	/* high 3 bits */
+	__m256i h3 = _mm256_srli_epi16(a, 4);
+	__m256i pre_h3 = _mm256_setr_epi16(
+	                     1, 302, 93, 91, 505, 319, 137, 145,
+	                     1, 302, 93, 91, 505, 319, 137, 145);
+	__m256i h3_shu = mm256_shuffle_epi16(pre_h3, h3);
+	/* low 4 bits */
+	__m256i mask_l4 = _mm256_set1_epi16(0x0F); //0b1111
+	__m256i l4 = _mm256_and_si256(a, mask_l4);
+	__m256i mask_l4_bit4 = _mm256_set1_epi16(0x8); //0b1000
+	__m256i l4_bit4 = _mm256_and_si256(a, mask_l4_bit4);
+	l4_bit4 = _mm256_srli_epi16(l4_bit4, 3);
+	__m256i l4_sub8 = _mm256_sub_epi16(l4, _mm256_set1_epi16(8));
+	__m256i pre_l4_0 = _mm256_setr_epi16(
+	                       1, 16, 256, 24, 384, 36, 67, 54,
+	                       1, 16, 256, 24, 384, 36, 67, 54);
+	__m256i l4_shu_0 = mm256_shuffle_epi16(pre_l4_0, l4);
+	__m256i pre_l4_1 = _mm256_setr_epi16(
+	                       355, 81, 278, 376, 417, 55, 371, 337,
+	                       355, 81, 278, 376, 417, 55, 371, 337);
+	__m256i l4_shu_1 = mm256_shuffle_epi16(pre_l4_1, l4_sub8);
+	__m256i l4_shu = mm256_cmov_epu16(l4_bit4, l4_shu_1, l4_shu_0);
+	/* multiply */
+	__m256i r = mm256_mulmod509_epu16(h3_shu, l4_shu);
+	return r;
+}
+
+
+
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
 void fp_dz_norm_synd(FP_ELEM v[N - K]) {
@@ -92,6 +199,7 @@ void restr_vec_by_fp_matrix(FP_ELEM res[N - K],
 	}
 }
 
+
 /* Computes e * [I_k V]^T, V is already in transposed form
  * since  */
 static
@@ -127,6 +235,7 @@ void fp_vec_by_fp_matrix(FP_ELEM res[N - K],
 		res[i] = FPRED_DOUBLE(res_dprec[i]);
 	}
 }
+
 
 static inline
 void fp_vec_by_fp_vec_pointwise(FP_ELEM res[N],
@@ -209,6 +318,8 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 	}
 	memcpy(res, res_align, N);
 }
+
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,9 @@
 #define   W (427)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +120,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 128, 256, 512}
@@ -130,3 +134,4 @@
 #define BITS_V_CT_RNG 108689
 #define BITS_N_FZ_CT_RNG 1431
 #define BITS_CWSTR_RNG 10746
+

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,11 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x07) + ((x) >> 3))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
+
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -63,3 +66,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -208,6 +208,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -224,6 +225,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake256_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -55,6 +55,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -154,14 +156,14 @@ void CROSS_sign(const sk_t *const SK,
 	FP_ELEM s_prime[N - K];
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -324,8 +326,8 @@ int CROSS_verify(const pk_t *const PK,
 	seed_leaves(round_seeds, seed_tree);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -416,6 +418,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -437,9 +440,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP256BALANCED_CLEAN_CRYPTO_RANDOMBYTES 32
+
 
 int PQCLEAN_CROSSRSDP256BALANCED_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -45,6 +45,8 @@
 #define FPRED_OPPOSITE(x) ((x) ^ 0x7F)
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -126,6 +128,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,9 @@
 #define   W (427)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +120,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 128, 256, 512}
@@ -130,3 +134,4 @@
 #define BITS_V_CT_RNG 108689
 #define BITS_N_FZ_CT_RNG 1431
 #define BITS_CWSTR_RNG 10746
+

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,8 @@
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
 
+
+
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
 	for (int i = 0; i < N; i++) {
@@ -63,3 +65,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -174,6 +174,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -190,6 +191,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-balanced_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -56,6 +56,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -537,6 +539,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -548,6 +551,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -557,6 +561,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -64,6 +64,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP256FAST_AVX2_CRYPTO_RANDOMBYTES 32
+
 
 int PQCLEAN_CROSSRSDP256FAST_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,113 @@
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
 
+
+/* AVX2 utility functions */
+
+/* reduce modulo 509 eigth 32-bit integers packed into a 256-bit vector, using Barrett's method
+ * each 32-bit integer sould be in the range [0, 508*508] i.e. the result of a mul in FP
+ * however, the function actually works for integers in the wider range [0, 8339743] */
+static inline __m256i mm256_mod509_epu32(__m256i a) {
+	int b_shift = 18; // ceil(log2(509))*2
+	int b_mul = (((uint64_t)1U << b_shift) / P);
+	/* r = a - ((B_MUL * a) >> B_SHIFT) * P) */
+	__m256i b_mul_32 = _mm256_set1_epi32(b_mul);
+	__m256i p_32 = _mm256_set1_epi32(P);
+	__m256i r = _mm256_mullo_epi32(a, b_mul_32);
+	r = _mm256_srli_epi32(r, b_shift);
+	r = _mm256_mullo_epi32(r, p_32);
+	r = _mm256_sub_epi32(a, r);
+	/* r = min(r, r - P) */
+	__m256i rs = _mm256_sub_epi32(r, p_32);
+	r = _mm256_min_epu32(r, rs);
+	return r;
+}
+
+/* reduce modulo 509 sixteen 16-bit integers packed into a 256-bit vector
+ * each 16-bit integer sould be in the range [0, 508*2] */
+static inline __m256i mm256_mod509_epu16(__m256i a) {
+	/* r = min(r, r - P) */
+	__m256i p_256 = _mm256_set1_epi16(509);
+	__m256i as = _mm256_sub_epi16(a, p_256);
+	return _mm256_min_epu16(a, as);
+}
+
+/* shuffle sixteen 16-bit integers packed into a 256-bit vector:
+ * shuffle(a[], b[]) returns c[] where c[i]=a[b[i]]
+ * operates within 128-bit lanes, so b[i] must be in the range [0,7] */
+static inline __m256i mm256_shuffle_epi16(__m256i a, __m256i b) {
+	__m256i x1 = _mm256_setr_epi8(0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14, 0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14);
+	__m256i x2 = _mm256_setr_epi8(0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1);
+	b = _mm256_adds_epu16(b, b);
+	b = _mm256_shuffle_epi8(b, x1);
+	b = _mm256_adds_epu8(b, x2);
+	b = _mm256_shuffle_epi8(a, b);
+	return b;
+}
+
+/* for each 16-bit integer packed into a 256-bit vector, select one of two
+ * values based on a boolean condition, without using if-else statements:
+ * cmov(cond[], true_val[], false_val[]) returns r[] where r[i]=true_val[i]
+ * if cond[i]==1, and r[i]=false_val[i] if cond[i]==0 */
+static inline __m256i mm256_cmov_epu16(__m256i c, __m256i t, __m256i f) {
+	__m256i zeros  = _mm256_setzero_si256();
+	__m256i cmask  = _mm256_sub_epi16(zeros, c);
+	__m256i cmaskn = _mm256_xor_si256(cmask, _mm256_set1_epi16(-1));
+	__m256i tval   = _mm256_and_si256(cmask, t);
+	__m256i fval   = _mm256_and_si256(cmaskn, f);
+	__m256i r      = _mm256_or_si256(tval, fval);
+	return r;
+}
+
+/* multiply 16-bit integers packed into 256-bit vectors and reduce the result
+ * modulo 509: mulmod509(a[], b[]) returns c[] where c[i]=(a[i]*b[i])%509 */
+static inline __m256i mm256_mulmod509_epu16(__m256i a, __m256i b) {
+	/* multiply */
+	__m256i l = _mm256_mullo_epi16(a, b);
+	__m256i h = _mm256_mulhi_epu16(a, b);
+	/* unpack 16-bit to 32-bit */
+	__m256i u0 = _mm256_unpacklo_epi16(l, h);
+	__m256i u1 = _mm256_unpackhi_epi16(l, h);
+	/* reduce */
+	u0 = mm256_mod509_epu32(u0);
+	u1 = mm256_mod509_epu32(u1);
+	/* pack 32-bit to 16-bit */
+	__m256i r = _mm256_packs_epi32(u0, u1);
+	return r;
+}
+
+/* for each 16-bit integer x packed into a 256-bit vector, with x in [1, 127],
+ * compute: (16^x) mod 509 */
+static inline __m256i mm256_exp16mod509_epu16(__m256i a) {
+	/* high 3 bits */
+	__m256i h3 = _mm256_srli_epi16(a, 4);
+	__m256i pre_h3 = _mm256_setr_epi16(
+	                     1, 302, 93, 91, 505, 319, 137, 145,
+	                     1, 302, 93, 91, 505, 319, 137, 145);
+	__m256i h3_shu = mm256_shuffle_epi16(pre_h3, h3);
+	/* low 4 bits */
+	__m256i mask_l4 = _mm256_set1_epi16(0x0F); //0b1111
+	__m256i l4 = _mm256_and_si256(a, mask_l4);
+	__m256i mask_l4_bit4 = _mm256_set1_epi16(0x8); //0b1000
+	__m256i l4_bit4 = _mm256_and_si256(a, mask_l4_bit4);
+	l4_bit4 = _mm256_srli_epi16(l4_bit4, 3);
+	__m256i l4_sub8 = _mm256_sub_epi16(l4, _mm256_set1_epi16(8));
+	__m256i pre_l4_0 = _mm256_setr_epi16(
+	                       1, 16, 256, 24, 384, 36, 67, 54,
+	                       1, 16, 256, 24, 384, 36, 67, 54);
+	__m256i l4_shu_0 = mm256_shuffle_epi16(pre_l4_0, l4);
+	__m256i pre_l4_1 = _mm256_setr_epi16(
+	                       355, 81, 278, 376, 417, 55, 371, 337,
+	                       355, 81, 278, 376, 417, 55, 371, 337);
+	__m256i l4_shu_1 = mm256_shuffle_epi16(pre_l4_1, l4_sub8);
+	__m256i l4_shu = mm256_cmov_epu16(l4_bit4, l4_shu_1, l4_shu_0);
+	/* multiply */
+	__m256i r = mm256_mulmod509_epu16(h3_shu, l4_shu);
+	return r;
+}
+
+
+
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
 void fp_dz_norm_synd(FP_ELEM v[N - K]) {
@@ -92,6 +199,7 @@ void restr_vec_by_fp_matrix(FP_ELEM res[N - K],
 	}
 }
 
+
 /* Computes e * [I_k V]^T, V is already in transposed form
  * since  */
 static
@@ -127,6 +235,7 @@ void fp_vec_by_fp_matrix(FP_ELEM res[N - K],
 		res[i] = FPRED_DOUBLE(res_dprec[i]);
 	}
 }
+
 
 static inline
 void fp_vec_by_fp_vec_pointwise(FP_ELEM res[N],
@@ -209,6 +318,8 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 	}
 	memcpy(res, res_align, N);
 }
+
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "csprng_hash.h"
 #include "merkle_tree.h"
 #include "parameters.h"
+
 
 #define TO_PUBLISH 1
 #define NOT_TO_PUBLISH 0
@@ -95,3 +96,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
 	tree_root(root, recomputed_leaves);
 	return 1;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -33,6 +33,7 @@
 
 #include "namespace.h"
 
+
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],
                uint8_t leaves[T][HASH_DIGEST_LENGTH]);
 
@@ -44,3 +45,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
                        uint8_t recomputed_leaves[T][HASH_DIGEST_LENGTH],
                        const uint8_t mtp[W * HASH_DIGEST_LENGTH],
                        const uint8_t leaves_to_reveal[T]);
+

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,9 @@
 #define   W (167)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +120,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 2, 2, 2, 2, 2, 2, 130}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 6, 12, 24, 48, 96, 192, 256}
@@ -130,3 +134,4 @@
 #define BITS_V_CT_RNG 108689
 #define BITS_N_FZ_CT_RNG 1431
 #define BITS_CWSTR_RNG 8343
+

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,11 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x07) + ((x) >> 3))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
+
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -63,3 +66,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake256_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -55,6 +55,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -152,14 +154,14 @@ void CROSS_sign(const sk_t *const SK,
 	FP_ELEM s_prime[N - K];
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -318,8 +320,8 @@ int CROSS_verify(const pk_t *const PK,
 	is_stree_padding_ok = rebuild_leaves(round_seeds, chall_2, sig->path);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -410,6 +412,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -431,9 +434,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -64,6 +64,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP256FAST_CLEAN_CRYPTO_RANDOMBYTES 32
+
 
 int PQCLEAN_CROSSRSDP256FAST_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -45,6 +45,8 @@
 #define FPRED_OPPOSITE(x) ((x) ^ 0x7F)
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -126,6 +128,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "csprng_hash.h"
 #include "merkle_tree.h"
 #include "parameters.h"
+
 
 #define TO_PUBLISH 1
 #define NOT_TO_PUBLISH 0
@@ -95,3 +96,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
 	tree_root(root, recomputed_leaves);
 	return 1;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -33,6 +33,7 @@
 
 #include "namespace.h"
 
+
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],
                uint8_t leaves[T][HASH_DIGEST_LENGTH]);
 
@@ -44,3 +45,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
                        uint8_t recomputed_leaves[T][HASH_DIGEST_LENGTH],
                        const uint8_t mtp[W * HASH_DIGEST_LENGTH],
                        const uint8_t leaves_to_reveal[T]);
+

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,9 @@
 #define   W (167)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +120,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 2, 2, 2, 2, 2, 2, 130}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 6, 12, 24, 48, 96, 192, 256}
@@ -130,3 +134,4 @@
 #define BITS_V_CT_RNG 108689
 #define BITS_N_FZ_CT_RNG 1431
 #define BITS_CWSTR_RNG 8343
+

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,8 @@
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
 
+
+
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
 	for (int i = 0; i < N; i++) {
@@ -63,3 +65,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-fast_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-fast_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -56,6 +56,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -543,6 +545,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -554,6 +557,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -563,6 +567,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP256SMALL_AVX2_CRYPTO_RANDOMBYTES 32
+
 
 int PQCLEAN_CROSSRSDP256SMALL_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,113 @@
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
 
+
+/* AVX2 utility functions */
+
+/* reduce modulo 509 eigth 32-bit integers packed into a 256-bit vector, using Barrett's method
+ * each 32-bit integer sould be in the range [0, 508*508] i.e. the result of a mul in FP
+ * however, the function actually works for integers in the wider range [0, 8339743] */
+static inline __m256i mm256_mod509_epu32(__m256i a) {
+	int b_shift = 18; // ceil(log2(509))*2
+	int b_mul = (((uint64_t)1U << b_shift) / P);
+	/* r = a - ((B_MUL * a) >> B_SHIFT) * P) */
+	__m256i b_mul_32 = _mm256_set1_epi32(b_mul);
+	__m256i p_32 = _mm256_set1_epi32(P);
+	__m256i r = _mm256_mullo_epi32(a, b_mul_32);
+	r = _mm256_srli_epi32(r, b_shift);
+	r = _mm256_mullo_epi32(r, p_32);
+	r = _mm256_sub_epi32(a, r);
+	/* r = min(r, r - P) */
+	__m256i rs = _mm256_sub_epi32(r, p_32);
+	r = _mm256_min_epu32(r, rs);
+	return r;
+}
+
+/* reduce modulo 509 sixteen 16-bit integers packed into a 256-bit vector
+ * each 16-bit integer sould be in the range [0, 508*2] */
+static inline __m256i mm256_mod509_epu16(__m256i a) {
+	/* r = min(r, r - P) */
+	__m256i p_256 = _mm256_set1_epi16(509);
+	__m256i as = _mm256_sub_epi16(a, p_256);
+	return _mm256_min_epu16(a, as);
+}
+
+/* shuffle sixteen 16-bit integers packed into a 256-bit vector:
+ * shuffle(a[], b[]) returns c[] where c[i]=a[b[i]]
+ * operates within 128-bit lanes, so b[i] must be in the range [0,7] */
+static inline __m256i mm256_shuffle_epi16(__m256i a, __m256i b) {
+	__m256i x1 = _mm256_setr_epi8(0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14, 0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14);
+	__m256i x2 = _mm256_setr_epi8(0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1);
+	b = _mm256_adds_epu16(b, b);
+	b = _mm256_shuffle_epi8(b, x1);
+	b = _mm256_adds_epu8(b, x2);
+	b = _mm256_shuffle_epi8(a, b);
+	return b;
+}
+
+/* for each 16-bit integer packed into a 256-bit vector, select one of two
+ * values based on a boolean condition, without using if-else statements:
+ * cmov(cond[], true_val[], false_val[]) returns r[] where r[i]=true_val[i]
+ * if cond[i]==1, and r[i]=false_val[i] if cond[i]==0 */
+static inline __m256i mm256_cmov_epu16(__m256i c, __m256i t, __m256i f) {
+	__m256i zeros  = _mm256_setzero_si256();
+	__m256i cmask  = _mm256_sub_epi16(zeros, c);
+	__m256i cmaskn = _mm256_xor_si256(cmask, _mm256_set1_epi16(-1));
+	__m256i tval   = _mm256_and_si256(cmask, t);
+	__m256i fval   = _mm256_and_si256(cmaskn, f);
+	__m256i r      = _mm256_or_si256(tval, fval);
+	return r;
+}
+
+/* multiply 16-bit integers packed into 256-bit vectors and reduce the result
+ * modulo 509: mulmod509(a[], b[]) returns c[] where c[i]=(a[i]*b[i])%509 */
+static inline __m256i mm256_mulmod509_epu16(__m256i a, __m256i b) {
+	/* multiply */
+	__m256i l = _mm256_mullo_epi16(a, b);
+	__m256i h = _mm256_mulhi_epu16(a, b);
+	/* unpack 16-bit to 32-bit */
+	__m256i u0 = _mm256_unpacklo_epi16(l, h);
+	__m256i u1 = _mm256_unpackhi_epi16(l, h);
+	/* reduce */
+	u0 = mm256_mod509_epu32(u0);
+	u1 = mm256_mod509_epu32(u1);
+	/* pack 32-bit to 16-bit */
+	__m256i r = _mm256_packs_epi32(u0, u1);
+	return r;
+}
+
+/* for each 16-bit integer x packed into a 256-bit vector, with x in [1, 127],
+ * compute: (16^x) mod 509 */
+static inline __m256i mm256_exp16mod509_epu16(__m256i a) {
+	/* high 3 bits */
+	__m256i h3 = _mm256_srli_epi16(a, 4);
+	__m256i pre_h3 = _mm256_setr_epi16(
+	                     1, 302, 93, 91, 505, 319, 137, 145,
+	                     1, 302, 93, 91, 505, 319, 137, 145);
+	__m256i h3_shu = mm256_shuffle_epi16(pre_h3, h3);
+	/* low 4 bits */
+	__m256i mask_l4 = _mm256_set1_epi16(0x0F); //0b1111
+	__m256i l4 = _mm256_and_si256(a, mask_l4);
+	__m256i mask_l4_bit4 = _mm256_set1_epi16(0x8); //0b1000
+	__m256i l4_bit4 = _mm256_and_si256(a, mask_l4_bit4);
+	l4_bit4 = _mm256_srli_epi16(l4_bit4, 3);
+	__m256i l4_sub8 = _mm256_sub_epi16(l4, _mm256_set1_epi16(8));
+	__m256i pre_l4_0 = _mm256_setr_epi16(
+	                       1, 16, 256, 24, 384, 36, 67, 54,
+	                       1, 16, 256, 24, 384, 36, 67, 54);
+	__m256i l4_shu_0 = mm256_shuffle_epi16(pre_l4_0, l4);
+	__m256i pre_l4_1 = _mm256_setr_epi16(
+	                       355, 81, 278, 376, 417, 55, 371, 337,
+	                       355, 81, 278, 376, 417, 55, 371, 337);
+	__m256i l4_shu_1 = mm256_shuffle_epi16(pre_l4_1, l4_sub8);
+	__m256i l4_shu = mm256_cmov_epu16(l4_bit4, l4_shu_1, l4_shu_0);
+	/* multiply */
+	__m256i r = mm256_mulmod509_epu16(h3_shu, l4_shu);
+	return r;
+}
+
+
+
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
 void fp_dz_norm_synd(FP_ELEM v[N - K]) {
@@ -92,6 +199,7 @@ void restr_vec_by_fp_matrix(FP_ELEM res[N - K],
 	}
 }
 
+
 /* Computes e * [I_k V]^T, V is already in transposed form
  * since  */
 static
@@ -127,6 +235,7 @@ void fp_vec_by_fp_matrix(FP_ELEM res[N - K],
 		res[i] = FPRED_DOUBLE(res_dprec[i]);
 	}
 }
+
 
 static inline
 void fp_vec_by_fp_vec_pointwise(FP_ELEM res[N],
@@ -209,6 +318,8 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 	}
 	memcpy(res, res_align, N);
 }
+
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,10 @@
 #define   W (762)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +121,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 128}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 128, 256, 384, 768}
@@ -130,3 +135,4 @@
 #define BITS_V_CT_RNG 108689
 #define BITS_N_FZ_CT_RNG 1431
 #define BITS_CWSTR_RNG 18150
+

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,11 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x07) + ((x) >> 3))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
+
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -63,3 +66,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -208,6 +208,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -224,6 +225,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake256_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdp-256-small_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdp-256-small_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -55,6 +55,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FP_ELEM V_tr[K][N - K],
@@ -84,6 +85,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	/* PQClean-edit: CSPRNG release context */
 	csprng_release(&csprng_state_e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -154,14 +156,14 @@ void CROSS_sign(const sk_t *const SK,
 	FP_ELEM s_prime[N - K];
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -324,8 +326,8 @@ int CROSS_verify(const pk_t *const PK,
 	seed_leaves(round_seeds, seed_tree);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -416,6 +418,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -437,9 +440,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdp-256-small_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdp-256-small_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDP256SMALL_CLEAN_CRYPTO_RANDOMBYTES 32
+
 
 int PQCLEAN_CROSSRSDP256SMALL_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdp-256-small_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-small_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-small_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -45,6 +45,8 @@
 #define FPRED_OPPOSITE(x) ((x) ^ 0x7F)
 #define FP_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7F)
 #define RESTR_TO_VAL(x) ( (FP_ELEM) (RESTR_G_TABLE >> (8*(uint64_t)(x))) )
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -126,6 +128,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdp-256-small_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdp-256-small_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdp-256-small_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-small_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -48,6 +48,7 @@ void pack_fp_syn(uint8_t out[DENSELY_PACKED_FP_SYN_SIZE],
 void pack_fz_vec(uint8_t out[DENSELY_PACKED_FZ_VEC_SIZE],
                  const FZ_ELEM in[N]);
 
+
 uint8_t unpack_fp_vec(FP_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FP_VEC_SIZE]);
 
@@ -56,3 +57,4 @@ uint8_t unpack_fp_syn(FP_ELEM out[N - K],
 
 uint8_t unpack_fz_vec(FZ_ELEM out[N],
                       const uint8_t in[DENSELY_PACKED_FZ_VEC_SIZE]);
+

--- a/src/sig/cross/upcross_cross-rsdp-256-small_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -62,6 +62,10 @@
 #define   W (762)
 #define POSITION_IN_FW_STRING_T uint16_t
 
+
+
+
+
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
 
@@ -117,6 +121,7 @@
 #define DENSELY_PACKED_FZ_VEC_SIZE ((N/8)*BITS_TO_REPRESENT(Z-1) + \
                                    ROUND_UP( ((N%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 128}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 128, 256, 384, 768}
@@ -130,3 +135,4 @@
 #define BITS_V_CT_RNG 108689
 #define BITS_N_FZ_CT_RNG 1431
 #define BITS_CWSTR_RNG 18150
+

--- a/src/sig/cross/upcross_cross-rsdp-256-small_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,8 @@
 #define FZRED_OPPOSITE(x) ((x) ^ 0x07)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 3)) & 0x07)
 
+
+
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
 	for (int i = 0; i < N; i++) {
@@ -63,3 +65,4 @@ int is_fz_vec_in_restr_group_n(const FZ_ELEM in[N]) {
 	}
 	return is_in_ok;
 }
+

--- a/src/sig/cross/upcross_cross-rsdp-256-small_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -174,6 +174,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -190,6 +191,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdp-256-small_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdp-256-small_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdp-256-small_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdp-256-small_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -59,6 +59,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -97,6 +98,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat_avx);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -590,6 +592,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -601,6 +604,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -610,6 +614,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG128BALANCED_AVX2_CRYPTO_RANDOMBYTES 16
+
 
 int PQCLEAN_CROSSRSDPG128BALANCED_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/fp_arith.h
@@ -298,7 +298,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N], const FZ_ELEM e[N], const FP_ELE
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* e: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		e_x[i] = e[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/fp_arith.h
@@ -340,7 +340,7 @@ void convert_restr_vec_to_fp(FP_ELEM res[N], const FZ_ELEM in[N]) {
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* in: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		in_x[i] = in[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,9 @@
 #define   T (256)
 #define   W (220)
 #define POSITION_IN_FW_STRING_T uint8_t
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +123,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 128, 256}
@@ -133,3 +138,4 @@
 #define BITS_W_CT_RNG 5677
 #define BITS_M_FZ_CT_RNG 343
 #define BITS_CWSTR_RNG 4776
+

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,12 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x7f) + ((x) >> 7))
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -93,6 +95,7 @@ void fz_inf_w_by_fz_matrix(FZ_ELEM res[N],
 			_mm256_store_si256 ((__m256i *) &res_dprec[j * EPI16_PER_REG], res_w);
 		}
 	}
+
 
 	/* Save result trimming to regular precision */
 	for (int i = 0; i < N - M; i++) {

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -208,6 +208,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -224,6 +225,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake128_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -58,6 +58,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -91,6 +92,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -169,14 +171,14 @@ void CROSS_sign(const sk_t *const SK,
 	FZ_ELEM e_G_bar_prime[M];
 	FZ_ELEM v_G_bar[T][M];
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -344,8 +346,8 @@ int CROSS_verify(const pk_t *const PK,
 	seed_leaves(round_seeds, seed_tree);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -441,6 +443,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -462,9 +465,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG128BALANCED_CLEAN_CRYPTO_RANDOMBYTES 16
+
 
 int PQCLEAN_CROSSRSDPG128BALANCED_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -82,6 +82,8 @@ FP_ELEM RESTR_TO_VAL(FP_ELEM x) {
 	 *     RESTR_G_GEN_16*RESTR_G_GEN_32*RESTR_G_GEN_64               < 2^32 */
 	return FPRED_SINGLE( FPRED_SINGLE(res1 * res2) * FPRED_SINGLE(res3 * res4) );
 }
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -163,6 +165,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,9 @@
 #define   T (256)
 #define   W (220)
 #define POSITION_IN_FW_STRING_T uint8_t
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +123,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 128, 256}
@@ -133,3 +138,4 @@
 #define BITS_W_CT_RNG 5677
 #define BITS_M_FZ_CT_RNG 343
 #define BITS_CWSTR_RNG 4776
+

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,7 @@
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -174,6 +174,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -190,6 +191,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-balanced_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -59,6 +59,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -97,6 +98,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat_avx);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -584,6 +586,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -595,6 +598,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -604,6 +608,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -64,6 +64,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG128FAST_AVX2_CRYPTO_RANDOMBYTES 16
+
 
 int PQCLEAN_CROSSRSDPG128FAST_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/fp_arith.h
@@ -298,7 +298,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N], const FZ_ELEM e[N], const FP_ELE
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* e: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		e_x[i] = e[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/fp_arith.h
@@ -340,7 +340,7 @@ void convert_restr_vec_to_fp(FP_ELEM res[N], const FZ_ELEM in[N]) {
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* in: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		in_x[i] = in[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "csprng_hash.h"
 #include "merkle_tree.h"
 #include "parameters.h"
+
 
 #define TO_PUBLISH 1
 #define NOT_TO_PUBLISH 0
@@ -95,3 +96,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
 	tree_root(root, recomputed_leaves);
 	return 1;
 }
+

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -33,6 +33,7 @@
 
 #include "namespace.h"
 
+
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],
                uint8_t leaves[T][HASH_DIGEST_LENGTH]);
 
@@ -44,3 +45,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
                        uint8_t recomputed_leaves[T][HASH_DIGEST_LENGTH],
                        const uint8_t mtp[W * HASH_DIGEST_LENGTH],
                        const uint8_t leaves_to_reveal[T]);
+

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,9 @@
 #define   T (147)
 #define   W (76)
 #define POSITION_IN_FW_STRING_T uint8_t
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +123,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 2, 6, 6, 38, 38}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 14, 24, 48, 64, 128}
@@ -133,3 +138,4 @@
 #define BITS_W_CT_RNG 5677
 #define BITS_M_FZ_CT_RNG 343
 #define BITS_CWSTR_RNG 3472
+

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,12 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x7f) + ((x) >> 7))
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -93,6 +95,7 @@ void fz_inf_w_by_fz_matrix(FZ_ELEM res[N],
 			_mm256_store_si256 ((__m256i *) &res_dprec[j * EPI16_PER_REG], res_w);
 		}
 	}
+
 
 	/* Save result trimming to regular precision */
 	for (int i = 0; i < N - M; i++) {

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake128_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -58,6 +58,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -91,6 +92,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -167,14 +169,14 @@ void CROSS_sign(const sk_t *const SK,
 	FZ_ELEM e_G_bar_prime[M];
 	FZ_ELEM v_G_bar[T][M];
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -338,8 +340,8 @@ int CROSS_verify(const pk_t *const PK,
 	is_stree_padding_ok = rebuild_leaves(round_seeds, chall_2, sig->path);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -435,6 +437,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -456,9 +459,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -64,6 +64,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG128FAST_CLEAN_CRYPTO_RANDOMBYTES 16
+
 
 int PQCLEAN_CROSSRSDPG128FAST_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -82,6 +82,8 @@ FP_ELEM RESTR_TO_VAL(FP_ELEM x) {
 	 *     RESTR_G_GEN_16*RESTR_G_GEN_32*RESTR_G_GEN_64               < 2^32 */
 	return FPRED_SINGLE( FPRED_SINGLE(res1 * res2) * FPRED_SINGLE(res3 * res4) );
 }
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -163,6 +165,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "csprng_hash.h"
 #include "merkle_tree.h"
 #include "parameters.h"
+
 
 #define TO_PUBLISH 1
 #define NOT_TO_PUBLISH 0
@@ -95,3 +96,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
 	tree_root(root, recomputed_leaves);
 	return 1;
 }
+

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -33,6 +33,7 @@
 
 #include "namespace.h"
 
+
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],
                uint8_t leaves[T][HASH_DIGEST_LENGTH]);
 
@@ -44,3 +45,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
                        uint8_t recomputed_leaves[T][HASH_DIGEST_LENGTH],
                        const uint8_t mtp[W * HASH_DIGEST_LENGTH],
                        const uint8_t leaves_to_reveal[T]);
+

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,9 @@
 #define   T (147)
 #define   W (76)
 #define POSITION_IN_FW_STRING_T uint8_t
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +123,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 2, 6, 6, 38, 38}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 14, 24, 48, 64, 128}
@@ -133,3 +138,4 @@
 #define BITS_W_CT_RNG 5677
 #define BITS_M_FZ_CT_RNG 343
 #define BITS_CWSTR_RNG 3472
+

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,7 @@
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-fast_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -59,6 +59,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -97,6 +98,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat_avx);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -590,6 +592,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -601,6 +604,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -610,6 +614,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG128SMALL_AVX2_CRYPTO_RANDOMBYTES 16
+
 
 int PQCLEAN_CROSSRSDPG128SMALL_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/fp_arith.h
@@ -298,7 +298,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N], const FZ_ELEM e[N], const FP_ELE
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* e: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		e_x[i] = e[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/fp_arith.h
@@ -340,7 +340,7 @@ void convert_restr_vec_to_fp(FP_ELEM res[N], const FZ_ELEM in[N]) {
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* in: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		in_x[i] = in[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,10 @@
 #define   T (512)
 #define   W (484)
 #define POSITION_IN_FW_STRING_T uint16_t
+
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +124,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 128, 256, 512}
@@ -133,3 +139,4 @@
 #define BITS_W_CT_RNG 5677
 #define BITS_M_FZ_CT_RNG 343
 #define BITS_CWSTR_RNG 9153
+

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,12 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x7f) + ((x) >> 7))
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -93,6 +95,7 @@ void fz_inf_w_by_fz_matrix(FZ_ELEM res[N],
 			_mm256_store_si256 ((__m256i *) &res_dprec[j * EPI16_PER_REG], res_w);
 		}
 	}
+
 
 	/* Save result trimming to regular precision */
 	for (int i = 0; i < N - M; i++) {

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -208,6 +208,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -224,6 +225,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake128_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -58,6 +58,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -91,6 +92,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -169,14 +171,14 @@ void CROSS_sign(const sk_t *const SK,
 	FZ_ELEM e_G_bar_prime[M];
 	FZ_ELEM v_G_bar[T][M];
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -344,8 +346,8 @@ int CROSS_verify(const pk_t *const PK,
 	seed_leaves(round_seeds, seed_tree);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -441,6 +443,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -462,9 +465,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG128SMALL_CLEAN_CRYPTO_RANDOMBYTES 16
+
 
 int PQCLEAN_CROSSRSDPG128SMALL_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -82,6 +82,8 @@ FP_ELEM RESTR_TO_VAL(FP_ELEM x) {
 	 *     RESTR_G_GEN_16*RESTR_G_GEN_32*RESTR_G_GEN_64               < 2^32 */
 	return FPRED_SINGLE( FPRED_SINGLE(res1 * res2) * FPRED_SINGLE(res3 * res4) );
 }
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -163,6 +165,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,10 @@
 #define   T (512)
 #define   W (484)
 #define POSITION_IN_FW_STRING_T uint16_t
+
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +124,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 128, 256, 512}
@@ -133,3 +139,4 @@
 #define BITS_W_CT_RNG 5677
 #define BITS_M_FZ_CT_RNG 343
 #define BITS_CWSTR_RNG 9153
+

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,7 @@
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -174,6 +174,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -190,6 +191,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-128-small_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-128-small_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -59,6 +59,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -97,6 +98,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat_avx);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -590,6 +592,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -601,6 +604,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -610,6 +614,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG192BALANCED_AVX2_CRYPTO_RANDOMBYTES 24
+
 
 int PQCLEAN_CROSSRSDPG192BALANCED_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/fp_arith.h
@@ -298,7 +298,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N], const FZ_ELEM e[N], const FP_ELE
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* e: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		e_x[i] = e[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/fp_arith.h
@@ -340,7 +340,7 @@ void convert_restr_vec_to_fp(FP_ELEM res[N], const FZ_ELEM in[N]) {
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* in: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		in_x[i] = in[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,9 @@
 #define   T (268)
 #define   W (196)
 #define POSITION_IN_FW_STRING_T uint8_t
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +123,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 8, 24, 24, 24, 24}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 24, 32, 64, 128, 256}
@@ -133,3 +138,4 @@
 #define BITS_W_CT_RNG 11655
 #define BITS_M_FZ_CT_RNG 539
 #define BITS_CWSTR_RNG 6444
+

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,12 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x7f) + ((x) >> 7))
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -93,6 +95,7 @@ void fz_inf_w_by_fz_matrix(FZ_ELEM res[N],
 			_mm256_store_si256 ((__m256i *) &res_dprec[j * EPI16_PER_REG], res_w);
 		}
 	}
+
 
 	/* Save result trimming to regular precision */
 	for (int i = 0; i < N - M; i++) {

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -208,6 +208,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -224,6 +225,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake256_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -58,6 +58,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -91,6 +92,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -169,14 +171,14 @@ void CROSS_sign(const sk_t *const SK,
 	FZ_ELEM e_G_bar_prime[M];
 	FZ_ELEM v_G_bar[T][M];
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -344,8 +346,8 @@ int CROSS_verify(const pk_t *const PK,
 	seed_leaves(round_seeds, seed_tree);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -441,6 +443,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -462,9 +465,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG192BALANCED_CLEAN_CRYPTO_RANDOMBYTES 24
+
 
 int PQCLEAN_CROSSRSDPG192BALANCED_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -82,6 +82,8 @@ FP_ELEM RESTR_TO_VAL(FP_ELEM x) {
 	 *     RESTR_G_GEN_16*RESTR_G_GEN_32*RESTR_G_GEN_64               < 2^32 */
 	return FPRED_SINGLE( FPRED_SINGLE(res1 * res2) * FPRED_SINGLE(res3 * res4) );
 }
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -163,6 +165,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,9 @@
 #define   T (268)
 #define   W (196)
 #define POSITION_IN_FW_STRING_T uint8_t
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +123,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 8, 24, 24, 24, 24}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 24, 32, 64, 128, 256}
@@ -133,3 +138,4 @@
 #define BITS_W_CT_RNG 11655
 #define BITS_M_FZ_CT_RNG 539
 #define BITS_CWSTR_RNG 6444
+

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,7 @@
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -174,6 +174,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -190,6 +191,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-balanced_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -59,6 +59,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -97,6 +98,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat_avx);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -584,6 +586,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -595,6 +598,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -604,6 +608,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -64,6 +64,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG192FAST_AVX2_CRYPTO_RANDOMBYTES 24
+
 
 int PQCLEAN_CROSSRSDPG192FAST_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/fp_arith.h
@@ -298,7 +298,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N], const FZ_ELEM e[N], const FP_ELE
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* e: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		e_x[i] = e[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/fp_arith.h
@@ -340,7 +340,7 @@ void convert_restr_vec_to_fp(FP_ELEM res[N], const FZ_ELEM in[N]) {
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* in: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		in_x[i] = in[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "csprng_hash.h"
 #include "merkle_tree.h"
 #include "parameters.h"
+
 
 #define TO_PUBLISH 1
 #define NOT_TO_PUBLISH 0
@@ -95,3 +96,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
 	tree_root(root, recomputed_leaves);
 	return 1;
 }
+

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -33,6 +33,7 @@
 
 #include "namespace.h"
 
+
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],
                uint8_t leaves[T][HASH_DIGEST_LENGTH]);
 
@@ -44,3 +45,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
                        uint8_t recomputed_leaves[T][HASH_DIGEST_LENGTH],
                        const uint8_t mtp[W * HASH_DIGEST_LENGTH],
                        const uint8_t leaves_to_reveal[T]);
+

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,9 @@
 #define   T (224)
 #define   W (119)
 #define POSITION_IN_FW_STRING_T uint8_t
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +123,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 0, 64}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 128, 192}
@@ -133,3 +138,4 @@
 #define BITS_W_CT_RNG 11655
 #define BITS_M_FZ_CT_RNG 539
 #define BITS_CWSTR_RNG 5128
+

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,12 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x7f) + ((x) >> 7))
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -93,6 +95,7 @@ void fz_inf_w_by_fz_matrix(FZ_ELEM res[N],
 			_mm256_store_si256 ((__m256i *) &res_dprec[j * EPI16_PER_REG], res_w);
 		}
 	}
+
 
 	/* Save result trimming to regular precision */
 	for (int i = 0; i < N - M; i++) {

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake256_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -58,6 +58,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -91,6 +92,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -167,14 +169,14 @@ void CROSS_sign(const sk_t *const SK,
 	FZ_ELEM e_G_bar_prime[M];
 	FZ_ELEM v_G_bar[T][M];
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -338,8 +340,8 @@ int CROSS_verify(const pk_t *const PK,
 	is_stree_padding_ok = rebuild_leaves(round_seeds, chall_2, sig->path);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -435,6 +437,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -456,9 +459,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -64,6 +64,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG192FAST_CLEAN_CRYPTO_RANDOMBYTES 24
+
 
 int PQCLEAN_CROSSRSDPG192FAST_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -82,6 +82,8 @@ FP_ELEM RESTR_TO_VAL(FP_ELEM x) {
 	 *     RESTR_G_GEN_16*RESTR_G_GEN_32*RESTR_G_GEN_64               < 2^32 */
 	return FPRED_SINGLE( FPRED_SINGLE(res1 * res2) * FPRED_SINGLE(res3 * res4) );
 }
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -163,6 +165,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "csprng_hash.h"
 #include "merkle_tree.h"
 #include "parameters.h"
+
 
 #define TO_PUBLISH 1
 #define NOT_TO_PUBLISH 0
@@ -95,3 +96,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
 	tree_root(root, recomputed_leaves);
 	return 1;
 }
+

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -33,6 +33,7 @@
 
 #include "namespace.h"
 
+
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],
                uint8_t leaves[T][HASH_DIGEST_LENGTH]);
 
@@ -44,3 +45,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
                        uint8_t recomputed_leaves[T][HASH_DIGEST_LENGTH],
                        const uint8_t mtp[W * HASH_DIGEST_LENGTH],
                        const uint8_t leaves_to_reveal[T]);
+

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,9 @@
 #define   T (224)
 #define   W (119)
 #define POSITION_IN_FW_STRING_T uint8_t
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +123,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 0, 64}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 128, 192}
@@ -133,3 +138,4 @@
 #define BITS_W_CT_RNG 11655
 #define BITS_M_FZ_CT_RNG 539
 #define BITS_CWSTR_RNG 5128
+

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,7 @@
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-fast_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -59,6 +59,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -97,6 +98,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat_avx);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -590,6 +592,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -601,6 +604,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -610,6 +614,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG192SMALL_AVX2_CRYPTO_RANDOMBYTES 24
+
 
 int PQCLEAN_CROSSRSDPG192SMALL_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/fp_arith.h
@@ -298,7 +298,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N], const FZ_ELEM e[N], const FP_ELE
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* e: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		e_x[i] = e[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/fp_arith.h
@@ -340,7 +340,7 @@ void convert_restr_vec_to_fp(FP_ELEM res[N], const FZ_ELEM in[N]) {
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* in: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		in_x[i] = in[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,10 @@
 #define   T (512)
 #define   W (463)
 #define POSITION_IN_FW_STRING_T uint16_t
+
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +124,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 128, 256, 512}
@@ -133,3 +139,4 @@
 #define BITS_W_CT_RNG 11655
 #define BITS_M_FZ_CT_RNG 539
 #define BITS_CWSTR_RNG 9981
+

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,12 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x7f) + ((x) >> 7))
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -93,6 +95,7 @@ void fz_inf_w_by_fz_matrix(FZ_ELEM res[N],
 			_mm256_store_si256 ((__m256i *) &res_dprec[j * EPI16_PER_REG], res_w);
 		}
 	}
+
 
 	/* Save result trimming to regular precision */
 	for (int i = 0; i < N - M; i++) {

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -208,6 +208,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -224,6 +225,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake256_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -58,6 +58,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -91,6 +92,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -169,14 +171,14 @@ void CROSS_sign(const sk_t *const SK,
 	FZ_ELEM e_G_bar_prime[M];
 	FZ_ELEM v_G_bar[T][M];
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -344,8 +346,8 @@ int CROSS_verify(const pk_t *const PK,
 	seed_leaves(round_seeds, seed_tree);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -441,6 +443,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -462,9 +465,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG192SMALL_CLEAN_CRYPTO_RANDOMBYTES 24
+
 
 int PQCLEAN_CROSSRSDPG192SMALL_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -82,6 +82,8 @@ FP_ELEM RESTR_TO_VAL(FP_ELEM x) {
 	 *     RESTR_G_GEN_16*RESTR_G_GEN_32*RESTR_G_GEN_64               < 2^32 */
 	return FPRED_SINGLE( FPRED_SINGLE(res1 * res2) * FPRED_SINGLE(res3 * res4) );
 }
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -163,6 +165,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,10 @@
 #define   T (512)
 #define   W (463)
 #define POSITION_IN_FW_STRING_T uint16_t
+
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +124,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 64, 128, 256, 512}
@@ -133,3 +139,4 @@
 #define BITS_W_CT_RNG 11655
 #define BITS_M_FZ_CT_RNG 539
 #define BITS_CWSTR_RNG 9981
+

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,7 @@
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -174,6 +174,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -190,6 +191,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-192-small_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-192-small_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -59,6 +59,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -97,6 +98,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat_avx);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -590,6 +592,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -601,6 +604,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -610,6 +614,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG256BALANCED_AVX2_CRYPTO_RANDOMBYTES 32
+
 
 int PQCLEAN_CROSSRSDPG256BALANCED_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/fp_arith.h
@@ -298,7 +298,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N], const FZ_ELEM e[N], const FP_ELE
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* e: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		e_x[i] = e[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/fp_arith.h
@@ -340,7 +340,7 @@ void convert_restr_vec_to_fp(FP_ELEM res[N], const FZ_ELEM in[N]) {
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* in: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		in_x[i] = in[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,9 @@
 #define   T (356)
 #define   W (258)
 #define POSITION_IN_FW_STRING_T uint16_t
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +123,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 8, 8, 8, 200}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 56, 112, 224, 256}
@@ -133,3 +138,4 @@
 #define BITS_W_CT_RNG 20594
 #define BITS_M_FZ_CT_RNG 679
 #define BITS_CWSTR_RNG 8937
+

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,12 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x7f) + ((x) >> 7))
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -93,6 +95,7 @@ void fz_inf_w_by_fz_matrix(FZ_ELEM res[N],
 			_mm256_store_si256 ((__m256i *) &res_dprec[j * EPI16_PER_REG], res_w);
 		}
 	}
+
 
 	/* Save result trimming to regular precision */
 	for (int i = 0; i < N - M; i++) {

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -208,6 +208,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -224,6 +225,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake256_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -58,6 +58,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -91,6 +92,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -169,14 +171,14 @@ void CROSS_sign(const sk_t *const SK,
 	FZ_ELEM e_G_bar_prime[M];
 	FZ_ELEM v_G_bar[T][M];
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -344,8 +346,8 @@ int CROSS_verify(const pk_t *const PK,
 	seed_leaves(round_seeds, seed_tree);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -441,6 +443,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -462,9 +465,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG256BALANCED_CLEAN_CRYPTO_RANDOMBYTES 32
+
 
 int PQCLEAN_CROSSRSDPG256BALANCED_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -82,6 +82,8 @@ FP_ELEM RESTR_TO_VAL(FP_ELEM x) {
 	 *     RESTR_G_GEN_16*RESTR_G_GEN_32*RESTR_G_GEN_64               < 2^32 */
 	return FPRED_SINGLE( FPRED_SINGLE(res1 * res2) * FPRED_SINGLE(res3 * res4) );
 }
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -163,6 +165,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,9 @@
 #define   T (356)
 #define   W (258)
 #define POSITION_IN_FW_STRING_T uint16_t
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +123,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 8, 8, 8, 200}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 56, 112, 224, 256}
@@ -133,3 +138,4 @@
 #define BITS_W_CT_RNG 20594
 #define BITS_M_FZ_CT_RNG 679
 #define BITS_CWSTR_RNG 8937
+

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,7 @@
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -174,6 +174,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -190,6 +191,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-balanced_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -59,6 +59,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -97,6 +98,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat_avx);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -584,6 +586,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -595,6 +598,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -604,6 +608,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -64,6 +64,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG256FAST_AVX2_CRYPTO_RANDOMBYTES 32
+
 
 int PQCLEAN_CROSSRSDPG256FAST_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/fp_arith.h
@@ -298,7 +298,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N], const FZ_ELEM e[N], const FP_ELE
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* e: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		e_x[i] = e[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/fp_arith.h
@@ -340,7 +340,7 @@ void convert_restr_vec_to_fp(FP_ELEM res[N], const FZ_ELEM in[N]) {
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* in: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		in_x[i] = in[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "csprng_hash.h"
 #include "merkle_tree.h"
 #include "parameters.h"
+
 
 #define TO_PUBLISH 1
 #define NOT_TO_PUBLISH 0
@@ -95,3 +96,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
 	tree_root(root, recomputed_leaves);
 	return 1;
 }
+

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -33,6 +33,7 @@
 
 #include "namespace.h"
 
+
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],
                uint8_t leaves[T][HASH_DIGEST_LENGTH]);
 
@@ -44,3 +45,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
                        uint8_t recomputed_leaves[T][HASH_DIGEST_LENGTH],
                        const uint8_t mtp[W * HASH_DIGEST_LENGTH],
                        const uint8_t leaves_to_reveal[T]);
+

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,9 @@
 #define   T (300)
 #define   W (153)
 #define POSITION_IN_FW_STRING_T uint16_t
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +123,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 8, 24, 88, 88}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 56, 96, 128, 256}
@@ -133,3 +138,4 @@
 #define BITS_W_CT_RNG 20594
 #define BITS_M_FZ_CT_RNG 679
 #define BITS_CWSTR_RNG 7929
+

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,12 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x7f) + ((x) >> 7))
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -93,6 +95,7 @@ void fz_inf_w_by_fz_matrix(FZ_ELEM res[N],
 			_mm256_store_si256 ((__m256i *) &res_dprec[j * EPI16_PER_REG], res_w);
 		}
 	}
+
 
 	/* Save result trimming to regular precision */
 	for (int i = 0; i < N - M; i++) {

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake256_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -58,6 +58,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -91,6 +92,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -167,14 +169,14 @@ void CROSS_sign(const sk_t *const SK,
 	FZ_ELEM e_G_bar_prime[M];
 	FZ_ELEM v_G_bar[T][M];
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -338,8 +340,8 @@ int CROSS_verify(const pk_t *const PK,
 	is_stree_padding_ok = rebuild_leaves(round_seeds, chall_2, sig->path);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -435,6 +437,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -456,9 +459,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -64,6 +64,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG256FAST_CLEAN_CRYPTO_RANDOMBYTES 32
+
 
 int PQCLEAN_CROSSRSDPG256FAST_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -82,6 +82,8 @@ FP_ELEM RESTR_TO_VAL(FP_ELEM x) {
 	 *     RESTR_G_GEN_16*RESTR_G_GEN_32*RESTR_G_GEN_64               < 2^32 */
 	return FPRED_SINGLE( FPRED_SINGLE(res1 * res2) * FPRED_SINGLE(res3 * res4) );
 }
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -163,6 +165,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "csprng_hash.h"
 #include "merkle_tree.h"
 #include "parameters.h"
+
 
 #define TO_PUBLISH 1
 #define NOT_TO_PUBLISH 0
@@ -95,3 +96,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
 	tree_root(root, recomputed_leaves);
 	return 1;
 }
+

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -33,6 +33,7 @@
 
 #include "namespace.h"
 
+
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],
                uint8_t leaves[T][HASH_DIGEST_LENGTH]);
 
@@ -44,3 +45,4 @@ uint8_t recompute_root(uint8_t root[HASH_DIGEST_LENGTH],
                        uint8_t recomputed_leaves[T][HASH_DIGEST_LENGTH],
                        const uint8_t mtp[W * HASH_DIGEST_LENGTH],
                        const uint8_t leaves_to_reveal[T]);
+

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,9 @@
 #define   T (300)
 #define   W (153)
 #define POSITION_IN_FW_STRING_T uint16_t
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +123,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 0, 0, 8, 24, 88, 88}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 16, 32, 56, 96, 128, 256}
@@ -133,3 +138,4 @@
 #define BITS_W_CT_RNG 20594
 #define BITS_M_FZ_CT_RNG 679
 #define BITS_CWSTR_RNG 7929
+

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,7 @@
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-fast_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -59,6 +59,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -97,6 +98,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat_avx);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -590,6 +592,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -601,6 +604,7 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_cmt_prime[HASH_DIGEST_LENGTH];
 	hash(digest_cmt_prime, digest_cmt0_cmt1, sizeof(digest_cmt0_cmt1), HASH_DOMAIN_SEP_CONST);
 
+
 	uint8_t y_digest_chall_1[T * DENSELY_PACKED_FP_VEC_SIZE + HASH_DIGEST_LENGTH];
 
 	for (int x = 0; x < T; x++) {
@@ -610,6 +614,7 @@ int CROSS_verify(const pk_t *const PK,
 
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
+
 
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG256SMALL_AVX2_CRYPTO_RANDOMBYTES 32
+
 
 int PQCLEAN_CROSSRSDPG256SMALL_AVX2_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/architecture_detect.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/architecture_detect.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -173,6 +173,7 @@ static inline
 void csprng_release_x4(CSPRNG_X4_STATE_T *const csprng_state) {
 	xof_shake_x4_release(csprng_state);
 }
+
 
 /**************** Common API for Parallel CSPRNG *****************/
 

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/fp_arith.h
@@ -298,7 +298,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N], const FZ_ELEM e[N], const FP_ELE
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* e: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM e_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		e_x[i] = e[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/fp_arith.h
@@ -340,7 +340,7 @@ void convert_restr_vec_to_fp(FP_ELEM res[N], const FZ_ELEM in[N]) {
 	/* res: expand, align */
 	alignas(32) FP_ELEM res_x[ROUND_UP(N, EPI16_PER_REG)];
 	/* in: convert from uint8 to uint16, expand, align */
-	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)];
+	alignas(32) FP_ELEM in_x[ROUND_UP(N, EPI16_PER_REG)] = {0};
 	for (int i = 0; i < N; i++) {
 		in_x[i] = in[i];
 	}

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,10 @@
 #define   T (642)
 #define   W (575)
 #define POSITION_IN_FW_STRING_T uint16_t
+
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +124,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 4, 4, 4, 4, 4, 4, 260}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 12, 24, 48, 96, 192, 384, 512}
@@ -133,3 +139,4 @@
 #define BITS_W_CT_RNG 20594
 #define BITS_M_FZ_CT_RNG 679
 #define BITS_CWSTR_RNG 15140
+

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -31,12 +31,14 @@
 
 #pragma once
 
+#include "architecture_detect.h"
 #include "parameters.h"
 
 #define FZRED_SINGLE(x)   (((x) & 0x7f) + ((x) >> 7))
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {
@@ -93,6 +95,7 @@ void fz_inf_w_by_fz_matrix(FZ_ELEM res[N],
 			_mm256_store_si256 ((__m256i *) &res_dprec[j * EPI16_PER_REG], res_w);
 		}
 	}
+
 
 	/* Save result trimming to regular precision */
 	for (int i = 0; i < N - M; i++) {

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -208,6 +208,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -224,6 +225,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -30,6 +30,9 @@
  **/
 
 #pragma once
+
+#include "architecture_detect.h"
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x1 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -72,6 +75,7 @@ void xof_shake_release(SHAKE_STATE_STRUCT *state) {
 	shake256_inc_ctx_release(state);
 }
 
+
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x4 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #include "fips202x4.h"
@@ -108,6 +112,7 @@ static inline void xof_shake_x4_extract(SHAKE_X4_STATE_STRUCT *states,
 static inline void xof_shake_x4_release(SHAKE_X4_STATE_STRUCT *states) {
 	SHAKE_X4_RELEASE(states);
 }
+
 
 // %%%%%%%%%%%%%%%%%% Self-contained SHAKE x2 Wrappers %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_avx2/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_clean/CROSS.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_clean/CROSS.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -58,6 +58,7 @@ void expand_pk(FP_ELEM V_tr[K][N - K],
 	csprng_release(&csprng_state_mat);
 }
 
+
 static
 void expand_sk(FZ_ELEM e_bar[N],
                FZ_ELEM e_G_bar[M],
@@ -91,6 +92,7 @@ void expand_sk(FZ_ELEM e_bar[N],
 	fz_inf_w_by_fz_matrix(e_bar, e_G_bar, W_mat);
 	fz_dz_norm_n(e_bar);
 }
+
 
 void CROSS_keygen(sk_t *SK,
                   pk_t *PK) {
@@ -169,14 +171,14 @@ void CROSS_sign(const sk_t *const SK,
 	FZ_ELEM e_G_bar_prime[M];
 	FZ_ELEM v_G_bar[T][M];
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt ; place salt at the end */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
 
 	uint8_t cmt_1_i_input[SEED_LENGTH_BYTES +
-	                      SALT_LENGTH_BYTES];
+	                                        SALT_LENGTH_BYTES];
 	/* cmt_1_i_input is concat(seed,salt,round index + 2T-1) */
 	memcpy(cmt_1_i_input + SEED_LENGTH_BYTES, sig->salt, SALT_LENGTH_BYTES);
 
@@ -344,8 +346,8 @@ int CROSS_verify(const pk_t *const PK,
 	seed_leaves(round_seeds, seed_tree);
 
 	uint8_t cmt_0_i_input[DENSELY_PACKED_FP_SYN_SIZE +
-	                      DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
-	                      SALT_LENGTH_BYTES];
+	                                                 DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE +
+	                                                 SALT_LENGTH_BYTES];
 	const int offset_salt = DENSELY_PACKED_FP_SYN_SIZE + DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE;
 	/* cmt_0_i_input is syndrome || v_bar resp. v_G_bar || salt */
 	memcpy(cmt_0_i_input + offset_salt, sig->salt, SALT_LENGTH_BYTES);
@@ -441,6 +443,7 @@ int CROSS_verify(const pk_t *const PK,
 		}
 	} /* end for iterating on ZKID iterations */
 
+
 	uint8_t digest_cmt0_cmt1[2 * HASH_DIGEST_LENGTH];
 
 	uint8_t is_mtree_padding_ok = recompute_root(digest_cmt0_cmt1,
@@ -462,9 +465,11 @@ int CROSS_verify(const pk_t *const PK,
 	uint8_t digest_chall_2_prime[HASH_DIGEST_LENGTH];
 	hash(digest_chall_2_prime, y_digest_chall_1, sizeof(y_digest_chall_1), HASH_DOMAIN_SEP_CONST);
 
+
 	int does_digest_cmt_match = ( memcmp(digest_cmt_prime,
 	                                     sig->digest_cmt,
 	                                     HASH_DIGEST_LENGTH) == 0);
+
 
 	int does_digest_chall_2_match = ( memcmp(digest_chall_2_prime,
 	                                  sig->digest_chall_2,

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_clean/CROSS.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_clean/CROSS.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -66,6 +66,7 @@ typedef struct {
 	uint8_t resp_1[T - W][HASH_DIGEST_LENGTH];
 	resp_0_t resp_0[T - W];
 } CROSS_sig_t;
+
 
 /* keygen cannot fail */
 void CROSS_keygen(sk_t *SK,

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_clean/api.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_clean/api.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -50,6 +50,7 @@
 
 /* required bytes of input randomness */
 #define PQCLEAN_CROSSRSDPG256SMALL_CLEAN_CRYPTO_RANDOMBYTES 32
+
 
 int PQCLEAN_CROSSRSDPG256SMALL_CLEAN_crypto_sign_keypair(unsigned char *pk,
         unsigned char *sk

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_clean/csprng_hash.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_clean/csprng_hash.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_clean/csprng_hash.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_clean/csprng_hash.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_clean/fp_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_clean/fp_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -82,6 +82,8 @@ FP_ELEM RESTR_TO_VAL(FP_ELEM x) {
 	 *     RESTR_G_GEN_16*RESTR_G_GEN_32*RESTR_G_GEN_64               < 2^32 */
 	return FPRED_SINGLE( FPRED_SINGLE(res1 * res2) * FPRED_SINGLE(res3 * res4) );
 }
+
+
 
 /* in-place normalization of redundant zero representation for syndromes*/
 static inline
@@ -163,6 +165,7 @@ void fp_vec_by_restr_vec_scaled(FP_ELEM res[N],
 		                       (FP_DOUBLEPREC) RESTR_TO_VAL(e[i]) * (FP_DOUBLEPREC) chall_1) ;
 	}
 }
+
 
 static inline
 void fp_synd_minus_fp_vec_scaled(FP_ELEM res[N - K],

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_clean/merkle.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_clean/merkle.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -36,6 +36,7 @@
 #include "merkle_tree.h"
 #include "parameters.h"
 
+
 #define PARENT(i) ( ((i)%2) ? (((i)-1)/2) : (((i)-2)/2) )
 #define SIBLING(i) ( ((i)%2) ? (i)+1 : (i)-1 )
 
@@ -46,7 +47,7 @@
 /*****************************************************************************/
 static
 void place_cmt_on_leaves(unsigned char merkle_tree[NUM_NODES_MERKLE_TREE *
-                         HASH_DIGEST_LENGTH],
+                                               HASH_DIGEST_LENGTH],
                          unsigned char commitments[T][HASH_DIGEST_LENGTH]) {
 	const uint16_t cons_leaves[TREE_SUBROOTS] = TREE_CONSECUTIVE_LEAVES;
 	const uint16_t leaves_start_indices[TREE_SUBROOTS] = TREE_LEAVES_START_INDICES;

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_clean/merkle_tree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_clean/merkle_tree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "namespace.h"
+
 
 /* Stub of the interface to Merkle tree root computer from all leaves */
 void tree_root(uint8_t root[HASH_DIGEST_LENGTH],

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_clean/pack_unpack.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_clean/pack_unpack.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_clean/pack_unpack.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_clean/pack_unpack.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_clean/parameters.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_clean/parameters.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -49,6 +49,7 @@
 #define FP_DOUBLEPREC uint32_t
 #define FP_TRIPLEPREC uint32_t
 
+
 /******************************************************************************/
 /****************************** RSDP(G) Parameters ****************************/
 /******************************************************************************/
@@ -61,6 +62,10 @@
 #define   T (642)
 #define   W (575)
 #define POSITION_IN_FW_STRING_T uint16_t
+
+
+
+
 
 #define CSPRNG_DOMAIN_SEP_CONST ((uint16_t)0)
 #define HASH_DOMAIN_SEP_CONST ((uint16_t)32768)
@@ -119,6 +124,7 @@
 #define DENSELY_PACKED_FZ_RSDP_G_VEC_SIZE ((M/8)*BITS_TO_REPRESENT(Z-1) + \
                                           ROUND_UP( ((M%8)*BITS_TO_REPRESENT(Z-1)),8)/8)
 
+
 /* Derived parameters computed via compute_derived_parameters.py */
 #define TREE_OFFSETS {0, 0, 0, 0, 4, 4, 4, 4, 4, 4, 260}
 #define TREE_NODES_PER_LEVEL {1, 2, 4, 8, 12, 24, 48, 96, 192, 384, 512}
@@ -133,3 +139,4 @@
 #define BITS_W_CT_RNG 20594
 #define BITS_M_FZ_CT_RNG 679
 #define BITS_CWSTR_RNG 15140
+

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_clean/restr_arith.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_clean/restr_arith.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -37,6 +37,7 @@
 #define FZRED_DOUBLE(x) FZRED_SINGLE(FZRED_SINGLE(x))
 #define FZRED_OPPOSITE(x) ((x) ^ 0x7f)
 #define FZ_DOUBLE_ZERO_NORM(x) (((x) + (((x) + 1) >> 7)) & 0x7f)
+
 
 static inline
 void fz_dz_norm_n(FZ_ELEM v[N]) {

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_clean/seedtree.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_clean/seedtree.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -174,6 +174,7 @@ void gen_seed_tree(unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYT
 	}
 } /* end generate_seed_tree */
 
+
 /*****************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]) {
@@ -190,6 +191,7 @@ void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
 		}
 	}
 }
+
 
 /*****************************************************************************/
 int seed_path(unsigned char *seed_storage,

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_clean/seedtree.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_clean/seedtree.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -35,6 +35,7 @@
 #include "namespace.h"
 #include "parameters.h"
 
+
 /******************************************************************************/
 void seed_leaves(unsigned char rounds_seeds[T * SEED_LENGTH_BYTES],
                  unsigned char seed_tree[NUM_NODES_SEED_TREE * SEED_LENGTH_BYTES]);
@@ -59,3 +60,4 @@ uint8_t rebuild_tree(unsigned char
                      const unsigned char indices_to_publish[T],
                      const unsigned char *stored_seeds,
                      const unsigned char salt[SALT_LENGTH_BYTES]);   // input
+

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_clean/sha3.h
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_clean/sha3.h
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *

--- a/src/sig/cross/upcross_cross-rsdpg-256-small_clean/sign.c
+++ b/src/sig/cross/upcross_cross-rsdpg-256-small_clean/sign.c
@@ -2,7 +2,7 @@
  *
  * Reference ISO-C11 Implementation of CROSS.
  *
- * @version 2.0 (February 2025)
+ * @version 2.2 (July 2025)
  *
  * Authors listed in alphabetical order:
  *
@@ -89,6 +89,7 @@ int crypto_sign_open(unsigned char *m,                          // out parameter
 	                      (const size_t) * mlen,                 // in parameter
 	                      (const CROSS_sig_t *const) (sm + *mlen)); // in parameter
 
+
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_open
 
@@ -132,6 +133,7 @@ int crypto_sign_verify(const unsigned char *sig,                // in parameter
 	                      (const char *const) m,                 // in parameter
 	                      (const size_t) mlen,                   // in parameter
 	                      (const CROSS_sig_t *const) sig);       // in parameter
+
 
 	return ok - 1; // NIST convention: 0 == zero errors, -1 == error condition
 } // end crypto_sign_verify


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

This pull request updates CROSS from version 2.0 to version 2.2. We optimized modular exponentiations in the RSDPG variants by leveraging AVX2 instructions.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

