### PR TITLE
Fix uninitialized encaps_derand pointer dereference for NTRU KEMs

### DIFF
--- a/scripts/copy_from_upstream/src/kem/family/kem_scheme.c
+++ b/scripts/copy_from_upstream/src/kem/family/kem_scheme.c
@@ -11,7 +11,7 @@
 {% endif %}
 OQS_KEM *OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}
@@ -46,7 +46,7 @@ OQS_KEM *OQS_KEM_{{ family }}_{{ scheme['scheme'] }}_new(void) {
 /** Alias */
 OQS_KEM *OQS_KEM_{{ family }}_{{ scheme['alias_scheme'] }}_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/scripts/copy_from_upstream/src/sig/family/sig_scheme.c
+++ b/scripts/copy_from_upstream/src/sig/family/sig_scheme.c
@@ -12,7 +12,7 @@
 {%- set default_impl = scheme['metadata']['implementations'] | selectattr("name", "equalto", scheme['default_implementation']) | first -%}
 OQS_SIG *OQS_SIG_{{ family }}_{{ scheme['scheme'] }}_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}
@@ -50,7 +50,7 @@ OQS_SIG *OQS_SIG_{{ family }}_{{ scheme['scheme'] }}_new(void) {
 /** Alias */
 OQS_SIG *OQS_SIG_{{ family }}_{{ scheme['alias_scheme'] }}_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/kem/bike/kem_bike.c
+++ b/src/kem/bike/kem_bike.c
@@ -6,7 +6,7 @@
 
 #ifdef OQS_ENABLE_KEM_bike_l1
 OQS_KEM *OQS_KEM_bike_l1_new(void) {
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}
@@ -35,7 +35,7 @@ OQS_KEM *OQS_KEM_bike_l1_new(void) {
 
 #ifdef OQS_ENABLE_KEM_bike_l3
 OQS_KEM *OQS_KEM_bike_l3_new(void) {
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}
@@ -64,7 +64,7 @@ OQS_KEM *OQS_KEM_bike_l3_new(void) {
 
 #ifdef OQS_ENABLE_KEM_bike_l5
 OQS_KEM *OQS_KEM_bike_l5_new(void) {
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/classic_mceliece/kem_classic_mceliece_348864.c
+++ b/src/kem/classic_mceliece/kem_classic_mceliece_348864.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_classic_mceliece_348864_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/classic_mceliece/kem_classic_mceliece_348864f.c
+++ b/src/kem/classic_mceliece/kem_classic_mceliece_348864f.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_classic_mceliece_348864f_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/classic_mceliece/kem_classic_mceliece_460896.c
+++ b/src/kem/classic_mceliece/kem_classic_mceliece_460896.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_classic_mceliece_460896_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/classic_mceliece/kem_classic_mceliece_460896f.c
+++ b/src/kem/classic_mceliece/kem_classic_mceliece_460896f.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_classic_mceliece_460896f_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/classic_mceliece/kem_classic_mceliece_6688128.c
+++ b/src/kem/classic_mceliece/kem_classic_mceliece_6688128.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_classic_mceliece_6688128_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/classic_mceliece/kem_classic_mceliece_6688128f.c
+++ b/src/kem/classic_mceliece/kem_classic_mceliece_6688128f.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_classic_mceliece_6688128f_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/classic_mceliece/kem_classic_mceliece_6960119.c
+++ b/src/kem/classic_mceliece/kem_classic_mceliece_6960119.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_classic_mceliece_6960119_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/classic_mceliece/kem_classic_mceliece_6960119f.c
+++ b/src/kem/classic_mceliece/kem_classic_mceliece_6960119f.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_classic_mceliece_6960119f_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/classic_mceliece/kem_classic_mceliece_8192128.c
+++ b/src/kem/classic_mceliece/kem_classic_mceliece_8192128.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_classic_mceliece_8192128_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/classic_mceliece/kem_classic_mceliece_8192128f.c
+++ b/src/kem/classic_mceliece/kem_classic_mceliece_8192128f.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_classic_mceliece_8192128f_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/frodokem/kem_efrodokem1344aes.c
+++ b/src/kem/frodokem/kem_efrodokem1344aes.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_efrodokem_1344_aes_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/frodokem/kem_efrodokem1344shake.c
+++ b/src/kem/frodokem/kem_efrodokem1344shake.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_efrodokem_1344_shake_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/frodokem/kem_efrodokem640aes.c
+++ b/src/kem/frodokem/kem_efrodokem640aes.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_efrodokem_640_aes_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/frodokem/kem_efrodokem640shake.c
+++ b/src/kem/frodokem/kem_efrodokem640shake.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_efrodokem_640_shake_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/frodokem/kem_efrodokem976aes.c
+++ b/src/kem/frodokem/kem_efrodokem976aes.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_efrodokem_976_aes_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/frodokem/kem_efrodokem976shake.c
+++ b/src/kem/frodokem/kem_efrodokem976shake.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_efrodokem_976_shake_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/frodokem/kem_frodokem1344aes.c
+++ b/src/kem/frodokem/kem_frodokem1344aes.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_frodokem_1344_aes_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/frodokem/kem_frodokem1344shake.c
+++ b/src/kem/frodokem/kem_frodokem1344shake.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_frodokem_1344_shake_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/frodokem/kem_frodokem640aes.c
+++ b/src/kem/frodokem/kem_frodokem640aes.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_frodokem_640_aes_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/frodokem/kem_frodokem640shake.c
+++ b/src/kem/frodokem/kem_frodokem640shake.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_frodokem_640_shake_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/frodokem/kem_frodokem976aes.c
+++ b/src/kem/frodokem/kem_frodokem976aes.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_frodokem_976_aes_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/frodokem/kem_frodokem976shake.c
+++ b/src/kem/frodokem/kem_frodokem976shake.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_frodokem_976_shake_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/hqc/kem_hqc_128.c
+++ b/src/kem/hqc/kem_hqc_128.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_hqc_128_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/hqc/kem_hqc_192.c
+++ b/src/kem/hqc/kem_hqc_192.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_hqc_192_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/hqc/kem_hqc_256.c
+++ b/src/kem/hqc/kem_hqc_256.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_hqc_256_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/kem.c
+++ b/src/kem/kem.c
@@ -623,7 +623,7 @@ OQS_API OQS_KEM *OQS_KEM_new(const char *method_name) {
 }
 
 OQS_API OQS_STATUS OQS_KEM_keypair_derand(const OQS_KEM *kem, uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
-	if (kem == NULL) {
+	if (kem == NULL || kem->keypair_derand == NULL) {
 		return OQS_ERROR;
 	} else {
 		return kem->keypair_derand(public_key, secret_key, seed);
@@ -631,7 +631,7 @@ OQS_API OQS_STATUS OQS_KEM_keypair_derand(const OQS_KEM *kem, uint8_t *public_ke
 }
 
 OQS_API OQS_STATUS OQS_KEM_keypair(const OQS_KEM *kem, uint8_t *public_key, uint8_t *secret_key) {
-	if (kem == NULL) {
+	if (kem == NULL || kem->keypair == NULL) {
 		return OQS_ERROR;
 	} else {
 		return kem->keypair(public_key, secret_key);
@@ -639,7 +639,7 @@ OQS_API OQS_STATUS OQS_KEM_keypair(const OQS_KEM *kem, uint8_t *public_key, uint
 }
 
 OQS_API OQS_STATUS OQS_KEM_encaps_derand(const OQS_KEM *kem, uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key, const uint8_t *seed) {
-	if (kem == NULL) {
+	if (kem == NULL || kem->encaps_derand == NULL) {
 		return OQS_ERROR;
 	} else {
 		return kem->encaps_derand(ciphertext, shared_secret, public_key, seed);
@@ -647,7 +647,7 @@ OQS_API OQS_STATUS OQS_KEM_encaps_derand(const OQS_KEM *kem, uint8_t *ciphertext
 }
 
 OQS_API OQS_STATUS OQS_KEM_encaps(const OQS_KEM *kem, uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key) {
-	if (kem == NULL) {
+	if (kem == NULL || kem->encaps == NULL) {
 		return OQS_ERROR;
 	} else {
 		return kem->encaps(ciphertext, shared_secret, public_key);
@@ -655,7 +655,7 @@ OQS_API OQS_STATUS OQS_KEM_encaps(const OQS_KEM *kem, uint8_t *ciphertext, uint8
 }
 
 OQS_API OQS_STATUS OQS_KEM_decaps(const OQS_KEM *kem, uint8_t *shared_secret, const uint8_t *ciphertext, const uint8_t *secret_key) {
-	if (kem == NULL) {
+	if (kem == NULL || kem->decaps == NULL) {
 		return OQS_ERROR;
 	} else {
 		return kem->decaps(shared_secret, ciphertext, secret_key);

--- a/src/kem/kyber/kem_kyber_1024.c
+++ b/src/kem/kyber/kem_kyber_1024.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_kyber_1024_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/kyber/kem_kyber_512.c
+++ b/src/kem/kyber/kem_kyber_512.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_kyber_512_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/kyber/kem_kyber_768.c
+++ b/src/kem/kyber/kem_kyber_768.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_kyber_768_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/ml_kem/kem_ml_kem_1024.c
+++ b/src/kem/ml_kem/kem_ml_kem_1024.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_ml_kem_1024_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/ml_kem/kem_ml_kem_512.c
+++ b/src/kem/ml_kem/kem_ml_kem_512.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_ml_kem_512_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/ml_kem/kem_ml_kem_768.c
+++ b/src/kem/ml_kem/kem_ml_kem_768.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_ml_kem_768_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/kem/ntru/kem_ntru.h
+++ b/src/kem/ntru/kem_ntru.h
@@ -16,6 +16,7 @@ OQS_KEM *OQS_KEM_ntru_hps2048509_new(void);
 OQS_API OQS_STATUS OQS_KEM_ntru_hps2048509_keypair(uint8_t *public_key, uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_KEM_ntru_hps2048509_keypair_derand(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_KEM_ntru_hps2048509_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_API OQS_STATUS OQS_KEM_ntru_hps2048509_encaps_derand(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_KEM_ntru_hps2048509_decaps(uint8_t *shared_secret, const uint8_t *ciphertext, const uint8_t *secret_key);
 #endif
 
@@ -30,6 +31,7 @@ OQS_KEM *OQS_KEM_ntru_hps2048677_new(void);
 OQS_API OQS_STATUS OQS_KEM_ntru_hps2048677_keypair(uint8_t *public_key, uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_KEM_ntru_hps2048677_keypair_derand(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_KEM_ntru_hps2048677_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_API OQS_STATUS OQS_KEM_ntru_hps2048677_encaps_derand(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_KEM_ntru_hps2048677_decaps(uint8_t *shared_secret, const uint8_t *ciphertext, const uint8_t *secret_key);
 #endif
 
@@ -44,6 +46,7 @@ OQS_KEM *OQS_KEM_ntru_hps4096821_new(void);
 OQS_API OQS_STATUS OQS_KEM_ntru_hps4096821_keypair(uint8_t *public_key, uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_KEM_ntru_hps4096821_keypair_derand(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_KEM_ntru_hps4096821_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_API OQS_STATUS OQS_KEM_ntru_hps4096821_encaps_derand(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_KEM_ntru_hps4096821_decaps(uint8_t *shared_secret, const uint8_t *ciphertext, const uint8_t *secret_key);
 #endif
 
@@ -58,6 +61,7 @@ OQS_KEM *OQS_KEM_ntru_hps40961229_new(void);
 OQS_API OQS_STATUS OQS_KEM_ntru_hps40961229_keypair(uint8_t *public_key, uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_KEM_ntru_hps40961229_keypair_derand(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_KEM_ntru_hps40961229_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_API OQS_STATUS OQS_KEM_ntru_hps40961229_encaps_derand(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_KEM_ntru_hps40961229_decaps(uint8_t *shared_secret, const uint8_t *ciphertext, const uint8_t *secret_key);
 #endif
 
@@ -72,6 +76,7 @@ OQS_KEM *OQS_KEM_ntru_hrss701_new(void);
 OQS_API OQS_STATUS OQS_KEM_ntru_hrss701_keypair(uint8_t *public_key, uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_KEM_ntru_hrss701_keypair_derand(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_KEM_ntru_hrss701_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_API OQS_STATUS OQS_KEM_ntru_hrss701_encaps_derand(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_KEM_ntru_hrss701_decaps(uint8_t *shared_secret, const uint8_t *ciphertext, const uint8_t *secret_key);
 #endif
 
@@ -86,6 +91,7 @@ OQS_KEM *OQS_KEM_ntru_hrss1373_new(void);
 OQS_API OQS_STATUS OQS_KEM_ntru_hrss1373_keypair(uint8_t *public_key, uint8_t *secret_key);
 OQS_API OQS_STATUS OQS_KEM_ntru_hrss1373_keypair_derand(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_KEM_ntru_hrss1373_encaps(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key);
+OQS_API OQS_STATUS OQS_KEM_ntru_hrss1373_encaps_derand(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key, const uint8_t *seed);
 OQS_API OQS_STATUS OQS_KEM_ntru_hrss1373_decaps(uint8_t *shared_secret, const uint8_t *ciphertext, const uint8_t *secret_key);
 #endif
 

--- a/src/kem/ntru/kem_ntru_hps2048509.c
+++ b/src/kem/ntru/kem_ntru_hps2048509.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_ntru_hps2048509_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}
@@ -28,6 +28,7 @@ OQS_KEM *OQS_KEM_ntru_hps2048509_new(void) {
 	kem->keypair = OQS_KEM_ntru_hps2048509_keypair;
 	kem->keypair_derand = OQS_KEM_ntru_hps2048509_keypair_derand;
 	kem->encaps = OQS_KEM_ntru_hps2048509_encaps;
+	kem->encaps_derand = OQS_KEM_ntru_hps2048509_encaps_derand;
 	kem->decaps = OQS_KEM_ntru_hps2048509_decaps;
 
 	return kem;
@@ -62,6 +63,14 @@ OQS_API OQS_STATUS OQS_KEM_ntru_hps2048509_keypair(uint8_t *public_key, uint8_t 
 OQS_API OQS_STATUS OQS_KEM_ntru_hps2048509_keypair_derand(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
 	(void)public_key;
 	(void)secret_key;
+	(void)seed;
+	return OQS_ERROR;
+}
+
+OQS_API OQS_STATUS OQS_KEM_ntru_hps2048509_encaps_derand(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key, const uint8_t *seed) {
+	(void)ciphertext;
+	(void)shared_secret;
+	(void)public_key;
 	(void)seed;
 	return OQS_ERROR;
 }

--- a/src/kem/ntru/kem_ntru_hps2048677.c
+++ b/src/kem/ntru/kem_ntru_hps2048677.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_ntru_hps2048677_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}
@@ -28,6 +28,7 @@ OQS_KEM *OQS_KEM_ntru_hps2048677_new(void) {
 	kem->keypair = OQS_KEM_ntru_hps2048677_keypair;
 	kem->keypair_derand = OQS_KEM_ntru_hps2048677_keypair_derand;
 	kem->encaps = OQS_KEM_ntru_hps2048677_encaps;
+	kem->encaps_derand = OQS_KEM_ntru_hps2048677_encaps_derand;
 	kem->decaps = OQS_KEM_ntru_hps2048677_decaps;
 
 	return kem;
@@ -62,6 +63,14 @@ OQS_API OQS_STATUS OQS_KEM_ntru_hps2048677_keypair(uint8_t *public_key, uint8_t 
 OQS_API OQS_STATUS OQS_KEM_ntru_hps2048677_keypair_derand(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
 	(void)public_key;
 	(void)secret_key;
+	(void)seed;
+	return OQS_ERROR;
+}
+
+OQS_API OQS_STATUS OQS_KEM_ntru_hps2048677_encaps_derand(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key, const uint8_t *seed) {
+	(void)ciphertext;
+	(void)shared_secret;
+	(void)public_key;
 	(void)seed;
 	return OQS_ERROR;
 }

--- a/src/kem/ntru/kem_ntru_hps40961229.c
+++ b/src/kem/ntru/kem_ntru_hps40961229.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_ntru_hps40961229_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}
@@ -28,6 +28,7 @@ OQS_KEM *OQS_KEM_ntru_hps40961229_new(void) {
 	kem->keypair = OQS_KEM_ntru_hps40961229_keypair;
 	kem->keypair_derand = OQS_KEM_ntru_hps40961229_keypair_derand;
 	kem->encaps = OQS_KEM_ntru_hps40961229_encaps;
+	kem->encaps_derand = OQS_KEM_ntru_hps40961229_encaps_derand;
 	kem->decaps = OQS_KEM_ntru_hps40961229_decaps;
 
 	return kem;
@@ -44,6 +45,14 @@ OQS_API OQS_STATUS OQS_KEM_ntru_hps40961229_keypair(uint8_t *public_key, uint8_t
 OQS_API OQS_STATUS OQS_KEM_ntru_hps40961229_keypair_derand(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
 	(void)public_key;
 	(void)secret_key;
+	(void)seed;
+	return OQS_ERROR;
+}
+
+OQS_API OQS_STATUS OQS_KEM_ntru_hps40961229_encaps_derand(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key, const uint8_t *seed) {
+	(void)ciphertext;
+	(void)shared_secret;
+	(void)public_key;
 	(void)seed;
 	return OQS_ERROR;
 }

--- a/src/kem/ntru/kem_ntru_hps4096821.c
+++ b/src/kem/ntru/kem_ntru_hps4096821.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_ntru_hps4096821_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}
@@ -28,6 +28,7 @@ OQS_KEM *OQS_KEM_ntru_hps4096821_new(void) {
 	kem->keypair = OQS_KEM_ntru_hps4096821_keypair;
 	kem->keypair_derand = OQS_KEM_ntru_hps4096821_keypair_derand;
 	kem->encaps = OQS_KEM_ntru_hps4096821_encaps;
+	kem->encaps_derand = OQS_KEM_ntru_hps4096821_encaps_derand;
 	kem->decaps = OQS_KEM_ntru_hps4096821_decaps;
 
 	return kem;
@@ -62,6 +63,14 @@ OQS_API OQS_STATUS OQS_KEM_ntru_hps4096821_keypair(uint8_t *public_key, uint8_t 
 OQS_API OQS_STATUS OQS_KEM_ntru_hps4096821_keypair_derand(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
 	(void)public_key;
 	(void)secret_key;
+	(void)seed;
+	return OQS_ERROR;
+}
+
+OQS_API OQS_STATUS OQS_KEM_ntru_hps4096821_encaps_derand(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key, const uint8_t *seed) {
+	(void)ciphertext;
+	(void)shared_secret;
+	(void)public_key;
 	(void)seed;
 	return OQS_ERROR;
 }

--- a/src/kem/ntru/kem_ntru_hrss1373.c
+++ b/src/kem/ntru/kem_ntru_hrss1373.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_ntru_hrss1373_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}
@@ -28,6 +28,7 @@ OQS_KEM *OQS_KEM_ntru_hrss1373_new(void) {
 	kem->keypair = OQS_KEM_ntru_hrss1373_keypair;
 	kem->keypair_derand = OQS_KEM_ntru_hrss1373_keypair_derand;
 	kem->encaps = OQS_KEM_ntru_hrss1373_encaps;
+	kem->encaps_derand = OQS_KEM_ntru_hrss1373_encaps_derand;
 	kem->decaps = OQS_KEM_ntru_hrss1373_decaps;
 
 	return kem;
@@ -44,6 +45,14 @@ OQS_API OQS_STATUS OQS_KEM_ntru_hrss1373_keypair(uint8_t *public_key, uint8_t *s
 OQS_API OQS_STATUS OQS_KEM_ntru_hrss1373_keypair_derand(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
 	(void)public_key;
 	(void)secret_key;
+	(void)seed;
+	return OQS_ERROR;
+}
+
+OQS_API OQS_STATUS OQS_KEM_ntru_hrss1373_encaps_derand(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key, const uint8_t *seed) {
+	(void)ciphertext;
+	(void)shared_secret;
+	(void)public_key;
 	(void)seed;
 	return OQS_ERROR;
 }

--- a/src/kem/ntru/kem_ntru_hrss701.c
+++ b/src/kem/ntru/kem_ntru_hrss701.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_ntru_hrss701_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}
@@ -28,6 +28,7 @@ OQS_KEM *OQS_KEM_ntru_hrss701_new(void) {
 	kem->keypair = OQS_KEM_ntru_hrss701_keypair;
 	kem->keypair_derand = OQS_KEM_ntru_hrss701_keypair_derand;
 	kem->encaps = OQS_KEM_ntru_hrss701_encaps;
+	kem->encaps_derand = OQS_KEM_ntru_hrss701_encaps_derand;
 	kem->decaps = OQS_KEM_ntru_hrss701_decaps;
 
 	return kem;
@@ -62,6 +63,14 @@ OQS_API OQS_STATUS OQS_KEM_ntru_hrss701_keypair(uint8_t *public_key, uint8_t *se
 OQS_API OQS_STATUS OQS_KEM_ntru_hrss701_keypair_derand(uint8_t *public_key, uint8_t *secret_key, const uint8_t *seed) {
 	(void)public_key;
 	(void)secret_key;
+	(void)seed;
+	return OQS_ERROR;
+}
+
+OQS_API OQS_STATUS OQS_KEM_ntru_hrss701_encaps_derand(uint8_t *ciphertext, uint8_t *shared_secret, const uint8_t *public_key, const uint8_t *seed) {
+	(void)ciphertext;
+	(void)shared_secret;
+	(void)public_key;
 	(void)seed;
 	return OQS_ERROR;
 }

--- a/src/kem/ntruprime/kem_ntruprime_sntrup761.c
+++ b/src/kem/ntruprime/kem_ntruprime_sntrup761.c
@@ -8,7 +8,7 @@
 
 OQS_KEM *OQS_KEM_ntruprime_sntrup761_new(void) {
 
-	OQS_KEM *kem = OQS_MEM_malloc(sizeof(OQS_KEM));
+	OQS_KEM *kem = OQS_MEM_calloc(1, sizeof(OQS_KEM));
 	if (kem == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdp_128_balanced.c
+++ b/src/sig/cross/sig_cross_rsdp_128_balanced.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdp_128_balanced)
 OQS_SIG *OQS_SIG_cross_rsdp_128_balanced_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdp_128_fast.c
+++ b/src/sig/cross/sig_cross_rsdp_128_fast.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdp_128_fast)
 OQS_SIG *OQS_SIG_cross_rsdp_128_fast_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdp_128_small.c
+++ b/src/sig/cross/sig_cross_rsdp_128_small.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdp_128_small)
 OQS_SIG *OQS_SIG_cross_rsdp_128_small_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdp_192_balanced.c
+++ b/src/sig/cross/sig_cross_rsdp_192_balanced.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdp_192_balanced)
 OQS_SIG *OQS_SIG_cross_rsdp_192_balanced_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdp_192_fast.c
+++ b/src/sig/cross/sig_cross_rsdp_192_fast.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdp_192_fast)
 OQS_SIG *OQS_SIG_cross_rsdp_192_fast_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdp_192_small.c
+++ b/src/sig/cross/sig_cross_rsdp_192_small.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdp_192_small)
 OQS_SIG *OQS_SIG_cross_rsdp_192_small_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdp_256_balanced.c
+++ b/src/sig/cross/sig_cross_rsdp_256_balanced.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdp_256_balanced)
 OQS_SIG *OQS_SIG_cross_rsdp_256_balanced_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdp_256_fast.c
+++ b/src/sig/cross/sig_cross_rsdp_256_fast.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdp_256_fast)
 OQS_SIG *OQS_SIG_cross_rsdp_256_fast_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdp_256_small.c
+++ b/src/sig/cross/sig_cross_rsdp_256_small.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdp_256_small)
 OQS_SIG *OQS_SIG_cross_rsdp_256_small_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdpg_128_balanced.c
+++ b/src/sig/cross/sig_cross_rsdpg_128_balanced.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_128_balanced)
 OQS_SIG *OQS_SIG_cross_rsdpg_128_balanced_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdpg_128_fast.c
+++ b/src/sig/cross/sig_cross_rsdpg_128_fast.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_128_fast)
 OQS_SIG *OQS_SIG_cross_rsdpg_128_fast_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdpg_128_small.c
+++ b/src/sig/cross/sig_cross_rsdpg_128_small.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_128_small)
 OQS_SIG *OQS_SIG_cross_rsdpg_128_small_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdpg_192_balanced.c
+++ b/src/sig/cross/sig_cross_rsdpg_192_balanced.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_192_balanced)
 OQS_SIG *OQS_SIG_cross_rsdpg_192_balanced_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdpg_192_fast.c
+++ b/src/sig/cross/sig_cross_rsdpg_192_fast.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_192_fast)
 OQS_SIG *OQS_SIG_cross_rsdpg_192_fast_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdpg_192_small.c
+++ b/src/sig/cross/sig_cross_rsdpg_192_small.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_192_small)
 OQS_SIG *OQS_SIG_cross_rsdpg_192_small_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdpg_256_balanced.c
+++ b/src/sig/cross/sig_cross_rsdpg_256_balanced.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_256_balanced)
 OQS_SIG *OQS_SIG_cross_rsdpg_256_balanced_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdpg_256_fast.c
+++ b/src/sig/cross/sig_cross_rsdpg_256_fast.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_256_fast)
 OQS_SIG *OQS_SIG_cross_rsdpg_256_fast_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/cross/sig_cross_rsdpg_256_small.c
+++ b/src/sig/cross/sig_cross_rsdpg_256_small.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_cross_rsdpg_256_small)
 OQS_SIG *OQS_SIG_cross_rsdpg_256_small_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/falcon/sig_falcon_1024.c
+++ b/src/sig/falcon/sig_falcon_1024.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_falcon_1024)
 OQS_SIG *OQS_SIG_falcon_1024_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/falcon/sig_falcon_512.c
+++ b/src/sig/falcon/sig_falcon_512.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_falcon_512)
 OQS_SIG *OQS_SIG_falcon_512_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/falcon/sig_falcon_padded_1024.c
+++ b/src/sig/falcon/sig_falcon_padded_1024.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_falcon_padded_1024)
 OQS_SIG *OQS_SIG_falcon_padded_1024_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/falcon/sig_falcon_padded_512.c
+++ b/src/sig/falcon/sig_falcon_padded_512.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_falcon_padded_512)
 OQS_SIG *OQS_SIG_falcon_padded_512_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/mayo/sig_mayo_1.c
+++ b/src/sig/mayo/sig_mayo_1.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_mayo_1)
 OQS_SIG *OQS_SIG_mayo_1_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/mayo/sig_mayo_2.c
+++ b/src/sig/mayo/sig_mayo_2.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_mayo_2)
 OQS_SIG *OQS_SIG_mayo_2_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/mayo/sig_mayo_3.c
+++ b/src/sig/mayo/sig_mayo_3.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_mayo_3)
 OQS_SIG *OQS_SIG_mayo_3_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/mayo/sig_mayo_5.c
+++ b/src/sig/mayo/sig_mayo_5.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_mayo_5)
 OQS_SIG *OQS_SIG_mayo_5_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/ml_dsa/sig_ml_dsa_44.c
+++ b/src/sig/ml_dsa/sig_ml_dsa_44.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_ml_dsa_44)
 OQS_SIG *OQS_SIG_ml_dsa_44_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/ml_dsa/sig_ml_dsa_65.c
+++ b/src/sig/ml_dsa/sig_ml_dsa_65.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_ml_dsa_65)
 OQS_SIG *OQS_SIG_ml_dsa_65_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/ml_dsa/sig_ml_dsa_87.c
+++ b/src/sig/ml_dsa/sig_ml_dsa_87.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_ml_dsa_87)
 OQS_SIG *OQS_SIG_ml_dsa_87_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/mqom/sig_mqom_mqom2_cat1_gf16_fast_r3.c
+++ b/src/sig/mqom/sig_mqom_mqom2_cat1_gf16_fast_r3.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_mqom_mqom2_cat1_gf16_fast_r3)
 OQS_SIG *OQS_SIG_mqom_mqom2_cat1_gf16_fast_r3_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/mqom/sig_mqom_mqom2_cat1_gf16_fast_r5.c
+++ b/src/sig/mqom/sig_mqom_mqom2_cat1_gf16_fast_r5.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_mqom_mqom2_cat1_gf16_fast_r5)
 OQS_SIG *OQS_SIG_mqom_mqom2_cat1_gf16_fast_r5_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/mqom/sig_mqom_mqom2_cat1_gf16_short_r3.c
+++ b/src/sig/mqom/sig_mqom_mqom2_cat1_gf16_short_r3.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_mqom_mqom2_cat1_gf16_short_r3)
 OQS_SIG *OQS_SIG_mqom_mqom2_cat1_gf16_short_r3_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/mqom/sig_mqom_mqom2_cat1_gf16_short_r5.c
+++ b/src/sig/mqom/sig_mqom_mqom2_cat1_gf16_short_r5.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_mqom_mqom2_cat1_gf16_short_r5)
 OQS_SIG *OQS_SIG_mqom_mqom2_cat1_gf16_short_r5_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/mqom/sig_mqom_mqom2_cat3_gf16_fast_r3.c
+++ b/src/sig/mqom/sig_mqom_mqom2_cat3_gf16_fast_r3.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_mqom_mqom2_cat3_gf16_fast_r3)
 OQS_SIG *OQS_SIG_mqom_mqom2_cat3_gf16_fast_r3_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/mqom/sig_mqom_mqom2_cat3_gf16_fast_r5.c
+++ b/src/sig/mqom/sig_mqom_mqom2_cat3_gf16_fast_r5.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_mqom_mqom2_cat3_gf16_fast_r5)
 OQS_SIG *OQS_SIG_mqom_mqom2_cat3_gf16_fast_r5_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/mqom/sig_mqom_mqom2_cat3_gf16_short_r3.c
+++ b/src/sig/mqom/sig_mqom_mqom2_cat3_gf16_short_r3.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_mqom_mqom2_cat3_gf16_short_r3)
 OQS_SIG *OQS_SIG_mqom_mqom2_cat3_gf16_short_r3_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/mqom/sig_mqom_mqom2_cat3_gf16_short_r5.c
+++ b/src/sig/mqom/sig_mqom_mqom2_cat3_gf16_short_r5.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_mqom_mqom2_cat3_gf16_short_r5)
 OQS_SIG *OQS_SIG_mqom_mqom2_cat3_gf16_short_r5_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/mqom/sig_mqom_mqom2_cat5_gf16_fast_r3.c
+++ b/src/sig/mqom/sig_mqom_mqom2_cat5_gf16_fast_r3.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_mqom_mqom2_cat5_gf16_fast_r3)
 OQS_SIG *OQS_SIG_mqom_mqom2_cat5_gf16_fast_r3_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/mqom/sig_mqom_mqom2_cat5_gf16_fast_r5.c
+++ b/src/sig/mqom/sig_mqom_mqom2_cat5_gf16_fast_r5.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_mqom_mqom2_cat5_gf16_fast_r5)
 OQS_SIG *OQS_SIG_mqom_mqom2_cat5_gf16_fast_r5_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/mqom/sig_mqom_mqom2_cat5_gf16_short_r3.c
+++ b/src/sig/mqom/sig_mqom_mqom2_cat5_gf16_short_r3.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_mqom_mqom2_cat5_gf16_short_r3)
 OQS_SIG *OQS_SIG_mqom_mqom2_cat5_gf16_short_r3_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/mqom/sig_mqom_mqom2_cat5_gf16_short_r5.c
+++ b/src/sig/mqom/sig_mqom_mqom2_cat5_gf16_short_r5.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_mqom_mqom2_cat5_gf16_short_r5)
 OQS_SIG *OQS_SIG_mqom_mqom2_cat5_gf16_short_r5_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/sig.c
+++ b/src/sig/sig.c
@@ -3060,7 +3060,7 @@ OQS_API OQS_SIG *OQS_SIG_new(const char *method_name) {
 }
 
 OQS_API OQS_STATUS OQS_SIG_keypair(const OQS_SIG *sig, uint8_t *public_key, uint8_t *secret_key) {
-	if (sig == NULL || sig->keypair(public_key, secret_key) != OQS_SUCCESS) {
+	if (sig == NULL || sig->keypair == NULL || sig->keypair(public_key, secret_key) != OQS_SUCCESS) {
 		return OQS_ERROR;
 	} else {
 		return OQS_SUCCESS;
@@ -3068,7 +3068,7 @@ OQS_API OQS_STATUS OQS_SIG_keypair(const OQS_SIG *sig, uint8_t *public_key, uint
 }
 
 OQS_API OQS_STATUS OQS_SIG_sign(const OQS_SIG *sig, uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *secret_key) {
-	if (sig == NULL || sig->sign(signature, signature_len, message, message_len, secret_key) != OQS_SUCCESS) {
+	if (sig == NULL || sig->sign == NULL || sig->sign(signature, signature_len, message, message_len, secret_key) != OQS_SUCCESS) {
 		return OQS_ERROR;
 	} else {
 		return OQS_SUCCESS;
@@ -3076,7 +3076,7 @@ OQS_API OQS_STATUS OQS_SIG_sign(const OQS_SIG *sig, uint8_t *signature, size_t *
 }
 
 OQS_API OQS_STATUS OQS_SIG_sign_with_ctx_str(const OQS_SIG *sig, uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, const uint8_t *ctx_str, size_t ctx_str_len, const uint8_t *secret_key) {
-	if (sig == NULL || sig->sign_with_ctx_str(signature, signature_len, message, message_len, ctx_str, ctx_str_len, secret_key) != OQS_SUCCESS) {
+	if (sig == NULL || sig->sign_with_ctx_str == NULL || sig->sign_with_ctx_str(signature, signature_len, message, message_len, ctx_str, ctx_str_len, secret_key) != OQS_SUCCESS) {
 		return OQS_ERROR;
 	} else {
 		return OQS_SUCCESS;
@@ -3084,7 +3084,7 @@ OQS_API OQS_STATUS OQS_SIG_sign_with_ctx_str(const OQS_SIG *sig, uint8_t *signat
 }
 
 OQS_API OQS_STATUS OQS_SIG_verify(const OQS_SIG *sig, const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *public_key) {
-	if (sig == NULL || sig->verify(message, message_len, signature, signature_len, public_key) != OQS_SUCCESS) {
+	if (sig == NULL || sig->verify == NULL || sig->verify(message, message_len, signature, signature_len, public_key) != OQS_SUCCESS) {
 		return OQS_ERROR;
 	} else {
 		return OQS_SUCCESS;
@@ -3092,7 +3092,7 @@ OQS_API OQS_STATUS OQS_SIG_verify(const OQS_SIG *sig, const uint8_t *message, si
 }
 
 OQS_API OQS_STATUS OQS_SIG_verify_with_ctx_str(const OQS_SIG *sig, const uint8_t *message, size_t message_len, const uint8_t *signature, size_t signature_len, const uint8_t *ctx_str, size_t ctx_str_len, const uint8_t *public_key) {
-	if (sig == NULL || sig->verify_with_ctx_str(message, message_len, signature, signature_len, ctx_str, ctx_str_len, public_key) != OQS_SUCCESS) {
+	if (sig == NULL || sig->verify_with_ctx_str == NULL || sig->verify_with_ctx_str(message, message_len, signature, signature_len, ctx_str, ctx_str_len, public_key) != OQS_SUCCESS) {
 		return OQS_ERROR;
 	} else {
 		return OQS_SUCCESS;

--- a/src/sig/slh_dsa/templates/slh_dsa_src_template.jinja
+++ b/src/sig/slh_dsa/templates/slh_dsa_src_template.jinja
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_pure_{{hashAlg}}_{{paramSet}})
 OQS_SIG *OQS_SIG_slh_dsa_pure_{{hashAlg}}_{{paramSet}}_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}
@@ -119,7 +119,7 @@ OQS_API OQS_STATUS OQS_SIG_slh_dsa_pure_{{hashAlg}}_{{paramSet}}_verify_with_ctx
 #if defined(OQS_ENABLE_SIG_slh_dsa_{{prehashHashAlg}}_prehash_{{hashAlg}}_{{paramSet}})
 OQS_SIG *OQS_SIG_slh_dsa_{{prehashHashAlg}}_prehash_{{hashAlg}}_{{paramSet}}_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_sha2_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_sha2_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_224_prehash_sha2_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_224_prehash_sha2_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_sha2_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_sha2_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_224_prehash_sha2_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_224_prehash_sha2_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_sha2_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_sha2_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_224_prehash_sha2_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_224_prehash_sha2_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_sha2_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_sha2_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_224_prehash_sha2_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_224_prehash_sha2_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_sha2_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_sha2_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_224_prehash_sha2_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_224_prehash_sha2_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_sha2_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_sha2_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_224_prehash_sha2_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_224_prehash_sha2_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_shake_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_shake_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_224_prehash_shake_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_224_prehash_shake_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_shake_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_shake_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_224_prehash_shake_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_224_prehash_shake_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_shake_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_shake_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_224_prehash_shake_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_224_prehash_shake_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_shake_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_shake_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_224_prehash_shake_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_224_prehash_shake_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_shake_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_shake_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_224_prehash_shake_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_224_prehash_shake_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_shake_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_224/slh_dsa_sha2_224_prehash_shake_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_224_prehash_shake_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_224_prehash_shake_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_sha2_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_sha2_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_256_prehash_sha2_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_256_prehash_sha2_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_sha2_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_sha2_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_256_prehash_sha2_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_256_prehash_sha2_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_sha2_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_sha2_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_256_prehash_sha2_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_256_prehash_sha2_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_sha2_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_sha2_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_256_prehash_sha2_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_256_prehash_sha2_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_sha2_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_sha2_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_256_prehash_sha2_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_256_prehash_sha2_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_sha2_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_sha2_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_256_prehash_sha2_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_256_prehash_sha2_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_shake_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_shake_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_256_prehash_shake_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_256_prehash_shake_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_shake_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_shake_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_256_prehash_shake_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_256_prehash_shake_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_shake_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_shake_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_256_prehash_shake_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_256_prehash_shake_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_shake_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_shake_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_256_prehash_shake_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_256_prehash_shake_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_shake_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_shake_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_256_prehash_shake_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_256_prehash_shake_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_shake_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_256/slh_dsa_sha2_256_prehash_shake_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_256_prehash_shake_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_256_prehash_shake_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_sha2_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_sha2_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_384_prehash_sha2_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_384_prehash_sha2_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_sha2_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_sha2_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_384_prehash_sha2_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_384_prehash_sha2_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_sha2_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_sha2_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_384_prehash_sha2_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_384_prehash_sha2_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_sha2_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_sha2_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_384_prehash_sha2_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_384_prehash_sha2_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_sha2_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_sha2_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_384_prehash_sha2_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_384_prehash_sha2_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_sha2_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_sha2_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_384_prehash_sha2_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_384_prehash_sha2_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_shake_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_shake_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_384_prehash_shake_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_384_prehash_shake_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_shake_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_shake_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_384_prehash_shake_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_384_prehash_shake_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_shake_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_shake_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_384_prehash_shake_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_384_prehash_shake_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_shake_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_shake_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_384_prehash_shake_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_384_prehash_shake_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_shake_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_shake_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_384_prehash_shake_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_384_prehash_shake_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_shake_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_384/slh_dsa_sha2_384_prehash_shake_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_384_prehash_shake_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_384_prehash_shake_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_sha2_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_sha2_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_prehash_sha2_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_prehash_sha2_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_sha2_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_sha2_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_prehash_sha2_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_prehash_sha2_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_sha2_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_sha2_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_prehash_sha2_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_prehash_sha2_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_sha2_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_sha2_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_prehash_sha2_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_prehash_sha2_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_sha2_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_sha2_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_prehash_sha2_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_prehash_sha2_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_sha2_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_sha2_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_prehash_sha2_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_prehash_sha2_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_shake_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_shake_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_prehash_shake_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_prehash_shake_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_shake_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_shake_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_prehash_shake_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_prehash_shake_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_shake_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_shake_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_prehash_shake_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_prehash_shake_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_shake_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_shake_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_prehash_shake_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_prehash_shake_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_shake_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_shake_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_prehash_shake_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_prehash_shake_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_shake_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512/slh_dsa_sha2_512_prehash_shake_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_prehash_shake_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_prehash_shake_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_sha2_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_sha2_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_224_prehash_sha2_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_224_prehash_sha2_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_sha2_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_sha2_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_224_prehash_sha2_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_224_prehash_sha2_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_sha2_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_sha2_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_224_prehash_sha2_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_224_prehash_sha2_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_sha2_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_sha2_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_224_prehash_sha2_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_224_prehash_sha2_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_sha2_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_sha2_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_224_prehash_sha2_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_224_prehash_sha2_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_sha2_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_sha2_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_224_prehash_sha2_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_224_prehash_sha2_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_shake_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_shake_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_224_prehash_shake_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_224_prehash_shake_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_shake_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_shake_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_224_prehash_shake_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_224_prehash_shake_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_shake_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_shake_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_224_prehash_shake_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_224_prehash_shake_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_shake_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_shake_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_224_prehash_shake_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_224_prehash_shake_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_shake_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_shake_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_224_prehash_shake_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_224_prehash_shake_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_shake_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_224/slh_dsa_sha2_512_224_prehash_shake_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_224_prehash_shake_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_224_prehash_shake_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_sha2_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_sha2_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_256_prehash_sha2_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_256_prehash_sha2_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_sha2_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_sha2_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_256_prehash_sha2_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_256_prehash_sha2_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_sha2_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_sha2_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_256_prehash_sha2_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_256_prehash_sha2_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_sha2_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_sha2_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_256_prehash_sha2_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_256_prehash_sha2_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_sha2_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_sha2_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_256_prehash_sha2_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_256_prehash_sha2_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_sha2_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_sha2_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_256_prehash_sha2_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_256_prehash_sha2_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_shake_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_shake_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_256_prehash_shake_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_256_prehash_shake_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_shake_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_shake_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_256_prehash_shake_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_256_prehash_shake_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_shake_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_shake_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_256_prehash_shake_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_256_prehash_shake_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_shake_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_shake_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_256_prehash_shake_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_256_prehash_shake_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_shake_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_shake_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_256_prehash_shake_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_256_prehash_shake_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_shake_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha2_512_256/slh_dsa_sha2_512_256_prehash_shake_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha2_512_256_prehash_shake_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha2_512_256_prehash_shake_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_sha2_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_sha2_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_224_prehash_sha2_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_224_prehash_sha2_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_sha2_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_sha2_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_224_prehash_sha2_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_224_prehash_sha2_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_sha2_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_sha2_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_224_prehash_sha2_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_224_prehash_sha2_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_sha2_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_sha2_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_224_prehash_sha2_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_224_prehash_sha2_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_sha2_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_sha2_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_224_prehash_sha2_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_224_prehash_sha2_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_sha2_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_sha2_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_224_prehash_sha2_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_224_prehash_sha2_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_shake_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_shake_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_224_prehash_shake_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_224_prehash_shake_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_shake_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_shake_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_224_prehash_shake_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_224_prehash_shake_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_shake_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_shake_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_224_prehash_shake_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_224_prehash_shake_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_shake_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_shake_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_224_prehash_shake_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_224_prehash_shake_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_shake_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_shake_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_224_prehash_shake_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_224_prehash_shake_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_shake_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_224/slh_dsa_sha3_224_prehash_shake_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_224_prehash_shake_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_224_prehash_shake_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_sha2_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_sha2_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_256_prehash_sha2_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_256_prehash_sha2_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_sha2_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_sha2_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_256_prehash_sha2_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_256_prehash_sha2_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_sha2_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_sha2_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_256_prehash_sha2_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_256_prehash_sha2_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_sha2_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_sha2_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_256_prehash_sha2_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_256_prehash_sha2_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_sha2_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_sha2_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_256_prehash_sha2_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_256_prehash_sha2_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_sha2_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_sha2_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_256_prehash_sha2_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_256_prehash_sha2_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_shake_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_shake_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_256_prehash_shake_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_256_prehash_shake_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_shake_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_shake_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_256_prehash_shake_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_256_prehash_shake_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_shake_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_shake_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_256_prehash_shake_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_256_prehash_shake_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_shake_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_shake_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_256_prehash_shake_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_256_prehash_shake_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_shake_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_shake_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_256_prehash_shake_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_256_prehash_shake_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_shake_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_256/slh_dsa_sha3_256_prehash_shake_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_256_prehash_shake_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_256_prehash_shake_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_sha2_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_sha2_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_384_prehash_sha2_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_384_prehash_sha2_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_sha2_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_sha2_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_384_prehash_sha2_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_384_prehash_sha2_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_sha2_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_sha2_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_384_prehash_sha2_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_384_prehash_sha2_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_sha2_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_sha2_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_384_prehash_sha2_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_384_prehash_sha2_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_sha2_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_sha2_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_384_prehash_sha2_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_384_prehash_sha2_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_sha2_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_sha2_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_384_prehash_sha2_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_384_prehash_sha2_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_shake_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_shake_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_384_prehash_shake_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_384_prehash_shake_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_shake_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_shake_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_384_prehash_shake_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_384_prehash_shake_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_shake_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_shake_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_384_prehash_shake_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_384_prehash_shake_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_shake_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_shake_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_384_prehash_shake_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_384_prehash_shake_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_shake_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_shake_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_384_prehash_shake_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_384_prehash_shake_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_shake_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_384/slh_dsa_sha3_384_prehash_shake_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_384_prehash_shake_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_384_prehash_shake_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_sha2_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_sha2_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_512_prehash_sha2_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_512_prehash_sha2_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_sha2_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_sha2_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_512_prehash_sha2_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_512_prehash_sha2_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_sha2_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_sha2_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_512_prehash_sha2_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_512_prehash_sha2_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_sha2_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_sha2_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_512_prehash_sha2_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_512_prehash_sha2_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_sha2_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_sha2_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_512_prehash_sha2_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_512_prehash_sha2_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_sha2_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_sha2_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_512_prehash_sha2_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_512_prehash_sha2_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_shake_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_shake_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_512_prehash_shake_128f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_512_prehash_shake_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_shake_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_shake_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_512_prehash_shake_128s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_512_prehash_shake_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_shake_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_shake_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_512_prehash_shake_192f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_512_prehash_shake_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_shake_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_shake_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_512_prehash_shake_192s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_512_prehash_shake_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_shake_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_shake_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_512_prehash_shake_256f)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_512_prehash_shake_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_shake_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_sha3_512/slh_dsa_sha3_512_prehash_shake_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_sha3_512_prehash_shake_256s)
 OQS_SIG *OQS_SIG_slh_dsa_sha3_512_prehash_shake_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_sha2_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_sha2_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_128_prehash_sha2_128f)
 OQS_SIG *OQS_SIG_slh_dsa_shake_128_prehash_sha2_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_sha2_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_sha2_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_128_prehash_sha2_128s)
 OQS_SIG *OQS_SIG_slh_dsa_shake_128_prehash_sha2_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_sha2_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_sha2_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_128_prehash_sha2_192f)
 OQS_SIG *OQS_SIG_slh_dsa_shake_128_prehash_sha2_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_sha2_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_sha2_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_128_prehash_sha2_192s)
 OQS_SIG *OQS_SIG_slh_dsa_shake_128_prehash_sha2_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_sha2_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_sha2_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_128_prehash_sha2_256f)
 OQS_SIG *OQS_SIG_slh_dsa_shake_128_prehash_sha2_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_sha2_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_sha2_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_128_prehash_sha2_256s)
 OQS_SIG *OQS_SIG_slh_dsa_shake_128_prehash_sha2_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_shake_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_shake_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_128_prehash_shake_128f)
 OQS_SIG *OQS_SIG_slh_dsa_shake_128_prehash_shake_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_shake_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_shake_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_128_prehash_shake_128s)
 OQS_SIG *OQS_SIG_slh_dsa_shake_128_prehash_shake_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_shake_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_shake_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_128_prehash_shake_192f)
 OQS_SIG *OQS_SIG_slh_dsa_shake_128_prehash_shake_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_shake_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_shake_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_128_prehash_shake_192s)
 OQS_SIG *OQS_SIG_slh_dsa_shake_128_prehash_shake_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_shake_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_shake_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_128_prehash_shake_256f)
 OQS_SIG *OQS_SIG_slh_dsa_shake_128_prehash_shake_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_shake_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_128/slh_dsa_shake_128_prehash_shake_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_128_prehash_shake_256s)
 OQS_SIG *OQS_SIG_slh_dsa_shake_128_prehash_shake_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_sha2_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_sha2_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_256_prehash_sha2_128f)
 OQS_SIG *OQS_SIG_slh_dsa_shake_256_prehash_sha2_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_sha2_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_sha2_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_256_prehash_sha2_128s)
 OQS_SIG *OQS_SIG_slh_dsa_shake_256_prehash_sha2_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_sha2_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_sha2_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_256_prehash_sha2_192f)
 OQS_SIG *OQS_SIG_slh_dsa_shake_256_prehash_sha2_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_sha2_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_sha2_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_256_prehash_sha2_192s)
 OQS_SIG *OQS_SIG_slh_dsa_shake_256_prehash_sha2_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_sha2_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_sha2_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_256_prehash_sha2_256f)
 OQS_SIG *OQS_SIG_slh_dsa_shake_256_prehash_sha2_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_sha2_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_sha2_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_256_prehash_sha2_256s)
 OQS_SIG *OQS_SIG_slh_dsa_shake_256_prehash_sha2_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_shake_128f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_shake_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_256_prehash_shake_128f)
 OQS_SIG *OQS_SIG_slh_dsa_shake_256_prehash_shake_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_shake_128s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_shake_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_256_prehash_shake_128s)
 OQS_SIG *OQS_SIG_slh_dsa_shake_256_prehash_shake_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_shake_192f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_shake_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_256_prehash_shake_192f)
 OQS_SIG *OQS_SIG_slh_dsa_shake_256_prehash_shake_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_shake_192s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_shake_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_256_prehash_shake_192s)
 OQS_SIG *OQS_SIG_slh_dsa_shake_256_prehash_shake_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_shake_256f.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_shake_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_256_prehash_shake_256f)
 OQS_SIG *OQS_SIG_slh_dsa_shake_256_prehash_shake_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_shake_256s.c
