### PR TITLE
Add bounded CBMC proofs for liboqs-owned code

### DIFF
--- a/tests/cbmc/README.md
+++ b/tests/cbmc/README.md
@@ -1,0 +1,32 @@
+# CBMC Proofs For Liboqs-Owned Code
+
+This directory contains bounded proofs for small API and utility functions that
+are implemented directly by liboqs. The proof set intentionally excludes copied
+or imported cryptographic implementations.
+
+Run the suite from the repository root:
+
+```sh
+tests/cbmc/run.sh
+```
+
+The runner writes safety results and companion assertion-coverage runs to
+`tests/cbmc/raw-runs/`. The checked-in results were produced with CBMC 6.9.0 at
+commit `d95fc734f5de9bdfc80c8c65d8166b30e9cff5cd`.
+
+| Proof | Owned source | Status |
+| --- | --- | --- |
+| `mem_secure_bcmp` | `src/common/common.c` | `PROVED_BOUNDED` |
+| `sig_status_normalization` | `src/sig/sig.c` | `PROVED_BOUNDED` |
+| `sig_stfl_dispatch_contract` | `src/sig_stfl/sig_stfl.c` | `PROVED_BOUNDED` |
+| `sig_stfl_lock_contract` | `src/sig_stfl/sig_stfl.c` | `PROVED_BOUNDED` |
+
+The model header disables every imported algorithm implementation while keeping
+the public `OQS_SIG` and full `OQS_SIG_STFL` layouts visible. This lets CBMC
+compile the real liboqs-owned translation units and reason about their wrapper
+control flow without claiming anything about algorithm internals.
+
+Every safety run uses bounds, pointer, pointer-overflow, division-by-zero,
+signed-overflow, and conversion checks with loop unwinding set to 5 and
+unwinding assertions enabled. The companion coverage runs are not proof
+statuses; they are kept to show that the harness assertions are reachable.

--- a/tests/cbmc/harnesses/mem_secure_bcmp_harness.c
+++ b/tests/cbmc/harnesses/mem_secure_bcmp_harness.c
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <oqs/oqs.h>
+
+#define OQS_CBMC_BCMP_MAX_LEN 4
+
+extern unsigned char nondet_uchar(void);
+extern size_t nondet_size_t(void);
+
+int main(void) {
+	uint8_t a[OQS_CBMC_BCMP_MAX_LEN];
+	uint8_t b[OQS_CBMC_BCMP_MAX_LEN];
+	uint8_t a_before[OQS_CBMC_BCMP_MAX_LEN];
+	uint8_t b_before[OQS_CBMC_BCMP_MAX_LEN];
+	size_t len = nondet_size_t();
+	int expected = 0;
+
+	__CPROVER_assume(len <= OQS_CBMC_BCMP_MAX_LEN);
+
+	for (size_t i = 0; i < OQS_CBMC_BCMP_MAX_LEN; i++) {
+		a[i] = nondet_uchar();
+		b[i] = nondet_uchar();
+		a_before[i] = a[i];
+		b_before[i] = b[i];
+	}
+
+	for (size_t i = 0; i < len; i++) {
+		if (a[i] != b[i]) {
+			expected = 1;
+		}
+	}
+
+	int result = OQS_MEM_secure_bcmp(a, b, len);
+
+	__CPROVER_assert(result == expected,
+	                 "secure_bcmp returns zero iff all bounded bytes match");
+	__CPROVER_assert(result == 0 || result == 1,
+	                 "secure_bcmp result is normalized to one bit");
+
+	for (size_t i = 0; i < OQS_CBMC_BCMP_MAX_LEN; i++) {
+		__CPROVER_assert(a[i] == a_before[i],
+		                 "secure_bcmp does not mutate left input");
+		__CPROVER_assert(b[i] == b_before[i],
+		                 "secure_bcmp does not mutate right input");
+	}
+
+	return 0;
+}

--- a/tests/cbmc/harnesses/sig_status_normalization_harness.c
+++ b/tests/cbmc/harnesses/sig_status_normalization_harness.c
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <oqs/oqs.h>
+
+extern _Bool nondet_bool(void);
+extern int nondet_int(void);
+extern size_t nondet_size_t(void);
+extern unsigned int nondet_uint(void);
+
+static unsigned int callback_calls;
+static OQS_STATUS callback_status;
+
+static uint8_t *expected_signature;
+static size_t *expected_signature_len;
+static const uint8_t *expected_message;
+static size_t expected_message_len;
+static const uint8_t *expected_ctx;
+static size_t expected_ctx_len;
+static uint8_t *expected_public_key;
+static const uint8_t *expected_secret_key;
+
+static OQS_STATUS model_keypair(uint8_t *public_key, uint8_t *secret_key) {
+	callback_calls++;
+	__CPROVER_assert(public_key == expected_public_key,
+	                 "keypair forwards public key pointer");
+	__CPROVER_assert(secret_key == expected_secret_key,
+	                 "keypair forwards secret key pointer");
+	return callback_status;
+}
+
+static OQS_STATUS model_sign(uint8_t *signature, size_t *signature_len,
+                             const uint8_t *message, size_t message_len,
+                             const uint8_t *secret_key) {
+	callback_calls++;
+	__CPROVER_assert(signature == expected_signature,
+	                 "sign forwards signature pointer");
+	__CPROVER_assert(signature_len == expected_signature_len,
+	                 "sign forwards signature length pointer");
+	__CPROVER_assert(message == expected_message,
+	                 "sign forwards message pointer");
+	__CPROVER_assert(message_len == expected_message_len,
+	                 "sign forwards message length");
+	__CPROVER_assert(secret_key == expected_secret_key,
+	                 "sign forwards secret key pointer");
+	return callback_status;
+}
+
+static OQS_STATUS model_sign_with_ctx(uint8_t *signature, size_t *signature_len,
+                                      const uint8_t *message, size_t message_len,
+                                      const uint8_t *ctx, size_t ctx_len,
+                                      const uint8_t *secret_key) {
+	callback_calls++;
+	__CPROVER_assert(signature == expected_signature,
+	                 "sign_with_ctx forwards signature pointer");
+	__CPROVER_assert(signature_len == expected_signature_len,
+	                 "sign_with_ctx forwards signature length pointer");
+	__CPROVER_assert(message == expected_message,
+	                 "sign_with_ctx forwards message pointer");
+	__CPROVER_assert(message_len == expected_message_len,
+	                 "sign_with_ctx forwards message length");
+	__CPROVER_assert(ctx == expected_ctx,
+	                 "sign_with_ctx forwards context pointer");
+	__CPROVER_assert(ctx_len == expected_ctx_len,
+	                 "sign_with_ctx forwards context length");
+	__CPROVER_assert(secret_key == expected_secret_key,
+	                 "sign_with_ctx forwards secret key pointer");
+	return callback_status;
+}
+
+static OQS_STATUS model_verify(const uint8_t *message, size_t message_len,
+                               const uint8_t *signature, size_t signature_len,
+                               const uint8_t *public_key) {
+	callback_calls++;
+	__CPROVER_assert(message == expected_message,
+	                 "verify forwards message pointer");
+	__CPROVER_assert(message_len == expected_message_len,
+	                 "verify forwards message length");
+	__CPROVER_assert(signature == expected_signature,
+	                 "verify forwards signature pointer");
+	__CPROVER_assert(signature_len == *expected_signature_len,
+	                 "verify forwards signature length");
+	__CPROVER_assert(public_key == expected_public_key,
+	                 "verify forwards public key pointer");
+	return callback_status;
+}
+
+static OQS_STATUS model_verify_with_ctx(const uint8_t *message,
+                                        size_t message_len,
+                                        const uint8_t *signature,
+                                        size_t signature_len,
+                                        const uint8_t *ctx, size_t ctx_len,
+                                        const uint8_t *public_key) {
+	callback_calls++;
+	__CPROVER_assert(message == expected_message,
+	                 "verify_with_ctx forwards message pointer");
+	__CPROVER_assert(message_len == expected_message_len,
+	                 "verify_with_ctx forwards message length");
+	__CPROVER_assert(signature == expected_signature,
+	                 "verify_with_ctx forwards signature pointer");
+	__CPROVER_assert(signature_len == *expected_signature_len,
+	                 "verify_with_ctx forwards signature length");
+	__CPROVER_assert(ctx == expected_ctx,
+	                 "verify_with_ctx forwards context pointer");
+	__CPROVER_assert(ctx_len == expected_ctx_len,
+	                 "verify_with_ctx forwards context length");
+	__CPROVER_assert(public_key == expected_public_key,
+	                 "verify_with_ctx forwards public key pointer");
+	return callback_status;
+}
+
+int main(void) {
+	OQS_SIG sig = {0};
+	uint8_t signature = 0;
+	uint8_t message = 0;
+	uint8_t ctx = 0;
+	uint8_t public_key = 0;
+	uint8_t secret_key = 0;
+	size_t signature_len = nondet_size_t();
+	unsigned int operation = nondet_uint();
+	_Bool null_sig = nondet_bool();
+	_Bool null_callback = nondet_bool();
+	OQS_STATUS result;
+
+	__CPROVER_assume(operation <= 4);
+
+	callback_status = (OQS_STATUS) nondet_int();
+	expected_signature = &signature;
+	expected_signature_len = &signature_len;
+	expected_message = &message;
+	expected_message_len = nondet_size_t();
+	expected_ctx = &ctx;
+	expected_ctx_len = nondet_size_t();
+	expected_public_key = &public_key;
+	expected_secret_key = &secret_key;
+
+	if (!null_callback) {
+		switch (operation) {
+		case 0:
+			sig.keypair = model_keypair;
+			break;
+		case 1:
+			sig.sign = model_sign;
+			break;
+		case 2:
+			sig.sign_with_ctx_str = model_sign_with_ctx;
+			break;
+		case 3:
+			sig.verify = model_verify;
+			break;
+		default:
+			sig.verify_with_ctx_str = model_verify_with_ctx;
+			break;
+		}
+	}
+
+	const OQS_SIG *sig_ptr = null_sig ? NULL : &sig;
+
+	switch (operation) {
+	case 0:
+		result = OQS_SIG_keypair(sig_ptr, &public_key, &secret_key);
+		break;
+	case 1:
+		result = OQS_SIG_sign(sig_ptr, &signature, &signature_len, &message,
+		                      expected_message_len, &secret_key);
+		break;
+	case 2:
+		result = OQS_SIG_sign_with_ctx_str(sig_ptr, &signature, &signature_len,
+		                                   &message, expected_message_len, &ctx,
+		                                   expected_ctx_len, &secret_key);
+		break;
+	case 3:
+		result = OQS_SIG_verify(sig_ptr, &message, expected_message_len,
+		                        &signature, signature_len, &public_key);
+		break;
+	default:
+		result = OQS_SIG_verify_with_ctx_str(sig_ptr, &message,
+		                                     expected_message_len, &signature,
+		                                     signature_len, &ctx,
+		                                     expected_ctx_len, &public_key);
+		break;
+	}
+
+	if (null_sig || null_callback) {
+		__CPROVER_assert(result == OQS_ERROR,
+		                 "signature dispatch rejects missing object or callback");
+		__CPROVER_assert(callback_calls == 0,
+		                 "signature dispatch short-circuits before callback");
+	} else {
+		OQS_STATUS expected_result =
+		    callback_status == OQS_SUCCESS ? OQS_SUCCESS : OQS_ERROR;
+		__CPROVER_assert(result == expected_result,
+		                 "signature dispatch normalizes callback status");
+		__CPROVER_assert(callback_calls == 1,
+		                 "signature dispatch invokes callback once");
+	}
+
+	return 0;
+}

