### PR TITLE
Adapt/Fix latest Wycheproof tests

### DIFF
--- a/tests/test_wycheproof_vectors.py
+++ b/tests/test_wycheproof_vectors.py
@@ -245,6 +245,7 @@ def test_wycheproof_vec_kem_decaps(kem_name):
 
     build_dir = helpers.get_current_build_dir_name()
     c_len = ML_KEM_PARAMS[kem_name].ct
+    pk_len = ML_KEM_PARAMS[kem_name].pk
     
     for suffix in ["test", "semi_expanded_decaps_test"]:
         test_cases = fetch_wycheproof_kem_test_cases(kem_name, suffix, ["MLKEMDecapsValidationTest", "MLKEMTest"])
@@ -253,11 +254,14 @@ def test_wycheproof_vec_kem_decaps(kem_name):
             expected_k = tc.get("K") or "00" * 32
             c = tc.get("c") or "00" * c_len
 
-            if "seed" in tc and "ek" in tc:
+            if "seed" in tc:
+                # Provide dummy 'ek' if the JSON omits it (e.g., for invalid seed length tests)
+                ek = tc.get("ek") or "00" * pk_len
+                seed = tc.get("seed") or ""
                 cmd = [
                     f"{build_dir}/tests/vectors_kem",
                     kem_name, "strcmp",
-                    tc["seed"], tc["ek"], c, expected_k
+                    seed, ek, c, expected_k
                 ]
             elif "dk" in tc:
                 cmd = [
@@ -273,7 +277,7 @@ def test_wycheproof_vec_kem_decaps(kem_name):
 @helpers.filtered_test
 @pytest.mark.parametrize("sig_name", helpers.available_sigs_by_name())
 def test_wycheproof_vec_sig_verify(sig_name):
-    if not helpers.is_sig_enabled_by_name(sig_name) or not sig_name.startswith("ML-DSA"):
+    if not helpers.is_sig_enabled_by_name(sig_name) or sig_name not in ML_DSA_PARAMS:
         pytest.skip("Not enabled or supported")
 
     build_dir = helpers.get_current_build_dir_name()
@@ -312,7 +316,7 @@ def test_wycheproof_vec_sig_verify(sig_name):
 @helpers.filtered_test
 @pytest.mark.parametrize("sig_name", helpers.available_sigs_by_name())
 def test_wycheproof_vec_sig_sign(sig_name):
-    if not helpers.is_sig_enabled_by_name(sig_name) or not sig_name.startswith("ML-DSA"):
+    if not helpers.is_sig_enabled_by_name(sig_name) or sig_name not in ML_DSA_PARAMS:
         pytest.skip("Not enabled or supported")
 
     build_dir = helpers.get_current_build_dir_name()
@@ -323,6 +327,7 @@ def test_wycheproof_vec_sig_sign(sig_name):
             pytest.skip("No sign test cases found.")
 
         for group, tc in test_cases:
+            is_valid = tc.get("result") == "valid"
             # 1. Try to fetch the fully expanded private key directly (standard for 'noseed' files)
             sk = tc.get("privateKey") or group.get("privateKey")
             
@@ -334,8 +339,12 @@ def test_wycheproof_vec_sig_sign(sig_name):
             # Passing None/empty to the subprocess would crash Python or fail the vector_sig arg parser.
             # Skip and move to next
             if not sk:
-                pytest.fail(f"TC {tc['tcId']} FAILED: Could not obtain or expand secret key.")
-                
+                if not is_valid:
+                    # Expansion failed as expected for invalid seed tests
+                    continue
+                else:
+                    pytest.fail(f"TC {tc['tcId']} FAILED: Seed expansion failed for valid input.") 
+ 
             msg = tc.get("msg", "")
             sig = tc.get("sig", "")
             ctx = tc.get("ctx", "")

--- a/tests/test_wycheproof_vectors.py
+++ b/tests/test_wycheproof_vectors.py
@@ -11,7 +11,8 @@ import pytest
 import helpers
 from helpers import requests_get, cached_requests_get
 
-WYCHE_ROOT = "https://raw.githubusercontent.com/C2SP/wycheproof/main/testvectors_v1/"
+WYCHEPROOF_COMMIT = "45d916899992c5e42dba75106104ca8ce7ff8370"
+WYCHE_ROOT = f"https://raw.githubusercontent.com/C2SP/wycheproof/{WYCHEPROOF_COMMIT}/testvectors_v1/"
 
 MlKemParam = namedtuple("MlKemParam", ["pk", "ct"])
 # Maps supported ML-KEM algorithms to their respective public key (ek) and ciphertext (c) byte lengths.

--- a/tests/test_wycheproof_vectors.py
+++ b/tests/test_wycheproof_vectors.py
@@ -327,6 +327,12 @@ def test_wycheproof_vec_sig_sign(sig_name):
             pytest.skip("No sign test cases found.")
 
         for group, tc in test_cases:
+            flags = tc.get("flags", [])
+            # FIPS 204 does not mandate validating secret keys, and mldsa-native does not perform
+            # this validation. We skip these cases atm
+            if "InvalidPrivateKey" in flags:
+                continue
+            
             is_valid = tc.get("result") == "valid"
             # 1. Try to fetch the fully expanded private key directly (standard for 'noseed' files)
             sk = tc.get("privateKey") or group.get("privateKey")
@@ -372,4 +378,5 @@ def test_wycheproof_vec_sig_sign(sig_name):
 
 if __name__ == "__main__":
     pytest.main(sys.argv)
+
 

--- a/tests/test_wycheproof_vectors.py
+++ b/tests/test_wycheproof_vectors.py
@@ -329,6 +329,12 @@ def test_wycheproof_vec_sig_sign(sig_name):
             pytest.skip("No sign test cases found.")
 
         for group, tc in test_cases:
+            flags = tc.get("flags", [])
+            # FIPS 204 does not mandate validating secret keys, and mldsa-native does not perform
+            # this validation. We skip these cases atm
+            if "InvalidPrivateKey" in flags:
+                continue
+            
             is_valid = tc.get("result") == "valid"
             # 1. Try to fetch the fully expanded private key directly (standard for 'noseed' files)
             sk = tc.get("privateKey") or group.get("privateKey")
@@ -373,4 +379,5 @@ def test_wycheproof_vec_sig_sign(sig_name):
 
 if __name__ == "__main__":
     pytest.main(sys.argv)
+
 

--- a/tests/test_wycheproof_vectors.py
+++ b/tests/test_wycheproof_vectors.py
@@ -11,8 +11,7 @@ import pytest
 import helpers
 from helpers import requests_get, cached_requests_get
 
-# TODO: 032b56a is the last good commit with which all test cases pass
-WYCHEPROOF_COMMIT = "032b56abd1368843e4def50b4975032ec1ec7ba4"
+WYCHEPROOF_COMMIT = "45d916899992c5e42dba75106104ca8ce7ff8370"
 WYCHE_ROOT = f"https://raw.githubusercontent.com/C2SP/wycheproof/{WYCHEPROOF_COMMIT}/testvectors_v1/"
 
 MlKemParam = namedtuple("MlKemParam", ["pk", "ct"])

--- a/tests/test_wycheproof_vectors.py
+++ b/tests/test_wycheproof_vectors.py
@@ -247,6 +247,7 @@ def test_wycheproof_vec_kem_decaps(kem_name):
 
     build_dir = helpers.get_current_build_dir_name()
     c_len = ML_KEM_PARAMS[kem_name].ct
+    pk_len = ML_KEM_PARAMS[kem_name].pk
     
     for suffix in ["test", "semi_expanded_decaps_test"]:
         test_cases = fetch_wycheproof_kem_test_cases(kem_name, suffix, ["MLKEMDecapsValidationTest", "MLKEMTest"])
@@ -255,11 +256,14 @@ def test_wycheproof_vec_kem_decaps(kem_name):
             expected_k = tc.get("K") or "00" * 32
             c = tc.get("c") or "00" * c_len
 
-            if "seed" in tc and "ek" in tc:
+            if "seed" in tc:
+                # Provide dummy 'ek' if the JSON omits it (e.g., for invalid seed length tests)
+                ek = tc.get("ek") or "00" * pk_len
+                seed = tc.get("seed") or ""
                 cmd = [
                     f"{build_dir}/tests/vectors_kem",
                     kem_name, "strcmp",
-                    tc["seed"], tc["ek"], c, expected_k
+                    seed, ek, c, expected_k
                 ]
             elif "dk" in tc:
                 cmd = [
@@ -342,7 +346,6 @@ def test_wycheproof_vec_sig_sign(sig_name):
                     continue
                 else:
                     pytest.fail(f"TC {tc['tcId']} FAILED: Seed expansion failed for valid input.") 
-
             msg = tc.get("msg", "")
             sig = tc.get("sig", "")
             ctx = tc.get("ctx", "")

--- a/tests/test_wycheproof_vectors.py
+++ b/tests/test_wycheproof_vectors.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 
 import json
-import os
 import subprocess
 import sys
 from urllib.parse import urljoin
@@ -9,7 +8,6 @@ from collections import namedtuple
 
 import pytest
 import helpers
-from helpers import requests_get, cached_requests_get
 
 WYCHEPROOF_COMMIT = "45d916899992c5e42dba75106104ca8ce7ff8370"
 WYCHE_ROOT = f"https://raw.githubusercontent.com/C2SP/wycheproof/{WYCHEPROOF_COMMIT}/testvectors_v1/"

--- a/tests/vectors_sig.c
+++ b/tests/vectors_sig.c
@@ -414,7 +414,7 @@ static int sig_ver_vector(const char *method_name,
 
 	fh = stdout;
 
-	if ((sigVer_pk_bytes == NULL) || (sigVer_msg_bytes == NULL) || (sigVer_sig_bytes == NULL)) {
+	if ((sigVer_pk_bytes == NULL) || (msgLen && sigVer_msg_bytes == NULL) || (sigVer_sig_bytes == NULL)) {
 		fprintf(stderr, "[vectors_sig] %s ERROR: inputs NULL!\n", method_name);
 		goto err;
 	}
@@ -477,7 +477,7 @@ static int sig_ver_vector_ext(const char *method_name,
 	OQS_SIG *sig = NULL;
 	int rc = -1, ret = -1;
 
-	if ((sigVer_pk_bytes == NULL) || (sigVer_msg_bytes == NULL) || (sigVer_sig_bytes == NULL) || (sigVer_ctxLen && sigVer_ctx == NULL)) {
+	if ((sigVer_pk_bytes == NULL) || (msgLen && sigVer_msg_bytes == NULL) || (sigVer_sig_bytes == NULL) || (sigVer_ctxLen && sigVer_ctx == NULL)) {
 		fprintf(stderr, "[vectors_sig] %s ERROR: inputs NULL!\n", method_name);
 		goto err;
 	}
@@ -623,7 +623,7 @@ static int sig_gen_vector(const char *method_name,
 		goto err;
 	}
 
-	if ((prng_output_stream == NULL) || (sigGen_sk == NULL) || (sigGen_msg == NULL) || (sigGen_sig == NULL)) {
+	if ((prng_output_stream == NULL) || (sigGen_sk == NULL) || (sigGen_msgLen && sigGen_msg == NULL) || (sigGen_sig == NULL)) {
 		fprintf(stderr, "[vectors_sig] %s ERROR: inputs NULL!\n", method_name);
 		goto err;
 	}
@@ -727,7 +727,7 @@ static int sig_gen_vector_ext(const char *method_name,
 		goto err;
 	}
 
-	if ((prng_output_stream == NULL) || (sigGen_sk == NULL) || (sigGen_msg == NULL) || (sigGen_sig == NULL) || (sigGen_ctxLen && sigGen_ctx == NULL)) {
+	if ((prng_output_stream == NULL) || (sigGen_sk == NULL) || (sigGen_msgLen && sigGen_msg == NULL) || (sigGen_sig == NULL) || (sigGen_ctxLen && sigGen_ctx == NULL)) {
 		fprintf(stderr, "[vectors_sig] %s ERROR: inputs NULL!\n", method_name);
 		goto err;
 	}
@@ -1032,17 +1032,19 @@ int main(int argc, char **argv) {
 		msgLen = strlen(sigGen_msg) / 2;
 
 		sigGen_sk_bytes = OQS_MEM_malloc(sig->length_secret_key);
-		sigGen_msg_bytes = OQS_MEM_malloc(msgLen);
+		sigGen_msg_bytes = (msgLen > 0) ? OQS_MEM_malloc(msgLen) : NULL;
 		sigGen_sig_bytes = OQS_MEM_malloc(sig->length_signature);
 		prng_output_stream_bytes = OQS_MEM_malloc(strlen(prng_output_stream) / 2);
 
-		if ((sigGen_sk_bytes == NULL) || (sigGen_msg_bytes == NULL) || (sigGen_sig_bytes == NULL) || (prng_output_stream_bytes == NULL)) {
+		if ((sigGen_sk_bytes == NULL) || (msgLen && sigGen_msg_bytes == NULL) || (sigGen_sig_bytes == NULL) || (prng_output_stream_bytes == NULL)) {
 			fprintf(stderr, "[vectors_sig] ERROR: OQS_MEM_malloc failed!\n");
 			goto err;
 		}
 
 		hexStringToByteArray(sigGen_sk, sigGen_sk_bytes);
-		hexStringToByteArray(sigGen_msg, sigGen_msg_bytes);
+		if (msgLen) {
+			hexStringToByteArray(sigGen_msg, sigGen_msg_bytes);
+		}
 		hexStringToByteArray(sigGen_sig, sigGen_sig_bytes);
 		hexStringToByteArray(prng_output_stream, prng_output_stream_bytes);
 
@@ -1100,7 +1102,7 @@ int main(int argc, char **argv) {
 		ctxlen = strlen(sigGen_ctx) / 2;
 
 		sigGen_sk_bytes = OQS_MEM_malloc(sig->length_secret_key);
-		sigGen_msg_bytes = OQS_MEM_malloc(msgLen);
+		sigGen_msg_bytes = (msgLen > 0) ? OQS_MEM_malloc(msgLen) : NULL;
 		sigGen_sig_bytes = OQS_MEM_malloc(sig->length_signature);
 		prng_output_stream_bytes = OQS_MEM_malloc(strlen(prng_output_stream) / 2);
 		/* allocate memory if required */
@@ -1108,15 +1110,17 @@ int main(int argc, char **argv) {
 			sigGen_ctx_bytes = OQS_MEM_malloc(ctxlen);
 		}
 
-		if ((sigGen_sk_bytes == NULL) || (sigGen_msg_bytes == NULL) || (sigGen_sig_bytes == NULL) || (ctxlen && sigGen_ctx_bytes == NULL) || (prng_output_stream_bytes == NULL)) {
+		if ((sigGen_sk_bytes == NULL) || (msgLen && sigGen_msg_bytes == NULL) || (sigGen_sig_bytes == NULL) || (ctxlen && sigGen_ctx_bytes == NULL) || (prng_output_stream_bytes == NULL)) {
 			fprintf(stderr, "[vectors_sig] ERROR: OQS_MEM_malloc failed!\n");
 			goto err;
 		}
 
 		hexStringToByteArray(prng_output_stream, prng_output_stream_bytes);
 		hexStringToByteArray(sigGen_sk, sigGen_sk_bytes);
-		hexStringToByteArray(sigGen_msg, sigGen_msg_bytes);
 		hexStringToByteArray(sigGen_sig, sigGen_sig_bytes);
+		if (msgLen) {
+			hexStringToByteArray(sigGen_msg, sigGen_msg_bytes);
+		}
 		if (ctxlen) {
 			hexStringToByteArray(sigGen_ctx, sigGen_ctx_bytes);
 		}
@@ -1220,16 +1224,18 @@ int main(int argc, char **argv) {
 		msgLen = strlen(sigVer_msg) / 2;
 
 		sigVer_pk_bytes = OQS_MEM_malloc(sig->length_public_key);
-		sigVer_msg_bytes = OQS_MEM_malloc(msgLen);
+		sigVer_msg_bytes = (msgLen > 0) ? OQS_MEM_malloc(msgLen) : NULL;
 		sigVer_sig_bytes = OQS_MEM_malloc(strlen(sigVer_sig) / 2);
 
-		if ((sigVer_pk_bytes == NULL) || (sigVer_msg_bytes == NULL) || (sigVer_sig_bytes == NULL)) {
+		if ((sigVer_pk_bytes == NULL) || (msgLen && sigVer_msg_bytes == NULL) || (sigVer_sig_bytes == NULL)) {
 			fprintf(stderr, "[vectors_sig] ERROR: OQS_MEM_malloc failed!\n");
 			goto err;
 		}
 
 		hexStringToByteArray(sigVer_pk, sigVer_pk_bytes);
-		hexStringToByteArray(sigVer_msg, sigVer_msg_bytes);
+		if (msgLen) {
+			hexStringToByteArray(sigVer_msg, sigVer_msg_bytes);
+		}
 		hexStringToByteArray(sigVer_sig, sigVer_sig_bytes);
 
 #if defined(OQS_ENABLE_SIG_ml_dsa_44) || defined(OQS_ENABLE_SIG_ml_dsa_65) || defined(OQS_ENABLE_SIG_ml_dsa_87) || defined(OQS_ENABLE_SIG_SLH_DSA)
@@ -1278,21 +1284,23 @@ int main(int argc, char **argv) {
 		ctxlen = strlen(sigVer_ctx) / 2;
 
 		sigVer_pk_bytes = OQS_MEM_malloc(sig->length_public_key);
-		sigVer_msg_bytes = OQS_MEM_malloc(msgLen);
+		sigVer_msg_bytes = (msgLen > 0) ? OQS_MEM_malloc(msgLen) : NULL;
 		sigVer_sig_bytes = OQS_MEM_malloc(strlen(sigVer_sig) / 2);
 		/* allocate memory if required */
 		if (ctxlen) {
 			sigVer_ctx_bytes = OQS_MEM_malloc(ctxlen);
 		}
 
-		if ((sigVer_pk_bytes == NULL) || (sigVer_msg_bytes == NULL) || (sigVer_sig_bytes == NULL) || (ctxlen && sigVer_ctx_bytes == NULL)) {
+		if ((sigVer_pk_bytes == NULL) || (msgLen && sigVer_msg_bytes == NULL) || (sigVer_sig_bytes == NULL) || (ctxlen && sigVer_ctx_bytes == NULL)) {
 			fprintf(stderr, "[vectors_sig] ERROR: OQS_MEM_malloc failed!\n");
 			goto err;
 		}
 
 		hexStringToByteArray(sigVer_pk, sigVer_pk_bytes);
-		hexStringToByteArray(sigVer_msg, sigVer_msg_bytes);
 		hexStringToByteArray(sigVer_sig, sigVer_sig_bytes);
+		if (msgLen) {
+			hexStringToByteArray(sigVer_msg, sigVer_msg_bytes);
+		}
 		if (ctxlen) {
 			hexStringToByteArray(sigVer_ctx, sigVer_ctx_bytes);
 		}

--- a/tests/vectors_sig.c
+++ b/tests/vectors_sig.c
@@ -1538,9 +1538,6 @@ int main(int argc, char **argv) {
 		if (msgLen) {
 			hexStringToByteArray(sigVer_msg, sigVer_msg_bytes);
 		}
-		if (ctxlen) {
-			hexStringToByteArray(sigVer_ctx, sigVer_ctx_bytes);
-		}
 
 #if defined(OQS_ENABLE_SIG_ml_dsa_44_extmu) || defined(OQS_ENABLE_SIG_ml_dsa_65_extmu) || defined(OQS_ENABLE_SIG_ml_dsa_87_extmu)
 		rc = sig_ver_vector_extmu(alg_name, sigVer_pk_bytes, sigVer_msg_bytes, msgLen, sigVer_sig_bytes, strlen(sigVer_sig) / 2, sigVerPassed);

--- a/tests/vectors_sig.c
+++ b/tests/vectors_sig.c
@@ -1313,10 +1313,22 @@ int main(int argc, char **argv) {
 
 		hexStringToByteArray(prng_output_stream, prng_output_stream_bytes);
 		hexStringToByteArray(sigGen_sk, sigGen_sk_bytes);
-		hexStringToByteArray(sigGen_msg, sigGen_msg_bytes);
 		hexStringToByteArray(sigGen_sig, sigGen_sig_bytes);
 #if defined(OQS_ENABLE_SIG_ml_dsa_44_extmu) || defined(OQS_ENABLE_SIG_ml_dsa_65_extmu) || defined(OQS_ENABLE_SIG_ml_dsa_87_extmu)
 		rc = sig_gen_vector_extmu(alg_name, prng_output_stream_bytes, sigGen_sk_bytes, sigGen_msg_bytes, msgLen, sigGen_sig_bytes);
+		if (msgLen) {
+			hexStringToByteArray(sigGen_msg, sigGen_msg_bytes);
+		}
+		if (ctxlen) {
+			hexStringToByteArray(sigGen_ctx, sigGen_ctx_bytes);
+		}
+#else
+		rc = EXIT_SUCCESS;
+		goto cleanup;
+#endif
+
+#if defined(OQS_ENABLE_SIG_ml_dsa_44) || defined(OQS_ENABLE_SIG_ml_dsa_65) || defined(OQS_ENABLE_SIG_ml_dsa_87) || defined(OQS_ENABLE_SIG_SLH_DSA)
+		rc = sig_gen_vector_ext(alg_name, prng_output_stream_bytes, sigGen_sk_bytes, sigGen_msg_bytes, msgLen, sigGen_ctx_bytes, ctxlen, sigGen_sig_bytes);
 #else
 		rc = EXIT_SUCCESS;
 		goto cleanup;
@@ -1530,8 +1542,13 @@ int main(int argc, char **argv) {
 		}
 
 		hexStringToByteArray(sigVer_pk, sigVer_pk_bytes);
-		hexStringToByteArray(sigVer_msg, sigVer_msg_bytes);
 		hexStringToByteArray(sigVer_sig, sigVer_sig_bytes);
+		if (msgLen) {
+			hexStringToByteArray(sigVer_msg, sigVer_msg_bytes);
+		}
+		if (ctxlen) {
+			hexStringToByteArray(sigVer_ctx, sigVer_ctx_bytes);
+		}
 
 #if defined(OQS_ENABLE_SIG_ml_dsa_44_extmu) || defined(OQS_ENABLE_SIG_ml_dsa_65_extmu) || defined(OQS_ENABLE_SIG_ml_dsa_87_extmu)
 		rc = sig_ver_vector_extmu(alg_name, sigVer_pk_bytes, sigVer_msg_bytes, msgLen, sigVer_sig_bytes, strlen(sigVer_sig) / 2, sigVerPassed);

--- a/tests/vectors_sig.c
+++ b/tests/vectors_sig.c
@@ -1302,7 +1302,7 @@ int main(int argc, char **argv) {
 		msgLen = strlen(sigGen_msg) / 2;
 
 		sigGen_sk_bytes = OQS_MEM_malloc(sig->length_secret_key);
-        sigGen_msg_bytes = (msgLen > 0) ? OQS_MEM_malloc(msgLen) : NULL;
+		sigGen_msg_bytes = (msgLen > 0) ? OQS_MEM_malloc(msgLen) : NULL;
 		sigGen_sig_bytes = OQS_MEM_malloc(sig->length_signature);
 		prng_output_stream_bytes = OQS_MEM_malloc(strlen(prng_output_stream) / 2);
 
@@ -1313,9 +1313,9 @@ int main(int argc, char **argv) {
 
 		hexStringToByteArray(prng_output_stream, prng_output_stream_bytes);
 		hexStringToByteArray(sigGen_sk, sigGen_sk_bytes);
-        if (msgLen) {
-            hexStringToByteArray(sigGen_msg, sigGen_msg_bytes);
-        }
+		if (msgLen) {
+			hexStringToByteArray(sigGen_msg, sigGen_msg_bytes);
+		}
 		hexStringToByteArray(sigGen_sig, sigGen_sig_bytes);
 #if defined(OQS_ENABLE_SIG_ml_dsa_44_extmu) || defined(OQS_ENABLE_SIG_ml_dsa_65_extmu) || defined(OQS_ENABLE_SIG_ml_dsa_87_extmu)
 		rc = sig_gen_vector_extmu(alg_name, prng_output_stream_bytes, sigGen_sk_bytes, sigGen_msg_bytes, msgLen, sigGen_sig_bytes);
@@ -1352,7 +1352,7 @@ int main(int argc, char **argv) {
 		ctxlen = strlen(sigGen_ctx) / 2;
 
 		sigGen_sk_bytes = OQS_MEM_malloc(sig->length_secret_key);
-		sigVer_msg_bytes = (msgLen > 0) ? OQS_MEM_malloc(msgLen) : NULL;
+		sigGen_msg_bytes = (msgLen > 0) ? OQS_MEM_malloc(msgLen) : NULL;
 		sigGen_sig_bytes = OQS_MEM_malloc(sig->length_signature);
 		prng_output_stream_bytes = OQS_MEM_malloc(strlen(prng_output_stream) / 2);
 		/* allocate memory if required */
@@ -1367,9 +1367,9 @@ int main(int argc, char **argv) {
 
 		hexStringToByteArray(prng_output_stream, prng_output_stream_bytes);
 		hexStringToByteArray(sigGen_sk, sigGen_sk_bytes);
-        if (msgLen) {
-            hexStringToByteArray(sigGen_msg, sigGen_msg_bytes);
-        }
+		if (msgLen) {
+			hexStringToByteArray(sigGen_msg, sigGen_msg_bytes);
+		}
 		hexStringToByteArray(sigGen_sig, sigGen_sig_bytes);
 		if (ctxlen) {
 			hexStringToByteArray(sigGen_ctx, sigGen_ctx_bytes);
@@ -1587,9 +1587,9 @@ int main(int argc, char **argv) {
 		}
 
 		hexStringToByteArray(sigVer_pk, sigVer_pk_bytes);
-        if (msgLen) {
-            hexStringToByteArray(sigVer_msg, sigVer_msg_bytes);
-        }
+		if (msgLen) {
+			hexStringToByteArray(sigVer_msg, sigVer_msg_bytes);
+		}
 		hexStringToByteArray(sigVer_sig, sigVer_sig_bytes);
 		if (ctxlen) {
 			hexStringToByteArray(sigVer_ctx, sigVer_ctx_bytes);

--- a/tests/vectors_sig.c
+++ b/tests/vectors_sig.c
@@ -1302,33 +1302,23 @@ int main(int argc, char **argv) {
 		msgLen = strlen(sigGen_msg) / 2;
 
 		sigGen_sk_bytes = OQS_MEM_malloc(sig->length_secret_key);
-		sigGen_msg_bytes = OQS_MEM_malloc(msgLen);
+        sigGen_msg_bytes = (msgLen > 0) ? OQS_MEM_malloc(msgLen) : NULL;
 		sigGen_sig_bytes = OQS_MEM_malloc(sig->length_signature);
 		prng_output_stream_bytes = OQS_MEM_malloc(strlen(prng_output_stream) / 2);
 
-		if ((sigGen_sk_bytes == NULL) || (sigGen_msg_bytes == NULL) || (sigGen_sig_bytes == NULL) || (prng_output_stream_bytes == NULL)) {
+		if ((sigGen_sk_bytes == NULL) || (msgLen && sigGen_msg_bytes == NULL) || (sigGen_sig_bytes == NULL) || (prng_output_stream_bytes == NULL)) {
 			fprintf(stderr, "[vectors_sig] ERROR: OQS_MEM_malloc failed!\n");
 			goto err;
 		}
 
 		hexStringToByteArray(prng_output_stream, prng_output_stream_bytes);
 		hexStringToByteArray(sigGen_sk, sigGen_sk_bytes);
+        if (msgLen) {
+            hexStringToByteArray(sigGen_msg, sigGen_msg_bytes);
+        }
 		hexStringToByteArray(sigGen_sig, sigGen_sig_bytes);
 #if defined(OQS_ENABLE_SIG_ml_dsa_44_extmu) || defined(OQS_ENABLE_SIG_ml_dsa_65_extmu) || defined(OQS_ENABLE_SIG_ml_dsa_87_extmu)
 		rc = sig_gen_vector_extmu(alg_name, prng_output_stream_bytes, sigGen_sk_bytes, sigGen_msg_bytes, msgLen, sigGen_sig_bytes);
-		if (msgLen) {
-			hexStringToByteArray(sigGen_msg, sigGen_msg_bytes);
-		}
-		if (ctxlen) {
-			hexStringToByteArray(sigGen_ctx, sigGen_ctx_bytes);
-		}
-#else
-		rc = EXIT_SUCCESS;
-		goto cleanup;
-#endif
-
-#if defined(OQS_ENABLE_SIG_ml_dsa_44) || defined(OQS_ENABLE_SIG_ml_dsa_65) || defined(OQS_ENABLE_SIG_ml_dsa_87) || defined(OQS_ENABLE_SIG_SLH_DSA)
-		rc = sig_gen_vector_ext(alg_name, prng_output_stream_bytes, sigGen_sk_bytes, sigGen_msg_bytes, msgLen, sigGen_ctx_bytes, ctxlen, sigGen_sig_bytes);
 #else
 		rc = EXIT_SUCCESS;
 		goto cleanup;
@@ -1362,7 +1352,7 @@ int main(int argc, char **argv) {
 		ctxlen = strlen(sigGen_ctx) / 2;
 
 		sigGen_sk_bytes = OQS_MEM_malloc(sig->length_secret_key);
-		sigGen_msg_bytes = OQS_MEM_malloc(msgLen);
+		sigVer_msg_bytes = (msgLen > 0) ? OQS_MEM_malloc(msgLen) : NULL;
 		sigGen_sig_bytes = OQS_MEM_malloc(sig->length_signature);
 		prng_output_stream_bytes = OQS_MEM_malloc(strlen(prng_output_stream) / 2);
 		/* allocate memory if required */
@@ -1370,14 +1360,16 @@ int main(int argc, char **argv) {
 			sigGen_ctx_bytes = OQS_MEM_malloc(ctxlen);
 		}
 
-		if ((sigGen_sk_bytes == NULL) || (sigGen_msg_bytes == NULL) || (sigGen_sig_bytes == NULL) || (ctxlen && sigGen_ctx_bytes == NULL) || (prng_output_stream_bytes == NULL)) {
+		if ((sigGen_sk_bytes == NULL) || (msgLen && sigGen_msg_bytes == NULL) || (sigGen_sig_bytes == NULL) || (ctxlen && sigGen_ctx_bytes == NULL) || (prng_output_stream_bytes == NULL)) {
 			fprintf(stderr, "[vectors_sig] ERROR: OQS_MEM_malloc failed!\n");
 			goto err;
 		}
 
 		hexStringToByteArray(prng_output_stream, prng_output_stream_bytes);
 		hexStringToByteArray(sigGen_sk, sigGen_sk_bytes);
-		hexStringToByteArray(sigGen_msg, sigGen_msg_bytes);
+        if (msgLen) {
+            hexStringToByteArray(sigGen_msg, sigGen_msg_bytes);
+        }
 		hexStringToByteArray(sigGen_sig, sigGen_sig_bytes);
 		if (ctxlen) {
 			hexStringToByteArray(sigGen_ctx, sigGen_ctx_bytes);
@@ -1533,10 +1525,10 @@ int main(int argc, char **argv) {
 
 		msgLen = strlen(sigVer_msg) / 2;
 		sigVer_pk_bytes = OQS_MEM_malloc(sig->length_public_key);
-		sigVer_msg_bytes = OQS_MEM_malloc(msgLen);
+		sigVer_msg_bytes = (msgLen > 0) ? OQS_MEM_malloc(msgLen) : NULL;
 		sigVer_sig_bytes = OQS_MEM_malloc(strlen(sigVer_sig) / 2);
 
-		if ((sigVer_pk_bytes == NULL) || (sigVer_msg_bytes == NULL) || (sigVer_sig_bytes == NULL)) {
+		if ((sigVer_pk_bytes == NULL) || (msgLen && sigVer_msg_bytes == NULL) || (sigVer_sig_bytes == NULL)) {
 			fprintf(stderr, "[vectors_sig] ERROR: OQS_MEM_malloc failed!\n");
 			goto err;
 		}
@@ -1585,20 +1577,22 @@ int main(int argc, char **argv) {
 		ctxlen = strlen(sigVer_ctx) / 2;
 
 		sigVer_pk_bytes = OQS_MEM_malloc(sig->length_public_key);
-		sigVer_msg_bytes = OQS_MEM_malloc(msgLen);
+		sigVer_msg_bytes = (msgLen > 0) ? OQS_MEM_malloc(msgLen) : NULL;
 		sigVer_sig_bytes = OQS_MEM_malloc(strlen(sigVer_sig) / 2);
 		/* allocate memory if required */
 		if (ctxlen) {
 			sigVer_ctx_bytes = OQS_MEM_malloc(ctxlen);
 		}
 
-		if ((sigVer_pk_bytes == NULL) || (sigVer_msg_bytes == NULL) || (sigVer_sig_bytes == NULL) || (ctxlen && sigVer_ctx_bytes == NULL)) {
+		if ((sigVer_pk_bytes == NULL) || (msgLen && sigVer_msg_bytes == NULL) || (sigVer_sig_bytes == NULL) || (ctxlen && sigVer_ctx_bytes == NULL)) {
 			fprintf(stderr, "[vectors_sig] ERROR: OQS_MEM_malloc failed!\n");
 			goto err;
 		}
 
 		hexStringToByteArray(sigVer_pk, sigVer_pk_bytes);
-		hexStringToByteArray(sigVer_msg, sigVer_msg_bytes);
+        if (msgLen) {
+            hexStringToByteArray(sigVer_msg, sigVer_msg_bytes);
+        }
 		hexStringToByteArray(sigVer_sig, sigVer_sig_bytes);
 		if (ctxlen) {
 			hexStringToByteArray(sigVer_ctx, sigVer_ctx_bytes);


### PR DESCRIPTION
Wycheproof vectors for ML-DSA were updated yesterday, adding a large number of new test cases that cover additional scenarios. Some of these cases were previously unhandled, such as allowing empty messages for signature generation and verification, invalid seed lengths etc.

This PR addresses those issues and updates the implementation accordingly. Since the Wycheproof vectors are fetched from the C2SP repository on every run, this fix is necessary; otherwise, other PRs would fail due to these newly introduced test cases.