### PR TITLE
Change 64 bit add to 32 bit add to wrap on 32 bit counter for AES-CTR…

### DIFF
--- a/src/common/aes/aes128_ni.c
+++ b/src/common/aes/aes128_ni.c
@@ -150,18 +150,18 @@ void oqs_aes128_ctr_enc_sch_upd_blks_ni(void *schedule, uint8_t *out, size_t out
 
 	while (out_blks >= 4) {
 		__m128i nv0 = _mm_shuffle_epi8(ctx->iv, mask);
-		__m128i nv1 = _mm_shuffle_epi8(_mm_add_epi64(ctx->iv, _mm_set_epi64x(1, 0)), mask);
-		__m128i nv2 = _mm_shuffle_epi8(_mm_add_epi64(ctx->iv, _mm_set_epi64x(2, 0)), mask);
-		__m128i nv3 = _mm_shuffle_epi8(_mm_add_epi64(ctx->iv, _mm_set_epi64x(3, 0)), mask);
+		__m128i nv1 = _mm_shuffle_epi8(_mm_add_epi32(ctx->iv, _mm_set_epi64x(1, 0)), mask);
+		__m128i nv2 = _mm_shuffle_epi8(_mm_add_epi32(ctx->iv, _mm_set_epi64x(2, 0)), mask);
+		__m128i nv3 = _mm_shuffle_epi8(_mm_add_epi32(ctx->iv, _mm_set_epi64x(3, 0)), mask);
 		aes128ni_encrypt_x4(schedule, nv0, nv1, nv2, nv3, out);
-		ctx->iv = _mm_add_epi64(ctx->iv, _mm_set_epi64x(4, 0));
+		ctx->iv = _mm_add_epi32(ctx->iv, _mm_set_epi64x(4, 0));
 		out += 64;
 		out_blks -= 4;
 	}
 	while (out_blks >= 1) {
 		__m128i nv0 = _mm_shuffle_epi8(ctx->iv, mask);
 		aes128ni_encrypt(schedule, nv0, out);
-		ctx->iv = _mm_add_epi64(ctx->iv, _mm_set_epi64x(1, 0));
+		ctx->iv = _mm_add_epi32(ctx->iv, _mm_set_epi64x(1, 0));
 		out += 16;
 		out_blks--;
 	}
@@ -181,11 +181,11 @@ void oqs_aes128_ctr_enc_sch_ni(const uint8_t *iv, const size_t iv_len, const voi
 
 	while (out_len >= 64) {
 		__m128i nv0 = block;
-		__m128i nv1 = _mm_shuffle_epi8(_mm_add_epi64(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(1, 0)), mask);
-		__m128i nv2 = _mm_shuffle_epi8(_mm_add_epi64(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(2, 0)), mask);
-		__m128i nv3 = _mm_shuffle_epi8(_mm_add_epi64(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(3, 0)), mask);
+		__m128i nv1 = _mm_shuffle_epi8(_mm_add_epi32(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(1, 0)), mask);
+		__m128i nv2 = _mm_shuffle_epi8(_mm_add_epi32(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(2, 0)), mask);
+		__m128i nv3 = _mm_shuffle_epi8(_mm_add_epi32(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(3, 0)), mask);
 		aes128ni_encrypt_x4(schedule, nv0, nv1, nv2, nv3, out);
-		block = _mm_shuffle_epi8(_mm_add_epi64(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(4, 0)), mask);
+		block = _mm_shuffle_epi8(_mm_add_epi32(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(4, 0)), mask);
 		out += 64;
 		out_len -= 64;
 	}
@@ -193,7 +193,7 @@ void oqs_aes128_ctr_enc_sch_ni(const uint8_t *iv, const size_t iv_len, const voi
 		aes128ni_encrypt(schedule, block, out);
 		out += 16;
 		out_len -= 16;
-		block = _mm_shuffle_epi8(_mm_add_epi64(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(1, 0)), mask);
+		block = _mm_shuffle_epi8(_mm_add_epi32(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(1, 0)), mask);
 	}
 	if (out_len > 0) {
 		uint8_t tmp[16];

--- a/src/common/aes/aes256_ni.c
+++ b/src/common/aes/aes256_ni.c
@@ -184,18 +184,18 @@ void oqs_aes256_ctr_enc_sch_upd_blks_ni(void *schedule, uint8_t *out, size_t out
 
 	while (out_blks >= 4) {
 		__m128i nv0 = _mm_shuffle_epi8(ctx->iv, mask);
-		__m128i nv1 = _mm_shuffle_epi8(_mm_add_epi64(ctx->iv, _mm_set_epi64x(1, 0)), mask);
-		__m128i nv2 = _mm_shuffle_epi8(_mm_add_epi64(ctx->iv, _mm_set_epi64x(2, 0)), mask);
-		__m128i nv3 = _mm_shuffle_epi8(_mm_add_epi64(ctx->iv, _mm_set_epi64x(3, 0)), mask);
+		__m128i nv1 = _mm_shuffle_epi8(_mm_add_epi32(ctx->iv, _mm_set_epi64x(1, 0)), mask);
+		__m128i nv2 = _mm_shuffle_epi8(_mm_add_epi32(ctx->iv, _mm_set_epi64x(2, 0)), mask);
+		__m128i nv3 = _mm_shuffle_epi8(_mm_add_epi32(ctx->iv, _mm_set_epi64x(3, 0)), mask);
 		aes256ni_encrypt_x4(schedule, nv0, nv1, nv2, nv3, out);
-		ctx->iv = _mm_add_epi64(ctx->iv, _mm_set_epi64x(4, 0));
+		ctx->iv = _mm_add_epi32(ctx->iv, _mm_set_epi64x(4, 0));
 		out += 64;
 		out_blks -= 4;
 	}
 	while (out_blks >= 1) {
 		__m128i nv0 = _mm_shuffle_epi8(ctx->iv, mask);
 		aes256ni_encrypt(schedule, nv0, out);
-		ctx->iv = _mm_add_epi64(ctx->iv, _mm_set_epi64x(1, 0));
+		ctx->iv = _mm_add_epi32(ctx->iv, _mm_set_epi64x(1, 0));
 		out += 16;
 		out_blks--;
 	}
@@ -215,11 +215,11 @@ void oqs_aes256_ctr_enc_sch_ni(const uint8_t *iv, const size_t iv_len, const voi
 
 	while (out_len >= 64) {
 		__m128i nv0 = block;
-		__m128i nv1 = _mm_shuffle_epi8(_mm_add_epi64(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(1, 0)), mask);
-		__m128i nv2 = _mm_shuffle_epi8(_mm_add_epi64(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(2, 0)), mask);
-		__m128i nv3 = _mm_shuffle_epi8(_mm_add_epi64(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(3, 0)), mask);
+		__m128i nv1 = _mm_shuffle_epi8(_mm_add_epi32(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(1, 0)), mask);
+		__m128i nv2 = _mm_shuffle_epi8(_mm_add_epi32(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(2, 0)), mask);
+		__m128i nv3 = _mm_shuffle_epi8(_mm_add_epi32(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(3, 0)), mask);
 		aes256ni_encrypt_x4(schedule, nv0, nv1, nv2, nv3, out);
-		block = _mm_shuffle_epi8(_mm_add_epi64(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(4, 0)), mask);
+		block = _mm_shuffle_epi8(_mm_add_epi32(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(4, 0)), mask);
 		out += 64;
 		out_len -= 64;
 	}
@@ -227,7 +227,7 @@ void oqs_aes256_ctr_enc_sch_ni(const uint8_t *iv, const size_t iv_len, const voi
 		aes256ni_encrypt(schedule, block, out);
 		out += 16;
 		out_len -= 16;
-		block = _mm_shuffle_epi8(_mm_add_epi64(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(1, 0)), mask);
+		block = _mm_shuffle_epi8(_mm_add_epi32(_mm_shuffle_epi8(block, mask), _mm_set_epi64x(1, 0)), mask);
 	}
 	if (out_len > 0) {
 		uint8_t tmp[16];


### PR DESCRIPTION
… AES-NI implementation

<!-- Please give a brief explanation of the purpose of this pull request. -->
In the AES256-CTR implementation with AES-NI instructions, the counter is 64 bits rather than 32 bits. The software implementation has a counter with 32 bits. The software and hardware implementations are expected to match, with a counter of 32 bits.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
Fixes #2234 

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [X] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

