### PR TITLE
Add loganaden as codeowner for Kyber

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 /src/common @dstebila
 /src/kem/bike @brian-jarvis-aws
 /src/kem/frodokem @dstebila
-/src/kem/kyber @bhess
+/src/kem/kyber @bhess @loganaden
 /src/kem/ml_kem @bhess @mkannwischer
 /src/kem/ntru @saitomst
 /src/kem/ntruprime @bbbrumley


### PR DESCRIPTION
As discussed in https://github.com/open-quantum-safe/liboqs/issues/1989#issuecomment-4327267869.