+++ b/src/sig/slh_dsa/wrappers/prehash_shake_256/slh_dsa_shake_256_prehash_shake_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_shake_256_prehash_shake_256s)
 OQS_SIG *OQS_SIG_slh_dsa_shake_256_prehash_shake_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if(sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_sha2_128f.c
+++ b/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_sha2_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_pure_sha2_128f)
 OQS_SIG *OQS_SIG_slh_dsa_pure_sha2_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_sha2_128s.c
+++ b/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_sha2_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_pure_sha2_128s)
 OQS_SIG *OQS_SIG_slh_dsa_pure_sha2_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_sha2_192f.c
+++ b/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_sha2_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_pure_sha2_192f)
 OQS_SIG *OQS_SIG_slh_dsa_pure_sha2_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_sha2_192s.c
+++ b/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_sha2_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_pure_sha2_192s)
 OQS_SIG *OQS_SIG_slh_dsa_pure_sha2_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_sha2_256f.c
+++ b/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_sha2_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_pure_sha2_256f)
 OQS_SIG *OQS_SIG_slh_dsa_pure_sha2_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_sha2_256s.c
+++ b/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_sha2_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_pure_sha2_256s)
 OQS_SIG *OQS_SIG_slh_dsa_pure_sha2_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_shake_128f.c
+++ b/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_shake_128f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_pure_shake_128f)
 OQS_SIG *OQS_SIG_slh_dsa_pure_shake_128f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_shake_128s.c
+++ b/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_shake_128s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_pure_shake_128s)
 OQS_SIG *OQS_SIG_slh_dsa_pure_shake_128s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_shake_192f.c
+++ b/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_shake_192f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_pure_shake_192f)
 OQS_SIG *OQS_SIG_slh_dsa_pure_shake_192f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_shake_192s.c
+++ b/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_shake_192s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_pure_shake_192s)
 OQS_SIG *OQS_SIG_slh_dsa_pure_shake_192s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_shake_256f.c
+++ b/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_shake_256f.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_pure_shake_256f)
 OQS_SIG *OQS_SIG_slh_dsa_pure_shake_256f_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_shake_256s.c
+++ b/src/sig/slh_dsa/wrappers/pure/slh_dsa_pure_shake_256s.c
@@ -11,7 +11,7 @@
 #if defined(OQS_ENABLE_SIG_slh_dsa_pure_shake_256s)
 OQS_SIG *OQS_SIG_slh_dsa_pure_shake_256s_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/snova/sig_snova_SNOVA_24_5_4.c
+++ b/src/sig/snova/sig_snova_SNOVA_24_5_4.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_snova_SNOVA_24_5_4)
 OQS_SIG *OQS_SIG_snova_SNOVA_24_5_4_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/snova/sig_snova_SNOVA_24_5_4_SHAKE.c
