### PR TITLE
add content:read permission to scorecard workflow

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       id-token: write
       security-events: write
+      contents: read
 
   extended-tests:
     uses: ./.github/workflows/extended.yml


### PR DESCRIPTION
Per #2260, `.github/workflows/scorecard.yml` requests `content: read` permissions, but `.github/workflows/weekly.yml` did not explicitly give such permission, causing weekly tests to fail.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)


