### PR TITLE
Demote armhf from a Tier 2 to Tier 3 supported platform and remove from weekly CI

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -97,52 +97,6 @@ jobs:
         timeout-minutes: 360
         run: mkdir -p tmp && python3 -m pytest --verbose ${{ matrix.PYTEST_ARGS }}
 
-  linux_arm_emulated:
-    runs-on: ubuntu-latest
-    timeout-minutes: 120 # max + 3*std over the last thousands of successful runs
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: armhf
-            ARCH: armhf
-            CMAKE_ARGS: -DOQS_USE_OPENSSL=OFF -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=generic -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-            PYTEST_ARGS: --numprocesses=auto --maxprocesses=10 --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
-            SKIP_ALGS: 'SLH_DSA_(SHA2|SHA3|SHAKE)(.)*'
-          - name: armhf-no-stfl-key-sig-gen
-            ARCH: armhf
-            CMAKE_ARGS: -DOQS_USE_OPENSSL=OFF -DOQS_DIST_BUILD=OFF -DOQS_OPT_TARGET=generic -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=OFF -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_ENABLE_SIG_STFL_LMS=ON
-            PYTEST_ARGS: --numprocesses=auto --maxprocesses=10 --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
-            SKIP_ALGS: 'SLH_DSA_(SHA2|SHA3|SHAKE)(.)*'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
-      - name: Install the emulation handlers
-        run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
-      - name: Build in an x86_64 container
-        run: |
-          docker run --rm \
-                     -v `pwd`:`pwd` \
-                     -w `pwd` \
-                     openquantumsafe/ci-debian-buster-amd64:latest /bin/bash \
-                     -c "mkdir build && \
-                         (cd build && \
-                          cmake .. -GNinja ${{ matrix.CMAKE_ARGS }} \
-                                   -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_${{ matrix.ARCH }}.cmake && \
-                          cmake -LA -N .. && \
-                          ninja)"
-      - name: Run the tests in an ${{ matrix.ARCH }} container
-        run: |
-          docker run --rm -e SKIP_TESTS=style,mem_kem,mem_sig \
-                          -v `pwd`:`pwd` \
-                          -w `pwd` \
-                          openquantumsafe/ci-debian-buster-${{ matrix.ARCH }}:latest /bin/bash \
-                          -c "mkdir -p tmp && \
-                              SKIP_ALGS='${{ matrix.SKIP_ALGS }}' \
-                              python3 -m pytest --verbose \
-                                                --numprocesses=auto \
-                                                --ignore=tests/test_code_conventions.py ${{ matrix.PYTEST_ARGS }}"
-
   slhdsa-leak-tests:
     strategy:
       fail-fast: false

--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -57,12 +57,12 @@ In this policy, the words "must" and "must not" specify absolute requirements th
 - armeabi-v7a, arm64-v8a, x86, x86_64 for Android
 - aarch64 for Apple iOS and tvOS (CMake `-DPLATFORM=OS64` and `TVOS`)
 - arm64, arm (32 bit), x86, x86_64, riscv32, riscv64 for Zephyr
-- armhf/ARM7 emulation on Ubuntu
 - amd64 for Alpine Linux
 
 ### Tier 3
 
 - x86 for Windows (Visual Studio Toolchain)
+- armhf/ARM7 emulation on Ubuntu
 - ppc64le for Ubuntu (Focal)
 - s390x for Ubuntu (Focal)
 - loongarch64 for Debian Linux (trixie)


### PR DESCRIPTION
As noted in https://github.com/open-quantum-safe/liboqs/issues/2401, armhf weekly tests have been failing for some time. Discussion in the weekly status meeting proposed demoting it from tier 2 to tier 3 and removing from extended/weekly CI:

https://github.com/open-quantum-safe/tsc/blob/main/oqs-status-meetings/2026-04-14%20-%20OQS%20status%20meeting%20-%20summary.md#ci-containers--armhf

* [NO] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [NO] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged. Also, make sure to update the list of algorithms in the continuous benchmarking files: .github/workflows/kem-bench.yml and sig-bench.yml)
