### PR TITLE
Suppress McEliece memcheck errors, remove legacy HQC constant-time test

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -73,30 +73,6 @@ jobs:
         timeout-minutes: 360
         run: mkdir -p tmp && python3 -m pytest --verbose ${{ matrix.PYTEST_ARGS }}
 
-  regression:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: GHSA-qq3m-rq9v-jfgm
-            container: openquantumsafe/ci-ubuntu-latest:latest
-            CMAKE_ARGS: -DCMAKE_BUILD_TYPE=Debug -DOQS_ENABLE_TEST_CONSTANT_TIME=ON -DOQS_ENABLE_TEST_CONSTANT_TIME_OPTIMIZED=ON -DOQS_ENABLE_KEM_HQC=ON -DCMAKE_C_COMPILER=clang-18
-            PYTEST_ARGS: --numprocesses=auto -k 'hqc and constant_time'
-    container:
-      image: ${{ matrix.container }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v4
-      - name: Configure
-        run: mkdir build && cd build && cmake -GNinja ${{ matrix.CMAKE_ARGS }} .. && cmake -LA -N ..
-      - name: Build
-        run: ninja
-        working-directory: build
-      - name: Run tests
-        timeout-minutes: 360
-        run: mkdir -p tmp && python3 -m pytest --verbose ${{ matrix.PYTEST_ARGS }}
-
   slhdsa-leak-tests:
     strategy:
       fail-fast: false

--- a/tests/constant_time/kem/issues/classic-mceliece-348864
+++ b/tests/constant_time/kem/issues/classic-mceliece-348864
@@ -1,25 +1,24 @@
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Value8
-   src:pk_gen.c:161
-   # fun:to_bitslicing_2x
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE348864_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE348864_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:pk_gen.c:159
-   # fun:to_bitslicing_2x
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE348864_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE348864_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:pk_gen.c:156
-   # fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE348864_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE348864_AVX2_crypto_kem_keypair
 }
 
 {

--- a/tests/constant_time/kem/issues/classic-mceliece-348864f
+++ b/tests/constant_time/kem/issues/classic-mceliece-348864f
@@ -1,25 +1,46 @@
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Value8
-   src:pk_gen.c:201
-   # fun:to_bitslicing_2x
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE348864F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE348864F_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:pk_gen.c:199
-   # fun:to_bitslicing_2x
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE348864F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE348864F_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:pk_gen.c:196
-   # fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE348864F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE348864F_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE348864F_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Value8
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE348864F_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   fun:vec256_cswap
+   fun:PQCLEAN_MCELIECE348864F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE348864F_AVX2_crypto_kem_keypair
 }
 
 {

--- a/tests/constant_time/kem/issues/classic-mceliece-460896
+++ b/tests/constant_time/kem/issues/classic-mceliece-460896
@@ -1,25 +1,46 @@
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Value8
-   src:pk_gen.c:35
-   # fun:extract_01_masks
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE460896_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE460896_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   fun:to_bitslicing_2x
+   fun:PQCLEAN_MCELIECE460896_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE460896_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   fun:PQCLEAN_MCELIECE460896_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE460896_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   fun:vec256_cswap
+   fun:PQCLEAN_MCELIECE460896_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE460896_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE460896_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Value8
-   src:pk_gen.c:43
-   # fun:extract_mask256
-   fun:PQCLEAN_MCELIECE460896_AVX2_pk_gen
-}
-
-{
-   This implementation of Classic McEliece may not be constant time.
-   Memcheck:Value8
-   src:pk_gen.c:162
-   # fun:to_bitslicing_2x
-   fun:PQCLEAN_MCELIECE460896_AVX2_pk_gen
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE460896_AVX2_crypto_kem_keypair
 }
 
 {

--- a/tests/constant_time/kem/issues/classic-mceliece-460896f
+++ b/tests/constant_time/kem/issues/classic-mceliece-460896f
@@ -1,25 +1,46 @@
 {
    This implementation of Classic McEliece may not be constant time.
+   Memcheck:Value8
+   fun:to_bitslicing_2x
+   fun:PQCLEAN_MCELIECE460896F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE460896F_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:util.h:16
-   # fun:store_i
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE460896F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE460896F_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   fun:PQCLEAN_MCELIECE460896F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE460896F_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   fun:vec256_cswap
+   fun:PQCLEAN_MCELIECE460896F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE460896F_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE460896F_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Value8
-   src:util.h:17
-   # fun:store_i
-   fun:PQCLEAN_MCELIECE460896F_AVX2_pk_gen
-}
-
-{
-   This implementation of Classic McEliece may not be constant time.
-   Memcheck:Value8
-   src:pk_gen.c:200
-   # fun:to_bitslicing_2x
-   fun:PQCLEAN_MCELIECE460896F_AVX2_pk_gen
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE460896F_AVX2_crypto_kem_keypair
 }
 
 {

--- a/tests/constant_time/kem/issues/classic-mceliece-6688128
+++ b/tests/constant_time/kem/issues/classic-mceliece-6688128
@@ -1,25 +1,46 @@
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Value8
-   src:pk_gen.c:162
-   # fun:to_bitslicing_2x
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE6688128_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE6688128_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:pk_gen.c:160
-   # fun:to_bitslicing_2x
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE6688128_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE6688128_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:pk_gen.c:157
-   # fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE6688128_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE6688128_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   fun:vec256_cswap
+   fun:PQCLEAN_MCELIECE6688128_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE6688128_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE6688128_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Value8
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE6688128_AVX2_crypto_kem_keypair
 }
 
 {

--- a/tests/constant_time/kem/issues/classic-mceliece-6688128f
+++ b/tests/constant_time/kem/issues/classic-mceliece-6688128f
@@ -1,25 +1,46 @@
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Value8
-   src:pk_gen.c:200
-   # fun:to_bitslicing_2x
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE6688128F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE6688128F_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:pk_gen.c:198
-   # fun:to_bitslicing_2x
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE6688128F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE6688128F_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:pk_gen.c:195
-   # fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE6688128F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE6688128F_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   fun:vec256_cswap
+   fun:PQCLEAN_MCELIECE6688128F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE6688128F_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE6688128F_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Value8
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE6688128F_AVX2_crypto_kem_keypair
 }
 
 {

--- a/tests/constant_time/kem/issues/classic-mceliece-6960119
+++ b/tests/constant_time/kem/issues/classic-mceliece-6960119
@@ -1,25 +1,46 @@
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Value8
-   src:pk_gen.c:162
-   # fun:to_bitslicing_2x
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE6960119_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE6960119_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:pk_gen.c:160
-   # fun:to_bitslicing_2x
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE6960119_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE6960119_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:pk_gen.c:157
-   # fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE6960119_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE6960119_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   fun:vec256_cswap
+   fun:PQCLEAN_MCELIECE6960119_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE6960119_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE6960119_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Value8
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE6960119_AVX2_crypto_kem_keypair
 }
 
 {

--- a/tests/constant_time/kem/issues/classic-mceliece-6960119f
+++ b/tests/constant_time/kem/issues/classic-mceliece-6960119f
@@ -1,25 +1,46 @@
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Value8
-   src:pk_gen.c:200
-   # fun:to_bitslicing_2x
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE6960119F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE6960119F_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:pk_gen.c:198
-   # fun:to_bitslicing_2x
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE6960119F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE6960119F_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:pk_gen.c:195
-   # fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE6960119F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE6960119F_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   fun:vec256_cswap
+   fun:PQCLEAN_MCELIECE6960119F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE6960119F_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE6960119F_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Value8
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE6960119F_AVX2_crypto_kem_keypair
 }
 
 {

--- a/tests/constant_time/kem/issues/classic-mceliece-8192128
+++ b/tests/constant_time/kem/issues/classic-mceliece-8192128
@@ -1,25 +1,46 @@
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Value8
-   src:pk_gen.c:162
-   # fun:to_bitslicing_2x
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE8192128_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE8192128_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:pk_gen.c:160
-   # fun:to_bitslicing_2x
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE8192128_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE8192128_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:pk_gen.c:157
-   # fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE8192128_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE8192128_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   fun:vec256_cswap
+   fun:PQCLEAN_MCELIECE8192128_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE8192128_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE8192128_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Value8
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE8192128_AVX2_crypto_kem_keypair
 }
 
 {

--- a/tests/constant_time/kem/issues/classic-mceliece-8192128f
+++ b/tests/constant_time/kem/issues/classic-mceliece-8192128f
@@ -1,25 +1,46 @@
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Value8
-   src:pk_gen.c:200
-   # fun:to_bitslicing_2x
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE8192128F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE8192128F_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:pk_gen.c:198
-   # fun:to_bitslicing_2x
+   fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE8192128F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE8192128F_AVX2_crypto_kem_keypair
 }
 
 {
    This implementation of Classic McEliece may not be constant time.
    Memcheck:Cond
-   src:pk_gen.c:195
-   # fun:to_bitslicing_2x
    fun:PQCLEAN_MCELIECE8192128F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE8192128F_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   fun:vec256_cswap
+   fun:PQCLEAN_MCELIECE8192128F_AVX2_pk_gen
+   fun:PQCLEAN_MCELIECE8192128F_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Cond
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE8192128F_AVX2_crypto_kem_keypair
+}
+
+{
+   This implementation of Classic McEliece may not be constant time.
+   Memcheck:Value8
+   src:vec256_mul_asm.S
+   fun:PQCLEAN_MCELIECE8192128F_AVX2_crypto_kem_keypair
 }
 
 {


### PR DESCRIPTION
This pull request fixes #2436.

Recent weekly test failures are likely attributed to GCC version change. The last good weekly test used GCC 13, and the first failed weekly test used GCC 15. I've checked with different versions of Valgrind and earlier commits of liboqs while using GCC 15 and got the same memcheck errors as in the failed weekly tests.

Here is the list of functions added to the list of suppressed memcheck errors:
- `to_bitslicing_2x` when called by `XXX_AVX2_pk_gen`
- Everything in `vec256_mul_asm.S`
- `vec256_cswap` when called by `XXX_AVX2_pk_gen`

It is admittedly not ideal to blindly suppress memcheck errors just to make them go away, but given that PQClean was archived and we will be moving to an alternative upstream for Classic McEliece, I think it acceptable for let it slip for this time.

Additionally, after #2407 merges, the regression constant-time tests for HQC are no longer necessary since HQC will be enabled by default and participate in the "regular" constant-time tests. They are removed. Log from local runs of Valgrind memcheck tests on HQC is attached below:

[hqc-valgrind.log](https://github.com/user-attachments/files/29054284/hqc-valgrind.log)

* [NO] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [NO] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged. Also, make sure to update the list of algorithms in the continuous benchmarking files: .github/workflows/kem-bench.yml and sig-bench.yml)