--- a/tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c
+++ b/tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: MIT
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <oqs/oqs.h>
+
+extern _Bool nondet_bool(void);
+extern int nondet_int(void);
+extern size_t nondet_size_t(void);
+extern unsigned int nondet_uint(void);
+
+static unsigned int callback_calls;
+static OQS_STATUS callback_status;
+
+static uint8_t *expected_signature;
+static size_t *expected_signature_len;
+static const uint8_t *expected_message;
+static size_t expected_message_len;
+static uint8_t *expected_public_key;
+static OQS_SIG_STFL_SECRET_KEY *expected_secret_key;
+static unsigned long long *expected_counter;
+static uint8_t **expected_serialized_ptr;
+static size_t *expected_serialized_len;
+static const uint8_t *expected_serialized_input;
+static size_t expected_serialized_input_len;
+static void *expected_context;
+
+static OQS_STATUS model_keypair(uint8_t *public_key,
+                                OQS_SIG_STFL_SECRET_KEY *secret_key) {
+	callback_calls++;
+	__CPROVER_assert(public_key == expected_public_key,
+	                 "stfl keypair forwards public key pointer");
+	__CPROVER_assert(secret_key == expected_secret_key,
+	                 "stfl keypair forwards secret key pointer");
+	return callback_status;
+}
+
+static OQS_STATUS model_sign(uint8_t *signature, size_t *signature_len,
+                             const uint8_t *message, size_t message_len,
+                             OQS_SIG_STFL_SECRET_KEY *secret_key) {
+	callback_calls++;
+	__CPROVER_assert(signature == expected_signature,
+	                 "stfl sign forwards signature pointer");
+	__CPROVER_assert(signature_len == expected_signature_len,
+	                 "stfl sign forwards signature length pointer");
+	__CPROVER_assert(message == expected_message,
+	                 "stfl sign forwards message pointer");
+	__CPROVER_assert(message_len == expected_message_len,
+	                 "stfl sign forwards message length");
+	__CPROVER_assert(secret_key == expected_secret_key,
+	                 "stfl sign forwards secret key pointer");
+	return callback_status;
+}
+
+static OQS_STATUS model_verify(const uint8_t *message, size_t message_len,
+                               const uint8_t *signature, size_t signature_len,
+                               const uint8_t *public_key) {
+	callback_calls++;
+	__CPROVER_assert(message == expected_message,
+	                 "stfl verify forwards message pointer");
+	__CPROVER_assert(message_len == expected_message_len,
+	                 "stfl verify forwards message length");
+	__CPROVER_assert(signature == expected_signature,
+	                 "stfl verify forwards signature pointer");
+	__CPROVER_assert(signature_len == *expected_signature_len,
+	                 "stfl verify forwards signature length");
+	__CPROVER_assert(public_key == expected_public_key,
+	                 "stfl verify forwards public key pointer");
+	return callback_status;
+}
+
+static OQS_STATUS model_sigs_remaining(unsigned long long *remain,
+                                       const OQS_SIG_STFL_SECRET_KEY *secret_key) {
+	callback_calls++;
+	__CPROVER_assert(remain == expected_counter,
+	                 "stfl sigs_remaining forwards counter pointer");
+	__CPROVER_assert(secret_key == expected_secret_key,
+	                 "stfl sigs_remaining forwards secret key pointer");
+	return callback_status;
+}
+
+static OQS_STATUS model_sigs_total(unsigned long long *total,
+                                   const OQS_SIG_STFL_SECRET_KEY *secret_key) {
+	callback_calls++;
+	__CPROVER_assert(total == expected_counter,
+	                 "stfl sigs_total forwards counter pointer");
+	__CPROVER_assert(secret_key == expected_secret_key,
+	                 "stfl sigs_total forwards secret key pointer");
+	return callback_status;
+}
+
+static OQS_STATUS model_serialize(uint8_t **serialized, size_t *serialized_len,
+                                  const OQS_SIG_STFL_SECRET_KEY *secret_key) {
+	callback_calls++;
+	__CPROVER_assert(serialized == expected_serialized_ptr,
+	                 "stfl serialize forwards output pointer");
+	__CPROVER_assert(serialized_len == expected_serialized_len,
+	                 "stfl serialize forwards output length pointer");
+	__CPROVER_assert(secret_key == expected_secret_key,
+	                 "stfl serialize forwards secret key pointer");
+	return callback_status;
+}
+
+static OQS_STATUS model_deserialize(OQS_SIG_STFL_SECRET_KEY *secret_key,
+                                    const uint8_t *serialized,
+                                    const size_t serialized_len,
+                                    void *context) {
+	callback_calls++;
+	__CPROVER_assert(secret_key == expected_secret_key,
+	                 "stfl deserialize forwards secret key pointer");
+	__CPROVER_assert(serialized == expected_serialized_input,
+	                 "stfl deserialize forwards input pointer");
+	__CPROVER_assert(serialized_len == expected_serialized_input_len,
+	                 "stfl deserialize forwards input length");
+	__CPROVER_assert(context == expected_context,
+	                 "stfl deserialize forwards context pointer");
+	return callback_status;
+}
+
+int main(void) {
+	OQS_SIG_STFL sig = {0};
+	OQS_SIG_STFL_SECRET_KEY secret_key = {0};
+	uint8_t signature = 0;
+	uint8_t message = 0;
+	uint8_t public_key = 0;
+	uint8_t serialized_input = 0;
+	uint8_t context = 0;
+	uint8_t *serialized_output = NULL;
+	size_t signature_len = nondet_size_t();
+	size_t serialized_output_len = nondet_size_t();
+	unsigned long long counter = 0;
+	unsigned int operation = nondet_uint();
+	_Bool null_object = nondet_bool();
+	_Bool null_callback = nondet_bool();
+	_Bool null_buffer_arg = nondet_bool();
+	_Bool null_length_arg = nondet_bool();
+	OQS_STATUS result;
+
+	__CPROVER_assume(operation <= 6);
+
+	callback_status = (OQS_STATUS) nondet_int();
+	expected_signature = &signature;
+	expected_signature_len = &signature_len;
+	expected_message = &message;
+	expected_message_len = nondet_size_t();
+	expected_public_key = &public_key;
+	expected_secret_key = &secret_key;
+	expected_counter = &counter;
+	expected_serialized_ptr = &serialized_output;
+	expected_serialized_len = &serialized_output_len;
+	expected_serialized_input = &serialized_input;
+	expected_serialized_input_len = nondet_size_t();
+	expected_context = &context;
+
+	if (!null_callback) {
+		switch (operation) {
+		case 0:
+			sig.keypair = model_keypair;
+			break;
+		case 1:
+			sig.sign = model_sign;
+			break;
+		case 2:
+			sig.verify = model_verify;
+			break;
+		case 3:
+			sig.sigs_remaining = model_sigs_remaining;
+			break;
+		case 4:
+			sig.sigs_total = model_sigs_total;
+			break;
+		case 5:
+			secret_key.serialize_key = model_serialize;
+			break;
+		default:
+			secret_key.deserialize_key = model_deserialize;
+			break;
+		}
+	}
+
+	const OQS_SIG_STFL *sig_ptr = null_object ? NULL : &sig;
+	OQS_SIG_STFL_SECRET_KEY *secret_key_ptr = null_object ? NULL : &secret_key;
+	uint8_t **serialized_output_arg =
+	    null_buffer_arg ? NULL : &serialized_output;
+	size_t *serialized_output_len_arg =
+	    null_length_arg ? NULL : &serialized_output_len;
+	const uint8_t *serialized_input_arg =
+	    null_buffer_arg ? NULL : &serialized_input;
+
+	switch (operation) {
+	case 0:
+		result = OQS_SIG_STFL_keypair(sig_ptr, &public_key, &secret_key);
+		break;
+	case 1:
+		result = OQS_SIG_STFL_sign(sig_ptr, &signature, &signature_len, &message,
+		                           expected_message_len, &secret_key);
+		break;
+	case 2:
+		result = OQS_SIG_STFL_verify(sig_ptr, &message, expected_message_len,
+		                             &signature, signature_len, &public_key);
+		break;
+	case 3:
+		result = OQS_SIG_STFL_sigs_remaining(sig_ptr, &counter, &secret_key);
+		break;
+	case 4:
+		result = OQS_SIG_STFL_sigs_total(sig_ptr, &counter, &secret_key);
+		break;
+	case 5:
+		result = OQS_SIG_STFL_SECRET_KEY_serialize(serialized_output_arg,
+		         serialized_output_len_arg,
+		         secret_key_ptr);
+		break;
+	default:
+		result = OQS_SIG_STFL_SECRET_KEY_deserialize(secret_key_ptr,
+		         serialized_input_arg,
+		         expected_serialized_input_len,
+		         &context);
+		break;
+	}
+
+	_Bool invalid_wrapper_input =
+	    null_object || null_callback ||
+	    (operation == 5 && (null_buffer_arg || null_length_arg)) ||
+	    (operation == 6 && null_buffer_arg);
+
+	if (invalid_wrapper_input) {
+		__CPROVER_assert(result == OQS_ERROR,
+		                 "stfl dispatch rejects missing wrapper input");
+		__CPROVER_assert(callback_calls == 0,
+		                 "stfl dispatch short-circuits before callback");
+	} else if (operation <= 4) {
+		OQS_STATUS expected_result =
+		    callback_status == OQS_SUCCESS ? OQS_SUCCESS : OQS_ERROR;
+		__CPROVER_assert(result == expected_result,
+		                 "stfl operation dispatch normalizes callback status");
+		__CPROVER_assert(callback_calls == 1,
+		                 "stfl operation dispatch invokes callback once");
+	} else {
+		__CPROVER_assert(result == callback_status,
+		                 "stfl key serialization dispatch preserves callback status");
+		__CPROVER_assert(callback_calls == 1,
+		                 "stfl key serialization dispatch invokes callback once");
+	}
+
+	return 0;
+}

--- a/tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c
+++ b/tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+
+#include <stdint.h>
+
+#include <oqs/oqs.h>
+
+extern _Bool nondet_bool(void);
+extern int nondet_int(void);
+
+static unsigned int callback_calls;
+static OQS_STATUS callback_status;
+static void *expected_mutex;
+
+static OQS_STATUS model_lock(void *mutex) {
+	callback_calls++;
+	__CPROVER_assert(mutex == expected_mutex,
+	                 "lock callback receives configured mutex");
+	return callback_status;
+}
+
+static OQS_STATUS model_unlock(void *mutex) {
+	callback_calls++;
+	__CPROVER_assert(mutex == expected_mutex,
+	                 "unlock callback receives configured mutex");
+	return callback_status;
+}
+
+int main(void) {
+	OQS_SIG_STFL_SECRET_KEY sk = {0};
+	uint8_t mutex = 0;
+	_Bool use_unlock = nondet_bool();
+	_Bool null_key = nondet_bool();
+	_Bool configured_callback = nondet_bool();
+	_Bool null_mutex = nondet_bool();
+	OQS_STATUS result;
+
+	callback_status = (OQS_STATUS) nondet_int();
+	expected_mutex = &mutex;
+
+	OQS_SIG_STFL_SECRET_KEY_SET_lock(&sk, model_lock);
+	OQS_SIG_STFL_SECRET_KEY_SET_unlock(&sk, model_unlock);
+	OQS_SIG_STFL_SECRET_KEY_SET_mutex(&sk, &mutex);
+	__CPROVER_assert(sk.lock_key == model_lock,
+	                 "lock setter stores callback");
+	__CPROVER_assert(sk.unlock_key == model_unlock,
+	                 "unlock setter stores callback");
+	__CPROVER_assert(sk.mutex == &mutex,
+	                 "mutex setter stores pointer");
+
+	sk.lock_key = NULL;
+	sk.unlock_key = NULL;
+	sk.mutex = null_mutex ? NULL : &mutex;
+	if (configured_callback) {
+		if (use_unlock) {
+			sk.unlock_key = model_unlock;
+		} else {
+			sk.lock_key = model_lock;
+		}
+	}
+
+	OQS_SIG_STFL_SECRET_KEY *sk_ptr = null_key ? NULL : &sk;
+	if (use_unlock) {
+		result = OQS_SIG_STFL_SECRET_KEY_unlock(sk_ptr);
+	} else {
+		result = OQS_SIG_STFL_SECRET_KEY_lock(sk_ptr);
+	}
+
+	if (null_key) {
+		__CPROVER_assert(result == OQS_ERROR,
+		                 "lock helpers reject null key");
+		__CPROVER_assert(callback_calls == 0,
+		                 "lock helpers do not call through null key");
+	} else if (!configured_callback) {
+		__CPROVER_assert(result == OQS_SUCCESS,
+		                 "unset lock callback is a no-op");
+		__CPROVER_assert(callback_calls == 0,
+		                 "unset lock callback is not invoked");
+	} else if (null_mutex) {
+		__CPROVER_assert(result == OQS_ERROR,
+		                 "configured lock callback requires mutex");
+		__CPROVER_assert(callback_calls == 0,
+		                 "missing mutex short-circuits callback");
+	} else {
+		__CPROVER_assert(result == callback_status,
+		                 "lock helper propagates callback status");
+		__CPROVER_assert(callback_calls == 1,
+		                 "lock helper invokes callback once");
+	}
+
+	return 0;
+}

--- a/tests/cbmc/manifest.yaml
+++ b/tests/cbmc/manifest.yaml
@@ -1,0 +1,54 @@
+suite: liboqs-owned-cbmc
+repo: trailofbits/ptp-liboqs
+commit: d95fc734f5de9bdfc80c8c65d8166b30e9cff5cd
+cbmc:
+  version: "6.9.0"
+  runner: tests/cbmc/run.sh
+  proof_command_template: "cbmc -I tests/cbmc/models --drop-unused-functions --bounds-check --pointer-check --pointer-overflow-check --div-by-zero-check --signed-overflow-check --conversion-check --unwind 5 --unwinding-assertions --trace <sources> <harness>"
+  coverage_command_template: "cbmc -I tests/cbmc/models --drop-unused-functions --cover assertion --unwind 5 <sources> <harness>"
+status_vocabulary:
+  - PROVED_BOUNDED
+  - FAILED_COUNTEREXAMPLE
+  - VACUOUS_OR_OVERCONSTRAINED
+  - UNPROVEN_BOUND
+  - UNPROVEN_MODELING
+  - UNPROVEN_ENVIRONMENT
+  - UNPROVEN_TOOLING
+  - SKIPPED_OUT_OF_SCOPE
+proofs:
+  - id: mem_secure_bcmp
+    source:
+      - src/common/common.c
+    harness: tests/cbmc/harnesses/mem_secure_bcmp_harness.c
+    raw_run: tests/cbmc/raw-runs/mem_secure_bcmp.txt
+    coverage_run: tests/cbmc/raw-runs/mem_secure_bcmp.coverage.txt
+    summary: tests/cbmc/summaries/mem_secure_bcmp.md
+    status: PROVED_BOUNDED
+    property: "OQS_MEM_secure_bcmp returns 0 iff all compared bytes match, returns only 0 or 1, and does not mutate either input for lengths up to four bytes."
+  - id: sig_status_normalization
+    source:
+      - src/sig/sig.c
+    harness: tests/cbmc/harnesses/sig_status_normalization_harness.c
+    raw_run: tests/cbmc/raw-runs/sig_status_normalization.txt
+    coverage_run: tests/cbmc/raw-runs/sig_status_normalization.coverage.txt
+    summary: tests/cbmc/summaries/sig_status_normalization.md
+    status: PROVED_BOUNDED
+    property: "The generic signature dispatchers reject missing objects or callbacks, forward arguments unchanged, invoke at most one callback, and normalize every non-success callback status to OQS_ERROR."
+  - id: sig_stfl_dispatch_contract
+    source:
+      - src/sig_stfl/sig_stfl.c
+    harness: tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c
+    raw_run: tests/cbmc/raw-runs/sig_stfl_dispatch_contract.txt
+    coverage_run: tests/cbmc/raw-runs/sig_stfl_dispatch_contract.coverage.txt
+    summary: tests/cbmc/summaries/sig_stfl_dispatch_contract.md
+    status: PROVED_BOUNDED
+    property: "The stateful-signature operation dispatchers reject missing objects or callbacks, forward arguments unchanged, normalize operation callback statuses, and the serialize/deserialize wrappers reject their owned NULL inputs while preserving callback statuses."
+  - id: sig_stfl_lock_contract
+    source:
+      - src/sig_stfl/sig_stfl.c
+    harness: tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c
+    raw_run: tests/cbmc/raw-runs/sig_stfl_lock_contract.txt
+    coverage_run: tests/cbmc/raw-runs/sig_stfl_lock_contract.coverage.txt
+    summary: tests/cbmc/summaries/sig_stfl_lock_contract.md
+    status: PROVED_BOUNDED
+    property: "The common stateful lock helpers reject a NULL key, treat an unset callback as a no-op, reject a configured callback without a mutex, and otherwise call exactly once with the configured mutex while propagating the callback status."

--- a/tests/cbmc/models/README.md
+++ b/tests/cbmc/models/README.md
@@ -1,0 +1,22 @@
+# Model Boundary
+
+The proofs in this directory target source files owned by liboqs rather than
+imported algorithm implementations.
+
+`oqs/oqsconfig.h` exposes the full stateful-signature object layout by defining
+`OQS_ALLOW_STFL_KEY_AND_SIG_GEN`, but it does not enable any KEM, signature, or
+stateful-signature algorithm implementation. `oqs/oqs.h` is a narrow umbrella
+header that includes only the public common, signature, and stateful-signature
+headers needed by the selected translation units.
+
+`oqs_memory.c` provides no-op models for free helpers referenced by wrapper
+translation units. Those functions are outside the reachable claims in the
+dispatch harnesses. The `mem_secure_bcmp` proof compiles the real
+`src/common/common.c` directly and does not use the free-helper model.
+
+The model does not cover:
+
+- imported algorithm constructors or cryptographic callbacks
+- allocator behavior, cleansing guarantees, or platform-specific free logic
+- thread scheduling or application callback implementations
+- constant-time behavior

--- a/tests/cbmc/models/oqs/common.h
+++ b/tests/cbmc/models/oqs/common.h
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef OQS_CBMC_MODEL_COMMON_H
+#define OQS_CBMC_MODEL_COMMON_H
+
+#include "../../../../src/common/common.h"
+
+#endif /* OQS_CBMC_MODEL_COMMON_H */

--- a/tests/cbmc/models/oqs/oqs.h
+++ b/tests/cbmc/models/oqs/oqs.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef OQS_H
+#define OQS_H
+
+#include <oqs/oqsconfig.h>
+
+/*
+ * This is intentionally narrower than the installed umbrella header.  The
+ * selected proofs exercise only common, signature, and stateful-signature API
+ * code owned by liboqs itself.
+ */
+#include "../../../../src/common/common.h"
+#include "../../../../src/sig/sig.h"
+#include "../../../../src/sig_stfl/sig_stfl.h"
+
+#endif /* OQS_H */

--- a/tests/cbmc/models/oqs/oqsconfig.h
+++ b/tests/cbmc/models/oqs/oqsconfig.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef OQS_CONFIG_H
+#define OQS_CONFIG_H
+
+/*
+ * CBMC only needs the public type surface for the liboqs-owned dispatch and
+ * utility translation units.  No imported algorithm implementation is enabled.
+ */
+#define OQS_VERSION_TEXT "cbmc-model"
+#define OQS_VERSION_MAJOR 0
+#define OQS_VERSION_MINOR 0
+#define OQS_VERSION_PATCH 0
+
+/* Keep the full stateful-signature object layout visible to the harnesses. */
+#define OQS_ALLOW_STFL_KEY_AND_SIG_GEN 1
+
+/* Avoid the non-POSIX malloc.h fallback while parsing common.c on macOS. */
+#define OQS_HAVE_POSIX_MEMALIGN 1
+
+#endif /* OQS_CONFIG_H */

--- a/tests/cbmc/models/oqs_memory.c
+++ b/tests/cbmc/models/oqs_memory.c
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+#include <oqs/oqs.h>
+
+/*
+ * The dispatch proofs do not reason about allocator internals.  These models
+ * satisfy source-level references from free helpers that are outside the
+ * reachable proof claims.
+ */
+void OQS_MEM_insecure_free(void *ptr) {
+	(void) ptr;
+}
+
+void OQS_MEM_secure_free(void *ptr, size_t len) {
+	(void) ptr;
+	(void) len;
+}

--- a/tests/cbmc/raw-runs/mem_secure_bcmp.coverage.txt
+++ b/tests/cbmc/raw-runs/mem_secure_bcmp.coverage.txt
@@ -1,0 +1,46 @@
+--cover is incompatible with --unwinding-assertions, so unwinding-assertions will be defaulted to false
+**** WARNING: Use --unwinding-assertions to obtain sound verification results
+CBMC version 6.9.0 (cbmc-6.9.0) 64-bit arm64 macos
+Type-checking common
+Type-checking mem_secure_bcmp_harness
+Generating GOTO Program
+Adding CPROVER library (arm64)
+Removal of function pointers and virtual functions
+Generic Property Instrumentation
+Removing unused functions
+Rewriting existing assertions as assumptions
+Starting Bounded Model Checking
+Passing problem to propositional reduction
+converting SSA
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+
+** coverage results:
+[OQS_MEM_secure_bcmp.coverage.1] file src/common/common.c line 264 function OQS_MEM_secure_bcmp dereference failure: pointer NULL in ((const uint8_t *)a)[(signed long int)i]: SATISFIED
+[OQS_MEM_secure_bcmp.coverage.2] file src/common/common.c line 264 function OQS_MEM_secure_bcmp dereference failure: pointer invalid in ((const uint8_t *)a)[(signed long int)i]: SATISFIED
+[OQS_MEM_secure_bcmp.coverage.3] file src/common/common.c line 264 function OQS_MEM_secure_bcmp dereference failure: deallocated dynamic object in ((const uint8_t *)a)[(signed long int)i]: SATISFIED
+[OQS_MEM_secure_bcmp.coverage.4] file src/common/common.c line 264 function OQS_MEM_secure_bcmp dereference failure: dead object in ((const uint8_t *)a)[(signed long int)i]: SATISFIED
+[OQS_MEM_secure_bcmp.coverage.5] file src/common/common.c line 264 function OQS_MEM_secure_bcmp dereference failure: pointer outside object bounds in ((const uint8_t *)a)[(signed long int)i]: SATISFIED
+[OQS_MEM_secure_bcmp.coverage.6] file src/common/common.c line 264 function OQS_MEM_secure_bcmp dereference failure: invalid integer address in ((const uint8_t *)a)[(signed long int)i]: SATISFIED
+[OQS_MEM_secure_bcmp.coverage.7] file src/common/common.c line 264 function OQS_MEM_secure_bcmp dereference failure: pointer NULL in ((const uint8_t *)b)[(signed long int)i]: SATISFIED
+[OQS_MEM_secure_bcmp.coverage.8] file src/common/common.c line 264 function OQS_MEM_secure_bcmp dereference failure: pointer invalid in ((const uint8_t *)b)[(signed long int)i]: SATISFIED
+[OQS_MEM_secure_bcmp.coverage.9] file src/common/common.c line 264 function OQS_MEM_secure_bcmp dereference failure: deallocated dynamic object in ((const uint8_t *)b)[(signed long int)i]: SATISFIED
+[OQS_MEM_secure_bcmp.coverage.10] file src/common/common.c line 264 function OQS_MEM_secure_bcmp dereference failure: dead object in ((const uint8_t *)b)[(signed long int)i]: SATISFIED
+[OQS_MEM_secure_bcmp.coverage.11] file src/common/common.c line 264 function OQS_MEM_secure_bcmp dereference failure: pointer outside object bounds in ((const uint8_t *)b)[(signed long int)i]: SATISFIED
+[OQS_MEM_secure_bcmp.coverage.12] file src/common/common.c line 264 function OQS_MEM_secure_bcmp dereference failure: invalid integer address in ((const uint8_t *)b)[(signed long int)i]: SATISFIED
+[main.coverage.1] file tests/cbmc/harnesses/mem_secure_bcmp_harness.c line 24 function main array 'a' upper bound in a[(signed long int)i]: SATISFIED
+[main.coverage.2] file tests/cbmc/harnesses/mem_secure_bcmp_harness.c line 25 function main array 'b' upper bound in b[(signed long int)i]: SATISFIED
+[main.coverage.3] file tests/cbmc/harnesses/mem_secure_bcmp_harness.c line 26 function main array 'a_before' upper bound in a_before[(signed long int)i]: SATISFIED
+[main.coverage.4] file tests/cbmc/harnesses/mem_secure_bcmp_harness.c line 27 function main array 'b_before' upper bound in b_before[(signed long int)i]: SATISFIED
+[main.coverage.5] file tests/cbmc/harnesses/mem_secure_bcmp_harness.c line 31 function main array 'a' upper bound in a[(signed long int)i]: SATISFIED
+[main.coverage.6] file tests/cbmc/harnesses/mem_secure_bcmp_harness.c line 31 function main array 'b' upper bound in b[(signed long int)i]: SATISFIED
+[main.coverage.7] file tests/cbmc/harnesses/mem_secure_bcmp_harness.c line 38 function main secure_bcmp returns zero iff all bounded bytes match: SATISFIED
+[main.coverage.8] file tests/cbmc/harnesses/mem_secure_bcmp_harness.c line 40 function main secure_bcmp result is normalized to one bit: SATISFIED
+[main.coverage.9] file tests/cbmc/harnesses/mem_secure_bcmp_harness.c line 44 function main array 'a' upper bound in a[(signed long int)i]: SATISFIED
+[main.coverage.10] file tests/cbmc/harnesses/mem_secure_bcmp_harness.c line 44 function main array 'a_before' upper bound in a_before[(signed long int)i]: SATISFIED
+[main.coverage.11] file tests/cbmc/harnesses/mem_secure_bcmp_harness.c line 44 function main secure_bcmp does not mutate left input: SATISFIED
+[main.coverage.12] file tests/cbmc/harnesses/mem_secure_bcmp_harness.c line 46 function main array 'b' upper bound in b[(signed long int)i]: SATISFIED
+[main.coverage.13] file tests/cbmc/harnesses/mem_secure_bcmp_harness.c line 46 function main array 'b_before' upper bound in b_before[(signed long int)i]: SATISFIED
+[main.coverage.14] file tests/cbmc/harnesses/mem_secure_bcmp_harness.c line 46 function main secure_bcmp does not mutate right input: SATISFIED
+
+** 26 of 26 covered (100.0%)

--- a/tests/cbmc/raw-runs/mem_secure_bcmp.txt
+++ b/tests/cbmc/raw-runs/mem_secure_bcmp.txt
@@ -1,0 +1,67 @@
+CBMC version 6.9.0 (cbmc-6.9.0) 64-bit arm64 macos
+Type-checking common
+Type-checking mem_secure_bcmp_harness
+Generating GOTO Program
+Adding CPROVER library (arm64)
+Removal of function pointers and virtual functions
+Generic Property Instrumentation
+Removing unused functions
+Starting Bounded Model Checking
+Passing problem to propositional reduction
+converting SSA
+Running propositional reduction
+SAT checker: instance is UNSATISFIABLE
+
+** Results:
+src/common/common.c function OQS_MEM_secure_bcmp
+[OQS_MEM_secure_bcmp.unwind.0] line 263 unwinding assertion loop 0: SUCCESS
+[OQS_MEM_secure_bcmp.overflow.1] line 264 arithmetic overflow on unsigned to signed type conversion in (signed long int)i: SUCCESS
+[OQS_MEM_secure_bcmp.overflow.2] line 264 arithmetic overflow on signed to unsigned type conversion in (uint8_t)((signed int)r | (signed int)((const uint8_t *)a)[(signed long int)i] ^ (signed int)((const uint8_t *)b)[(signed long int)i]): SUCCESS
+[OQS_MEM_secure_bcmp.pointer_arithmetic.1] line 264 pointer arithmetic: pointer NULL in (const uint8_t *)a + (signed long int)i: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_arithmetic.2] line 264 pointer arithmetic: pointer invalid in (const uint8_t *)a + (signed long int)i: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_arithmetic.3] line 264 pointer arithmetic: deallocated dynamic object in (const uint8_t *)a + (signed long int)i: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_arithmetic.4] line 264 pointer arithmetic: dead object in (const uint8_t *)a + (signed long int)i: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_arithmetic.5] line 264 pointer arithmetic: pointer outside object bounds in (const uint8_t *)a + (signed long int)i: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_arithmetic.6] line 264 pointer arithmetic: invalid integer address in (const uint8_t *)a + (signed long int)i: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_arithmetic.7] line 264 pointer arithmetic: pointer NULL in (const uint8_t *)b + (signed long int)i: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_arithmetic.8] line 264 pointer arithmetic: pointer invalid in (const uint8_t *)b + (signed long int)i: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_arithmetic.9] line 264 pointer arithmetic: deallocated dynamic object in (const uint8_t *)b + (signed long int)i: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_arithmetic.10] line 264 pointer arithmetic: dead object in (const uint8_t *)b + (signed long int)i: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_arithmetic.11] line 264 pointer arithmetic: pointer outside object bounds in (const uint8_t *)b + (signed long int)i: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_arithmetic.12] line 264 pointer arithmetic: invalid integer address in (const uint8_t *)b + (signed long int)i: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_dereference.1] line 264 dereference failure: pointer NULL in ((const uint8_t *)a)[(signed long int)i]: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_dereference.2] line 264 dereference failure: pointer invalid in ((const uint8_t *)a)[(signed long int)i]: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_dereference.3] line 264 dereference failure: deallocated dynamic object in ((const uint8_t *)a)[(signed long int)i]: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_dereference.4] line 264 dereference failure: dead object in ((const uint8_t *)a)[(signed long int)i]: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_dereference.5] line 264 dereference failure: pointer outside object bounds in ((const uint8_t *)a)[(signed long int)i]: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_dereference.6] line 264 dereference failure: invalid integer address in ((const uint8_t *)a)[(signed long int)i]: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_dereference.7] line 264 dereference failure: pointer NULL in ((const uint8_t *)b)[(signed long int)i]: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_dereference.8] line 264 dereference failure: pointer invalid in ((const uint8_t *)b)[(signed long int)i]: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_dereference.9] line 264 dereference failure: deallocated dynamic object in ((const uint8_t *)b)[(signed long int)i]: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_dereference.10] line 264 dereference failure: dead object in ((const uint8_t *)b)[(signed long int)i]: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_dereference.11] line 264 dereference failure: pointer outside object bounds in ((const uint8_t *)b)[(signed long int)i]: SUCCESS
+[OQS_MEM_secure_bcmp.pointer_dereference.12] line 264 dereference failure: invalid integer address in ((const uint8_t *)b)[(signed long int)i]: SUCCESS
+[OQS_MEM_secure_bcmp.overflow.3] line 268 arithmetic overflow on unsigned to signed type conversion in (signed int)((unsigned int)1 & -((unsigned int)r) >> 8): SUCCESS
+
+tests/cbmc/harnesses/mem_secure_bcmp_harness.c function main
+[main.array_bounds.1] line 24 array 'a' upper bound in a[(signed long int)i]: SUCCESS
+[main.overflow.1] line 24 arithmetic overflow on unsigned to signed type conversion in (signed long int)i: SUCCESS
+[main.array_bounds.2] line 25 array 'b' upper bound in b[(signed long int)i]: SUCCESS
+[main.array_bounds.3] line 26 array 'a_before' upper bound in a_before[(signed long int)i]: SUCCESS
+[main.array_bounds.4] line 27 array 'b_before' upper bound in b_before[(signed long int)i]: SUCCESS
+[main.unwind.1] line 30 unwinding assertion loop 1: SUCCESS
+[main.array_bounds.5] line 31 array 'a' upper bound in a[(signed long int)i]: SUCCESS
+[main.array_bounds.6] line 31 array 'b' upper bound in b[(signed long int)i]: SUCCESS
+[main.overflow.2] line 31 arithmetic overflow on unsigned to signed type conversion in (signed long int)i: SUCCESS
+[main.assertion.1] line 38 secure_bcmp returns zero iff all bounded bytes match: SUCCESS
+[main.assertion.2] line 40 secure_bcmp result is normalized to one bit: SUCCESS
+[main.array_bounds.7] line 44 array 'a' upper bound in a[(signed long int)i]: SUCCESS
+[main.array_bounds.8] line 44 array 'a_before' upper bound in a_before[(signed long int)i]: SUCCESS
+[main.assertion.3] line 44 secure_bcmp does not mutate left input: SUCCESS
+[main.overflow.3] line 44 arithmetic overflow on unsigned to signed type conversion in (signed long int)i: SUCCESS
+[main.array_bounds.9] line 46 array 'b' upper bound in b[(signed long int)i]: SUCCESS
+[main.array_bounds.10] line 46 array 'b_before' upper bound in b_before[(signed long int)i]: SUCCESS
+[main.assertion.4] line 46 secure_bcmp does not mutate right input: SUCCESS
+
+** 0 of 46 failed (1 iterations)
+VERIFICATION SUCCESSFUL

