### PR TITLE
Alpine Linux is distinct from Ubuntu/Debian because Alpine's standard…

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -58,6 +58,7 @@ In this policy, the words "must" and "must not" specify absolute requirements th
 - aarch64 for Apple iOS and tvOS (CMake `-DPLATFORM=OS64` and `TVOS`)
 - arm64, arm (32 bit), x86, x86_64, riscv32, riscv64 for Zephyr
 - armhf/ARM7 emulation on Ubuntu
+- amd64 for Alpine Linux
 
 ### Tier 3
 


### PR DESCRIPTION
Update `PLATFORMS.md` to reflect a tier 2 support for Alpine Linux. The commit message briefly explains why Alpine Linux is supported, and why it is a tier 2 support (for now, though maybe extending constant-time tests to Alpine is easy, and we can quickly whip up the GitHub Action workflow for that, as well?).

This PR closes #2304.

* [NO] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [NO] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged. Also, make sure to update the list of algorithms in the continuous benchmarking files: .github/workflows/kem-bench.yml and sig-bench.yml)