+++ b/src/sig/snova/sig_snova_SNOVA_24_5_4_SHAKE.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_snova_SNOVA_24_5_4_SHAKE)
 OQS_SIG *OQS_SIG_snova_SNOVA_24_5_4_SHAKE_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/snova/sig_snova_SNOVA_24_5_4_SHAKE_esk.c
+++ b/src/sig/snova/sig_snova_SNOVA_24_5_4_SHAKE_esk.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_snova_SNOVA_24_5_4_SHAKE_esk)
 OQS_SIG *OQS_SIG_snova_SNOVA_24_5_4_SHAKE_esk_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/snova/sig_snova_SNOVA_24_5_4_esk.c
+++ b/src/sig/snova/sig_snova_SNOVA_24_5_4_esk.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_snova_SNOVA_24_5_4_esk)
 OQS_SIG *OQS_SIG_snova_SNOVA_24_5_4_esk_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/snova/sig_snova_SNOVA_24_5_5.c
+++ b/src/sig/snova/sig_snova_SNOVA_24_5_5.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_snova_SNOVA_24_5_5)
 OQS_SIG *OQS_SIG_snova_SNOVA_24_5_5_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/snova/sig_snova_SNOVA_25_8_3.c
+++ b/src/sig/snova/sig_snova_SNOVA_25_8_3.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_snova_SNOVA_25_8_3)
 OQS_SIG *OQS_SIG_snova_SNOVA_25_8_3_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/snova/sig_snova_SNOVA_29_6_5.c
+++ b/src/sig/snova/sig_snova_SNOVA_29_6_5.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_snova_SNOVA_29_6_5)
 OQS_SIG *OQS_SIG_snova_SNOVA_29_6_5_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/snova/sig_snova_SNOVA_37_17_2.c
+++ b/src/sig/snova/sig_snova_SNOVA_37_17_2.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_snova_SNOVA_37_17_2)
 OQS_SIG *OQS_SIG_snova_SNOVA_37_17_2_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/snova/sig_snova_SNOVA_37_8_4.c
+++ b/src/sig/snova/sig_snova_SNOVA_37_8_4.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_snova_SNOVA_37_8_4)
 OQS_SIG *OQS_SIG_snova_SNOVA_37_8_4_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/snova/sig_snova_SNOVA_49_11_3.c
+++ b/src/sig/snova/sig_snova_SNOVA_49_11_3.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_snova_SNOVA_49_11_3)
 OQS_SIG *OQS_SIG_snova_SNOVA_49_11_3_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/snova/sig_snova_SNOVA_56_25_2.c
+++ b/src/sig/snova/sig_snova_SNOVA_56_25_2.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_snova_SNOVA_56_25_2)
 OQS_SIG *OQS_SIG_snova_SNOVA_56_25_2_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/snova/sig_snova_SNOVA_60_10_4.c