--- a/tests/cbmc/raw-runs/sig_status_normalization.coverage.txt
+++ b/tests/cbmc/raw-runs/sig_status_normalization.coverage.txt
@@ -1,0 +1,178 @@
+--cover is incompatible with --unwinding-assertions, so unwinding-assertions will be defaulted to false
+**** WARNING: Use --unwinding-assertions to obtain sound verification results
+CBMC version 6.9.0 (cbmc-6.9.0) 64-bit arm64 macos
+Type-checking oqs_memory
+Type-checking sig
+Type-checking sig_status_normalization_harness
+Generating GOTO Program
+Adding CPROVER library (arm64)
+Removal of function pointers and virtual functions
+Generic Property Instrumentation
+Removing unused functions
+Rewriting existing assertions as assumptions
+Starting Bounded Model Checking
+Passing problem to propositional reduction
+converting SSA
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is UNSATISFIABLE
+
+** coverage results:
+[OQS_SIG_keypair.coverage.1] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: pointer NULL in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.2] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: pointer invalid in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.3] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: deallocated dynamic object in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.4] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: dead object in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.5] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: pointer outside object bounds in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.6] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: invalid integer address in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.7] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: pointer NULL in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.8] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: pointer invalid in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.9] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: deallocated dynamic object in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.10] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: dead object in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.11] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: pointer outside object bounds in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.12] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: invalid integer address in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.13] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: pointer NULL in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.14] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: pointer invalid in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.15] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: deallocated dynamic object in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.16] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: dead object in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.17] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: pointer outside object bounds in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.18] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereference failure: invalid integer address in sig->keypair: SATISFIED
+[OQS_SIG_keypair.coverage.19] file src/sig/sig.c line 3063 function OQS_SIG_keypair dereferenced function pointer must be model_keypair: FAILED
+[OQS_SIG_sign.coverage.1] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: pointer NULL in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.2] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: pointer invalid in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.3] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: deallocated dynamic object in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.4] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: dead object in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.5] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: pointer outside object bounds in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.6] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: invalid integer address in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.7] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: pointer NULL in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.8] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: pointer invalid in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.9] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: deallocated dynamic object in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.10] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: dead object in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.11] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: pointer outside object bounds in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.12] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: invalid integer address in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.13] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: pointer NULL in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.14] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: pointer invalid in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.15] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: deallocated dynamic object in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.16] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: dead object in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.17] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: pointer outside object bounds in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.18] file src/sig/sig.c line 3071 function OQS_SIG_sign dereference failure: invalid integer address in sig->sign: SATISFIED
+[OQS_SIG_sign.coverage.19] file src/sig/sig.c line 3071 function OQS_SIG_sign dereferenced function pointer must be one of [model_sign, model_verify]: FAILED
+[OQS_SIG_sign_with_ctx_str.coverage.1] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: pointer NULL in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.2] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: pointer invalid in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.3] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: deallocated dynamic object in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.4] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: dead object in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.5] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: pointer outside object bounds in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.6] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: invalid integer address in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.7] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: pointer NULL in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.8] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: pointer invalid in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.9] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: deallocated dynamic object in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.10] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: dead object in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.11] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: pointer outside object bounds in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.12] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: invalid integer address in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.13] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: pointer NULL in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.14] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: pointer invalid in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.15] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: deallocated dynamic object in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.16] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: dead object in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.17] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: pointer outside object bounds in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.18] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereference failure: invalid integer address in sig->sign_with_ctx_str: SATISFIED
+[OQS_SIG_sign_with_ctx_str.coverage.19] file src/sig/sig.c line 3079 function OQS_SIG_sign_with_ctx_str dereferenced function pointer must be one of [model_sign_with_ctx, model_verify_with_ctx]: FAILED
+[OQS_SIG_verify.coverage.1] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: pointer NULL in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.2] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: pointer invalid in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.3] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: deallocated dynamic object in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.4] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: dead object in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.5] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: pointer outside object bounds in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.6] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: invalid integer address in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.7] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: pointer NULL in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.8] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: pointer invalid in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.9] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: deallocated dynamic object in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.10] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: dead object in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.11] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: pointer outside object bounds in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.12] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: invalid integer address in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.13] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: pointer NULL in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.14] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: pointer invalid in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.15] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: deallocated dynamic object in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.16] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: dead object in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.17] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: pointer outside object bounds in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.18] file src/sig/sig.c line 3087 function OQS_SIG_verify dereference failure: invalid integer address in sig->verify: SATISFIED
+[OQS_SIG_verify.coverage.19] file src/sig/sig.c line 3087 function OQS_SIG_verify dereferenced function pointer must be one of [model_sign, model_verify]: FAILED
+[OQS_SIG_verify_with_ctx_str.coverage.1] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: pointer NULL in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.2] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: pointer invalid in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.3] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: deallocated dynamic object in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.4] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: dead object in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.5] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: pointer outside object bounds in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.6] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: invalid integer address in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.7] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: pointer NULL in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.8] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: pointer invalid in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.9] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: deallocated dynamic object in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.10] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: dead object in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.11] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: pointer outside object bounds in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.12] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: invalid integer address in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.13] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: pointer NULL in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.14] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: pointer invalid in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.15] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: deallocated dynamic object in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.16] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: dead object in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.17] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: pointer outside object bounds in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.18] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereference failure: invalid integer address in sig->verify_with_ctx_str: SATISFIED
+[OQS_SIG_verify_with_ctx_str.coverage.19] file src/sig/sig.c line 3095 function OQS_SIG_verify_with_ctx_str dereferenced function pointer must be one of [model_sign_with_ctx, model_verify_with_ctx]: FAILED
+[main.coverage.1] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 187 function main signature dispatch rejects missing object or callback: SATISFIED
+[main.coverage.2] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 189 function main signature dispatch short-circuits before callback: SATISFIED
+[main.coverage.3] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 194 function main signature dispatch normalizes callback status: SATISFIED
+[main.coverage.4] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 196 function main signature dispatch invokes callback once: SATISFIED
+[model_keypair.coverage.1] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 27 function model_keypair keypair forwards public key pointer: SATISFIED
+[model_keypair.coverage.2] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 29 function model_keypair keypair forwards secret key pointer: SATISFIED
+[model_sign.coverage.1] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 38 function model_sign sign forwards signature pointer: SATISFIED
+[model_sign.coverage.2] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 40 function model_sign sign forwards signature length pointer: SATISFIED
+[model_sign.coverage.3] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 42 function model_sign sign forwards message pointer: SATISFIED
+[model_sign.coverage.4] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 44 function model_sign sign forwards message length: SATISFIED
+[model_sign.coverage.5] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 46 function model_sign sign forwards secret key pointer: SATISFIED
+[model_sign_with_ctx.coverage.1] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 56 function model_sign_with_ctx sign_with_ctx forwards signature pointer: SATISFIED
+[model_sign_with_ctx.coverage.2] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 58 function model_sign_with_ctx sign_with_ctx forwards signature length pointer: SATISFIED
+[model_sign_with_ctx.coverage.3] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 60 function model_sign_with_ctx sign_with_ctx forwards message pointer: SATISFIED
+[model_sign_with_ctx.coverage.4] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 62 function model_sign_with_ctx sign_with_ctx forwards message length: SATISFIED
+[model_sign_with_ctx.coverage.5] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 64 function model_sign_with_ctx sign_with_ctx forwards context pointer: SATISFIED
+[model_sign_with_ctx.coverage.6] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 66 function model_sign_with_ctx sign_with_ctx forwards context length: SATISFIED
+[model_sign_with_ctx.coverage.7] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 68 function model_sign_with_ctx sign_with_ctx forwards secret key pointer: SATISFIED
+[model_verify.coverage.1] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 77 function model_verify verify forwards message pointer: SATISFIED
+[model_verify.coverage.2] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 79 function model_verify verify forwards message length: SATISFIED
+[model_verify.coverage.3] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 81 function model_verify verify forwards signature pointer: SATISFIED
+[model_verify.coverage.4] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 83 function model_verify dereference failure: pointer NULL in *expected_signature_len: SATISFIED
+[model_verify.coverage.5] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 83 function model_verify dereference failure: pointer invalid in *expected_signature_len: SATISFIED
+[model_verify.coverage.6] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 83 function model_verify dereference failure: deallocated dynamic object in *expected_signature_len: SATISFIED
+[model_verify.coverage.7] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 83 function model_verify dereference failure: dead object in *expected_signature_len: SATISFIED
+[model_verify.coverage.8] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 83 function model_verify dereference failure: pointer outside object bounds in *expected_signature_len: SATISFIED
+[model_verify.coverage.9] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 83 function model_verify dereference failure: invalid integer address in *expected_signature_len: SATISFIED
+[model_verify.coverage.10] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 83 function model_verify verify forwards signature length: SATISFIED
+[model_verify.coverage.11] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 85 function model_verify verify forwards public key pointer: SATISFIED
+[model_verify_with_ctx.coverage.1] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 97 function model_verify_with_ctx verify_with_ctx forwards message pointer: SATISFIED
+[model_verify_with_ctx.coverage.2] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 99 function model_verify_with_ctx verify_with_ctx forwards message length: SATISFIED
+[model_verify_with_ctx.coverage.3] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 101 function model_verify_with_ctx verify_with_ctx forwards signature pointer: SATISFIED
+[model_verify_with_ctx.coverage.4] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 103 function model_verify_with_ctx dereference failure: pointer NULL in *expected_signature_len: SATISFIED
+[model_verify_with_ctx.coverage.5] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 103 function model_verify_with_ctx dereference failure: pointer invalid in *expected_signature_len: SATISFIED
+[model_verify_with_ctx.coverage.6] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 103 function model_verify_with_ctx dereference failure: deallocated dynamic object in *expected_signature_len: SATISFIED
+[model_verify_with_ctx.coverage.7] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 103 function model_verify_with_ctx dereference failure: dead object in *expected_signature_len: SATISFIED
+[model_verify_with_ctx.coverage.8] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 103 function model_verify_with_ctx dereference failure: pointer outside object bounds in *expected_signature_len: SATISFIED
+[model_verify_with_ctx.coverage.9] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 103 function model_verify_with_ctx dereference failure: invalid integer address in *expected_signature_len: SATISFIED
+[model_verify_with_ctx.coverage.10] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 103 function model_verify_with_ctx verify_with_ctx forwards signature length: SATISFIED
+[model_verify_with_ctx.coverage.11] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 105 function model_verify_with_ctx verify_with_ctx forwards context pointer: SATISFIED
+[model_verify_with_ctx.coverage.12] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 107 function model_verify_with_ctx verify_with_ctx forwards context length: SATISFIED
+[model_verify_with_ctx.coverage.13] file tests/cbmc/harnesses/sig_status_normalization_harness.c line 109 function model_verify_with_ctx verify_with_ctx forwards public key pointer: SATISFIED
+
+** 132 of 137 covered (96.4%)

--- a/tests/cbmc/raw-runs/sig_status_normalization.txt
+++ b/tests/cbmc/raw-runs/sig_status_normalization.txt
@@ -1,0 +1,177 @@
+CBMC version 6.9.0 (cbmc-6.9.0) 64-bit arm64 macos
+Type-checking oqs_memory
+Type-checking sig
+Type-checking sig_status_normalization_harness
+Generating GOTO Program
+Adding CPROVER library (arm64)
+Removal of function pointers and virtual functions
+Generic Property Instrumentation
+Removing unused functions
+Starting Bounded Model Checking
+Passing problem to propositional reduction
+converting SSA
+Running propositional reduction
+SAT checker: instance is UNSATISFIABLE
+
+** Results:
+src/sig/sig.c function OQS_SIG_keypair
+[OQS_SIG_keypair.pointer_dereference.1] line 3063 dereference failure: pointer NULL in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.2] line 3063 dereference failure: pointer invalid in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.3] line 3063 dereference failure: deallocated dynamic object in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.4] line 3063 dereference failure: dead object in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.5] line 3063 dereference failure: pointer outside object bounds in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.6] line 3063 dereference failure: invalid integer address in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.7] line 3063 dereference failure: pointer NULL in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.8] line 3063 dereference failure: pointer invalid in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.9] line 3063 dereference failure: deallocated dynamic object in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.10] line 3063 dereference failure: dead object in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.11] line 3063 dereference failure: pointer outside object bounds in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.12] line 3063 dereference failure: invalid integer address in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.13] line 3063 dereference failure: pointer NULL in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.14] line 3063 dereference failure: pointer invalid in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.15] line 3063 dereference failure: deallocated dynamic object in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.16] line 3063 dereference failure: dead object in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.17] line 3063 dereference failure: pointer outside object bounds in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.18] line 3063 dereference failure: invalid integer address in sig->keypair: SUCCESS
+[OQS_SIG_keypair.pointer_dereference.19] line 3063 dereferenced function pointer must be model_keypair: SUCCESS
+
+src/sig/sig.c function OQS_SIG_sign
+[OQS_SIG_sign.pointer_dereference.1] line 3071 dereference failure: pointer NULL in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.2] line 3071 dereference failure: pointer invalid in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.3] line 3071 dereference failure: deallocated dynamic object in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.4] line 3071 dereference failure: dead object in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.5] line 3071 dereference failure: pointer outside object bounds in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.6] line 3071 dereference failure: invalid integer address in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.7] line 3071 dereference failure: pointer NULL in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.8] line 3071 dereference failure: pointer invalid in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.9] line 3071 dereference failure: deallocated dynamic object in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.10] line 3071 dereference failure: dead object in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.11] line 3071 dereference failure: pointer outside object bounds in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.12] line 3071 dereference failure: invalid integer address in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.13] line 3071 dereference failure: pointer NULL in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.14] line 3071 dereference failure: pointer invalid in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.15] line 3071 dereference failure: deallocated dynamic object in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.16] line 3071 dereference failure: dead object in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.17] line 3071 dereference failure: pointer outside object bounds in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.18] line 3071 dereference failure: invalid integer address in sig->sign: SUCCESS
+[OQS_SIG_sign.pointer_dereference.19] line 3071 dereferenced function pointer must be one of [model_sign, model_verify]: SUCCESS
+
+src/sig/sig.c function OQS_SIG_sign_with_ctx_str
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.1] line 3079 dereference failure: pointer NULL in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.2] line 3079 dereference failure: pointer invalid in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.3] line 3079 dereference failure: deallocated dynamic object in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.4] line 3079 dereference failure: dead object in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.5] line 3079 dereference failure: pointer outside object bounds in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.6] line 3079 dereference failure: invalid integer address in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.7] line 3079 dereference failure: pointer NULL in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.8] line 3079 dereference failure: pointer invalid in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.9] line 3079 dereference failure: deallocated dynamic object in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.10] line 3079 dereference failure: dead object in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.11] line 3079 dereference failure: pointer outside object bounds in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.12] line 3079 dereference failure: invalid integer address in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.13] line 3079 dereference failure: pointer NULL in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.14] line 3079 dereference failure: pointer invalid in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.15] line 3079 dereference failure: deallocated dynamic object in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.16] line 3079 dereference failure: dead object in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.17] line 3079 dereference failure: pointer outside object bounds in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.18] line 3079 dereference failure: invalid integer address in sig->sign_with_ctx_str: SUCCESS
+[OQS_SIG_sign_with_ctx_str.pointer_dereference.19] line 3079 dereferenced function pointer must be one of [model_sign_with_ctx, model_verify_with_ctx]: SUCCESS
+
+src/sig/sig.c function OQS_SIG_verify
+[OQS_SIG_verify.pointer_dereference.1] line 3087 dereference failure: pointer NULL in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.2] line 3087 dereference failure: pointer invalid in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.3] line 3087 dereference failure: deallocated dynamic object in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.4] line 3087 dereference failure: dead object in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.5] line 3087 dereference failure: pointer outside object bounds in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.6] line 3087 dereference failure: invalid integer address in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.7] line 3087 dereference failure: pointer NULL in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.8] line 3087 dereference failure: pointer invalid in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.9] line 3087 dereference failure: deallocated dynamic object in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.10] line 3087 dereference failure: dead object in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.11] line 3087 dereference failure: pointer outside object bounds in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.12] line 3087 dereference failure: invalid integer address in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.13] line 3087 dereference failure: pointer NULL in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.14] line 3087 dereference failure: pointer invalid in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.15] line 3087 dereference failure: deallocated dynamic object in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.16] line 3087 dereference failure: dead object in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.17] line 3087 dereference failure: pointer outside object bounds in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.18] line 3087 dereference failure: invalid integer address in sig->verify: SUCCESS
+[OQS_SIG_verify.pointer_dereference.19] line 3087 dereferenced function pointer must be one of [model_sign, model_verify]: SUCCESS
+
+src/sig/sig.c function OQS_SIG_verify_with_ctx_str
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.1] line 3095 dereference failure: pointer NULL in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.2] line 3095 dereference failure: pointer invalid in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.3] line 3095 dereference failure: deallocated dynamic object in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.4] line 3095 dereference failure: dead object in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.5] line 3095 dereference failure: pointer outside object bounds in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.6] line 3095 dereference failure: invalid integer address in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.7] line 3095 dereference failure: pointer NULL in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.8] line 3095 dereference failure: pointer invalid in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.9] line 3095 dereference failure: deallocated dynamic object in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.10] line 3095 dereference failure: dead object in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.11] line 3095 dereference failure: pointer outside object bounds in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.12] line 3095 dereference failure: invalid integer address in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.13] line 3095 dereference failure: pointer NULL in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.14] line 3095 dereference failure: pointer invalid in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.15] line 3095 dereference failure: deallocated dynamic object in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.16] line 3095 dereference failure: dead object in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.17] line 3095 dereference failure: pointer outside object bounds in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.18] line 3095 dereference failure: invalid integer address in sig->verify_with_ctx_str: SUCCESS
+[OQS_SIG_verify_with_ctx_str.pointer_dereference.19] line 3095 dereferenced function pointer must be one of [model_sign_with_ctx, model_verify_with_ctx]: SUCCESS
+
+tests/cbmc/harnesses/sig_status_normalization_harness.c function main
+[main.assertion.1] line 187 signature dispatch rejects missing object or callback: SUCCESS
+[main.assertion.2] line 189 signature dispatch short-circuits before callback: SUCCESS
+[main.assertion.3] line 194 signature dispatch normalizes callback status: SUCCESS
+[main.assertion.4] line 196 signature dispatch invokes callback once: SUCCESS
+
+tests/cbmc/harnesses/sig_status_normalization_harness.c function model_keypair
+[model_keypair.assertion.1] line 27 keypair forwards public key pointer: SUCCESS
+[model_keypair.assertion.2] line 29 keypair forwards secret key pointer: SUCCESS
+
+tests/cbmc/harnesses/sig_status_normalization_harness.c function model_sign
+[model_sign.assertion.1] line 38 sign forwards signature pointer: SUCCESS
+[model_sign.assertion.2] line 40 sign forwards signature length pointer: SUCCESS
+[model_sign.assertion.3] line 42 sign forwards message pointer: SUCCESS
+[model_sign.assertion.4] line 44 sign forwards message length: SUCCESS
+[model_sign.assertion.5] line 46 sign forwards secret key pointer: SUCCESS
+
+tests/cbmc/harnesses/sig_status_normalization_harness.c function model_sign_with_ctx
+[model_sign_with_ctx.assertion.1] line 56 sign_with_ctx forwards signature pointer: SUCCESS
+[model_sign_with_ctx.assertion.2] line 58 sign_with_ctx forwards signature length pointer: SUCCESS
+[model_sign_with_ctx.assertion.3] line 60 sign_with_ctx forwards message pointer: SUCCESS
+[model_sign_with_ctx.assertion.4] line 62 sign_with_ctx forwards message length: SUCCESS
+[model_sign_with_ctx.assertion.5] line 64 sign_with_ctx forwards context pointer: SUCCESS
+[model_sign_with_ctx.assertion.6] line 66 sign_with_ctx forwards context length: SUCCESS
+[model_sign_with_ctx.assertion.7] line 68 sign_with_ctx forwards secret key pointer: SUCCESS
+
+tests/cbmc/harnesses/sig_status_normalization_harness.c function model_verify
+[model_verify.assertion.1] line 77 verify forwards message pointer: SUCCESS
+[model_verify.assertion.2] line 79 verify forwards message length: SUCCESS
+[model_verify.assertion.3] line 81 verify forwards signature pointer: SUCCESS
+[model_verify.assertion.4] line 83 verify forwards signature length: SUCCESS
+[model_verify.pointer_dereference.1] line 83 dereference failure: pointer NULL in *expected_signature_len: SUCCESS
+[model_verify.pointer_dereference.2] line 83 dereference failure: pointer invalid in *expected_signature_len: SUCCESS
+[model_verify.pointer_dereference.3] line 83 dereference failure: deallocated dynamic object in *expected_signature_len: SUCCESS
+[model_verify.pointer_dereference.4] line 83 dereference failure: dead object in *expected_signature_len: SUCCESS
+[model_verify.pointer_dereference.5] line 83 dereference failure: pointer outside object bounds in *expected_signature_len: SUCCESS
+[model_verify.pointer_dereference.6] line 83 dereference failure: invalid integer address in *expected_signature_len: SUCCESS
+[model_verify.assertion.5] line 85 verify forwards public key pointer: SUCCESS
+
+tests/cbmc/harnesses/sig_status_normalization_harness.c function model_verify_with_ctx
+[model_verify_with_ctx.assertion.1] line 97 verify_with_ctx forwards message pointer: SUCCESS
+[model_verify_with_ctx.assertion.2] line 99 verify_with_ctx forwards message length: SUCCESS
+[model_verify_with_ctx.assertion.3] line 101 verify_with_ctx forwards signature pointer: SUCCESS
+[model_verify_with_ctx.assertion.4] line 103 verify_with_ctx forwards signature length: SUCCESS
+[model_verify_with_ctx.pointer_dereference.1] line 103 dereference failure: pointer NULL in *expected_signature_len: SUCCESS
+[model_verify_with_ctx.pointer_dereference.2] line 103 dereference failure: pointer invalid in *expected_signature_len: SUCCESS
+[model_verify_with_ctx.pointer_dereference.3] line 103 dereference failure: deallocated dynamic object in *expected_signature_len: SUCCESS
+[model_verify_with_ctx.pointer_dereference.4] line 103 dereference failure: dead object in *expected_signature_len: SUCCESS
+[model_verify_with_ctx.pointer_dereference.5] line 103 dereference failure: pointer outside object bounds in *expected_signature_len: SUCCESS
+[model_verify_with_ctx.pointer_dereference.6] line 103 dereference failure: invalid integer address in *expected_signature_len: SUCCESS
+[model_verify_with_ctx.assertion.5] line 105 verify_with_ctx forwards context pointer: SUCCESS
+[model_verify_with_ctx.assertion.6] line 107 verify_with_ctx forwards context length: SUCCESS
+[model_verify_with_ctx.assertion.7] line 109 verify_with_ctx forwards public key pointer: SUCCESS
+
+** 0 of 137 failed (1 iterations)
+VERIFICATION SUCCESSFUL

