### PR TITLE
[vote] Update GOVERNANCE.md and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,25 +1,29 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# Note: the LAST matching pattern wins, so more general patterns must come before more specific ones.
 
-* @dstebila @baentsch
-/.github/workflows @SWilson4
+* @dstebila @baentsch @xuganyu96
+/scripts/ @xuganyu96
+/tests/ @xuganyu96 @bhess
+/zephyr/ @Frauschi @bhess
 /docs/cbom.json @bhess
-/scripts/copy_from_upstream @baentsch @bhess @alexrow @praveksharma
+/scripts/copy_from_upstream @xuganyu96
 /src/common @dstebila
-/src/common/*/*arm* @Martyrshot
-/src/common/libjade_shims @praveksharma
 /src/kem/bike @brian-jarvis-aws
 /src/kem/frodokem @dstebila
 /src/kem/kyber @bhess
-/src/kem/kyber/libjade* @praveksharma
-/src/kem/ml_kem @bhess
+/src/kem/ml_kem @bhess @mkannwischer
 /src/kem/ntru @saitomst
 /src/kem/ntruprime @bbbrumley
-/src/sig/cross @alexrow
+/src/sig/cross @alexrow @rtjk
 /src/sig/mayo @bhess
-/src/sig/ml_dsa @bhess
+/src/sig/ml_dsa @bhess @mkannwischer
+/src/sig/mqom @rben-dev
+/src/sig/uov @mkannwischer
 /src/sig_stfl/lms @ashman-p
-/src/sig_stfl/xmss @cothan
-/tests/ACVP_Vectors @bhess
+/src/sig_stfl/xmss @cothan @ashman-p
+/tests/ACVP_Vectors @bhess @abhi-dev-engg
+/tests/Wycheproof_Vectors @bhess @abhi-dev-engg
 /tests/PQC_Intermediate_Values @bhess
-/tests/test_acvp_vectors.py @bhess
+/tests/test_acvp_vectors.py @bhess @abhi-dev-engg
+/tests/test_wycheproof_vectors.py @bhess @abhi-dev-engg
 /tests/test_sig_stfl.c @ashman-p @cothan

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,7 +6,7 @@ The Open Quantum Safe project aims to operate by the following principles:
 
 - **Openness**: The project will be open in its operation, open to contributions, and produce open source software.
 - **Respect**: The project will foster respectful interactions with all participants.
-- **Scientific integrity**: The project will follow advancements in cryptographic research and will be guided by standards and best practices.
+- **Scientific integrity**: The project will follow advancements in cryptographic research and will be guided by standards and best practices with a slant towards favouring the advancement of long term research goals over short term commercial interests.
 
 Decision making in the project will follow the principles above, and be governed first and foremost by reason and mutually respectful interaction between all participants.
 The project will aim to build consensus for decisions, and will where possible operate by the approach of [lazy consensus](https://community.apache.org/committers/decisionMaking.html).
@@ -41,26 +41,36 @@ A **Contributor** is a Community Member who contributes directly to the project 
 
 ### Committers
 
-A **Committer** is a Contributor with increased experience in the project who helps review pull requests and actively participates in discussions about the project. Committers will be members of the open-quantum-safe GitHub organization and will have "write" permissions in GitHub.
+A **Committer** is a Contributor with increased interest in the project who helps review pull requests and actively participates in discussions about the project. Committers will be members of the open-quantum-safe GitHub organization and will have "write" permissions in GitHub.
 
 Responsibilities:
 
 - Further the goals of the project.
 - Monitor and respond to GitHub issues.
-- Review and merge pull requests.
+- Review and merge pull requests in cooperation with other Committers.
 - Assist with security releases when required.
+- Jointly agree on general and technical guidelines for the project.
+- Jointly agree project priorities.
 - Participate in discussions and project meetings.
 
-### Maintainers
+### Release managers
 
-A **Maintainer** is a Committer who makes significant and sustained contributions to the project, and is committed to guiding the direction of the project. Maintainers will have "administrative" permissions in GitHub.
+A release manager is a Contributor versed in creating releases of the project.
 
 Responsibilities:
 
-- Oversee the overall project health and growth.
-- Lead communication for the project.
-- Define general and technical guidelines for the project.
-- Identify priorities and manage the release cycle.
+- Manage the release cycle, incl. creation of suitable user documentation.
+- Execution of downstream tests ascertaining quality of releases.
+
+### Maintainers
+
+A **Maintainer** is a Committer with additional responsibilities and experience. Maintainers will have "administrative" permissions in GitHub.
+
+Responsibilities:
+
+- Assess project status and role assignments.
+- Propose communication about the project.
+- Propose changes to this governance document.
 
 ### Change of role
 
@@ -96,28 +106,36 @@ Votes are to be executed by way of open GitHub discussions. No quorum is needed 
 
 ### Maintainers
 
-@baentsch (on leave of absence as of March 11, 2025)
+@baentsch
 @dstebila
-@SWilson4
+@xuganyu96
 
 ### Committers
 
-@baentsch (on leave of absence as of March 11, 2025)
+@ashman-p
+@baentsch
 @bhess
-@christianpaquin
 @dstebila
-@Martyrshot
-@praveksharma
-@SWilson4
-@vsoftco
+@mkannwischer
+@RodriM11
+@xuganyu96
 
 ## Former Maintainers and Committers
 
 OQS is grateful to the following individuals who have previously served as Maintainers or Committers for liboqs.
 
-### Former Committers
+### Emeritus Maintainers
 
+@SWilson4
+
+### Emeritus Committers
+
+@christianpaquin
 @jschanck
+@Martyrshot
+@praveksharma
+@SWilson4
+@vsoftco
 
 ## Afterword
 


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->
Updates liboqs GOVERNANCE.md and CODEOWNERS file to reflect (my understanding of) the current state of the contributor base.  Also updates to reflect wording revisions in oqs-provider's GOVERNANCE.md.

I have moved some existing contributors and maintainers to the emeritus category, based on my understanding of their current engagement.  Any of them (@christianpaquin @Martyrshot @praveksharma @SWilson4 @vsoftco) who would like to stay within the active category are welcome to do so; just say the word.

Also based on recent activity, I propose adding @xuganyu96 as a maintainer and @ashman-p @mkannwischer @RodriM11 as committers.

This will be paired with a matching PR on tsc/config.yaml.

Fixes #2404.

## Approvals required

GOVERNANCE.md says (roughly speaking) that additions/promotions should be approved by a majority of committers / maintainers, and that removals should be approved by a 2/3 majority of committers / maintainers. 

GOVERNANCE.md also says that committers / maintainers that have been inactive for 90 days can be automatically converted to contributor status.  As far as I can tell, @SWilson4 @Martyrshot @praveksharma @christianpaquin and @vsoftco have been inactive by that definition, though @christianpaquin has been in various meetings.

In light of all of that, I think the voting pool would consist of: @baentsch @dstebila @bhess and optionally @christianpaquin. (And the narrowness of that voting pool is itself a reason that this PR is needed -- my apologies for letting this issue stagnate.)