### PR TITLE
Fix incorrect Actual signature length (0) in sig fullcycle speed test

### DIFF
--- a/tests/speed_sig.c
+++ b/tests/speed_sig.c
@@ -17,16 +17,16 @@
 #include "ds_benchmark.h"
 #include "system_info.c"
 
-static void fullcycle(OQS_SIG *sig, uint8_t *public_key, uint8_t *secret_key, uint8_t *signature, size_t signature_len, uint8_t *message, size_t message_len) {
+static void fullcycle(OQS_SIG *sig, uint8_t *public_key, uint8_t *secret_key, uint8_t *signature, size_t *signature_len, uint8_t *message, size_t message_len) {
 	if (OQS_SIG_keypair(sig, public_key, secret_key) != OQS_SUCCESS) {
 		printf("keygen error. Exiting.\n");
 		exit(-1);
 	}
-	if (OQS_SIG_sign(sig, signature, &signature_len, message, message_len, secret_key) != OQS_SUCCESS) {
+	if (OQS_SIG_sign(sig, signature, signature_len, message, message_len, secret_key) != OQS_SUCCESS) {
 		printf("sign error. Exiting.\n");
 		exit(-1);
 	}
-	if (OQS_SIG_verify(sig, message, message_len, signature, signature_len, public_key) != OQS_SUCCESS) {
+	if (OQS_SIG_verify(sig, message, message_len, signature, *signature_len, public_key) != OQS_SUCCESS) {
 		printf("verify error. Exiting.\n");
 		exit(-1);
 	}
@@ -66,7 +66,7 @@ static OQS_STATUS sig_speed_wrapper(const char *method_name, uint64_t duration, 
 		TIME_OPERATION_SECONDS(OQS_SIG_sign(sig, signature, &signature_len, message, message_len, secret_key), "sign", duration)
 		TIME_OPERATION_SECONDS(OQS_SIG_verify(sig, message, message_len, signature, signature_len, public_key), "verify", duration)
 	} else {
-		TIME_OPERATION_SECONDS(fullcycle(sig, public_key, secret_key, signature, signature_len, message, message_len), "fullcycle", duration)
+		TIME_OPERATION_SECONDS(fullcycle(sig, public_key, secret_key, signature, &signature_len, message, message_len), "fullcycle", duration)
 	}
 
 


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
Fix an incorrect Actual signature length (0) in sig fullcycle speed test

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->
Fix #2292 

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged. Also, make sure to update the list of algorithms in the continuous benchmarking files: .github/workflows/kem-bench.yml and sig-bench.yml)

<!-- If this contribution (code, documentation, descriptive text) was produced with the help of generative AI, please describe the nature of the use. Contributors are expected to have verified and affirm such contributions themselves before submission. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