--- a/tests/cbmc/raw-runs/sig_stfl_dispatch_contract.coverage.txt
+++ b/tests/cbmc/raw-runs/sig_stfl_dispatch_contract.coverage.txt
@@ -1,0 +1,217 @@
+--cover is incompatible with --unwinding-assertions, so unwinding-assertions will be defaulted to false
+**** WARNING: Use --unwinding-assertions to obtain sound verification results
+CBMC version 6.9.0 (cbmc-6.9.0) 64-bit arm64 macos
+Type-checking oqs_memory
+Type-checking sig_stfl
+Type-checking sig_stfl_dispatch_contract_harness
+Generating GOTO Program
+Adding CPROVER library (arm64)
+Removal of function pointers and virtual functions
+Generic Property Instrumentation
+Removing unused functions
+Rewriting existing assertions as assumptions
+Starting Bounded Model Checking
+Passing problem to propositional reduction
+converting SSA
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker inconsistent: instance is UNSATISFIABLE
+
+** coverage results:
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.1] file src/sig_stfl/sig_stfl.c line 1555 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: pointer NULL in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.2] file src/sig_stfl/sig_stfl.c line 1555 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: pointer invalid in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.3] file src/sig_stfl/sig_stfl.c line 1555 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: deallocated dynamic object in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.4] file src/sig_stfl/sig_stfl.c line 1555 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: dead object in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.5] file src/sig_stfl/sig_stfl.c line 1555 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: pointer outside object bounds in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.6] file src/sig_stfl/sig_stfl.c line 1555 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: invalid integer address in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.7] file src/sig_stfl/sig_stfl.c line 1559 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: pointer NULL in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.8] file src/sig_stfl/sig_stfl.c line 1559 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: pointer invalid in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.9] file src/sig_stfl/sig_stfl.c line 1559 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: deallocated dynamic object in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.10] file src/sig_stfl/sig_stfl.c line 1559 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: dead object in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.11] file src/sig_stfl/sig_stfl.c line 1559 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: pointer outside object bounds in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.12] file src/sig_stfl/sig_stfl.c line 1559 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: invalid integer address in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.13] file src/sig_stfl/sig_stfl.c line 1559 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: pointer NULL in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.14] file src/sig_stfl/sig_stfl.c line 1559 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: pointer invalid in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.15] file src/sig_stfl/sig_stfl.c line 1559 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: deallocated dynamic object in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.16] file src/sig_stfl/sig_stfl.c line 1559 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: dead object in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.17] file src/sig_stfl/sig_stfl.c line 1559 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: pointer outside object bounds in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.18] file src/sig_stfl/sig_stfl.c line 1559 function OQS_SIG_STFL_SECRET_KEY_deserialize dereference failure: invalid integer address in sk->deserialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_deserialize.coverage.19] file src/sig_stfl/sig_stfl.c line 1559 function OQS_SIG_STFL_SECRET_KEY_deserialize dereferenced function pointer must be model_deserialize: FAILED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.1] file src/sig_stfl/sig_stfl.c line 1546 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: pointer NULL in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.2] file src/sig_stfl/sig_stfl.c line 1546 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: pointer invalid in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.3] file src/sig_stfl/sig_stfl.c line 1546 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: deallocated dynamic object in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.4] file src/sig_stfl/sig_stfl.c line 1546 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: dead object in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.5] file src/sig_stfl/sig_stfl.c line 1546 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: pointer outside object bounds in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.6] file src/sig_stfl/sig_stfl.c line 1546 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: invalid integer address in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.7] file src/sig_stfl/sig_stfl.c line 1550 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: pointer NULL in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.8] file src/sig_stfl/sig_stfl.c line 1550 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: pointer invalid in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.9] file src/sig_stfl/sig_stfl.c line 1550 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: deallocated dynamic object in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.10] file src/sig_stfl/sig_stfl.c line 1550 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: dead object in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.11] file src/sig_stfl/sig_stfl.c line 1550 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: pointer outside object bounds in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.12] file src/sig_stfl/sig_stfl.c line 1550 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: invalid integer address in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.13] file src/sig_stfl/sig_stfl.c line 1550 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: pointer NULL in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.14] file src/sig_stfl/sig_stfl.c line 1550 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: pointer invalid in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.15] file src/sig_stfl/sig_stfl.c line 1550 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: deallocated dynamic object in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.16] file src/sig_stfl/sig_stfl.c line 1550 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: dead object in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.17] file src/sig_stfl/sig_stfl.c line 1550 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: pointer outside object bounds in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.18] file src/sig_stfl/sig_stfl.c line 1550 function OQS_SIG_STFL_SECRET_KEY_serialize dereference failure: invalid integer address in sk->serialize_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_serialize.coverage.19] file src/sig_stfl/sig_stfl.c line 1550 function OQS_SIG_STFL_SECRET_KEY_serialize dereferenced function pointer must be model_serialize: FAILED
+[OQS_SIG_STFL_keypair.coverage.1] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: pointer NULL in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.2] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: pointer invalid in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.3] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: deallocated dynamic object in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.4] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: dead object in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.5] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: pointer outside object bounds in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.6] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: invalid integer address in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.7] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: pointer NULL in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.8] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: pointer invalid in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.9] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: deallocated dynamic object in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.10] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: dead object in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.11] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: pointer outside object bounds in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.12] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: invalid integer address in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.13] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: pointer NULL in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.14] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: pointer invalid in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.15] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: deallocated dynamic object in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.16] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: dead object in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.17] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: pointer outside object bounds in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.18] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereference failure: invalid integer address in sig->keypair: SATISFIED
+[OQS_SIG_STFL_keypair.coverage.19] file src/sig_stfl/sig_stfl.c line 1014 function OQS_SIG_STFL_keypair dereferenced function pointer must be one of [model_keypair, model_sigs_remaining, model_sigs_total]: FAILED
+[OQS_SIG_STFL_sign.coverage.1] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: pointer NULL in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.2] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: pointer invalid in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.3] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: deallocated dynamic object in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.4] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: dead object in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.5] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: pointer outside object bounds in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.6] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: invalid integer address in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.7] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: pointer NULL in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.8] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: pointer invalid in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.9] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: deallocated dynamic object in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.10] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: dead object in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.11] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: pointer outside object bounds in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.12] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: invalid integer address in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.13] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: pointer NULL in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.14] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: pointer invalid in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.15] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: deallocated dynamic object in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.16] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: dead object in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.17] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: pointer outside object bounds in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.18] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereference failure: invalid integer address in sig->sign: SATISFIED
+[OQS_SIG_STFL_sign.coverage.19] file src/sig_stfl/sig_stfl.c line 1035 function OQS_SIG_STFL_sign dereferenced function pointer must be one of [model_sign, model_verify]: FAILED
+[OQS_SIG_STFL_sigs_remaining.coverage.1] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: pointer NULL in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.2] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: pointer invalid in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.3] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: deallocated dynamic object in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.4] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: dead object in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.5] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: pointer outside object bounds in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.6] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: invalid integer address in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.7] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: pointer NULL in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.8] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: pointer invalid in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.9] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: deallocated dynamic object in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.10] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: dead object in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.11] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: pointer outside object bounds in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.12] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: invalid integer address in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.13] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: pointer NULL in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.14] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: pointer invalid in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.15] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: deallocated dynamic object in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.16] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: dead object in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.17] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: pointer outside object bounds in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.18] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereference failure: invalid integer address in sig->sigs_remaining: SATISFIED
+[OQS_SIG_STFL_sigs_remaining.coverage.19] file src/sig_stfl/sig_stfl.c line 1059 function OQS_SIG_STFL_sigs_remaining dereferenced function pointer must be one of [model_keypair, model_sigs_remaining, model_sigs_total]: FAILED
+[OQS_SIG_STFL_sigs_total.coverage.1] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: pointer NULL in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.2] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: pointer invalid in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.3] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: deallocated dynamic object in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.4] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: dead object in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.5] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: pointer outside object bounds in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.6] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: invalid integer address in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.7] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: pointer NULL in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.8] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: pointer invalid in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.9] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: deallocated dynamic object in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.10] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: dead object in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.11] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: pointer outside object bounds in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.12] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: invalid integer address in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.13] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: pointer NULL in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.14] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: pointer invalid in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.15] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: deallocated dynamic object in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.16] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: dead object in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.17] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: pointer outside object bounds in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.18] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereference failure: invalid integer address in sig->sigs_total: SATISFIED
+[OQS_SIG_STFL_sigs_total.coverage.19] file src/sig_stfl/sig_stfl.c line 1075 function OQS_SIG_STFL_sigs_total dereferenced function pointer must be one of [model_keypair, model_sigs_remaining, model_sigs_total]: FAILED
+[OQS_SIG_STFL_verify.coverage.1] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: pointer NULL in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.2] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: pointer invalid in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.3] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: deallocated dynamic object in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.4] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: dead object in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.5] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: pointer outside object bounds in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.6] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: invalid integer address in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.7] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: pointer NULL in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.8] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: pointer invalid in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.9] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: deallocated dynamic object in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.10] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: dead object in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.11] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: pointer outside object bounds in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.12] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: invalid integer address in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.13] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: pointer NULL in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.14] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: pointer invalid in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.15] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: deallocated dynamic object in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.16] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: dead object in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.17] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: pointer outside object bounds in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.18] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereference failure: invalid integer address in sig->verify: SATISFIED
+[OQS_SIG_STFL_verify.coverage.19] file src/sig_stfl/sig_stfl.c line 1044 function OQS_SIG_STFL_verify dereferenced function pointer must be one of [model_sign, model_verify]: FAILED
+[main.coverage.1] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 228 function main stfl dispatch rejects missing wrapper input: SATISFIED
+[main.coverage.2] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 230 function main stfl dispatch short-circuits before callback: SATISFIED
+[main.coverage.3] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 235 function main stfl operation dispatch normalizes callback status: SATISFIED
+[main.coverage.4] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 237 function main stfl operation dispatch invokes callback once: SATISFIED
+[main.coverage.5] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 240 function main stfl key serialization dispatch preserves callback status: SATISFIED
+[main.coverage.6] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 242 function main stfl key serialization dispatch invokes callback once: SATISFIED
+[model_deserialize.coverage.1] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 110 function model_deserialize stfl deserialize forwards secret key pointer: SATISFIED
+[model_deserialize.coverage.2] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 112 function model_deserialize stfl deserialize forwards input pointer: SATISFIED
+[model_deserialize.coverage.3] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 114 function model_deserialize stfl deserialize forwards input length: SATISFIED
+[model_deserialize.coverage.4] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 116 function model_deserialize stfl deserialize forwards context pointer: SATISFIED
+[model_keypair.coverage.1] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 32 function model_keypair stfl keypair forwards public key pointer: SATISFIED
+[model_keypair.coverage.2] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 34 function model_keypair stfl keypair forwards secret key pointer: SATISFIED
+[model_serialize.coverage.1] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 96 function model_serialize stfl serialize forwards output pointer: SATISFIED
+[model_serialize.coverage.2] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 98 function model_serialize stfl serialize forwards output length pointer: SATISFIED
+[model_serialize.coverage.3] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 100 function model_serialize stfl serialize forwards secret key pointer: SATISFIED
+[model_sign.coverage.1] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 43 function model_sign stfl sign forwards signature pointer: SATISFIED
+[model_sign.coverage.2] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 45 function model_sign stfl sign forwards signature length pointer: SATISFIED
+[model_sign.coverage.3] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 47 function model_sign stfl sign forwards message pointer: SATISFIED
+[model_sign.coverage.4] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 49 function model_sign stfl sign forwards message length: SATISFIED
+[model_sign.coverage.5] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 51 function model_sign stfl sign forwards secret key pointer: SATISFIED
+[model_sigs_remaining.coverage.1] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 76 function model_sigs_remaining stfl sigs_remaining forwards counter pointer: SATISFIED
+[model_sigs_remaining.coverage.2] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 78 function model_sigs_remaining stfl sigs_remaining forwards secret key pointer: SATISFIED
+[model_sigs_total.coverage.1] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 86 function model_sigs_total stfl sigs_total forwards counter pointer: SATISFIED
+[model_sigs_total.coverage.2] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 88 function model_sigs_total stfl sigs_total forwards secret key pointer: SATISFIED
+[model_verify.coverage.1] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 60 function model_verify stfl verify forwards message pointer: SATISFIED
+[model_verify.coverage.2] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 62 function model_verify stfl verify forwards message length: SATISFIED
+[model_verify.coverage.3] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 64 function model_verify stfl verify forwards signature pointer: SATISFIED
+[model_verify.coverage.4] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 66 function model_verify dereference failure: pointer NULL in *expected_signature_len: SATISFIED
+[model_verify.coverage.5] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 66 function model_verify dereference failure: pointer invalid in *expected_signature_len: SATISFIED
+[model_verify.coverage.6] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 66 function model_verify dereference failure: deallocated dynamic object in *expected_signature_len: SATISFIED
+[model_verify.coverage.7] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 66 function model_verify dereference failure: dead object in *expected_signature_len: SATISFIED
+[model_verify.coverage.8] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 66 function model_verify dereference failure: pointer outside object bounds in *expected_signature_len: SATISFIED
+[model_verify.coverage.9] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 66 function model_verify dereference failure: invalid integer address in *expected_signature_len: SATISFIED
+[model_verify.coverage.10] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 66 function model_verify stfl verify forwards signature length: SATISFIED
+[model_verify.coverage.11] file tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c line 68 function model_verify stfl verify forwards public key pointer: SATISFIED
+
+** 161 of 168 covered (95.8%)

