### PR TITLE
Fall back when EVP_DigestSqueeze is unavailable or unsupported

### DIFF
--- a/src/common/ossl_functions.h
+++ b/src/common/ossl_functions.h
@@ -18,6 +18,14 @@ FUNC(int, EVP_DigestInit_ex,
      (EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl), (ctx, type, impl))
 FUNC(int, EVP_DigestUpdate, (EVP_MD_CTX *ctx, const void *d, size_t cnt),
      (ctx, d, cnt))
+#if OPENSSL_VERSION_NUMBER >= 0x30300000L
+/* Optional: may be absent from the libcrypto loaded at runtime, or rejected by
+ * the active provider (e.g. a FIPS 3.0 provider under libcrypto 3.3). Callers
+ * must check OSSL_FUNC_AVAILABLE and the return value. */
+OPTIONAL_FUNC(int, EVP_DigestSqueeze,
+              (EVP_MD_CTX *ctx, unsigned char *out, size_t outlen),
+              (ctx, out, outlen))
+#endif
 FUNC(int, EVP_EncryptFinal_ex,
      (EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl), (ctx, out, outl))
 FUNC(int, EVP_EncryptInit_ex,

--- a/src/common/ossl_helpers.c
+++ b/src/common/ossl_helpers.c
@@ -14,6 +14,9 @@
 
 static pthread_once_t init_once_control = PTHREAD_ONCE_INIT;
 static pthread_once_t free_once_control = PTHREAD_ONCE_INIT;
+#if OPENSSL_VERSION_NUMBER >= 0x30300000L
+static pthread_once_t squeeze_probe_once_control = PTHREAD_ONCE_INIT;
+#endif
 #endif
 
 static EVP_MD *sha256_ptr, *sha384_ptr, *sha512_ptr,
@@ -100,6 +103,47 @@ void oqs_ossl_destroy(void) {
 void oqs_thread_stop(void) {
 	OSSL_FUNC(OPENSSL_thread_stop)();
 }
+
+#if OPENSSL_VERSION_NUMBER >= 0x30300000L
+/* Cached result of probing whether the active provider implements
+ * EVP_DigestSqueeze. A FIPS 3.0 provider loaded under libcrypto >= 3.3 will
+ * raise EVP_R_METHOD_NOT_SUPPORTED; under OQS_DLOPEN_OPENSSL the symbol itself
+ * may be absent from the libcrypto loaded at runtime. The provider's
+ * capability does not change across the process lifetime, so probe once. */
+static int oqs_ossl_squeeze_works = 0;
+
+static void probe_digest_squeeze(void) {
+	if (!OSSL_FUNC_AVAILABLE(EVP_DigestSqueeze)) {
+		return;
+	}
+	EVP_MD_CTX *probe = OSSL_FUNC(EVP_MD_CTX_new)();
+	if (probe == NULL) {
+		return;
+	}
+	if (OSSL_FUNC(EVP_DigestInit_ex)(probe, oqs_shake128(), NULL) == 1) {
+		unsigned char scratch[1];
+		if (OSSL_FUNC(EVP_DigestSqueeze)(probe, scratch, sizeof(scratch)) == 1) {
+			oqs_ossl_squeeze_works = 1;
+		} else {
+			ERR_clear_error();
+		}
+	}
+	OSSL_FUNC(EVP_MD_CTX_free)(probe);
+}
+
+int oqs_ossl_can_digest_squeeze(void) {
+#if defined(OQS_USE_PTHREADS)
+	pthread_once(&squeeze_probe_once_control, probe_digest_squeeze);
+#else
+	static int probed = 0;
+	if (!probed) {
+		probe_digest_squeeze();
+		probed = 1;
+	}
+#endif
+	return oqs_ossl_squeeze_works;
+}
+#endif
 
 const EVP_MD *oqs_sha256(void) {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
@@ -332,7 +376,9 @@ static pthread_once_t dlopen_once_control = PTHREAD_ONCE_INIT;
     static ret(*_oqs_ossl_sym_##name)args;
 #endif
 #define VOID_FUNC FUNC
+#define OPTIONAL_FUNC FUNC
 #include "ossl_functions.h"
+#undef OPTIONAL_FUNC
 #undef VOID_FUNC
 #undef FUNC
 
@@ -351,7 +397,23 @@ ret _oqs_ossl_##name args           \
     assert(_oqs_ossl_sym_##name);       \
     _oqs_ossl_sym_##name cargs;  \
 }
+/* Optional symbols may legitimately be absent from the loaded libcrypto.
+ * Wrapper returns 0 (failure) when the symbol is unresolved; an
+ * _oqs_ossl_has_##name() probe lets callers branch before invoking. */
+#define OPTIONAL_FUNC(ret, name, args, cargs)   \
+ret _oqs_ossl_##name args                       \
+{                                               \
+    ENSURE_LIBRARY;                             \
+    if (!_oqs_ossl_sym_##name) { return 0; }    \
+    return _oqs_ossl_sym_##name cargs;          \
+}                                               \
+int _oqs_ossl_has_##name(void)                  \
+{                                               \
+    ENSURE_LIBRARY;                             \
+    return _oqs_ossl_sym_##name != NULL;        \
+}
 #include "ossl_functions.h"
+#undef OPTIONAL_FUNC
 #undef VOID_FUNC
 #undef FUNC
 
@@ -362,6 +424,13 @@ static void ensure_symbol(const char *name, void **symp) {
 			exit(EXIT_FAILURE);
 		}
 		*symp = sym;
+	}
+}
+
+/* Non-fatal: leaves *symp NULL when the symbol is missing. */
+static void ensure_optional_symbol(const char *name, void **symp) {
+	if (!*symp) {
+		*symp = dlsym(libcrypto_dlhandle, name);
 	}
 }
 
@@ -376,12 +445,18 @@ static void ensure_library(void) {
 
 #define ENSURE_SYMBOL(name) \
     ensure_symbol(#name, (void **)&_oqs_ossl_sym_##name)
+#define ENSURE_OPTIONAL_SYMBOL(name) \
+    ensure_optional_symbol(#name, (void **)&_oqs_ossl_sym_##name)
 #define FUNC(ret, name, args, cargs)        \
     ENSURE_SYMBOL(name);
 #define VOID_FUNC FUNC
+#define OPTIONAL_FUNC(ret, name, args, cargs) \
+    ENSURE_OPTIONAL_SYMBOL(name);
 #include "ossl_functions.h"
+#undef OPTIONAL_FUNC
 #undef VOID_FUNC
 #undef FUNC
+#undef ENSURE_OPTIONAL_SYMBOL
 #undef ENSURE_SYMBOL
 }
 

--- a/src/common/ossl_helpers.h
+++ b/src/common/ossl_helpers.h
@@ -40,19 +40,33 @@ const EVP_CIPHER *oqs_aes_256_ecb(void);
 
 const EVP_CIPHER *oqs_aes_256_ctr(void);
 
+#if OPENSSL_VERSION_NUMBER >= 0x30300000L
+/* Returns nonzero iff the active OpenSSL provider implements
+ * EVP_DigestSqueeze (probed once per process against a SHAKE128 context). */
+int oqs_ossl_can_digest_squeeze(void);
+#endif
+
 #ifdef OQS_DLOPEN_OPENSSL
 
 #define FUNC(ret, name, args, cargs) ret _oqs_ossl_##name args;
 #define VOID_FUNC FUNC
+#define OPTIONAL_FUNC(ret, name, args, cargs) \
+    ret _oqs_ossl_##name args;                \
+    int _oqs_ossl_has_##name(void);
 #include "ossl_functions.h"
+#undef OPTIONAL_FUNC
 #undef VOID_FUNC
 #undef FUNC
 
 #define OSSL_FUNC(name) _oqs_ossl_##name
+#define OSSL_FUNC_AVAILABLE(name) (_oqs_ossl_has_##name())
 
 #else
 
 #define OSSL_FUNC(name) name
+/* In non-DLOPEN mode the linker has already bound the symbol, so it is always
+ * available when the corresponding header guard admits the call site. */
+#define OSSL_FUNC_AVAILABLE(name) 1
 
 #endif
 

--- a/src/common/sha3/ossl_sha3.c
+++ b/src/common/sha3/ossl_sha3.c
@@ -188,8 +188,11 @@ static void SHA3_shake128_inc_finalize(OQS_SHA3_shake128_inc_ctx *state) {
 static void SHA3_shake128_inc_squeeze(uint8_t *output, size_t outlen, OQS_SHA3_shake128_inc_ctx *state) {
 	intrn_shake128_inc_ctx *s = (intrn_shake128_inc_ctx *)state->ctx;
 #if OPENSSL_VERSION_NUMBER >= 0x30300000L
-	EVP_DigestSqueeze(s->mdctx, output, outlen);
-#else
+	if (oqs_ossl_can_digest_squeeze()) {
+		OQS_OPENSSL_GUARD(OSSL_FUNC(EVP_DigestSqueeze)(s->mdctx, output, outlen));
+		return;
+	}
+#endif
 	EVP_MD_CTX *clone;
 
 	clone = OSSL_FUNC(EVP_MD_CTX_new)();
@@ -206,7 +209,6 @@ static void SHA3_shake128_inc_squeeze(uint8_t *output, size_t outlen, OQS_SHA3_s
 	}
 	OSSL_FUNC(EVP_MD_CTX_free)(clone);
 	s->n_out += outlen;
-#endif
 }
 
 static void SHA3_shake128_inc_ctx_release(OQS_SHA3_shake128_inc_ctx *state) {
@@ -263,8 +265,11 @@ static void SHA3_shake256_inc_finalize(OQS_SHA3_shake256_inc_ctx *state) {
 static void SHA3_shake256_inc_squeeze(uint8_t *output, size_t outlen, OQS_SHA3_shake256_inc_ctx *state) {
 	intrn_shake256_inc_ctx *s = (intrn_shake256_inc_ctx *)state->ctx;
 #if OPENSSL_VERSION_NUMBER >= 0x30300000L
-	EVP_DigestSqueeze(s->mdctx, output, outlen);
-#else
+	if (oqs_ossl_can_digest_squeeze()) {
+		OQS_OPENSSL_GUARD(OSSL_FUNC(EVP_DigestSqueeze)(s->mdctx, output, outlen));
+		return;
+	}
+#endif
 	EVP_MD_CTX *clone;
 
 	clone = OSSL_FUNC(EVP_MD_CTX_new)();
@@ -281,7 +286,6 @@ static void SHA3_shake256_inc_squeeze(uint8_t *output, size_t outlen, OQS_SHA3_s
 	}
 	OSSL_FUNC(EVP_MD_CTX_free)(clone);
 	s->n_out += outlen;
-#endif
 }
 
 static void SHA3_shake256_inc_ctx_release(OQS_SHA3_shake256_inc_ctx *state) {

--- a/src/common/sha3/ossl_sha3x4.c
+++ b/src/common/sha3/ossl_sha3x4.c
@@ -62,11 +62,14 @@ static void SHA3_shake128_x4_inc_finalize(OQS_SHA3_shake128_x4_inc_ctx *state) {
 static void SHA3_shake128_x4_inc_squeeze(uint8_t *out0, uint8_t *out1, uint8_t *out2, uint8_t *out3, size_t outlen, OQS_SHA3_shake128_x4_inc_ctx *state) {
 	intrn_shake128_x4_inc_ctx *s = (intrn_shake128_x4_inc_ctx *)state->ctx;
 #if OPENSSL_VERSION_NUMBER >= 0x30300000L
-	EVP_DigestSqueeze(s->mdctx0, out0, outlen);
-	EVP_DigestSqueeze(s->mdctx1, out1, outlen);
-	EVP_DigestSqueeze(s->mdctx2, out2, outlen);
-	EVP_DigestSqueeze(s->mdctx3, out3, outlen);
-#else
+	if (oqs_ossl_can_digest_squeeze()) {
+		OQS_OPENSSL_GUARD(OSSL_FUNC(EVP_DigestSqueeze)(s->mdctx0, out0, outlen));
+		OQS_OPENSSL_GUARD(OSSL_FUNC(EVP_DigestSqueeze)(s->mdctx1, out1, outlen));
+		OQS_OPENSSL_GUARD(OSSL_FUNC(EVP_DigestSqueeze)(s->mdctx2, out2, outlen));
+		OQS_OPENSSL_GUARD(OSSL_FUNC(EVP_DigestSqueeze)(s->mdctx3, out3, outlen));
+		return;
+	}
+#endif
 	EVP_MD_CTX *clone;
 
 	clone = OSSL_FUNC(EVP_MD_CTX_new)();
@@ -99,7 +102,6 @@ static void SHA3_shake128_x4_inc_squeeze(uint8_t *out0, uint8_t *out1, uint8_t *
 	}
 	OSSL_FUNC(EVP_MD_CTX_free)(clone);
 	s->n_out += outlen;
-#endif
 }
 
 static void SHA3_shake128_x4_inc_ctx_clone(OQS_SHA3_shake128_x4_inc_ctx *dest, const OQS_SHA3_shake128_x4_inc_ctx *src) {
@@ -184,11 +186,14 @@ static void SHA3_shake256_x4_inc_finalize(OQS_SHA3_shake256_x4_inc_ctx *state) {
 static void SHA3_shake256_x4_inc_squeeze(uint8_t *out0, uint8_t *out1, uint8_t *out2, uint8_t *out3, size_t outlen, OQS_SHA3_shake256_x4_inc_ctx *state) {
 	intrn_shake256_x4_inc_ctx *s = (intrn_shake256_x4_inc_ctx *)state->ctx;
 #if OPENSSL_VERSION_NUMBER >= 0x30300000L
-	EVP_DigestSqueeze(s->mdctx0, out0, outlen);
-	EVP_DigestSqueeze(s->mdctx1, out1, outlen);
-	EVP_DigestSqueeze(s->mdctx2, out2, outlen);
-	EVP_DigestSqueeze(s->mdctx3, out3, outlen);
-#else
+	if (oqs_ossl_can_digest_squeeze()) {
+		OQS_OPENSSL_GUARD(OSSL_FUNC(EVP_DigestSqueeze)(s->mdctx0, out0, outlen));
+		OQS_OPENSSL_GUARD(OSSL_FUNC(EVP_DigestSqueeze)(s->mdctx1, out1, outlen));
+		OQS_OPENSSL_GUARD(OSSL_FUNC(EVP_DigestSqueeze)(s->mdctx2, out2, outlen));
+		OQS_OPENSSL_GUARD(OSSL_FUNC(EVP_DigestSqueeze)(s->mdctx3, out3, outlen));
+		return;
+	}
+#endif
 	EVP_MD_CTX *clone;
 
 	clone = OSSL_FUNC(EVP_MD_CTX_new)();
@@ -221,7 +226,6 @@ static void SHA3_shake256_x4_inc_squeeze(uint8_t *out0, uint8_t *out1, uint8_t *
 	}
 	OSSL_FUNC(EVP_MD_CTX_free)(clone);
 	s->n_out += outlen;
-#endif
 }
 
 static void SHA3_shake256_x4_inc_ctx_clone(OQS_SHA3_shake256_x4_inc_ctx *dest, const OQS_SHA3_shake256_x4_inc_ctx *src) {


### PR DESCRIPTION
_PR description written by Claude._

## Summary

Fixes #2042 and the root cause of open-quantum-safe/liboqs-python#122.

Both issues trace back to the same code: `EVP_DigestSqueeze` was called
unconditionally on OpenSSL 3.3+ headers, with no handling for the cases
where the symbol or the operation isn't actually available at runtime.

- **#2042**: with an active FIPS 3.0 provider under libcrypto 3.3+,
  `EVP_DigestSqueeze` returns `EVP_R_METHOD_NOT_SUPPORTED` and SHAKE
  incremental squeeze produces no output.
- **liboqs-python#122**: every other OpenSSL EVP call in
  [src/common/ossl_functions.h](src/common/ossl_functions.h) goes
  through the dlopen-wrapper indirection, but `EVP_DigestSqueeze` was
  the lone exception. `liboqs.so` therefore carried
  `U EVP_DigestSqueeze` and `dlopen` failed on libcrypto < 3.3.

## Approach

A single mechanism resolves both:

1. **`OPTIONAL_FUNC` macro** alongside `FUNC` / `VOID_FUNC` in the
   dlopen wrapper machinery. Optional symbols use a non-fatal `dlsym`
   (the default `ensure_symbol` calls `exit(EXIT_FAILURE)` on missing
   symbols — desired behavior for required APIs). The wrapper returns
   0 when the pointer is NULL; an `_oqs_ossl_has_<name>()` predicate
   lets callers probe.
2. **`OSSL_FUNC_AVAILABLE(name)`** — the probe in DLOPEN builds, a
   constant `1` in non-DLOPEN builds (the linker has already bound the
   symbol).
3. **`EVP_DigestSqueeze`** added to
   [ossl_functions.h](src/common/ossl_functions.h) as an
   `OPTIONAL_FUNC`, gated on `OPENSSL_VERSION_NUMBER >= 0x30300000L`.
4. **Process-wide one-shot probe**
   ([oqs_ossl_can_digest_squeeze](src/common/ossl_helpers.c)): on first
   call, allocate a throwaway SHAKE128 context, attempt a 1-byte
   `EVP_DigestSqueeze`, cache the boolean result.
   `pthread_once`-guarded under `OQS_USE_PTHREADS`. Provider capability
   does not change across the process lifetime, so the result is
   reusable everywhere.
5. **Squeeze call sites** in
   [ossl_sha3.c](src/common/sha3/ossl_sha3.c) and
   [ossl_sha3x4.c](src/common/sha3/ossl_sha3x4.c) become:
   ```c
   if (oqs_ossl_can_digest_squeeze()) {
       OQS_OPENSSL_GUARD(OSSL_FUNC(EVP_DigestSqueeze)(s->mdctx, output, outlen));
       return;
   }
   /* existing clone + EVP_DigestFinalXOF fallback, unchanged */
   ```
   `OQS_OPENSSL_GUARD` turns a post-probe failure into a loud
   `exit(EXIT_FAILURE)` rather than silently emitting wrong
   cryptographic output.

## Test plan

Verified in Docker on `ubuntu:25.04` (OpenSSL 3.4.1, aarch64):

- [x] On `main`, `nm -uD build/lib/liboqs.so | grep EVP_Digest` shows
      `U EVP_DigestSqueeze`. On this branch it shows nothing. Closes
      the dlopen symbol error behind liboqs-python#122.
- [x] `test_sha3` (SHA3-256/384/512, SHAKE-128/256, four-way parallel
      SHAKE-128/256 KATs) passes with `OQS_DLOPEN_OPENSSL=OFF` and
      `OQS_USE_SHA3_OPENSSL=ON`.
- [x] Same `test_sha3` passes with `OQS_DLOPEN_OPENSSL=ON`.
- [x] `kat_kem ML-KEM-768` and `kat_sig ML-DSA-65` (both SHAKE-heavy)
      pass under both DLOPEN configurations.
- [ ] **Not yet exercised in CI:** the actual FIPS-3.0-under-libcrypto-3.3
      runtime trigger (#2042 scenario). The fallback path is the same
      clone + `EVP_DigestFinalXOF` sequence used on OpenSSL < 3.3
      today, which is exercised by every pre-3.3 build. A CI job that
      forces the probe to return 0 (or runs against a FIPS-only
      provider) would close this gap.

## Notes for reviewers

- No benchmark of fast-path vs. fallback-path is included. If the
  performance delta is small, deleting the `EVP_DigestSqueeze` path
  entirely and always using the clone fallback would simplify this
  further. Open to going that way if measurements support it.
- `OQS_OPENSSL_GUARD` is reused from `aes/aes_ossl.c`. It uses
  `exit(EXIT_FAILURE)`, which is consistent with existing liboqs
  practice but is a more aggressive failure mode than main's
  silent-wrong-output. The tradeoff is: noisy crash vs. silently broken
  cryptography. Happy to discuss.
- Probe is lazy (first squeeze call) rather than eager (library init).
  Trivial latency on cold start; could move to `OQS_init` if eager
  initialization is preferred.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
