### PR TITLE
Fix incorrect arg register update in avx512 Keccak

### DIFF
--- a/src/common/sha3/avx512vl_low/KeccakP-1600-times4-AVX512VL.S
+++ b/src/common/sha3/avx512vl_low/KeccakP-1600-times4-AVX512VL.S
@@ -359,10 +359,10 @@ keccak_1600_extract_bytes_x4:
     vmovdqu8    %xmm31, (arg4){%k1}             # Extract 1 to 7 bytes of state into output 3
 
     # increment output pointers
+    addq        %r12, arg1
     addq        %r12, arg2
     addq        %r12, arg3
     addq        %r12, arg4
-    addq        %r12, arg5
     ret
 .size   keccak_1600_extract_bytes_x4,.-keccak_1600_extract_bytes_x4
 


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
Fix for a bug in the AVX512 Keccak implementation where the wrong registers were being updated after extracting bytes from the state. This is currently not an issue as it only occurs when fewer than 8 bytes are extracted using the multi-buffer API, and both ML-KEM and ML-DSA always squeeze data in multiples of 8 bytes, so this code path currently isn’t exercised in practice.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged. Also, make sure to update the list of algorithms in the continuous benchmarking files: .github/workflows/kem-bench.yml and sig-bench.yml)

<!-- If this contribution (code, documentation, descriptive text) was produced with the help of generative AI, please describe the nature of the use. Contributors are expected to have verified and affirm such contributions themselves before submission. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