--- a/tests/cbmc/raw-runs/sig_stfl_dispatch_contract.txt
+++ b/tests/cbmc/raw-runs/sig_stfl_dispatch_contract.txt
@@ -1,0 +1,216 @@
+CBMC version 6.9.0 (cbmc-6.9.0) 64-bit arm64 macos
+Type-checking oqs_memory
+Type-checking sig_stfl
+Type-checking sig_stfl_dispatch_contract_harness
+Generating GOTO Program
+Adding CPROVER library (arm64)
+Removal of function pointers and virtual functions
+Generic Property Instrumentation
+Removing unused functions
+Starting Bounded Model Checking
+Passing problem to propositional reduction
+converting SSA
+Running propositional reduction
+SAT checker: instance is UNSATISFIABLE
+
+** Results:
+src/sig_stfl/sig_stfl.c function OQS_SIG_STFL_SECRET_KEY_deserialize
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.1] line 1555 dereference failure: pointer NULL in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.2] line 1555 dereference failure: pointer invalid in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.3] line 1555 dereference failure: deallocated dynamic object in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.4] line 1555 dereference failure: dead object in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.5] line 1555 dereference failure: pointer outside object bounds in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.6] line 1555 dereference failure: invalid integer address in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.7] line 1559 dereference failure: pointer NULL in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.8] line 1559 dereference failure: pointer invalid in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.9] line 1559 dereference failure: deallocated dynamic object in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.10] line 1559 dereference failure: dead object in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.11] line 1559 dereference failure: pointer outside object bounds in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.12] line 1559 dereference failure: invalid integer address in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.13] line 1559 dereference failure: pointer NULL in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.14] line 1559 dereference failure: pointer invalid in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.15] line 1559 dereference failure: deallocated dynamic object in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.16] line 1559 dereference failure: dead object in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.17] line 1559 dereference failure: pointer outside object bounds in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.18] line 1559 dereference failure: invalid integer address in sk->deserialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_deserialize.pointer_dereference.19] line 1559 dereferenced function pointer must be model_deserialize: SUCCESS
+
+src/sig_stfl/sig_stfl.c function OQS_SIG_STFL_SECRET_KEY_serialize
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.1] line 1546 dereference failure: pointer NULL in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.2] line 1546 dereference failure: pointer invalid in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.3] line 1546 dereference failure: deallocated dynamic object in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.4] line 1546 dereference failure: dead object in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.5] line 1546 dereference failure: pointer outside object bounds in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.6] line 1546 dereference failure: invalid integer address in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.7] line 1550 dereference failure: pointer NULL in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.8] line 1550 dereference failure: pointer invalid in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.9] line 1550 dereference failure: deallocated dynamic object in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.10] line 1550 dereference failure: dead object in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.11] line 1550 dereference failure: pointer outside object bounds in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.12] line 1550 dereference failure: invalid integer address in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.13] line 1550 dereference failure: pointer NULL in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.14] line 1550 dereference failure: pointer invalid in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.15] line 1550 dereference failure: deallocated dynamic object in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.16] line 1550 dereference failure: dead object in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.17] line 1550 dereference failure: pointer outside object bounds in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.18] line 1550 dereference failure: invalid integer address in sk->serialize_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_serialize.pointer_dereference.19] line 1550 dereferenced function pointer must be model_serialize: SUCCESS
+
+src/sig_stfl/sig_stfl.c function OQS_SIG_STFL_keypair
+[OQS_SIG_STFL_keypair.pointer_dereference.1] line 1014 dereference failure: pointer NULL in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.2] line 1014 dereference failure: pointer invalid in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.3] line 1014 dereference failure: deallocated dynamic object in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.4] line 1014 dereference failure: dead object in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.5] line 1014 dereference failure: pointer outside object bounds in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.6] line 1014 dereference failure: invalid integer address in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.7] line 1014 dereference failure: pointer NULL in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.8] line 1014 dereference failure: pointer invalid in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.9] line 1014 dereference failure: deallocated dynamic object in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.10] line 1014 dereference failure: dead object in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.11] line 1014 dereference failure: pointer outside object bounds in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.12] line 1014 dereference failure: invalid integer address in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.13] line 1014 dereference failure: pointer NULL in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.14] line 1014 dereference failure: pointer invalid in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.15] line 1014 dereference failure: deallocated dynamic object in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.16] line 1014 dereference failure: dead object in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.17] line 1014 dereference failure: pointer outside object bounds in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.18] line 1014 dereference failure: invalid integer address in sig->keypair: SUCCESS
+[OQS_SIG_STFL_keypair.pointer_dereference.19] line 1014 dereferenced function pointer must be one of [model_keypair, model_sigs_remaining, model_sigs_total]: SUCCESS
+
+src/sig_stfl/sig_stfl.c function OQS_SIG_STFL_sign
+[OQS_SIG_STFL_sign.pointer_dereference.1] line 1035 dereference failure: pointer NULL in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.2] line 1035 dereference failure: pointer invalid in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.3] line 1035 dereference failure: deallocated dynamic object in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.4] line 1035 dereference failure: dead object in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.5] line 1035 dereference failure: pointer outside object bounds in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.6] line 1035 dereference failure: invalid integer address in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.7] line 1035 dereference failure: pointer NULL in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.8] line 1035 dereference failure: pointer invalid in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.9] line 1035 dereference failure: deallocated dynamic object in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.10] line 1035 dereference failure: dead object in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.11] line 1035 dereference failure: pointer outside object bounds in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.12] line 1035 dereference failure: invalid integer address in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.13] line 1035 dereference failure: pointer NULL in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.14] line 1035 dereference failure: pointer invalid in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.15] line 1035 dereference failure: deallocated dynamic object in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.16] line 1035 dereference failure: dead object in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.17] line 1035 dereference failure: pointer outside object bounds in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.18] line 1035 dereference failure: invalid integer address in sig->sign: SUCCESS
+[OQS_SIG_STFL_sign.pointer_dereference.19] line 1035 dereferenced function pointer must be one of [model_sign, model_verify]: SUCCESS
+
+src/sig_stfl/sig_stfl.c function OQS_SIG_STFL_sigs_remaining
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.1] line 1059 dereference failure: pointer NULL in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.2] line 1059 dereference failure: pointer invalid in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.3] line 1059 dereference failure: deallocated dynamic object in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.4] line 1059 dereference failure: dead object in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.5] line 1059 dereference failure: pointer outside object bounds in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.6] line 1059 dereference failure: invalid integer address in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.7] line 1059 dereference failure: pointer NULL in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.8] line 1059 dereference failure: pointer invalid in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.9] line 1059 dereference failure: deallocated dynamic object in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.10] line 1059 dereference failure: dead object in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.11] line 1059 dereference failure: pointer outside object bounds in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.12] line 1059 dereference failure: invalid integer address in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.13] line 1059 dereference failure: pointer NULL in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.14] line 1059 dereference failure: pointer invalid in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.15] line 1059 dereference failure: deallocated dynamic object in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.16] line 1059 dereference failure: dead object in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.17] line 1059 dereference failure: pointer outside object bounds in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.18] line 1059 dereference failure: invalid integer address in sig->sigs_remaining: SUCCESS
+[OQS_SIG_STFL_sigs_remaining.pointer_dereference.19] line 1059 dereferenced function pointer must be one of [model_keypair, model_sigs_remaining, model_sigs_total]: SUCCESS
+
+src/sig_stfl/sig_stfl.c function OQS_SIG_STFL_sigs_total
+[OQS_SIG_STFL_sigs_total.pointer_dereference.1] line 1075 dereference failure: pointer NULL in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.2] line 1075 dereference failure: pointer invalid in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.3] line 1075 dereference failure: deallocated dynamic object in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.4] line 1075 dereference failure: dead object in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.5] line 1075 dereference failure: pointer outside object bounds in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.6] line 1075 dereference failure: invalid integer address in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.7] line 1075 dereference failure: pointer NULL in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.8] line 1075 dereference failure: pointer invalid in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.9] line 1075 dereference failure: deallocated dynamic object in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.10] line 1075 dereference failure: dead object in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.11] line 1075 dereference failure: pointer outside object bounds in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.12] line 1075 dereference failure: invalid integer address in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.13] line 1075 dereference failure: pointer NULL in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.14] line 1075 dereference failure: pointer invalid in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.15] line 1075 dereference failure: deallocated dynamic object in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.16] line 1075 dereference failure: dead object in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.17] line 1075 dereference failure: pointer outside object bounds in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.18] line 1075 dereference failure: invalid integer address in sig->sigs_total: SUCCESS
+[OQS_SIG_STFL_sigs_total.pointer_dereference.19] line 1075 dereferenced function pointer must be one of [model_keypair, model_sigs_remaining, model_sigs_total]: SUCCESS
+
+src/sig_stfl/sig_stfl.c function OQS_SIG_STFL_verify
+[OQS_SIG_STFL_verify.pointer_dereference.1] line 1044 dereference failure: pointer NULL in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.2] line 1044 dereference failure: pointer invalid in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.3] line 1044 dereference failure: deallocated dynamic object in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.4] line 1044 dereference failure: dead object in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.5] line 1044 dereference failure: pointer outside object bounds in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.6] line 1044 dereference failure: invalid integer address in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.7] line 1044 dereference failure: pointer NULL in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.8] line 1044 dereference failure: pointer invalid in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.9] line 1044 dereference failure: deallocated dynamic object in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.10] line 1044 dereference failure: dead object in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.11] line 1044 dereference failure: pointer outside object bounds in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.12] line 1044 dereference failure: invalid integer address in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.13] line 1044 dereference failure: pointer NULL in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.14] line 1044 dereference failure: pointer invalid in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.15] line 1044 dereference failure: deallocated dynamic object in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.16] line 1044 dereference failure: dead object in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.17] line 1044 dereference failure: pointer outside object bounds in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.18] line 1044 dereference failure: invalid integer address in sig->verify: SUCCESS
+[OQS_SIG_STFL_verify.pointer_dereference.19] line 1044 dereferenced function pointer must be one of [model_sign, model_verify]: SUCCESS
+
+tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c function main
+[main.assertion.1] line 228 stfl dispatch rejects missing wrapper input: SUCCESS
+[main.assertion.2] line 230 stfl dispatch short-circuits before callback: SUCCESS
+[main.assertion.3] line 235 stfl operation dispatch normalizes callback status: SUCCESS
+[main.assertion.4] line 237 stfl operation dispatch invokes callback once: SUCCESS
+[main.assertion.5] line 240 stfl key serialization dispatch preserves callback status: SUCCESS
+[main.assertion.6] line 242 stfl key serialization dispatch invokes callback once: SUCCESS
+
+tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c function model_deserialize
+[model_deserialize.assertion.1] line 110 stfl deserialize forwards secret key pointer: SUCCESS
+[model_deserialize.assertion.2] line 112 stfl deserialize forwards input pointer: SUCCESS
+[model_deserialize.assertion.3] line 114 stfl deserialize forwards input length: SUCCESS
+[model_deserialize.assertion.4] line 116 stfl deserialize forwards context pointer: SUCCESS
+
+tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c function model_keypair
+[model_keypair.assertion.1] line 32 stfl keypair forwards public key pointer: SUCCESS
+[model_keypair.assertion.2] line 34 stfl keypair forwards secret key pointer: SUCCESS
+
+tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c function model_serialize
+[model_serialize.assertion.1] line 96 stfl serialize forwards output pointer: SUCCESS
+[model_serialize.assertion.2] line 98 stfl serialize forwards output length pointer: SUCCESS
+[model_serialize.assertion.3] line 100 stfl serialize forwards secret key pointer: SUCCESS
+
+tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c function model_sign
+[model_sign.assertion.1] line 43 stfl sign forwards signature pointer: SUCCESS
+[model_sign.assertion.2] line 45 stfl sign forwards signature length pointer: SUCCESS
+[model_sign.assertion.3] line 47 stfl sign forwards message pointer: SUCCESS
+[model_sign.assertion.4] line 49 stfl sign forwards message length: SUCCESS
+[model_sign.assertion.5] line 51 stfl sign forwards secret key pointer: SUCCESS
+
+tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c function model_sigs_remaining
+[model_sigs_remaining.assertion.1] line 76 stfl sigs_remaining forwards counter pointer: SUCCESS
+[model_sigs_remaining.assertion.2] line 78 stfl sigs_remaining forwards secret key pointer: SUCCESS
+
+tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c function model_sigs_total
+[model_sigs_total.assertion.1] line 86 stfl sigs_total forwards counter pointer: SUCCESS
+[model_sigs_total.assertion.2] line 88 stfl sigs_total forwards secret key pointer: SUCCESS
+
+tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c function model_verify
+[model_verify.assertion.1] line 60 stfl verify forwards message pointer: SUCCESS
+[model_verify.assertion.2] line 62 stfl verify forwards message length: SUCCESS
+[model_verify.assertion.3] line 64 stfl verify forwards signature pointer: SUCCESS
+[model_verify.assertion.4] line 66 stfl verify forwards signature length: SUCCESS
+[model_verify.pointer_dereference.1] line 66 dereference failure: pointer NULL in *expected_signature_len: SUCCESS
+[model_verify.pointer_dereference.2] line 66 dereference failure: pointer invalid in *expected_signature_len: SUCCESS
+[model_verify.pointer_dereference.3] line 66 dereference failure: deallocated dynamic object in *expected_signature_len: SUCCESS
+[model_verify.pointer_dereference.4] line 66 dereference failure: dead object in *expected_signature_len: SUCCESS
+[model_verify.pointer_dereference.5] line 66 dereference failure: pointer outside object bounds in *expected_signature_len: SUCCESS
+[model_verify.pointer_dereference.6] line 66 dereference failure: invalid integer address in *expected_signature_len: SUCCESS
+[model_verify.assertion.5] line 68 stfl verify forwards public key pointer: SUCCESS
+
+** 0 of 168 failed (1 iterations)
+VERIFICATION SUCCESSFUL

