### PR TITLE
Add parantheses around the use of sizeof operator

### DIFF
--- a/tests/test_helpers.c
+++ b/tests/test_helpers.c
@@ -203,7 +203,7 @@ OQS_STATUS test_sig_bitflip(OQS_SIG *sig, uint8_t *message, size_t message_len, 
 			} else {
 				rc = OQS_SIG_verify(sig, message, message_len, signature, signature_len, public_key);
 			}
-			OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+			OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 			if (rc != OQS_ERROR) {
 				fprintf(stderr, "ERROR: OQS_SIG_verify should have failed after flipping bit %llu of the %s!\n", (unsigned long long)bit_index, (test == 0) ? "message" : "signature");
 				return OQS_ERROR;
@@ -243,7 +243,7 @@ OQS_STATUS test_sig_stfl_bitflip(OQS_SIG_STFL *sig, uint8_t *message, size_t mes
 			}
 			/* check that the verification fails */
 			rc = OQS_SIG_STFL_verify(sig, message, message_len, signature, signature_len, public_key);
-			OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+			OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 			if (rc != OQS_ERROR) {
 				fprintf(stderr, "ERROR: OQS_SIG_STFL_verify should have failed after flipping bit %llu of the %s!\n", (unsigned long long)bit_index, (test == 0) ? "message" : "signature");
 				return OQS_ERROR;

--- a/tests/test_kem.c
+++ b/tests/test_kem.c
@@ -57,7 +57,7 @@ static bool mlkem_rej_testcase(OQS_KEM *kem, uint8_t *ciphertext, uint8_t *secre
 	// Calculate expected secret in case of corrupted cipher: shake256(z || c)
 	OQS_SHA3_shake256(shared_secret_r, MLKEM_SECRET_LEN, buff_z_c, length_z_c);
 	rc = OQS_KEM_decaps(kem, shared_secret_d, ciphertext, secret_key);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_KEM_decaps failed for rejection testcase scenario 1\n");
 		goto cleanup;
@@ -82,7 +82,7 @@ static bool mlkem_rej_testcase(OQS_KEM *kem, uint8_t *ciphertext, uint8_t *secre
 	// Calculate expected secret in case of corrupted cipher: shake256(z || c)
 	OQS_SHA3_shake256(shared_secret_r, MLKEM_SECRET_LEN, buff_z_c, length_z_c);
 	rc = OQS_KEM_decaps(kem, shared_secret_d, ciphertext, secret_key);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_KEM_decaps failed for rejection testcase scenario 2\n");
 		goto cleanup;
@@ -201,7 +201,7 @@ static OQS_STATUS kem_test_correctness(const char *method_name, bool derand) {
 			OQS_randombytes(keypair_seed, kem->length_keypair_seed);
 		}
 		rc = OQS_KEM_keypair_derand(kem, public_key, secret_key, keypair_seed);
-		OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+		OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 		if (kem->length_keypair_seed == 0) {
 			// If length_keypair_seed is set to 0 for this KEM scheme, a failure is expected
 			if (rc != OQS_ERROR) {
@@ -219,7 +219,7 @@ static OQS_STATUS kem_test_correctness(const char *method_name, bool derand) {
 		}
 	} else {
 		rc = OQS_KEM_keypair(kem, public_key, secret_key);
-		OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+		OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 		if (rc != OQS_SUCCESS) {
 			fprintf(stderr, "ERROR: OQS_KEM_keypair failed\n");
 			goto err;
@@ -233,7 +233,7 @@ static OQS_STATUS kem_test_correctness(const char *method_name, bool derand) {
 			OQS_randombytes(encaps_seed, kem->length_encaps_seed);
 		}
 		rc = OQS_KEM_encaps_derand(kem, ciphertext, shared_secret_e, public_key, encaps_seed);
-		OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+		OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 		if (kem->length_encaps_seed == 0) {
 			// If length_encaps_seed is set to 0 for this KEM scheme, a failure is expected
 			if (rc != OQS_ERROR) {
@@ -251,7 +251,7 @@ static OQS_STATUS kem_test_correctness(const char *method_name, bool derand) {
 		}
 	} else {
 		rc = OQS_KEM_encaps(kem, ciphertext, shared_secret_e, public_key);
-		OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+		OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 		if (rc != OQS_SUCCESS) {
 			fprintf(stderr, "ERROR: OQS_KEM_encaps failed\n");
 			goto err;
@@ -260,7 +260,7 @@ static OQS_STATUS kem_test_correctness(const char *method_name, bool derand) {
 
 	OQS_TEST_CT_DECLASSIFY(ciphertext, kem->length_ciphertext);
 	rc = OQS_KEM_decaps(kem, shared_secret_d, ciphertext, secret_key);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_KEM_decaps failed\n");
 		goto err;
@@ -290,7 +290,7 @@ static OQS_STATUS kem_test_correctness(const char *method_name, bool derand) {
 	OQS_TEST_CT_DECLASSIFY(ciphertext, kem->length_ciphertext);
 	rc = OQS_KEM_decaps(kem, shared_secret_d, ciphertext, secret_key);
 	OQS_TEST_CT_DECLASSIFY(shared_secret_d, kem->length_shared_secret);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc == OQS_SUCCESS && memcmp(shared_secret_e, shared_secret_d, kem->length_shared_secret) == 0) {
 		fprintf(stderr, "ERROR: OQS_KEM_decaps succeeded on wrong input\n");
 		goto err;

--- a/tests/test_sig.c
+++ b/tests/test_sig.c
@@ -98,14 +98,14 @@ static OQS_STATUS sig_test_correctness(const char *method_name, bool bitflips_al
 	OQS_TEST_CT_DECLASSIFY(message, message_len);
 
 	rc = OQS_SIG_keypair(sig, public_key, secret_key);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_SIG_keypair failed\n");
 		goto err;
 	}
 
 	rc = OQS_SIG_sign(sig, signature, &signature_len, message, message_len, secret_key);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_SIG_sign failed\n");
 		goto err;
@@ -114,7 +114,7 @@ static OQS_STATUS sig_test_correctness(const char *method_name, bool bitflips_al
 	OQS_TEST_CT_DECLASSIFY(public_key, sig->length_public_key);
 	OQS_TEST_CT_DECLASSIFY(signature, signature_len);
 	rc = OQS_SIG_verify(sig, message, message_len, signature, signature_len, public_key);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_SIG_verify failed\n");
 		goto err;
@@ -122,7 +122,7 @@ static OQS_STATUS sig_test_correctness(const char *method_name, bool bitflips_al
 
 	if (extended_tests) {
 		rc = test_sig_bitflip(sig, message, message_len, signature, signature_len, public_key, bitflips_all, bitflips, false, NULL, 0);
-		OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+		OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 		if (rc != OQS_SUCCESS) {
 			goto err;
 		}
@@ -139,7 +139,7 @@ static OQS_STATUS sig_test_correctness(const char *method_name, bool bitflips_al
 		for (size_t i = 0; i < 256; ++i) {
 			if (((i % ctx_step == 0) && extended_tests) || i == 255) {
 				rc = OQS_SIG_sign_with_ctx_str(sig, signature, &signature_len, message, message_len, ctx, i, secret_key);
-				OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+				OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 				if (rc != OQS_SUCCESS) {
 					fprintf(stderr, "ERROR: OQS_SIG_sign_with_ctx_str failed\n");
 					goto err;
@@ -148,7 +148,7 @@ static OQS_STATUS sig_test_correctness(const char *method_name, bool bitflips_al
 				OQS_TEST_CT_DECLASSIFY(public_key, sig->length_public_key);
 				OQS_TEST_CT_DECLASSIFY(signature, signature_len);
 				rc = OQS_SIG_verify_with_ctx_str(sig, message, message_len, signature, signature_len, ctx, i, public_key);
-				OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+				OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 				if (rc != OQS_SUCCESS) {
 					fprintf(stderr, "ERROR: OQS_SIG_verify_with_ctx_str failed\n");
 					goto err;
@@ -156,7 +156,7 @@ static OQS_STATUS sig_test_correctness(const char *method_name, bool bitflips_al
 
 				if (extended_tests) {
 					rc = test_sig_bitflip(sig, message, message_len, signature, signature_len, public_key, bitflips_all, bitflips, true, ctx, i);
-					OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+					OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 					if (rc != OQS_SUCCESS) {
 						goto err;
 					}
@@ -166,7 +166,7 @@ static OQS_STATUS sig_test_correctness(const char *method_name, bool bitflips_al
 
 		if (extended_tests) {
 			rc = OQS_SIG_sign_with_ctx_str(sig, signature, &signature_len, message, message_len, ctx, 256, secret_key);
-			OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+			OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 			if (rc != OQS_ERROR) {
 				fprintf(stderr, "ERROR: OQS_SIG_sign_with_ctx_str should only support up to 255 byte contexts\n");
 				goto err;
@@ -182,7 +182,7 @@ static OQS_STATUS sig_test_correctness(const char *method_name, bool bitflips_al
 
 	if (extended_tests) {
 		rc = OQS_SIG_sign_with_ctx_str(sig, signature, &signature_len, message, message_len, NULL, 0, secret_key);
-		OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+		OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 		if (rc != OQS_SUCCESS) {
 			fprintf(stderr, "ERROR: OQS_SIG_sign_with_ctx_str should always succeed when providing a NULL context string\n");
 			goto err;
@@ -190,14 +190,14 @@ static OQS_STATUS sig_test_correctness(const char *method_name, bool bitflips_al
 		OQS_TEST_CT_DECLASSIFY(public_key, sig->length_public_key);
 		OQS_TEST_CT_DECLASSIFY(signature, signature_len);
 		rc = OQS_SIG_verify_with_ctx_str(sig, message, message_len, signature, signature_len, NULL, 0, public_key);
-		OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+		OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 		if (rc != OQS_SUCCESS) {
 			fprintf(stderr, "ERROR: OQS_SIG_verify_with_ctx_str failed\n");
 			goto err;
 		}
 
 		rc = test_sig_bitflip(sig, message, message_len, signature, signature_len, public_key, bitflips_all, bitflips, true, NULL, 0);
-		OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+		OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 		if (rc != OQS_SUCCESS) {
 			goto err;
 		}

--- a/tests/test_sig_stfl.c
+++ b/tests/test_sig_stfl.c
@@ -199,7 +199,7 @@ OQS_STATUS sig_stfl_keypair_from_keygen(OQS_SIG_STFL *sig, uint8_t *public_key, 
 	OQS_STATUS rc;
 
 	rc = OQS_SIG_STFL_keypair(sig, public_key, secret_key);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		return OQS_ERROR;
 	}
@@ -567,7 +567,7 @@ static OQS_STATUS sig_stfl_test_correctness(const char *method_name, const char 
 	 * Some keypair generation is fast, so we only read keypair from KATs for slow XMSS parameters
 	 */
 	rc = sig_stfl_KATs_keygen(sig, public_key, secret_key, katfile);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_SIG_STFL_keypair failed\n");
 		goto err;
@@ -588,7 +588,7 @@ static OQS_STATUS sig_stfl_test_correctness(const char *method_name, const char 
 	}
 
 	rc = OQS_SIG_STFL_sign(sig, signature, &signature_len, message, message_len, secret_key);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_SIG_STFL_sign failed\n");
 		goto err;
@@ -597,7 +597,7 @@ static OQS_STATUS sig_stfl_test_correctness(const char *method_name, const char 
 	OQS_TEST_CT_DECLASSIFY(public_key, sig->length_public_key);
 	OQS_TEST_CT_DECLASSIFY(signature, signature_len);
 	rc = OQS_SIG_STFL_verify(sig, message, message_len, signature, signature_len, public_key);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: OQS_SIG_STFL_verify failed\n");
 		goto err;
@@ -609,13 +609,13 @@ static OQS_STATUS sig_stfl_test_correctness(const char *method_name, const char 
 		goto err;
 	}
 	rc = OQS_SIG_STFL_verify(sig, message, message_len, signature, signature_len, read_pk_buf);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: 2nd Verify with restored public key OQS_SIG_STFL_verify failed\n");
 	}
 
 	rc = test_sig_stfl_bitflip(sig, message, message_len, signature, signature_len, public_key, bitflips_all, bitflips);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		goto err;
 	}
@@ -836,7 +836,7 @@ static OQS_STATUS sig_stfl_test_query_key(const char *method_name) {
 	printf("================================================================================\n");
 
 	rc = OQS_SIG_STFL_verify(lock_test_sig_obj, message_1, message_len_1, signature_1, signature_len_1, lock_test_public_key);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: lock thread test OQS_SIG_STFL_verify failed\n");
 		goto err;
@@ -847,7 +847,7 @@ static OQS_STATUS sig_stfl_test_query_key(const char *method_name) {
 	printf("================================================================================\n");
 
 	rc = OQS_SIG_STFL_verify(lock_test_sig_obj, message_2, message_len_2, signature_2, signature_len_2, lock_test_public_key);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: lock thread test OQS_SIG_STFL_verify failed\n");
 		goto err;
@@ -910,7 +910,7 @@ static OQS_STATUS sig_stfl_test_sig_gen(const char *method_name) {
 	signature_1 = OQS_MEM_malloc(lock_test_sig_obj->length_signature);
 
 	rc = OQS_SIG_STFL_sign(lock_test_sig_obj, signature_1, &signature_len_1, message_1, message_len_1, lock_test_sk);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: lock thread test OQS_SIG_STFL_sign failed\n");
 		goto err;
@@ -939,7 +939,7 @@ static OQS_STATUS sig_stfl_test_sig_gen(const char *method_name) {
 	signature_2 = OQS_MEM_malloc(lock_test_sig_obj->length_signature);
 
 	rc = OQS_SIG_STFL_sign(lock_test_sig_obj, signature_2, &signature_len_2, message_2, message_len_2, lock_test_sk);
-	OQS_TEST_CT_DECLASSIFY(&rc, sizeof rc);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "ERROR: lock thread test OQS_SIG_STFL_sign failed\n");
 		goto err;


### PR DESCRIPTION
**Purpose**
This PR fixes a formatting issue with the use of the sizeof operator.
Basically surrounding the use of sizeof operator with parantheses.

**Checklist**
Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?
No. This PR just addresses a code formatting issue.

Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API?
No. This PR just addresses a code formatting issue.

