### PR TITLE
Pin Wycheproof test vectors to last good commit

### DIFF
--- a/tests/test_wycheproof_vectors.py
+++ b/tests/test_wycheproof_vectors.py
@@ -11,7 +11,9 @@ import pytest
 import helpers
 from helpers import requests_get, cached_requests_get
 
-WYCHE_ROOT = "https://raw.githubusercontent.com/C2SP/wycheproof/main/testvectors_v1/"
+# TODO: 032b56a is the last good commit with which all test cases pass
+WYCHEPROOF_COMMIT = "032b56abd1368843e4def50b4975032ec1ec7ba4"
+WYCHE_ROOT = f"https://raw.githubusercontent.com/C2SP/wycheproof/{WYCHEPROOF_COMMIT}/testvectors_v1/"
 
 MlKemParam = namedtuple("MlKemParam", ["pk", "ct"])
 # Maps supported ML-KEM algorithms to their respective public key (ek) and ciphertext (c) byte lengths.


### PR DESCRIPTION
This pull request is a partial duplicate of #2387. Its sole purpose is to unblock CI pipeline for other pull requests with higher priority while [#2387 goes through further review](https://github.com/open-quantum-safe/liboqs/pull/2387#issuecomment-4157079295).

* [**NO**] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [**NO**] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged. Also, make sure to update the list of algorithms in the continuous benchmarking files: .github/workflows/kem-bench.yml and sig-bench.yml)