--- a/tests/cbmc/raw-runs/sig_stfl_lock_contract.coverage.txt
+++ b/tests/cbmc/raw-runs/sig_stfl_lock_contract.coverage.txt
@@ -1,0 +1,140 @@
+--cover is incompatible with --unwinding-assertions, so unwinding-assertions will be defaulted to false
+**** WARNING: Use --unwinding-assertions to obtain sound verification results
+CBMC version 6.9.0 (cbmc-6.9.0) 64-bit arm64 macos
+Type-checking oqs_memory
+Type-checking sig_stfl
+Type-checking sig_stfl_lock_contract_harness
+Generating GOTO Program
+Adding CPROVER library (arm64)
+Removal of function pointers and virtual functions
+Generic Property Instrumentation
+Removing unused functions
+Rewriting existing assertions as assumptions
+Starting Bounded Model Checking
+Passing problem to propositional reduction
+converting SSA
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker: instance is SATISFIABLE
+Running propositional reduction
+SAT checker inconsistent: instance is UNSATISFIABLE
+
+** coverage results:
+[OQS_SIG_STFL_SECRET_KEY_SET_lock.coverage.1] file src/sig_stfl/sig_stfl.c line 1567 function OQS_SIG_STFL_SECRET_KEY_SET_lock dereference failure: pointer NULL in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_lock.coverage.2] file src/sig_stfl/sig_stfl.c line 1567 function OQS_SIG_STFL_SECRET_KEY_SET_lock dereference failure: pointer invalid in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_lock.coverage.3] file src/sig_stfl/sig_stfl.c line 1567 function OQS_SIG_STFL_SECRET_KEY_SET_lock dereference failure: deallocated dynamic object in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_lock.coverage.4] file src/sig_stfl/sig_stfl.c line 1567 function OQS_SIG_STFL_SECRET_KEY_SET_lock dereference failure: dead object in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_lock.coverage.5] file src/sig_stfl/sig_stfl.c line 1567 function OQS_SIG_STFL_SECRET_KEY_SET_lock dereference failure: pointer outside object bounds in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_lock.coverage.6] file src/sig_stfl/sig_stfl.c line 1567 function OQS_SIG_STFL_SECRET_KEY_SET_lock dereference failure: invalid integer address in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_mutex.coverage.1] file src/sig_stfl/sig_stfl.c line 1583 function OQS_SIG_STFL_SECRET_KEY_SET_mutex dereference failure: pointer NULL in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_mutex.coverage.2] file src/sig_stfl/sig_stfl.c line 1583 function OQS_SIG_STFL_SECRET_KEY_SET_mutex dereference failure: pointer invalid in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_mutex.coverage.3] file src/sig_stfl/sig_stfl.c line 1583 function OQS_SIG_STFL_SECRET_KEY_SET_mutex dereference failure: deallocated dynamic object in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_mutex.coverage.4] file src/sig_stfl/sig_stfl.c line 1583 function OQS_SIG_STFL_SECRET_KEY_SET_mutex dereference failure: dead object in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_mutex.coverage.5] file src/sig_stfl/sig_stfl.c line 1583 function OQS_SIG_STFL_SECRET_KEY_SET_mutex dereference failure: pointer outside object bounds in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_mutex.coverage.6] file src/sig_stfl/sig_stfl.c line 1583 function OQS_SIG_STFL_SECRET_KEY_SET_mutex dereference failure: invalid integer address in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_unlock.coverage.1] file src/sig_stfl/sig_stfl.c line 1575 function OQS_SIG_STFL_SECRET_KEY_SET_unlock dereference failure: pointer NULL in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_unlock.coverage.2] file src/sig_stfl/sig_stfl.c line 1575 function OQS_SIG_STFL_SECRET_KEY_SET_unlock dereference failure: pointer invalid in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_unlock.coverage.3] file src/sig_stfl/sig_stfl.c line 1575 function OQS_SIG_STFL_SECRET_KEY_SET_unlock dereference failure: deallocated dynamic object in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_unlock.coverage.4] file src/sig_stfl/sig_stfl.c line 1575 function OQS_SIG_STFL_SECRET_KEY_SET_unlock dereference failure: dead object in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_unlock.coverage.5] file src/sig_stfl/sig_stfl.c line 1575 function OQS_SIG_STFL_SECRET_KEY_SET_unlock dereference failure: pointer outside object bounds in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_SET_unlock.coverage.6] file src/sig_stfl/sig_stfl.c line 1575 function OQS_SIG_STFL_SECRET_KEY_SET_unlock dereference failure: invalid integer address in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.1] file src/sig_stfl/sig_stfl.c line 1591 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer NULL in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.2] file src/sig_stfl/sig_stfl.c line 1591 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer invalid in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.3] file src/sig_stfl/sig_stfl.c line 1591 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: deallocated dynamic object in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.4] file src/sig_stfl/sig_stfl.c line 1591 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: dead object in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.5] file src/sig_stfl/sig_stfl.c line 1591 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer outside object bounds in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.6] file src/sig_stfl/sig_stfl.c line 1591 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: invalid integer address in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.7] file src/sig_stfl/sig_stfl.c line 1596 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer NULL in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.8] file src/sig_stfl/sig_stfl.c line 1596 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer invalid in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.9] file src/sig_stfl/sig_stfl.c line 1596 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: deallocated dynamic object in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.10] file src/sig_stfl/sig_stfl.c line 1596 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: dead object in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.11] file src/sig_stfl/sig_stfl.c line 1596 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer outside object bounds in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.12] file src/sig_stfl/sig_stfl.c line 1596 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: invalid integer address in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.13] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer NULL in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.14] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer invalid in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.15] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: deallocated dynamic object in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.16] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: dead object in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.17] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer outside object bounds in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.18] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: invalid integer address in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.19] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer NULL in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.20] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer invalid in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.21] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: deallocated dynamic object in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.22] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: dead object in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.23] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer outside object bounds in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.24] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: invalid integer address in sk->lock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.25] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereferenced function pointer must be one of [model_lock, model_unlock]: FAILED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.26] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer NULL in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.27] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer invalid in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.28] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: deallocated dynamic object in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.29] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: dead object in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.30] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer outside object bounds in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.31] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: invalid integer address in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.32] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer NULL in sk->mutex: FAILED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.33] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer invalid in sk->mutex: FAILED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.34] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: deallocated dynamic object in sk->mutex: FAILED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.35] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: dead object in sk->mutex: FAILED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.36] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: pointer outside object bounds in sk->mutex: FAILED
+[OQS_SIG_STFL_SECRET_KEY_lock.coverage.37] file src/sig_stfl/sig_stfl.c line 1600 function OQS_SIG_STFL_SECRET_KEY_lock dereference failure: invalid integer address in sk->mutex: FAILED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.1] file src/sig_stfl/sig_stfl.c line 1608 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer NULL in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.2] file src/sig_stfl/sig_stfl.c line 1608 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer invalid in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.3] file src/sig_stfl/sig_stfl.c line 1608 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: deallocated dynamic object in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.4] file src/sig_stfl/sig_stfl.c line 1608 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: dead object in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.5] file src/sig_stfl/sig_stfl.c line 1608 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer outside object bounds in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.6] file src/sig_stfl/sig_stfl.c line 1608 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: invalid integer address in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.7] file src/sig_stfl/sig_stfl.c line 1613 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer NULL in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.8] file src/sig_stfl/sig_stfl.c line 1613 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer invalid in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.9] file src/sig_stfl/sig_stfl.c line 1613 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: deallocated dynamic object in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.10] file src/sig_stfl/sig_stfl.c line 1613 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: dead object in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.11] file src/sig_stfl/sig_stfl.c line 1613 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer outside object bounds in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.12] file src/sig_stfl/sig_stfl.c line 1613 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: invalid integer address in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.13] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer NULL in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.14] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer invalid in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.15] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: deallocated dynamic object in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.16] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: dead object in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.17] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer outside object bounds in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.18] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: invalid integer address in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.19] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer NULL in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.20] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer invalid in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.21] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: deallocated dynamic object in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.22] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: dead object in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.23] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer outside object bounds in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.24] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: invalid integer address in sk->unlock_key: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.25] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereferenced function pointer must be one of [model_lock, model_unlock]: FAILED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.26] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer NULL in sk->mutex: FAILED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.27] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer invalid in sk->mutex: FAILED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.28] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: deallocated dynamic object in sk->mutex: FAILED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.29] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: dead object in sk->mutex: FAILED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.30] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer outside object bounds in sk->mutex: FAILED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.31] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: invalid integer address in sk->mutex: FAILED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.32] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer NULL in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.33] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer invalid in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.34] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: deallocated dynamic object in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.35] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: dead object in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.36] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: pointer outside object bounds in sk->mutex: SATISFIED
+[OQS_SIG_STFL_SECRET_KEY_unlock.coverage.37] file src/sig_stfl/sig_stfl.c line 1617 function OQS_SIG_STFL_SECRET_KEY_unlock dereference failure: invalid integer address in sk->mutex: SATISFIED
+[main.coverage.1] file tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c line 43 function main lock setter stores callback: SATISFIED
+[main.coverage.2] file tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c line 45 function main unlock setter stores callback: SATISFIED
+[main.coverage.3] file tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c line 47 function main mutex setter stores pointer: SATISFIED
+[main.coverage.4] file tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c line 69 function main lock helpers reject null key: SATISFIED
+[main.coverage.5] file tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c line 71 function main lock helpers do not call through null key: SATISFIED
+[main.coverage.6] file tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c line 74 function main unset lock callback is a no-op: SATISFIED
+[main.coverage.7] file tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c line 76 function main unset lock callback is not invoked: SATISFIED
+[main.coverage.8] file tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c line 79 function main configured lock callback requires mutex: SATISFIED
+[main.coverage.9] file tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c line 81 function main missing mutex short-circuits callback: SATISFIED
+[main.coverage.10] file tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c line 84 function main lock helper propagates callback status: SATISFIED
+[main.coverage.11] file tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c line 86 function main lock helper invokes callback once: SATISFIED
+[model_lock.coverage.1] file tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c line 16 function model_lock lock callback receives configured mutex: SATISFIED
+[model_unlock.coverage.1] file tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c line 23 function model_unlock unlock callback receives configured mutex: SATISFIED
+
+** 91 of 105 covered (86.7%)

--- a/tests/cbmc/raw-runs/sig_stfl_lock_contract.txt
+++ b/tests/cbmc/raw-runs/sig_stfl_lock_contract.txt
@@ -1,0 +1,139 @@
+CBMC version 6.9.0 (cbmc-6.9.0) 64-bit arm64 macos
+Type-checking oqs_memory
+Type-checking sig_stfl
+Type-checking sig_stfl_lock_contract_harness
+Generating GOTO Program
+Adding CPROVER library (arm64)
+Removal of function pointers and virtual functions
+Generic Property Instrumentation
+Removing unused functions
+Starting Bounded Model Checking
+Passing problem to propositional reduction
+converting SSA
+Running propositional reduction
+SAT checker: instance is UNSATISFIABLE
+
+** Results:
+src/sig_stfl/sig_stfl.c function OQS_SIG_STFL_SECRET_KEY_SET_lock
+[OQS_SIG_STFL_SECRET_KEY_SET_lock.pointer_dereference.1] line 1567 dereference failure: pointer NULL in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_SET_lock.pointer_dereference.2] line 1567 dereference failure: pointer invalid in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_SET_lock.pointer_dereference.3] line 1567 dereference failure: deallocated dynamic object in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_SET_lock.pointer_dereference.4] line 1567 dereference failure: dead object in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_SET_lock.pointer_dereference.5] line 1567 dereference failure: pointer outside object bounds in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_SET_lock.pointer_dereference.6] line 1567 dereference failure: invalid integer address in sk->lock_key: SUCCESS
+
+src/sig_stfl/sig_stfl.c function OQS_SIG_STFL_SECRET_KEY_SET_mutex
+[OQS_SIG_STFL_SECRET_KEY_SET_mutex.pointer_dereference.1] line 1583 dereference failure: pointer NULL in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_SET_mutex.pointer_dereference.2] line 1583 dereference failure: pointer invalid in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_SET_mutex.pointer_dereference.3] line 1583 dereference failure: deallocated dynamic object in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_SET_mutex.pointer_dereference.4] line 1583 dereference failure: dead object in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_SET_mutex.pointer_dereference.5] line 1583 dereference failure: pointer outside object bounds in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_SET_mutex.pointer_dereference.6] line 1583 dereference failure: invalid integer address in sk->mutex: SUCCESS
+
+src/sig_stfl/sig_stfl.c function OQS_SIG_STFL_SECRET_KEY_SET_unlock
+[OQS_SIG_STFL_SECRET_KEY_SET_unlock.pointer_dereference.1] line 1575 dereference failure: pointer NULL in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_SET_unlock.pointer_dereference.2] line 1575 dereference failure: pointer invalid in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_SET_unlock.pointer_dereference.3] line 1575 dereference failure: deallocated dynamic object in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_SET_unlock.pointer_dereference.4] line 1575 dereference failure: dead object in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_SET_unlock.pointer_dereference.5] line 1575 dereference failure: pointer outside object bounds in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_SET_unlock.pointer_dereference.6] line 1575 dereference failure: invalid integer address in sk->unlock_key: SUCCESS
+
+src/sig_stfl/sig_stfl.c function OQS_SIG_STFL_SECRET_KEY_lock
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.1] line 1591 dereference failure: pointer NULL in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.2] line 1591 dereference failure: pointer invalid in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.3] line 1591 dereference failure: deallocated dynamic object in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.4] line 1591 dereference failure: dead object in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.5] line 1591 dereference failure: pointer outside object bounds in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.6] line 1591 dereference failure: invalid integer address in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.7] line 1596 dereference failure: pointer NULL in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.8] line 1596 dereference failure: pointer invalid in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.9] line 1596 dereference failure: deallocated dynamic object in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.10] line 1596 dereference failure: dead object in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.11] line 1596 dereference failure: pointer outside object bounds in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.12] line 1596 dereference failure: invalid integer address in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.13] line 1600 dereference failure: pointer NULL in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.14] line 1600 dereference failure: pointer invalid in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.15] line 1600 dereference failure: deallocated dynamic object in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.16] line 1600 dereference failure: dead object in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.17] line 1600 dereference failure: pointer outside object bounds in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.18] line 1600 dereference failure: invalid integer address in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.19] line 1600 dereference failure: pointer NULL in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.20] line 1600 dereference failure: pointer invalid in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.21] line 1600 dereference failure: deallocated dynamic object in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.22] line 1600 dereference failure: dead object in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.23] line 1600 dereference failure: pointer outside object bounds in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.24] line 1600 dereference failure: invalid integer address in sk->lock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.25] line 1600 dereferenced function pointer must be one of [model_lock, model_unlock]: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.26] line 1600 dereference failure: pointer NULL in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.27] line 1600 dereference failure: pointer invalid in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.28] line 1600 dereference failure: deallocated dynamic object in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.29] line 1600 dereference failure: dead object in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.30] line 1600 dereference failure: pointer outside object bounds in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.31] line 1600 dereference failure: invalid integer address in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.32] line 1600 dereference failure: pointer NULL in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.33] line 1600 dereference failure: pointer invalid in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.34] line 1600 dereference failure: deallocated dynamic object in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.35] line 1600 dereference failure: dead object in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.36] line 1600 dereference failure: pointer outside object bounds in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_lock.pointer_dereference.37] line 1600 dereference failure: invalid integer address in sk->mutex: SUCCESS
+
+src/sig_stfl/sig_stfl.c function OQS_SIG_STFL_SECRET_KEY_unlock
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.1] line 1608 dereference failure: pointer NULL in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.2] line 1608 dereference failure: pointer invalid in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.3] line 1608 dereference failure: deallocated dynamic object in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.4] line 1608 dereference failure: dead object in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.5] line 1608 dereference failure: pointer outside object bounds in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.6] line 1608 dereference failure: invalid integer address in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.7] line 1613 dereference failure: pointer NULL in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.8] line 1613 dereference failure: pointer invalid in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.9] line 1613 dereference failure: deallocated dynamic object in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.10] line 1613 dereference failure: dead object in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.11] line 1613 dereference failure: pointer outside object bounds in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.12] line 1613 dereference failure: invalid integer address in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.13] line 1617 dereference failure: pointer NULL in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.14] line 1617 dereference failure: pointer invalid in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.15] line 1617 dereference failure: deallocated dynamic object in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.16] line 1617 dereference failure: dead object in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.17] line 1617 dereference failure: pointer outside object bounds in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.18] line 1617 dereference failure: invalid integer address in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.19] line 1617 dereference failure: pointer NULL in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.20] line 1617 dereference failure: pointer invalid in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.21] line 1617 dereference failure: deallocated dynamic object in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.22] line 1617 dereference failure: dead object in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.23] line 1617 dereference failure: pointer outside object bounds in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.24] line 1617 dereference failure: invalid integer address in sk->unlock_key: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.25] line 1617 dereferenced function pointer must be one of [model_lock, model_unlock]: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.26] line 1617 dereference failure: pointer NULL in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.27] line 1617 dereference failure: pointer invalid in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.28] line 1617 dereference failure: deallocated dynamic object in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.29] line 1617 dereference failure: dead object in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.30] line 1617 dereference failure: pointer outside object bounds in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.31] line 1617 dereference failure: invalid integer address in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.32] line 1617 dereference failure: pointer NULL in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.33] line 1617 dereference failure: pointer invalid in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.34] line 1617 dereference failure: deallocated dynamic object in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.35] line 1617 dereference failure: dead object in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.36] line 1617 dereference failure: pointer outside object bounds in sk->mutex: SUCCESS
+[OQS_SIG_STFL_SECRET_KEY_unlock.pointer_dereference.37] line 1617 dereference failure: invalid integer address in sk->mutex: SUCCESS
+
+tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c function main
+[main.assertion.1] line 43 lock setter stores callback: SUCCESS
+[main.assertion.2] line 45 unlock setter stores callback: SUCCESS
+[main.assertion.3] line 47 mutex setter stores pointer: SUCCESS
+[main.assertion.4] line 69 lock helpers reject null key: SUCCESS
+[main.assertion.5] line 71 lock helpers do not call through null key: SUCCESS
+[main.assertion.6] line 74 unset lock callback is a no-op: SUCCESS
+[main.assertion.7] line 76 unset lock callback is not invoked: SUCCESS
+[main.assertion.8] line 79 configured lock callback requires mutex: SUCCESS
+[main.assertion.9] line 81 missing mutex short-circuits callback: SUCCESS
+[main.assertion.10] line 84 lock helper propagates callback status: SUCCESS
+[main.assertion.11] line 86 lock helper invokes callback once: SUCCESS
+
+tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c function model_lock
+[model_lock.assertion.1] line 16 lock callback receives configured mutex: SUCCESS
+
+tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c function model_unlock
+[model_unlock.assertion.1] line 23 unlock callback receives configured mutex: SUCCESS
+
+** 0 of 105 failed (1 iterations)
+VERIFICATION SUCCESSFUL

