### PR TITLE
Document imported implementation status contract

### DIFF
--- a/scripts/copy_from_upstream/README.md
+++ b/scripts/copy_from_upstream/README.md
@@ -92,6 +92,19 @@ implementations:
         required_flags: [avx2]
 ```
 
+### Return Value Contract
+
+The generated KEM and signature dispatchers cast implementation return values
+to `OQS_STATUS`. Every implementation entry point invoked by a generated
+dispatcher, whether named explicitly in `META.yml` or selected by convention,
+must therefore return a documented `OQS_STATUS` value. In particular,
+successful operations return `OQS_SUCCESS` and generic failures return
+`OQS_ERROR`. An upstream whose native API uses different status codes must
+translate them in the upstream integration layer before exposing the entry
+point to liboqs. An integration-specific wrapper referenced by `META.yml` is one
+way to do so. Native status values not defined by `OQS_STATUS` must not reach a
+generated dispatcher.
+
 ### Common Dependencies
 
 Shared code used by multiple implementations is declared in a commons YAML file (referenced by `common_meta_path` in the upstream entry):

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -157,6 +157,12 @@ extern "C" {
 /**
  * Represents return values from functions.
  *
+ * Functions declared to return OQS_STATUS must return one of the values below.
+ * Algorithm implementations imported into liboqs must return OQS_SUCCESS on
+ * success and OQS_ERROR for generic failures. Implementations with their own
+ * status codes must translate them in the upstream integration layer before
+ * exposing the function to liboqs.
+ *
  * Callers should compare with the symbol rather than the individual value.
  * For example,
  *


### PR DESCRIPTION
## summary

Documents the algorithm-independent return-value contract for imported KEM and signature implementations

The generated dispatchers expose implementation results as `OQS_STATUS`. Imported entry points now explicitly need to return a documented status, using `OQS_SUCCESS` for success and `OQS_ERROR` for generic failures. Upstreams with native status codes need to translate them in their integration layer before those values reach liboqs

This replaces the earlier ML-KEM-specific template change with the general contract discussed in review. It gives mlkem-native a documented integration target without adding source-specific logic to the generic generators

Refs #2437

## testing

- `git diff --check`
- `python3 -m pytest --verbose tests/test_code_conventions.py` in `openquantumsafe/ci-ubuntu-latest:latest` (`265 passed, 3 skipped`)
- `cmake -B /build -GNinja -DOQS_STRICT_WARNINGS=ON -DOQS_MINIMAL_BUILD="KEM_ml_kem_768;SIG_ml_dsa_65" --warn-uninitialized .`
- `ninja -j2`
- `ninja -j2 gen_docs`
- `./scripts/run_doxygen.sh /usr/bin/doxygen ./docs/.Doxyfile /build`
- `./scripts/validate_cbom.sh` in `openquantumsafe/ci-ubuntu-latest:latest`

## checklist

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm, i.e. known answer test values? No
* [ ] Does this PR change the list of algorithms available, or otherwise change an API? No

## AI use

the idea and final direction were mine. i used AI assistance mostly for autocomplete-style edits, checking a few local paths, and helping run local checks. i reviewed the final diff and test results myself before submitting this
