### PR TITLE
Fix comments in SHA3 AVX512VL assembly file

### DIFF
--- a/src/common/sha3/avx512vl_low/SHA3-times4-AVX512VL.S
+++ b/src/common/sha3/avx512vl_low/SHA3-times4-AVX512VL.S
@@ -347,7 +347,7 @@
 
 # -----------------------------------------------------------------------------
 #
-# void SHA3_shake128_x4_inc_ctx_reset_avx512vl(OQS_SHA3_shake128_inc_ctx *state);
+# void SHA3_shake128_x4_inc_ctx_reset_avx512vl(OQS_SHA3_shake128_x4_inc_ctx *state);
 #
 .globl  SHA3_shake128_x4_inc_ctx_reset_avx512vl
 .type   SHA3_shake128_x4_inc_ctx_reset_avx512vl,@function
@@ -356,7 +356,7 @@
 
 # -----------------------------------------------------------------------------
 #
-# void SHA3_shake256_inc_ctx_reset_x4_avx512vl(OQS_SHA3_shake256_inc_ctx *state);
+# void SHA3_shake256_x4_inc_ctx_reset_avx512vl(OQS_SHA3_shake256_x4_inc_ctx *state);
 #
 .globl  SHA3_shake256_x4_inc_ctx_reset_avx512vl
 .type   SHA3_shake256_x4_inc_ctx_reset_avx512vl,@function


### PR DESCRIPTION
Reported by Anthony Plank

<!-- Please give a brief explanation of the purpose of this pull request. -->
Comments in SHA3 AVX512VL assembly file refer to the wrong data type, but the the code is accurage.