--- a/tests/cbmc/report.md
+++ b/tests/cbmc/report.md
@@ -1,0 +1,56 @@
+# Liboqs-Owned CBMC Proof Report
+
+## Scope
+
+This report records four bounded CBMC proofs over source files implemented
+directly by liboqs:
+
+- `src/common/common.c`
+- `src/sig/sig.c`
+- `src/sig_stfl/sig_stfl.c`
+
+Imported algorithm implementations are disabled by the model header and are
+not part of these claims.
+
+## Results
+
+| Proof | Property | Status | Safety result |
+| --- | --- | --- | --- |
+| `mem_secure_bcmp` | Four-byte bounded functional and non-mutation contract for `OQS_MEM_secure_bcmp` | `PROVED_BOUNDED` | `0 of 46 failed` |
+| `sig_status_normalization` | Generic signature callback forwarding and status normalization | `PROVED_BOUNDED` | `0 of 137 failed` |
+| `sig_stfl_dispatch_contract` | Stateful wrapper forwarding, null rejection, and status handling | `PROVED_BOUNDED` | `0 of 168 failed` |
+| `sig_stfl_lock_contract` | Common stateful lock helper callback boundary contract | `PROVED_BOUNDED` | `0 of 105 failed` |
+
+Every safety run ended in `VERIFICATION SUCCESSFUL`. Companion
+assertion-coverage runs are checked in beside the safety output and show the
+harness assertions as reachable; they are not used as proof statuses.
+
+## Method
+
+The suite runs CBMC 6.9.0 with bounds, pointer, pointer-overflow,
+division-by-zero, signed-overflow, and conversion checks. Loops are unwound to
+5 with unwinding assertions enabled. `mem_secure_bcmp` is bounded to four
+compared bytes, which requires at most four loop iterations plus the terminating
+condition.
+
+The signature and stateful-signature harnesses compile the real liboqs-owned
+translation units with a narrow public-header model. The model keeps the
+relevant object layouts intact, disables imported algorithms, and replaces only
+unreachable free helpers with no-op stubs. Callback bodies are harness models
+because the claims stop at the liboqs-owned dispatch boundary.
+
+## Interpretation
+
+These proofs establish small, reusable contracts at the common API boundary:
+
+- generic signature wrappers cannot leak backend-specific nonzero statuses
+  through the generic API
+- stateful wrapper null checks and callback routing behave consistently with
+  their source implementation
+- the common stateful lock helpers enforce their local callback/mutex contract
+- the constant-time compare helper's bounded functional result is normalized
+  and non-mutating
+
+They do not establish algorithm-level parsing, canonicality, side-channel, or
+state-machine properties. Those exclusions are recorded in
+`tests/cbmc/unproven-segments.md`.

--- a/tests/cbmc/run.sh
+++ b/tests/cbmc/run.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env sh
+# SPDX-License-Identifier: MIT
+
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+cd "$ROOT_DIR"
+
+RAW_DIR="${1:-tests/cbmc/raw-runs}"
+MODEL_DIR="tests/cbmc/models"
+HARNESS_DIR="tests/cbmc/harnesses"
+
+mkdir -p "$RAW_DIR"
+
+if ! command -v cbmc >/dev/null 2>&1; then
+	echo "cbmc not found" >&2
+	exit 1
+fi
+
+run_proof() {
+	id=$1
+	shift
+	raw="$RAW_DIR/$id.txt"
+	coverage="$RAW_DIR/$id.coverage.txt"
+
+	echo "Running $id"
+	if cbmc \
+		-I "$MODEL_DIR" \
+		--drop-unused-functions \
+		--bounds-check \
+		--pointer-check \
+		--pointer-overflow-check \
+		--div-by-zero-check \
+		--signed-overflow-check \
+		--conversion-check \
+		--unwind 5 \
+		--unwinding-assertions \
+		--trace \
+		"$@" >"$raw" 2>&1; then
+		echo "$id: PROVED_BOUNDED"
+	else
+		echo "$id: FAILED"
+		cat "$raw"
+		return 1
+	fi
+
+	if cbmc \
+		-I "$MODEL_DIR" \
+		--drop-unused-functions \
+		--cover assertion \
+		--unwind 5 \
+		"$@" >"$coverage" 2>&1; then
+		echo "$id coverage: captured"
+	else
+		echo "$id coverage: FAILED"
+		cat "$coverage"
+		return 1
+	fi
+}
+
+run_proof mem_secure_bcmp \
+	"src/common/common.c" \
+	"$HARNESS_DIR/mem_secure_bcmp_harness.c"
+
+run_proof sig_status_normalization \
+	"src/sig/sig.c" \
+	"$MODEL_DIR/oqs_memory.c" \
+	"$HARNESS_DIR/sig_status_normalization_harness.c"
+
+run_proof sig_stfl_dispatch_contract \
+	"src/sig_stfl/sig_stfl.c" \
+	"$MODEL_DIR/oqs_memory.c" \
+	"$HARNESS_DIR/sig_stfl_dispatch_contract_harness.c"
+
+run_proof sig_stfl_lock_contract \
+	"src/sig_stfl/sig_stfl.c" \
+	"$MODEL_DIR/oqs_memory.c" \
+	"$HARNESS_DIR/sig_stfl_lock_contract_harness.c"

--- a/tests/cbmc/summaries/mem_secure_bcmp.md
+++ b/tests/cbmc/summaries/mem_secure_bcmp.md
@@ -1,0 +1,27 @@
+# mem_secure_bcmp
+
+Status: `PROVED_BOUNDED`
+
+Source: `src/common/common.c:259`
+
+Harness: `tests/cbmc/harnesses/mem_secure_bcmp_harness.c`
+
+Property: For byte arrays of length at least `len`, with `0 <= len <= 4`,
+`OQS_MEM_secure_bcmp` returns `0` iff all compared bytes match, returns only
+`0` or `1`, and does not modify either input array.
+
+Bound and assumptions:
+
+- The harness allocates two four-byte arrays and assumes `len <= 4`.
+- CBMC unwinds every loop to 5 with unwinding assertions enabled.
+- The proof checks the real implementation in `src/common/common.c`; it does
+  not model constant-time execution.
+
+Result: The safety run reports `0 of 46 failed` and ends in
+`VERIFICATION SUCCESSFUL`. The companion coverage run reports `26 of 26
+covered`, including all four harness assertions.
+
+Evidence:
+
+- `tests/cbmc/raw-runs/mem_secure_bcmp.txt`
+- `tests/cbmc/raw-runs/mem_secure_bcmp.coverage.txt`

--- a/tests/cbmc/summaries/sig_status_normalization.md
+++ b/tests/cbmc/summaries/sig_status_normalization.md
@@ -1,0 +1,33 @@
+# sig_status_normalization
+
+Status: `PROVED_BOUNDED`
+
+Source: `src/sig/sig.c:3062`
+
+Harness: `tests/cbmc/harnesses/sig_status_normalization_harness.c`
+
+Property: `OQS_SIG_keypair`, `OQS_SIG_sign`, `OQS_SIG_sign_with_ctx_str`,
+`OQS_SIG_verify`, and `OQS_SIG_verify_with_ctx_str` reject a missing object or
+missing selected callback without calling through it. For a present callback,
+they forward every argument unchanged, invoke exactly once, and return
+`OQS_SUCCESS` only when the callback returned `OQS_SUCCESS`; all other callback
+statuses become `OQS_ERROR`.
+
+Bound and assumptions:
+
+- Imported algorithms are disabled; callbacks are harness models with
+  nondeterministic `OQS_STATUS` results.
+- The harness nondeterministically selects each of the five generic
+  dispatchers, a NULL object case, and a NULL callback case.
+- No callback dereferences caller-provided byte buffers; the claim is about the
+  liboqs-owned dispatch contract only.
+
+Result: The safety run reports `0 of 137 failed` and ends in
+`VERIFICATION SUCCESSFUL`. The companion assertion-coverage run marks every
+harness callback assertion and every top-level dispatch assertion as
+`SATISFIED`.
+
+Evidence:
+
+- `tests/cbmc/raw-runs/sig_status_normalization.txt`
+- `tests/cbmc/raw-runs/sig_status_normalization.coverage.txt`

--- a/tests/cbmc/summaries/sig_stfl_dispatch_contract.md
+++ b/tests/cbmc/summaries/sig_stfl_dispatch_contract.md
@@ -1,0 +1,36 @@
+# sig_stfl_dispatch_contract
+
+Status: `PROVED_BOUNDED`
+
+Source: `src/sig_stfl/sig_stfl.c:1006`, `src/sig_stfl/sig_stfl.c:1545`
+
+Harness: `tests/cbmc/harnesses/sig_stfl_dispatch_contract_harness.c`
+
+Property: `OQS_SIG_STFL_keypair`, `OQS_SIG_STFL_sign`,
+`OQS_SIG_STFL_verify`, `OQS_SIG_STFL_sigs_remaining`, and
+`OQS_SIG_STFL_sigs_total` reject missing objects or callbacks, forward all
+arguments unchanged, invoke exactly once, and normalize nonzero callback
+results to `OQS_ERROR`. `OQS_SIG_STFL_SECRET_KEY_serialize` and
+`OQS_SIG_STFL_SECRET_KEY_deserialize` reject their wrapper-owned NULL object,
+callback, output-pointer, output-length, and input-buffer cases before
+dispatching, then preserve the selected callback's `OQS_STATUS` result.
+
+Bound and assumptions:
+
+- The model defines `OQS_ALLOW_STFL_KEY_AND_SIG_GEN` so the actual stateful
+  object layout is visible while imported XMSS/LMS implementations remain
+  disabled.
+- The harness nondeterministically selects all seven wrapper paths plus NULL
+  object, NULL callback, and wrapper-owned NULL serialization argument cases.
+- Callback internals are intentionally abstract; the proof covers only the
+  liboqs-owned dispatch boundary.
+
+Result: The safety run reports `0 of 168 failed` and ends in
+`VERIFICATION SUCCESSFUL`. The companion assertion-coverage run marks every
+top-level harness assertion and every modeled callback forwarding assertion as
+`SATISFIED`.
+
+Evidence:
+
+- `tests/cbmc/raw-runs/sig_stfl_dispatch_contract.txt`
+- `tests/cbmc/raw-runs/sig_stfl_dispatch_contract.coverage.txt`

--- a/tests/cbmc/summaries/sig_stfl_lock_contract.md
+++ b/tests/cbmc/summaries/sig_stfl_lock_contract.md
@@ -1,0 +1,33 @@
+# sig_stfl_lock_contract
+
+Status: `PROVED_BOUNDED`
+
+Source: `src/sig_stfl/sig_stfl.c:1563`, `src/sig_stfl/sig_stfl.c:1587`
+
+Harness: `tests/cbmc/harnesses/sig_stfl_lock_contract_harness.c`
+
+Property: The common stateful-signature setter functions store the selected
+lock, unlock, and mutex fields. `OQS_SIG_STFL_SECRET_KEY_lock` and
+`OQS_SIG_STFL_SECRET_KEY_unlock` return `OQS_ERROR` for a NULL key, return
+`OQS_SUCCESS` without invoking anything when the selected callback is unset,
+return `OQS_ERROR` without invoking anything when a selected callback has no
+mutex, and otherwise invoke exactly once with the configured mutex while
+preserving the callback status.
+
+Bound and assumptions:
+
+- The harness selects lock or unlock nondeterministically and explores NULL
+  key, absent callback, absent mutex, and configured callback cases.
+- The application callback is modeled as a side-effect-free function that
+  records its argument and returns a nondeterministic `OQS_STATUS`.
+- This proof is about the common helper functions, not algorithm-specific use
+  of those helpers inside XMSS or LMS signing code.
+
+Result: The safety run reports `0 of 105 failed` and ends in
+`VERIFICATION SUCCESSFUL`. The companion assertion-coverage run marks all 13
+harness assertions as `SATISFIED`.
+
+Evidence:
+
+- `tests/cbmc/raw-runs/sig_stfl_lock_contract.txt`
+- `tests/cbmc/raw-runs/sig_stfl_lock_contract.coverage.txt`

--- a/tests/cbmc/unproven-segments.md
+++ b/tests/cbmc/unproven-segments.md
@@ -1,0 +1,14 @@
+# Unproven Segments
+
+This proof set is intentionally limited to small liboqs-owned utility and
+dispatch functions. The following segments were not claimed by any bounded
+proof in this directory.
+
+| Segment | Status | Reason |
+| --- | --- | --- |
+| Imported KEM and signature algorithm implementations | `SKIPPED_OUT_OF_SCOPE` | The deliverable is limited to code directly owned by liboqs. |
+| XMSS and LMS algorithm-specific signing, verification, deserialization, and lock usage | `SKIPPED_OUT_OF_SCOPE` | These paths are copied/imported implementation code rather than the common wrapper boundary. |
+| Registry constructor chains and algorithm identifier string matching | `SKIPPED_OUT_OF_SCOPE` | The selected properties concern callback dispatch after object construction. |
+| Platform-specific allocation, cleansing, and free behavior | `SKIPPED_OUT_OF_SCOPE` | The dispatch proofs use no-op free models, and the common proof targets only `OQS_MEM_secure_bcmp`. |
+| Constant-time behavior of `OQS_MEM_secure_bcmp` or any cryptographic primitive | `SKIPPED_OUT_OF_SCOPE` | CBMC safety proofs here do not model timing or generated assembly. |
+| Application callback implementations and thread scheduling | `SKIPPED_OUT_OF_SCOPE` | The lock proof establishes only the common helper's callback boundary contract. |


### PR DESCRIPTION
<!-- Please give a brief explanation of the purpose of this pull request. -->

This PR adds a bounded CBMC proof suite under `tests/cbmc/` for small utility and wrapper functions that are implemented directly by liboqs.

The proof set intentionally excludes imported cryptographic implementations and focuses on common API contracts at the liboqs-owned boundary. It adds:

- a reproducible `tests/cbmc/run.sh` runner
- four harnesses
- a narrow model layer for public headers and free helpers
- checked-in raw CBMC outputs and assertion coverage runs
- a manifest, per-proof summaries, a consolidated report, and an explicit list of unproven/out-of-scope segments

The included proofs cover:

- `OQS_MEM_secure_bcmp`
  - bounded functional correctness for inputs up to four bytes
  - return-value normalization to `0` or `1`
  - non-mutation of inputs

- generic signature dispatchers in `src/sig/sig.c`
  - NULL object/callback rejection
  - argument forwarding
  - one-callback invocation behavior
  - normalization of non-success callback statuses to `OQS_ERROR`

- stateful signature dispatchers in `src/sig_stfl/sig_stfl.c`
  - NULL object/callback handling
  - argument forwarding
  - wrapper-owned NULL rejection for serialize/deserialize
  - callback status propagation rules

- stateful lock/unlock helper contracts
  - NULL key rejection
  - no-op behavior when callbacks are unset
  - mutex validation
  - single callback invocation with the configured mutex

All four proofs are marked `PROVED_BOUNDED` and the checked-in runs were generated with CBMC 6.9.0. The proof suite uses bounds, pointer, pointer-overflow, division-by-zero, signed-overflow, and conversion checks with loop unwinding set to 5 and unwinding assertions enabled.

This PR does not change algorithm implementations, serialization formats, or public API behavior.

This PR does not currently add a GitHub Actions workflow. The proof suite is fully reproducible via `tests/cbmc/run.sh`, but integrating CBMC into CI requires a separate decision about how to install and pin the CBMC toolchain in the project's CI images.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

No issue is resolved by this PR.

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged. Also, make sure to update the list of algorithms in the continuous benchmarking files: .github/workflows/kem-bench.yml and sig-bench.yml)

<!-- If this contribution (code, documentation, descriptive text) was produced with the help of generative AI, please describe the nature of the use. Contributors are expected to have verified and affirm such contributions themselves before submission. -->

This contribution was prepared with the assistance of generative AI for drafting proof harnesses and documentation. I reviewed the resulting code, ran the proof suite, and verified the checked-in results and claims before submission.

As with the previous pull requests, this was generated with Codex-5.5-Cyber as part of the Patch The Planet program.

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