+++ b/src/sig/snova/sig_snova_SNOVA_60_10_4.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_snova_SNOVA_60_10_4)
 OQS_SIG *OQS_SIG_snova_SNOVA_60_10_4_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/uov/sig_uov_ov_III.c
+++ b/src/sig/uov/sig_uov_ov_III.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_uov_ov_III)
 OQS_SIG *OQS_SIG_uov_ov_III_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/uov/sig_uov_ov_III_pkc.c
+++ b/src/sig/uov/sig_uov_ov_III_pkc.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_uov_ov_III_pkc)
 OQS_SIG *OQS_SIG_uov_ov_III_pkc_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/uov/sig_uov_ov_III_pkc_skc.c
+++ b/src/sig/uov/sig_uov_ov_III_pkc_skc.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_uov_ov_III_pkc_skc)
 OQS_SIG *OQS_SIG_uov_ov_III_pkc_skc_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/uov/sig_uov_ov_Ip.c
+++ b/src/sig/uov/sig_uov_ov_Ip.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_uov_ov_Ip)
 OQS_SIG *OQS_SIG_uov_ov_Ip_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/uov/sig_uov_ov_Ip_pkc.c
+++ b/src/sig/uov/sig_uov_ov_Ip_pkc.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_uov_ov_Ip_pkc)
 OQS_SIG *OQS_SIG_uov_ov_Ip_pkc_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/uov/sig_uov_ov_Ip_pkc_skc.c
