### PR TITLE
Moving continuous benchmarking to weekly tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 <!-- Please answer the following questions to help manage version and changes across projects. -->
 
 * [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
-* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.)
+* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged. Also, make sure to update the list of algorithms in the continuous benchmarking files: .github/workflows/kem-bench.yml and sig-bench.yml)
 
 <!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
 

--- a/.github/workflows/commit-to-main.yml
+++ b/.github/workflows/commit-to-main.yml
@@ -27,13 +27,3 @@ jobs:
   basic-downstream:
     uses: ./.github/workflows/downstream-basic.yml
     secrets: inherit
-
-  call-kem-benchmarking:
-    uses: ./.github/workflows/kem-bench.yml
-    permissions:
-      contents: write
-    
-  call-sig-benchmarking:
-    uses: ./.github/workflows/sig-bench.yml
-    permissions:
-      contents: write

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -20,3 +20,14 @@ jobs:
 
   extended-tests:
     uses: ./.github/workflows/extended.yml
+
+  kem-continuous-benchmarking:
+    uses: ./.github/workflows/kem-bench.yml
+    permissions:
+      contents: write
+    
+  sig-continuous-benchmarking:
+    uses: ./.github/workflows/sig-bench.yml
+    permissions:
+      contents: write
+

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -30,4 +30,3 @@ jobs:
     uses: ./.github/workflows/sig-bench.yml
     permissions:
       contents: write
-

--- a/CI.md
+++ b/CI.md
@@ -36,7 +36,7 @@ It calls [platform tests](#platforms.yml), [code coverage tests](#code-coverage.
 #### <a name="weekly.yml"></a> Weekly workflow (`weekly.yml`)
 
 This workflow is triggered by a weekly schedule.
-It calls [extended tests](#extended.yml) and [scorecard analysis](#scorecard.yml).
+It calls [extended tests](#extended.yml), [scorecard analysis](#scorecard.yml), and [continuous benchmarking](#kems-and-signatures-continuous-benchmarking-kem-benchyml-and-sig-bench-yml).
 
 #### <a name="release.yml"></a> Release workflow (`release.yml`)
 
@@ -104,6 +104,11 @@ Callers must include `secrets: inherit` in order for the appropriate access toke
 This workflow runs the [OpenSSF scorecard](https://github.com/ossf/scorecard) tool.
 It is additionally triggered automatically when branch protection rules are changed.
 Callers must include `secrets: inherit` in order for the appropriate access tokens to be passed to this workflow.
+
+#### <a name="kem-bench.yml and sig-bench.yml"></a> KEMs and signatures continuous benchmarking (`kem-bench.yml` and `sig-bench-yml`)
+
+These workflows execute a benchmarkig framework to retrieve the performance of KEM and signature algorithms in CPU cycles.
+When new algorithms are added to the codebase, they must be included inside the algorithms matrices found within these files.
 
 ## Travis CI
 

--- a/CI.md
+++ b/CI.md
@@ -36,7 +36,7 @@ It calls [platform tests](#platforms.yml), [code coverage tests](#code-coverage.
 #### <a name="weekly.yml"></a> Weekly workflow (`weekly.yml`)
 
 This workflow is triggered by a weekly schedule.
-It calls [extended tests](#extended.yml), [scorecard analysis](#scorecard.yml), and [continuous benchmarking](#kems-and-signatures-continuous-benchmarking-kem-benchyml-and-sig-bench-yml).
+It calls [extended tests](#extended.yml), [scorecard analysis](#scorecard.yml), and [continuous benchmarking](#kem-bench.yml-sig-bench.yml)
 
 #### <a name="release.yml"></a> Release workflow (`release.yml`)
 
@@ -105,7 +105,7 @@ This workflow runs the [OpenSSF scorecard](https://github.com/ossf/scorecard) to
 It is additionally triggered automatically when branch protection rules are changed.
 Callers must include `secrets: inherit` in order for the appropriate access tokens to be passed to this workflow.
 
-#### <a name="kem-bench.yml and sig-bench.yml"></a> KEMs and signatures continuous benchmarking (`kem-bench.yml` and `sig-bench-yml`)
+#### <a name="kem-bench.yml-sig-bench.yml"></a> KEMs and signatures continuous benchmarking (`kem-bench.yml` and `sig-bench-yml`)
 
 These workflows execute a benchmarkig framework to retrieve the performance of KEM and signature algorithms in CPU cycles.
 When new algorithms are added to the codebase, they must be included inside the algorithms matrices found within these files.


### PR DESCRIPTION
This PR aims to include the suggestion made by @baentsch in #2134 to move the continuous benchmarking tests to `weekly.yml` thus reducing the amount of warnings received.  Let me know if you have any comments or concerns.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged.