### PR TITLE
Switch linux_x86_emulated to download Intel SDE from alternative source

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -277,6 +277,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v4
       - name: Setup Intel SDE
         # TODO: one day we will automate the checksum. For now, just inspect visually
+        #   source: https://www.intel.com/content/www/us/en/download/684897/850782/intel-software-development-emulator.html
         run: |
           wget -O sde-external-9.53.0-2025-03-16-lin.tar.xz "$SDE_URL" && \
             sha256sum sde-external-9.53.0-2025-03-16-lin.tar.xz && \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -271,8 +271,7 @@ jobs:
             PYTEST_ARGS: tests/test_hash.py::test_sha3 tests/test_kat.py tests/test_acvp_vectors.py
     env:
       # NOTE: https://downloadmirror.intel.com returns 202 and an empty file
-      # SDE_URL: https://downloadmirror.intel.com/850782/sde-external-9.53.0-2025-03-16-lin.tar.xz
-      SDE_URL: https://raw.githubusercontent.com/open-quantum-safe/ci-containers/refs/heads/main/intel-sde/sde-external-9.53.0-2025-03-16-lin.tar.xz
+      SDE_URL: https://api.github.com/repos/open-quantum-safe/ci-containers/contents/intel-sde/sde-external-9.53.0-2025-03-16-lin.tar.xz
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v4
@@ -281,7 +280,7 @@ jobs:
       #   https://www.intel.com/content/www/us/en/download/684897/850782/intel-software-development-emulator.html
         run: |
           set -e && \
-          wget -O sde-external-9.53.0-2025-03-16-lin.tar.xz "$SDE_URL" && \
+          wget --header="Accept: application/vnd.github.raw+json" "$SDE_URL" && \
             sha256sum sde-external-9.53.0-2025-03-16-lin.tar.xz > lhs && \
             echo "f55138df53378198e8c0a89598351cdb3c5e7f8819e63e472b0bc179afaad34c  sde-external-9.53.0-2025-03-16-lin.tar.xz" > rhs && \
             diff lhs rhs && \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -281,7 +281,7 @@ jobs:
           wget -O sde-external-9.53.0-2025-03-16-lin.tar.xz "$SDE_URL" && \
             sha256sum sde-external-9.53.0-2025-03-16-lin.tar.xz && \
             echo "Expected sha256 checksum: f55138df53378198e8c0a89598351cdb3c5e7f8819e63e472b0bc179afaad34c" && \
-            mkdir sde && tar -xf sde.tar.xz -C sde --strip-components=1 && \
+            mkdir sde && tar -xf sde-external-9.53.0-2025-03-16-lin.tar.xz -C sde --strip-components=1 && \
             echo "$(pwd)/sde" >> $GITHUB_PATH
       - name: Configure
         run: mkdir build && cd build && cmake -GNinja ${{ matrix.CMAKE_ARGS }} .. && cmake -LA -N ..

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -270,7 +270,8 @@ jobs:
             CMAKE_ARGS: -DOQS_MINIMAL_BUILD="KEM_ml_kem_512;KEM_ml_kem_768;KEM_ml_kem_1024;SIG_ml_dsa_44;SIG_ml_dsa_65;SIG_ml_dsa_87"
             PYTEST_ARGS: tests/test_hash.py::test_sha3 tests/test_kat.py tests/test_acvp_vectors.py
     env:
-      SDE_URL: https://downloadmirror.intel.com/850782/sde-external-9.53.0-2025-03-16-lin.tar.xz
+      # SDE_URL: https://downloadmirror.intel.com/850782/sde-external-9.53.0-2025-03-16-lin.tar.xz
+      SDE_URL: https://raw.githubusercontent.com/open-quantum-safe/ci-containers/refs/heads/fix/host-intel-sde-9.53.0/intel-sde/sde-external-9.53.0-2025-03-16-lin.tar.xz
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -276,8 +276,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v4
       - name: Setup Intel SDE
+        # TODO: one day we will automate the checksum. For now, just inspect visually
         run: |
-          wget -O sde.tar.xz "$SDE_URL" && \
+          wget -O sde-external-9.53.0-2025-03-16-lin.tar.xz "$SDE_URL" && \
+            sha256sum sde-external-9.53.0-2025-03-16-lin.tar.xz && \
+            echo "Expected sha256 checksum: f55138df53378198e8c0a89598351cdb3c5e7f8819e63e472b0bc179afaad34c" && \
             mkdir sde && tar -xf sde.tar.xz -C sde --strip-components=1 && \
             echo "$(pwd)/sde" >> $GITHUB_PATH
       - name: Configure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -276,12 +276,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v4
       - name: Setup Intel SDE
-        # TODO: one day we will automate the checksum. For now, just inspect visually
-        #   source: https://www.intel.com/content/www/us/en/download/684897/850782/intel-software-development-emulator.html
+      # NOTE: source of checksum:
+      #   https://www.intel.com/content/www/us/en/download/684897/850782/intel-software-development-emulator.html
         run: |
+          set -e && \
           wget -O sde-external-9.53.0-2025-03-16-lin.tar.xz "$SDE_URL" && \
-            sha256sum sde-external-9.53.0-2025-03-16-lin.tar.xz && \
-            echo "Expected sha256 checksum: f55138df53378198e8c0a89598351cdb3c5e7f8819e63e472b0bc179afaad34c" && \
+            sha256sum sde-external-9.53.0-2025-03-16-lin.tar.xz > lhs && \
+            echo "f55138df53378198e8c0a89598351cdb3c5e7f8819e63e472b0bc179afaad34c  sde-external-9.53.0-2025-03-16-lin.tar.xz" > rhs && \
+            diff lhs rhs && \
             mkdir sde && tar -xf sde-external-9.53.0-2025-03-16-lin.tar.xz -C sde --strip-components=1 && \
             echo "$(pwd)/sde" >> $GITHUB_PATH
       - name: Configure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -270,8 +270,9 @@ jobs:
             CMAKE_ARGS: -DOQS_MINIMAL_BUILD="KEM_ml_kem_512;KEM_ml_kem_768;KEM_ml_kem_1024;SIG_ml_dsa_44;SIG_ml_dsa_65;SIG_ml_dsa_87"
             PYTEST_ARGS: tests/test_hash.py::test_sha3 tests/test_kat.py tests/test_acvp_vectors.py
     env:
+      # NOTE: https://downloadmirror.intel.com returns 202 and an empty file
       # SDE_URL: https://downloadmirror.intel.com/850782/sde-external-9.53.0-2025-03-16-lin.tar.xz
-      SDE_URL: https://raw.githubusercontent.com/open-quantum-safe/ci-containers/refs/heads/fix/host-intel-sde-9.53.0/intel-sde/sde-external-9.53.0-2025-03-16-lin.tar.xz
+      SDE_URL: https://raw.githubusercontent.com/open-quantum-safe/ci-containers/refs/heads/main/intel-sde/sde-external-9.53.0-2025-03-16-lin.tar.xz
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v4


### PR DESCRIPTION
This pull request fixes #2461

## Summary

A copy of Intel SDE 9.53.0 will be checked into open-quantum-safe/ci-containers. After that, `linux_x86_emulated` will switch to download the SDE from the aforementioned repository instead of <https://mirrordownload.intel.com>.

I also added a step in the job to facilitate visually checking the SHA256 checksum of the SDE.

* [NO] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [NO] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged. Also, make sure to update the list of algorithms in the continuous benchmarking files: .github/workflows/kem-bench.yml and sig-bench.yml)