+++ b/src/sig/uov/sig_uov_ov_Ip_pkc_skc.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_uov_ov_Ip_pkc_skc)
 OQS_SIG *OQS_SIG_uov_ov_Ip_pkc_skc_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/uov/sig_uov_ov_Is.c
+++ b/src/sig/uov/sig_uov_ov_Is.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_uov_ov_Is)
 OQS_SIG *OQS_SIG_uov_ov_Is_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/uov/sig_uov_ov_Is_pkc.c
+++ b/src/sig/uov/sig_uov_ov_Is_pkc.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_uov_ov_Is_pkc)
 OQS_SIG *OQS_SIG_uov_ov_Is_pkc_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/uov/sig_uov_ov_Is_pkc_skc.c
+++ b/src/sig/uov/sig_uov_ov_Is_pkc_skc.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_uov_ov_Is_pkc_skc)
 OQS_SIG *OQS_SIG_uov_ov_Is_pkc_skc_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/uov/sig_uov_ov_V.c
+++ b/src/sig/uov/sig_uov_ov_V.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_uov_ov_V)
 OQS_SIG *OQS_SIG_uov_ov_V_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/uov/sig_uov_ov_V_pkc.c
+++ b/src/sig/uov/sig_uov_ov_V_pkc.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_uov_ov_V_pkc)
 OQS_SIG *OQS_SIG_uov_ov_V_pkc_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig/uov/sig_uov_ov_V_pkc_skc.c
