### PR TITLE
tests: Mark rc as public via declassification

### DIFF
--- a/tests/test_sig.c
+++ b/tests/test_sig.c
@@ -174,6 +174,7 @@ static OQS_STATUS sig_test_correctness(const char *method_name, bool bitflips_al
 		}
 	} else if (extended_tests) {
 		rc = OQS_SIG_sign_with_ctx_str(sig, signature, &signature_len, message, message_len, ctx, 1, secret_key);
+		OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 		if (rc != OQS_ERROR) {
 			fprintf(stderr, "ERROR: OQS_SIG_sign_with_ctx_str should fail without support for context strings\n");
 			goto err;

--- a/tests/test_sig_stfl.c
+++ b/tests/test_sig_stfl.c
@@ -708,7 +708,7 @@ static OQS_STATUS sig_stfl_test_secret_key(const char *method_name, const char *
 	printf("================================================================================\n");
 
 	rc = sig_stfl_KATs_keygen(sig_obj, public_key, sk, katfile);
-
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "OQS STFL key gen failed.\n");
 		goto err;
@@ -718,12 +718,14 @@ static OQS_STATUS sig_stfl_test_secret_key(const char *method_name, const char *
 	 * Get max num signature and the amount remaining
 	 */
 	rc = OQS_SIG_STFL_sigs_total((const OQS_SIG_STFL *)sig_obj, &max_num_sigs, (const OQS_SIG_STFL_SECRET_KEY *)sk);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "OQS STFL key: Failed to get max number of sig from %s.\n", method_name);
 		goto err;
 	}
 
 	rc = OQS_SIG_STFL_sigs_remaining((const OQS_SIG_STFL *)sig_obj, &num_sig_left, (const OQS_SIG_STFL_SECRET_KEY *)sk);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "OQS STFL key: Failed to get the remaining number of sig from %s.\n", method_name);
 		goto err;
@@ -769,7 +771,7 @@ static OQS_STATUS sig_stfl_test_secret_key(const char *method_name, const char *
 
 	context_2 = strdup(file_store_name);
 	rc = OQS_SIG_STFL_SECRET_KEY_deserialize(sk_from_file, from_file_sk_buf, from_file_sk_len, (void *)context_2);
-
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "OQS restore %s from file failed.\n", method_name);
 		goto err;
@@ -892,12 +894,14 @@ static OQS_STATUS sig_stfl_test_sig_gen(const char *method_name) {
 	 */
 	unsigned long long num_sig_left = 0, max_num_sigs = 0;
 	rc = OQS_SIG_STFL_sigs_total((const OQS_SIG_STFL *)lock_test_sig_obj, &max_num_sigs, (const OQS_SIG_STFL_SECRET_KEY *)lock_test_sk);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "OQS STFL key: Failed to get max number of sig from %s.\n", method_name);
 		goto err;
 	}
 
 	rc = OQS_SIG_STFL_sigs_remaining((const OQS_SIG_STFL *)lock_test_sig_obj, &num_sig_left, (const OQS_SIG_STFL_SECRET_KEY *)lock_test_sk);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "OQS STFL key: Failed to get the remaining number of sig from %s.\n", method_name);
 		goto err;
@@ -921,12 +925,14 @@ static OQS_STATUS sig_stfl_test_sig_gen(const char *method_name) {
 	 */
 	num_sig_left = 0, max_num_sigs = 0;
 	rc = OQS_SIG_STFL_sigs_total((const OQS_SIG_STFL *)lock_test_sig_obj, &max_num_sigs, (const OQS_SIG_STFL_SECRET_KEY *)lock_test_sk);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "OQS STFL key: Failed to get max number of sig from %s.\n", method_name);
 		goto err;
 	}
 
 	rc = OQS_SIG_STFL_sigs_remaining((const OQS_SIG_STFL *)lock_test_sig_obj, &num_sig_left, (const OQS_SIG_STFL_SECRET_KEY *)lock_test_sk);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "OQS STFL key: Failed to get the remaining number of sig from %s.\n", method_name);
 		goto err;
@@ -954,12 +960,14 @@ static OQS_STATUS sig_stfl_test_sig_gen(const char *method_name) {
 	 */
 	num_sig_left = 0, max_num_sigs = 0;
 	rc = OQS_SIG_STFL_sigs_total((const OQS_SIG_STFL *)lock_test_sig_obj, &max_num_sigs, (const OQS_SIG_STFL_SECRET_KEY *)lock_test_sk);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "OQS STFL key: Failed to get max number of sig from %s.\n", method_name);
 		goto err;
 	}
 
 	rc = OQS_SIG_STFL_sigs_remaining((const OQS_SIG_STFL *)lock_test_sig_obj, &num_sig_left, (const OQS_SIG_STFL_SECRET_KEY *)lock_test_sk);
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "OQS STFL key: Failed to get the remaining number of sig from %s.\n", method_name);
 		goto err;
@@ -1019,7 +1027,7 @@ static OQS_STATUS sig_stfl_test_secret_key_lock(const char *method_name, const c
 	printf("================================================================================\n");
 
 	rc = sig_stfl_KATs_keygen(lock_test_sig_obj, lock_test_public_key, lock_test_sk, katfile);
-
+	OQS_TEST_CT_DECLASSIFY(&rc, sizeof(rc));
 	if (rc != OQS_SUCCESS) {
 		fprintf(stderr, "OQS STFL key gen failed.\n");
 		goto err;


### PR DESCRIPTION
**Purpose**
Without the declassify call, Valgrind would report a false positive — flagging the if (rc != OQS_SUCCESS) check as secret-dependent control flow, when in reality the return code is intentionally a public value.

**Checklist**
Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  
No 
Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API?
No 

