### PR TITLE
Re-enable all ACVP tests

### DIFF
--- a/tests/test_acvp_vectors.py
+++ b/tests/test_acvp_vectors.py
@@ -339,5 +339,4 @@ def test_acvp_vec_slh_dsa_sig_ver(sig_name):
 
 if __name__ == "__main__":
     import sys
-    test_acvp_vec_slh_dsa_sig_gen("SLH_DSA_SHA2_224_PREHASH_SHA2_128S")
-    # pytest.main(sys.argv)
+    pytest.main(sys.argv)


### PR DESCRIPTION
It appears that #2237 inadvertently disabled running all ACVP tests in test_acvp_vectors.py, which I missed during review.

This PR re-enables running all ACVP tests.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged. Also, make sure to update the list of algorithms in the continuous benchmarking files: .github/workflows/kem-bench.yml and sig-bench.yml)