+++ b/src/sig/uov/sig_uov_ov_V_pkc_skc.c
@@ -7,7 +7,7 @@
 #if defined(OQS_ENABLE_SIG_uov_ov_V_pkc_skc)
 OQS_SIG *OQS_SIG_uov_ov_V_pkc_skc_new(void) {
 
-	OQS_SIG *sig = OQS_MEM_malloc(sizeof(OQS_SIG));
+	OQS_SIG *sig = OQS_MEM_calloc(1, sizeof(OQS_SIG));
 	if (sig == NULL) {
 		return NULL;
 	}

--- a/src/sig_stfl/lms/sig_stfl_lms.c
+++ b/src/sig_stfl/lms/sig_stfl_lms.c
@@ -70,7 +70,7 @@ static void OQS_SECRET_KEY_LMS_set_store_cb(OQS_SIG_STFL_SECRET_KEY *sk, secure_
 #define LMS_ALG(lms_variant, LMS_VARIANT) \
 OQS_SIG_STFL *OQS_SIG_STFL_alg_lms_##lms_variant##_new(void) { \
 \
-        OQS_SIG_STFL *sig = (OQS_SIG_STFL *)OQS_MEM_malloc(sizeof(OQS_SIG_STFL)); \
+        OQS_SIG_STFL *sig = (OQS_SIG_STFL *)OQS_MEM_calloc(1, sizeof(OQS_SIG_STFL)); \
         if (sig == NULL) { \
                 return NULL; \
         } \
@@ -104,7 +104,7 @@ OQS_STATUS OQS_SIG_STFL_alg_lms_##lms_variant##_keypair(uint8_t *public_key, OQS
 \
 OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_LMS_##LMS_VARIANT##_new(void) {\
 \
-        OQS_SIG_STFL_SECRET_KEY *sk = OQS_MEM_malloc(sizeof(OQS_SIG_STFL_SECRET_KEY));\
+        OQS_SIG_STFL_SECRET_KEY *sk = OQS_MEM_calloc(1, sizeof(OQS_SIG_STFL_SECRET_KEY));\
         if (sk == NULL) {\
                 return NULL;\
         }\

--- a/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_secret_key_functions.c
@@ -14,7 +14,7 @@
 extern inline OQS_SIG_STFL_SECRET_KEY *OQS_SECRET_KEY_XMSS_new(size_t length_secret_key) {
 
 	// Initialize the secret key in the heap with adequate memory
-	OQS_SIG_STFL_SECRET_KEY *sk = OQS_MEM_malloc(sizeof(OQS_SIG_STFL_SECRET_KEY));
+	OQS_SIG_STFL_SECRET_KEY *sk = OQS_MEM_calloc(1, sizeof(OQS_SIG_STFL_SECRET_KEY));
 	if (sk == NULL) {
 		return NULL;
 	}

--- a/src/sig_stfl/xmss/sig_stfl_xmss_xmssmt.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_xmssmt.c
@@ -30,7 +30,7 @@
 #define XMSS_ALG(mt, xmss_v, XMSS_V) \
 OQS_SIG_STFL *OQS_SIG_STFL_alg_xmss##xmss_v##_new(void) { \
 \
-        OQS_SIG_STFL *sig = (OQS_SIG_STFL *)OQS_MEM_malloc(sizeof(OQS_SIG_STFL)); \
+        OQS_SIG_STFL *sig = (OQS_SIG_STFL *)OQS_MEM_calloc(1, sizeof(OQS_SIG_STFL)); \
         if (sig == NULL) { \
                 return NULL; \
         } \


### PR DESCRIPTION
The six NTRU KEM constructors (hps2048509, hps2048677, hps4096821, hps40961229, hrss701, hrss1373) did not initialize the encaps_derand function pointer in OQS_KEM, and OQS_KEM_encaps_derand did not guard against a NULL function pointer. Calling OQS_KEM_encaps_derand on an NTRU KEM dereferenced uninitialized heap memory, causing a crash.

Three layers of fix:

1. Add explicit OQS_KEM_ntru_<scheme>_encaps_derand stubs returning OQS_ERROR (matching the existing keypair_derand stubs), and wire them into the NTRU constructors.

2. NULL-check the function pointer in all five OQS_KEM_* API wrappers in src/kem/kem.c as defense in depth against future omissions.

3. Switch all KEM constructors from OQS_MEM_malloc to OQS_MEM_calloc so any unset field is guaranteed NULL, making the API NULL check reliable. The jinja template in scripts/copy_from_upstream is updated to match.

Reported by Arthur Chan of Ada Logics on behalf of Anthropic.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [NO] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [NO] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged. Also, make sure to update the list of algorithms in the continuous benchmarking files: .github/workflows/kem-bench.yml and sig-bench.yml)

<!-- If this contribution (code, documentation, descriptive text) was produced with the help of generative AI, please describe the nature of the use. Contributors are expected to have verified and affirm such contributions themselves before submission. -->

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
