### PR TITLE
fix: correct cuPQC ML-KEM derand symbol names and #if/#elif chains

### DIFF
--- a/scripts/copy_from_upstream/src/kem/family/kem_scheme.c
+++ b/scripts/copy_from_upstream/src/kem/family/kem_scheme.c
@@ -167,7 +167,7 @@ extern int libjade_{{ scheme['pqclean_scheme_c'] }}_{{ impl['name'] }}_dec(uint8
 
 OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_keypair_derand(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
 {%- if scheme['derandomized_keypair'] %}
-    {%- for impl in scheme['metadata']['implementations'] if impl['name'] != scheme['default_implementation'] %}
+    {%- for impl in scheme['metadata']['implementations'] if impl['name'] != scheme['default_implementation'] and impl['signature_keypair_derand'] %}
     {%- if loop.first %}
 #if defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }}) {%- if 'alias_scheme' in scheme %} || defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['alias_scheme'] }}_{{ impl['name'] }}){%- endif %}
     {%- else %}
@@ -178,13 +178,7 @@ OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_keypair_derand(ui
 	if ({%- for flag in impl['required_flags'] -%}OQS_CPU_has_extension(OQS_CPU_EXT_{{ flag|upper }}){%- if not loop.last %} && {% endif -%}{%- endfor -%}) {
 #endif /* OQS_DIST_BUILD */
     {%- endif -%}
-        {%- if impl['signature_keypair_derand'] %}
 	{% if 'required_flags' in impl and impl['required_flags'] %}	{% endif -%}return (OQS_STATUS) {{ impl['signature_keypair_derand'] }}(public_key, secret_key, seed);
-        {%- elif impl['name'] not in ['cuda', 'icicle_cuda'] %}
-	{% if 'required_flags' in impl and impl['required_flags'] %}	{% endif -%}return (OQS_STATUS) PQCLEAN_{{ scheme['pqclean_scheme_c']|upper }}_{{ impl['name']|upper }}_crypto_kem_keypair_derand(public_key, secret_key, seed);
-        {%- else %}
-	{% if 'required_flags' in impl and impl['required_flags'] %}	{% endif -%}return (OQS_STATUS) {{ scheme['metadata']['default_keypair_derand_signature'] }}(public_key, secret_key, seed);
-        {%- endif %}
     {%- if 'required_flags' in impl and impl['required_flags'] %}
 #if defined(OQS_DIST_BUILD)
 	} else {
@@ -193,11 +187,11 @@ OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_keypair_derand(ui
 #endif /* OQS_DIST_BUILD */
     {%- endif -%}
     {%- endfor %}
-    {%- if scheme['metadata']['implementations']|rejectattr('name', 'equalto', scheme['default_implementation'])|list %}
+    {%- if scheme['metadata']['implementations']|rejectattr('name', 'equalto', scheme['default_implementation'])|selectattr('signature_keypair_derand')|list %}
 #else
     {%- endif %}
 	return (OQS_STATUS) {{ scheme['metadata']['default_keypair_derand_signature'] }}(public_key, secret_key, seed);
-    {%- if scheme['metadata']['implementations']|rejectattr('name', 'equalto', scheme['default_implementation'])|list %}
+    {%- if scheme['metadata']['implementations']|rejectattr('name', 'equalto', scheme['default_implementation'])|selectattr('signature_keypair_derand')|list %}
 #endif
     {%- endif %}
     {%- else %}
@@ -301,7 +295,7 @@ OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_keypair(uint8_t *
 
 OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_encaps_derand(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key, const uint8_t *seed) {
 {%- if scheme['derandomized_encaps'] %}
-    {%- for impl in scheme['metadata']['implementations'] if impl['name'] != scheme['default_implementation'] %}
+    {%- for impl in scheme['metadata']['implementations'] if impl['name'] != scheme['default_implementation'] and impl['signature_enc_derand'] %}
     {%- if loop.first %}
 #if defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }}) {%- if 'alias_scheme' in scheme %} || defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['alias_scheme'] }}_{{ impl['name'] }}){%- endif %}
     {%- else %}
@@ -312,13 +306,7 @@ OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_encaps_derand(uin
 	if ({%- for flag in impl['required_flags'] -%}OQS_CPU_has_extension(OQS_CPU_EXT_{{ flag|upper }}){%- if not loop.last %} && {% endif -%}{%- endfor -%}) {
 #endif /* OQS_DIST_BUILD */
     {%- endif -%}
-        {%- if impl['signature_enc_derand'] %}
 	{% if 'required_flags' in impl and impl['required_flags'] %}	{% endif -%}return (OQS_STATUS) {{ impl['signature_enc_derand'] }}(ciphertext, shared_secret, public_key, seed);
-        {%- elif impl['name'] not in ['cuda', 'icicle_cuda'] %}
-	{% if 'required_flags' in impl and impl['required_flags'] %}	{% endif -%}return (OQS_STATUS) PQCLEAN_{{ scheme['pqclean_scheme_c']|upper }}_{{ impl['name']|upper }}_crypto_kem_enc_derand(ciphertext, shared_secret, public_key, seed);
-        {%- else %}
-	{% if 'required_flags' in impl and impl['required_flags'] %}	{% endif -%}return (OQS_STATUS) {{ scheme['metadata']['default_enc_derand_signature'] }}(ciphertext, shared_secret, public_key, seed);
-        {%- endif %}
     {%- if 'required_flags' in impl and impl['required_flags'] %}
 #if defined(OQS_DIST_BUILD)
 	} else {
@@ -327,11 +315,11 @@ OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_encaps_derand(uin
 #endif /* OQS_DIST_BUILD */
     {%- endif -%}
     {%- endfor %}
-    {%- if scheme['metadata']['implementations']|rejectattr('name', 'equalto', scheme['default_implementation'])|list %}
+    {%- if scheme['metadata']['implementations']|rejectattr('name', 'equalto', scheme['default_implementation'])|selectattr('signature_enc_derand')|list %}
 #else
     {%- endif %}
 	return (OQS_STATUS) {{ scheme['metadata']['default_enc_derand_signature'] }}(ciphertext, shared_secret, public_key, seed);
-    {%- if scheme['metadata']['implementations']|rejectattr('name', 'equalto', scheme['default_implementation'])|list %}
+    {%- if scheme['metadata']['implementations']|rejectattr('name', 'equalto', scheme['default_implementation'])|selectattr('signature_enc_derand')|list %}
 #endif
     {%- endif %}
     {%- else %}

--- a/scripts/copy_from_upstream/src/kem/family/kem_scheme.c
+++ b/scripts/copy_from_upstream/src/kem/family/kem_scheme.c
@@ -180,8 +180,10 @@ OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_keypair_derand(ui
     {%- endif -%}
         {%- if impl['signature_keypair_derand'] %}
 	{% if 'required_flags' in impl and impl['required_flags'] %}	{% endif -%}return (OQS_STATUS) {{ impl['signature_keypair_derand'] }}(public_key, secret_key, seed);
-        {%- else %}
+        {%- elif impl['name'] not in ['cuda', 'icicle_cuda'] %}
 	{% if 'required_flags' in impl and impl['required_flags'] %}	{% endif -%}return (OQS_STATUS) PQCLEAN_{{ scheme['pqclean_scheme_c']|upper }}_{{ impl['name']|upper }}_crypto_kem_keypair_derand(public_key, secret_key, seed);
+        {%- else %}
+	{% if 'required_flags' in impl and impl['required_flags'] %}	{% endif -%}return (OQS_STATUS) {{ scheme['metadata']['default_keypair_derand_signature'] }}(public_key, secret_key, seed);
         {%- endif %}
     {%- if 'required_flags' in impl and impl['required_flags'] %}
 #if defined(OQS_DIST_BUILD)
@@ -244,18 +246,25 @@ OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_keypair(uint8_t *
 {% endfor -%}
 #else /*OQS_LIBJADE_BUILD && (OQS_ENABLE_LIBJADE_KEM_{{ family }}_{{ scheme['scheme'] }} {%- if 'alias_scheme' in scheme %} || OQS_ENABLE_LIBJADE_KEM_{{ family }}_{{ scheme['alias_scheme'] }}{%- endif %})*/
 {%- endif %}
+    {%- set ns = namespace(gpu_chain_open=false) %}
     {%- for impl in scheme['metadata']['implementations'] if impl['name'] == 'cuda' %}
+        {%- set ns.gpu_chain_open = true %}
 #if defined(OQS_USE_CUPQC) && defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }})
 	return (OQS_STATUS) {{ impl['signature_keypair'] }}(public_key, secret_key);
-#endif /* OQS_USE_CUPQC && OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }} */
     {%- endfor %}
     {%- for impl in scheme['metadata']['implementations'] if impl['name'] == 'icicle_cuda' %}
+        {%- if ns.gpu_chain_open %}
+#elif defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }})
+        {%- else %}
+            {%- set ns.gpu_chain_open = true %}
 #if defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }})
+        {%- endif %}
 	return (OQS_STATUS) {{ impl['signature_keypair'] }}(public_key, secret_key);
-#endif /* OQS_USE_ICICLE && OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }} */
     {%- endfor %}
     {%- for impl in scheme['metadata']['implementations'] if (impl['name'] != scheme['default_implementation'] and impl['name'] != 'cuda' and impl['name'] != 'icicle_cuda') %}
-    {%- if loop.first %}
+    {%- if loop.first and ns.gpu_chain_open %}
+#elif defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }}) {%- if 'alias_scheme' in scheme %} || defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['alias_scheme'] }}_{{ impl['name'] }}){%- endif %}
+    {%- elif loop.first %}
 #if defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }}) {%- if 'alias_scheme' in scheme %} || defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['alias_scheme'] }}_{{ impl['name'] }}){%- endif %}
     {%- else %}
 #elif defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }}) {%- if 'alias_scheme' in scheme %} || defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['alias_scheme'] }}_{{ impl['name'] }}){%- endif %}
@@ -305,8 +314,10 @@ OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_encaps_derand(uin
     {%- endif -%}
         {%- if impl['signature_enc_derand'] %}
 	{% if 'required_flags' in impl and impl['required_flags'] %}	{% endif -%}return (OQS_STATUS) {{ impl['signature_enc_derand'] }}(ciphertext, shared_secret, public_key, seed);
-        {%- else %}
+        {%- elif impl['name'] not in ['cuda', 'icicle_cuda'] %}
 	{% if 'required_flags' in impl and impl['required_flags'] %}	{% endif -%}return (OQS_STATUS) PQCLEAN_{{ scheme['pqclean_scheme_c']|upper }}_{{ impl['name']|upper }}_crypto_kem_enc_derand(ciphertext, shared_secret, public_key, seed);
+        {%- else %}
+	{% if 'required_flags' in impl and impl['required_flags'] %}	{% endif -%}return (OQS_STATUS) {{ scheme['metadata']['default_enc_derand_signature'] }}(ciphertext, shared_secret, public_key, seed);
         {%- endif %}
     {%- if 'required_flags' in impl and impl['required_flags'] %}
 #if defined(OQS_DIST_BUILD)
@@ -370,18 +381,25 @@ OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_encaps(uint8_t *c
 {% endfor -%}
 #else /*OQS_LIBJADE_BUILD && (OQS_ENABLE_LIBJADE_KEM_{{ family }}_{{ scheme['scheme'] }} {%- if 'alias_scheme' in scheme %} || OQS_ENABLE_LIBJADE_KEM_{{ family }}_{{ scheme['alias_scheme'] }}{%- endif %})*/
 {%- endif %}
+    {%- set ns = namespace(gpu_chain_open=false) %}
     {%- for impl in scheme['metadata']['implementations'] if impl['name'] == 'cuda' %}
+        {%- set ns.gpu_chain_open = true %}
 #if defined(OQS_USE_CUPQC) && defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }})
 	return (OQS_STATUS) {{ impl['signature_enc'] }}(ciphertext, shared_secret, public_key);
-#endif /* OQS_USE_CUPQC && OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }} */
     {%- endfor %}
     {%- for impl in scheme['metadata']['implementations'] if impl['name'] == 'icicle_cuda' %}
+        {%- if ns.gpu_chain_open %}
+#elif defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }})
+        {%- else %}
+            {%- set ns.gpu_chain_open = true %}
 #if defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }})
+        {%- endif %}
 	return (OQS_STATUS) {{ impl['signature_enc'] }}(ciphertext, shared_secret, public_key);
-#endif /* OQS_USE_ICICLE && OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }} */
     {%- endfor %}
     {%- for impl in scheme['metadata']['implementations'] if (impl['name'] != scheme['default_implementation'] and impl['name'] != 'cuda' and impl['name'] != 'icicle_cuda') %}
-    {%- if loop.first %}
+    {%- if loop.first and ns.gpu_chain_open %}
+#elif defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }}) {%- if 'alias_scheme' in scheme %} || defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['alias_scheme'] }}_{{ impl['name'] }}){%- endif %}
+    {%- elif loop.first %}
 #if defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }}) {%- if 'alias_scheme' in scheme %} || defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['alias_scheme'] }}_{{ impl['name'] }}){%- endif %}
     {%- else %}
 #elif defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }}) {%- if 'alias_scheme' in scheme %} || defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['alias_scheme'] }}_{{ impl['name'] }}){%- endif %}
@@ -454,18 +472,25 @@ OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_decaps(uint8_t *s
 {% endfor -%}
 #else /*OQS_LIBJADE_BUILD && (OQS_ENABLE_LIBJADE_KEM_{{ family }}_{{ scheme['scheme'] }} {%- if 'alias_scheme' in scheme %} || OQS_ENABLE_LIBJADE_KEM_{{ family }}_{{ scheme['alias_scheme'] }}{%- endif %})*/
 {%- endif %}
+    {%- set ns = namespace(gpu_chain_open=false) %}
     {%- for impl in scheme['metadata']['implementations'] if impl['name'] == 'cuda' %}
+        {%- set ns.gpu_chain_open = true %}
 #if defined(OQS_USE_CUPQC) && defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }})
 	return (OQS_STATUS) {{ impl['signature_dec'] }}(shared_secret, ciphertext, secret_key);
-#endif /* OQS_USE_CUPQC && OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }} */
     {%- endfor %}
     {%- for impl in scheme['metadata']['implementations'] if impl['name'] == 'icicle_cuda' %}
+        {%- if ns.gpu_chain_open %}
+#elif defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }})
+        {%- else %}
+            {%- set ns.gpu_chain_open = true %}
 #if defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }})
+        {%- endif %}
 	return (OQS_STATUS) {{ impl['signature_dec'] }}(shared_secret, ciphertext, secret_key);
-#endif /* OQS_USE_ICICLE && OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }} */
     {%- endfor %}
     {%- for impl in scheme['metadata']['implementations'] if (impl['name'] != scheme['default_implementation'] and impl['name'] != 'cuda' and impl['name'] != 'icicle_cuda') %}
-    {%- if loop.first %}
+    {%- if loop.first and ns.gpu_chain_open %}
+#elif defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }}) {%- if 'alias_scheme' in scheme %} || defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['alias_scheme'] }}_{{ impl['name'] }}){%- endif %}
+    {%- elif loop.first %}
 #if defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }}) {%- if 'alias_scheme' in scheme %} || defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['alias_scheme'] }}_{{ impl['name'] }}){%- endif %}
     {%- else %}
 #elif defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }}) {%- if 'alias_scheme' in scheme %} || defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['alias_scheme'] }}_{{ impl['name'] }}){%- endif %}

--- a/scripts/copy_from_upstream/src/kem/family/kem_scheme.c
+++ b/scripts/copy_from_upstream/src/kem/family/kem_scheme.c
@@ -167,7 +167,7 @@ extern int libjade_{{ scheme['pqclean_scheme_c'] }}_{{ impl['name'] }}_dec(uint8
 
 OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_keypair_derand(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
 {%- if scheme['derandomized_keypair'] %}
-    {%- for impl in scheme['metadata']['implementations'] if impl['name'] != scheme['default_implementation'] and impl['signature_keypair_derand'] %}
+    {%- for impl in scheme['metadata']['implementations'] if impl['name'] != scheme['default_implementation'] and impl.get('signature_keypair_derand') %}
     {%- if loop.first %}
 #if defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }}) {%- if 'alias_scheme' in scheme %} || defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['alias_scheme'] }}_{{ impl['name'] }}){%- endif %}
     {%- else %}
@@ -177,7 +177,7 @@ OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_keypair_derand(ui
 #if defined(OQS_DIST_BUILD)
 	if ({%- for flag in impl['required_flags'] -%}OQS_CPU_has_extension(OQS_CPU_EXT_{{ flag|upper }}){%- if not loop.last %} && {% endif -%}{%- endfor -%}) {
 #endif /* OQS_DIST_BUILD */
-    {%- endif -%}
+    {%- endif %}
 	{% if 'required_flags' in impl and impl['required_flags'] %}	{% endif -%}return (OQS_STATUS) {{ impl['signature_keypair_derand'] }}(public_key, secret_key, seed);
     {%- if 'required_flags' in impl and impl['required_flags'] %}
 #if defined(OQS_DIST_BUILD)
@@ -295,7 +295,7 @@ OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_keypair(uint8_t *
 
 OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_encaps_derand(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key, const uint8_t *seed) {
 {%- if scheme['derandomized_encaps'] %}
-    {%- for impl in scheme['metadata']['implementations'] if impl['name'] != scheme['default_implementation'] and impl['signature_enc_derand'] %}
+    {%- for impl in scheme['metadata']['implementations'] if impl['name'] != scheme['default_implementation'] and impl.get('signature_enc_derand') %}
     {%- if loop.first %}
 #if defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }}) {%- if 'alias_scheme' in scheme %} || defined(OQS_ENABLE_KEM_{{ family }}_{{ scheme['alias_scheme'] }}_{{ impl['name'] }}){%- endif %}
     {%- else %}
@@ -305,7 +305,7 @@ OQS_API OQS_STATUS OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_encaps_derand(uin
 #if defined(OQS_DIST_BUILD)
 	if ({%- for flag in impl['required_flags'] -%}OQS_CPU_has_extension(OQS_CPU_EXT_{{ flag|upper }}){%- if not loop.last %} && {% endif -%}{%- endfor -%}) {
 #endif /* OQS_DIST_BUILD */
-    {%- endif -%}
+    {%- endif %}
 	{% if 'required_flags' in impl and impl['required_flags'] %}	{% endif -%}return (OQS_STATUS) {{ impl['signature_enc_derand'] }}(ciphertext, shared_secret, public_key, seed);
     {%- if 'required_flags' in impl and impl['required_flags'] %}
 #if defined(OQS_DIST_BUILD)

--- a/src/kem/ml_kem/kem_ml_kem_1024.c
+++ b/src/kem/ml_kem/kem_ml_kem_1024.c
@@ -94,10 +94,6 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_1024_keypair_derand(uint8_t *public_key, uint8
 		return (OQS_STATUS) PQCP_MLKEM_NATIVE_MLKEM1024_C_keypair_derand(public_key, secret_key, seed);
 	}
 #endif /* OQS_DIST_BUILD */
-#elif defined(OQS_ENABLE_KEM_ml_kem_1024_cuda)
-	return (OQS_STATUS) PQCLEAN_MLKEM1024_CUDA_crypto_kem_keypair_derand(public_key, secret_key, seed);
-#elif defined(OQS_ENABLE_KEM_ml_kem_1024_icicle_cuda)
-	return (OQS_STATUS) PQCLEAN_MLKEM1024_ICICLE_CUDA_crypto_kem_keypair_derand(public_key, secret_key, seed);
 #else
 	return (OQS_STATUS) PQCP_MLKEM_NATIVE_MLKEM1024_C_keypair_derand(public_key, secret_key, seed);
 #endif
@@ -106,11 +102,9 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_1024_keypair_derand(uint8_t *public_key, uint8
 OQS_API OQS_STATUS OQS_KEM_ml_kem_1024_keypair(uint8_t *public_key, uint8_t *secret_key) {
 #if defined(OQS_USE_CUPQC) && defined(OQS_ENABLE_KEM_ml_kem_1024_cuda)
 	return (OQS_STATUS) cupqc_ml_kem_1024_keypair(public_key, secret_key);
-#endif /* OQS_USE_CUPQC && OQS_ENABLE_KEM_ml_kem_1024_cuda */
-#if defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_1024_icicle_cuda)
+#elif defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_1024_icicle_cuda)
 	return (OQS_STATUS) icicle_ml_kem_1024_keypair(public_key, secret_key);
-#endif /* OQS_USE_ICICLE && OQS_ENABLE_KEM_ml_kem_1024_icicle_cuda */
-#if defined(OQS_ENABLE_KEM_ml_kem_1024_x86_64)
+#elif defined(OQS_ENABLE_KEM_ml_kem_1024_x86_64)
 #if defined(OQS_DIST_BUILD)
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_BMI2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
 #endif /* OQS_DIST_BUILD */
@@ -156,8 +150,6 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_1024_encaps_derand(uint8_t *ciphertext, uint8_
 		return (OQS_STATUS) PQCP_MLKEM_NATIVE_MLKEM1024_C_enc_derand(ciphertext, shared_secret, public_key, seed);
 	}
 #endif /* OQS_DIST_BUILD */
-#elif defined(OQS_ENABLE_KEM_ml_kem_1024_cuda)
-	return (OQS_STATUS) PQCLEAN_MLKEM1024_CUDA_crypto_kem_enc_derand(ciphertext, shared_secret, public_key, seed);
 #elif defined(OQS_ENABLE_KEM_ml_kem_1024_icicle_cuda)
 	return (OQS_STATUS) icicle_ml_kem_1024_enc_derand(ciphertext, shared_secret, public_key, seed);
 #else
@@ -168,11 +160,9 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_1024_encaps_derand(uint8_t *ciphertext, uint8_
 OQS_API OQS_STATUS OQS_KEM_ml_kem_1024_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key) {
 #if defined(OQS_USE_CUPQC) && defined(OQS_ENABLE_KEM_ml_kem_1024_cuda)
 	return (OQS_STATUS) cupqc_ml_kem_1024_enc(ciphertext, shared_secret, public_key);
-#endif /* OQS_USE_CUPQC && OQS_ENABLE_KEM_ml_kem_1024_cuda */
-#if defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_1024_icicle_cuda)
+#elif defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_1024_icicle_cuda)
 	return (OQS_STATUS) icicle_ml_kem_1024_enc(ciphertext, shared_secret, public_key);
-#endif /* OQS_USE_ICICLE && OQS_ENABLE_KEM_ml_kem_1024_icicle_cuda */
-#if defined(OQS_ENABLE_KEM_ml_kem_1024_x86_64)
+#elif defined(OQS_ENABLE_KEM_ml_kem_1024_x86_64)
 #if defined(OQS_DIST_BUILD)
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_BMI2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
 #endif /* OQS_DIST_BUILD */
@@ -200,11 +190,9 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_1024_encaps(uint8_t *ciphertext, uint8_t *shar
 OQS_API OQS_STATUS OQS_KEM_ml_kem_1024_decaps(uint8_t *shared_secret, const uint8_t *ciphertext, const uint8_t *secret_key) {
 #if defined(OQS_USE_CUPQC) && defined(OQS_ENABLE_KEM_ml_kem_1024_cuda)
 	return (OQS_STATUS) cupqc_ml_kem_1024_dec(shared_secret, ciphertext, secret_key);
-#endif /* OQS_USE_CUPQC && OQS_ENABLE_KEM_ml_kem_1024_cuda */
-#if defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_1024_icicle_cuda)
+#elif defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_1024_icicle_cuda)
 	return (OQS_STATUS) icicle_ml_kem_1024_dec(shared_secret, ciphertext, secret_key);
-#endif /* OQS_USE_ICICLE && OQS_ENABLE_KEM_ml_kem_1024_icicle_cuda */
-#if defined(OQS_ENABLE_KEM_ml_kem_1024_x86_64)
+#elif defined(OQS_ENABLE_KEM_ml_kem_1024_x86_64)
 #if defined(OQS_DIST_BUILD)
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_BMI2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
 #endif /* OQS_DIST_BUILD */

--- a/src/kem/ml_kem/kem_ml_kem_512.c
+++ b/src/kem/ml_kem/kem_ml_kem_512.c
@@ -94,10 +94,6 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_512_keypair_derand(uint8_t *public_key, uint8_
 		return (OQS_STATUS) PQCP_MLKEM_NATIVE_MLKEM512_C_keypair_derand(public_key, secret_key, seed);
 	}
 #endif /* OQS_DIST_BUILD */
-#elif defined(OQS_ENABLE_KEM_ml_kem_512_cuda)
-	return (OQS_STATUS) PQCLEAN_MLKEM512_CUDA_crypto_kem_keypair_derand(public_key, secret_key, seed);
-#elif defined(OQS_ENABLE_KEM_ml_kem_512_icicle_cuda)
-	return (OQS_STATUS) PQCLEAN_MLKEM512_ICICLE_CUDA_crypto_kem_keypair_derand(public_key, secret_key, seed);
 #else
 	return (OQS_STATUS) PQCP_MLKEM_NATIVE_MLKEM512_C_keypair_derand(public_key, secret_key, seed);
 #endif
@@ -106,11 +102,9 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_512_keypair_derand(uint8_t *public_key, uint8_
 OQS_API OQS_STATUS OQS_KEM_ml_kem_512_keypair(uint8_t *public_key, uint8_t *secret_key) {
 #if defined(OQS_USE_CUPQC) && defined(OQS_ENABLE_KEM_ml_kem_512_cuda)
 	return (OQS_STATUS) cupqc_ml_kem_512_keypair(public_key, secret_key);
-#endif /* OQS_USE_CUPQC && OQS_ENABLE_KEM_ml_kem_512_cuda */
-#if defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_512_icicle_cuda)
+#elif defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_512_icicle_cuda)
 	return (OQS_STATUS) icicle_ml_kem_512_keypair(public_key, secret_key);
-#endif /* OQS_USE_ICICLE && OQS_ENABLE_KEM_ml_kem_512_icicle_cuda */
-#if defined(OQS_ENABLE_KEM_ml_kem_512_x86_64)
+#elif defined(OQS_ENABLE_KEM_ml_kem_512_x86_64)
 #if defined(OQS_DIST_BUILD)
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_BMI2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
 #endif /* OQS_DIST_BUILD */
@@ -156,8 +150,6 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_512_encaps_derand(uint8_t *ciphertext, uint8_t
 		return (OQS_STATUS) PQCP_MLKEM_NATIVE_MLKEM512_C_enc_derand(ciphertext, shared_secret, public_key, seed);
 	}
 #endif /* OQS_DIST_BUILD */
-#elif defined(OQS_ENABLE_KEM_ml_kem_512_cuda)
-	return (OQS_STATUS) PQCLEAN_MLKEM512_CUDA_crypto_kem_enc_derand(ciphertext, shared_secret, public_key, seed);
 #elif defined(OQS_ENABLE_KEM_ml_kem_512_icicle_cuda)
 	return (OQS_STATUS) icicle_ml_kem_512_enc_derand(ciphertext, shared_secret, public_key, seed);
 #else
@@ -168,11 +160,9 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_512_encaps_derand(uint8_t *ciphertext, uint8_t
 OQS_API OQS_STATUS OQS_KEM_ml_kem_512_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key) {
 #if defined(OQS_USE_CUPQC) && defined(OQS_ENABLE_KEM_ml_kem_512_cuda)
 	return (OQS_STATUS) cupqc_ml_kem_512_enc(ciphertext, shared_secret, public_key);
-#endif /* OQS_USE_CUPQC && OQS_ENABLE_KEM_ml_kem_512_cuda */
-#if defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_512_icicle_cuda)
+#elif defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_512_icicle_cuda)
 	return (OQS_STATUS) icicle_ml_kem_512_enc(ciphertext, shared_secret, public_key);
-#endif /* OQS_USE_ICICLE && OQS_ENABLE_KEM_ml_kem_512_icicle_cuda */
-#if defined(OQS_ENABLE_KEM_ml_kem_512_x86_64)
+#elif defined(OQS_ENABLE_KEM_ml_kem_512_x86_64)
 #if defined(OQS_DIST_BUILD)
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_BMI2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
 #endif /* OQS_DIST_BUILD */
@@ -200,11 +190,9 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_512_encaps(uint8_t *ciphertext, uint8_t *share
 OQS_API OQS_STATUS OQS_KEM_ml_kem_512_decaps(uint8_t *shared_secret, const uint8_t *ciphertext, const uint8_t *secret_key) {
 #if defined(OQS_USE_CUPQC) && defined(OQS_ENABLE_KEM_ml_kem_512_cuda)
 	return (OQS_STATUS) cupqc_ml_kem_512_dec(shared_secret, ciphertext, secret_key);
-#endif /* OQS_USE_CUPQC && OQS_ENABLE_KEM_ml_kem_512_cuda */
-#if defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_512_icicle_cuda)
+#elif defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_512_icicle_cuda)
 	return (OQS_STATUS) icicle_ml_kem_512_dec(shared_secret, ciphertext, secret_key);
-#endif /* OQS_USE_ICICLE && OQS_ENABLE_KEM_ml_kem_512_icicle_cuda */
-#if defined(OQS_ENABLE_KEM_ml_kem_512_x86_64)
+#elif defined(OQS_ENABLE_KEM_ml_kem_512_x86_64)
 #if defined(OQS_DIST_BUILD)
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_BMI2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
 #endif /* OQS_DIST_BUILD */

--- a/src/kem/ml_kem/kem_ml_kem_768.c
+++ b/src/kem/ml_kem/kem_ml_kem_768.c
@@ -94,10 +94,6 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_768_keypair_derand(uint8_t *public_key, uint8_
 		return (OQS_STATUS) PQCP_MLKEM_NATIVE_MLKEM768_C_keypair_derand(public_key, secret_key, seed);
 	}
 #endif /* OQS_DIST_BUILD */
-#elif defined(OQS_ENABLE_KEM_ml_kem_768_cuda)
-	return (OQS_STATUS) PQCLEAN_MLKEM768_CUDA_crypto_kem_keypair_derand(public_key, secret_key, seed);
-#elif defined(OQS_ENABLE_KEM_ml_kem_768_icicle_cuda)
-	return (OQS_STATUS) PQCLEAN_MLKEM768_ICICLE_CUDA_crypto_kem_keypair_derand(public_key, secret_key, seed);
 #else
 	return (OQS_STATUS) PQCP_MLKEM_NATIVE_MLKEM768_C_keypair_derand(public_key, secret_key, seed);
 #endif
@@ -106,11 +102,9 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_768_keypair_derand(uint8_t *public_key, uint8_
 OQS_API OQS_STATUS OQS_KEM_ml_kem_768_keypair(uint8_t *public_key, uint8_t *secret_key) {
 #if defined(OQS_USE_CUPQC) && defined(OQS_ENABLE_KEM_ml_kem_768_cuda)
 	return (OQS_STATUS) cupqc_ml_kem_768_keypair(public_key, secret_key);
-#endif /* OQS_USE_CUPQC && OQS_ENABLE_KEM_ml_kem_768_cuda */
-#if defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_768_icicle_cuda)
+#elif defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_768_icicle_cuda)
 	return (OQS_STATUS) icicle_ml_kem_768_keypair(public_key, secret_key);
-#endif /* OQS_USE_ICICLE && OQS_ENABLE_KEM_ml_kem_768_icicle_cuda */
-#if defined(OQS_ENABLE_KEM_ml_kem_768_x86_64)
+#elif defined(OQS_ENABLE_KEM_ml_kem_768_x86_64)
 #if defined(OQS_DIST_BUILD)
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_BMI2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
 #endif /* OQS_DIST_BUILD */
@@ -156,8 +150,6 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_768_encaps_derand(uint8_t *ciphertext, uint8_t
 		return (OQS_STATUS) PQCP_MLKEM_NATIVE_MLKEM768_C_enc_derand(ciphertext, shared_secret, public_key, seed);
 	}
 #endif /* OQS_DIST_BUILD */
-#elif defined(OQS_ENABLE_KEM_ml_kem_768_cuda)
-	return (OQS_STATUS) PQCLEAN_MLKEM768_CUDA_crypto_kem_enc_derand(ciphertext, shared_secret, public_key, seed);
 #elif defined(OQS_ENABLE_KEM_ml_kem_768_icicle_cuda)
 	return (OQS_STATUS) icicle_ml_kem_768_enc_derand(ciphertext, shared_secret, public_key, seed);
 #else
@@ -168,11 +160,9 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_768_encaps_derand(uint8_t *ciphertext, uint8_t
 OQS_API OQS_STATUS OQS_KEM_ml_kem_768_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key) {
 #if defined(OQS_USE_CUPQC) && defined(OQS_ENABLE_KEM_ml_kem_768_cuda)
 	return (OQS_STATUS) cupqc_ml_kem_768_enc(ciphertext, shared_secret, public_key);
-#endif /* OQS_USE_CUPQC && OQS_ENABLE_KEM_ml_kem_768_cuda */
-#if defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_768_icicle_cuda)
+#elif defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_768_icicle_cuda)
 	return (OQS_STATUS) icicle_ml_kem_768_enc(ciphertext, shared_secret, public_key);
-#endif /* OQS_USE_ICICLE && OQS_ENABLE_KEM_ml_kem_768_icicle_cuda */
-#if defined(OQS_ENABLE_KEM_ml_kem_768_x86_64)
+#elif defined(OQS_ENABLE_KEM_ml_kem_768_x86_64)
 #if defined(OQS_DIST_BUILD)
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_BMI2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
 #endif /* OQS_DIST_BUILD */
@@ -200,11 +190,9 @@ OQS_API OQS_STATUS OQS_KEM_ml_kem_768_encaps(uint8_t *ciphertext, uint8_t *share
 OQS_API OQS_STATUS OQS_KEM_ml_kem_768_decaps(uint8_t *shared_secret, const uint8_t *ciphertext, const uint8_t *secret_key) {
 #if defined(OQS_USE_CUPQC) && defined(OQS_ENABLE_KEM_ml_kem_768_cuda)
 	return (OQS_STATUS) cupqc_ml_kem_768_dec(shared_secret, ciphertext, secret_key);
-#endif /* OQS_USE_CUPQC && OQS_ENABLE_KEM_ml_kem_768_cuda */
-#if defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_768_icicle_cuda)
+#elif defined(OQS_USE_ICICLE) && defined(OQS_ENABLE_KEM_ml_kem_768_icicle_cuda)
 	return (OQS_STATUS) icicle_ml_kem_768_dec(shared_secret, ciphertext, secret_key);
-#endif /* OQS_USE_ICICLE && OQS_ENABLE_KEM_ml_kem_768_icicle_cuda */
-#if defined(OQS_ENABLE_KEM_ml_kem_768_x86_64)
+#elif defined(OQS_ENABLE_KEM_ml_kem_768_x86_64)
 #if defined(OQS_DIST_BUILD)
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2) && OQS_CPU_has_extension(OQS_CPU_EXT_BMI2) && OQS_CPU_has_extension(OQS_CPU_EXT_POPCNT)) {
 #endif /* OQS_DIST_BUILD */


### PR DESCRIPTION
Fixes #2388

## Problem

The `keypair_derand` and `encaps_derand` functions in `kem_ml_kem_{512,768,1024}.c` reference `PQCLEAN_MLKEM{N}_CUDA_crypto_kem_keypair_derand` and `PQCLEAN_MLKEM{N}_CUDA_crypto_kem_enc_derand` when built with `OQS_USE_CUPQC`. These symbols don't exist in cuPQC, the library uses `cupqc_ml_kem_{N}_*` naming and does not expose `_derand` variants. This causes linker failures when building with cuPQC enabled.

The same issue existed for the ICICLE `keypair_derand` path (`PQCLEAN_MLKEM{N}_ICICLE_CUDA_crypto_kem_keypair_derand`), which also doesn't exist upstream.

Additionally, the cuPQC and ICICLE `#if` blocks in `keypair`, `encaps`, and `decaps` used separate `#if...#endif` chains rather than `#elif`, allowing cuPQC to silently take priority when both backends are enabled.

## Fix

- Remove cuPQC branches from `keypair_derand` and `encaps_derand` (cuPQC has no derand functions, falls through to C reference implementation)
- Remove ICICLE branch from `keypair_derand` (ICICLE has no keypair_derand, falls through to C reference)
- Keep ICICLE `encaps_derand` branch (icicle_ml_kem_{N}_enc_derand exists and was already correct)
- Convert separate `#if...#endif` blocks for cuPQC/ICICLE/CPU into proper `#elif` chains in `keypair`, `encaps`, and `decaps`
- Update the Jinja2 generation template (`scripts/copy_from_upstream/src/kem/family/kem_scheme.c`) so future regeneration produces correct code

## Verification

Preprocessor output verified for all 6 scenarios (3 ML-KEM sizes × 2 GPU backends):
- cuPQC enabled: derand functions fall to C ref, non-derand correctly call `cupqc_ml_kem_*`
- ICICLE enabled: `encaps_derand` correctly calls `icicle_ml_kem_*_enc_derand`, `keypair_derand` falls to C ref, non-derand correctly call `icicle_ml_kem_*`
- Zero `PQCLEAN_*_CUDA_*` references in any preprocessed output

## Files changed

- `src/kem/ml_kem/kem_ml_kem_512.c`
- `src/kem/ml_kem/kem_ml_kem_768.c`
- `src/kem/ml_kem/kem_ml_kem_1024.c`
- `scripts/copy_from_upstream/src/kem/family/kem_scheme.c`

## Note

Similar to the ICICLE fix in #2258. The template change generates explicit `#elif` fallback branches for GPU implementations without derand support, while the direct .c edits simply remove those branches (functionally equivalent, both call the C reference). Happy to adjust the template approach if maintainers prefer a different pattern.