### PR TITLE
Fix undefined ERR_clear_error symbol in OQS_DLOPEN_OPENSSL builds

### DIFF
--- a/src/common/ossl_functions.h
+++ b/src/common/ossl_functions.h
@@ -6,6 +6,7 @@
 // code by defining the FUNC macro, so no header guard should be
 // added here.
 
+VOID_FUNC(void, ERR_clear_error, (void), ())
 VOID_FUNC(void, ERR_print_errors_fp, (FILE *fp), (fp))
 VOID_FUNC(void, EVP_CIPHER_CTX_free, (EVP_CIPHER_CTX *c), (c))
 FUNC(EVP_CIPHER_CTX *, EVP_CIPHER_CTX_new, (void), ())

--- a/src/common/ossl_helpers.c
+++ b/src/common/ossl_helpers.c
@@ -125,7 +125,7 @@ static void probe_digest_squeeze(void) {
 		if (OSSL_FUNC(EVP_DigestSqueeze)(probe, scratch, sizeof(scratch)) == 1) {
 			oqs_ossl_squeeze_works = 1;
 		} else {
-			ERR_clear_error();
+			OSSL_FUNC(ERR_clear_error)();
 		}
 	}
 	OSSL_FUNC(EVP_MD_CTX_free)(probe);


### PR DESCRIPTION
## Summary

When liboqs is built with `OQS_DLOPEN_OPENSSL=ON`, every OpenSSL call must go through the `OSSL_FUNC()` dlsym wrappers generated from `ossl_functions.h`, because the library is not linked against libcrypto at build time. The `EVP_DigestSqueeze` probe added in #2433 introduced a direct call to `ERR_clear_error()` (src/common/ossl_helpers.c:128), and `ERR_clear_error` was never added to the dlsym table.

As a result, a DLOPEN build leaves an undefined `ERR_clear_error` symbol in `liboqs.so`. On distros that link with BIND_NOW / full RELRO (the default almost everywhere), the symbol is resolved eagerly at `dlopen()` time, so the library cannot be loaded at all — e.g. via liboqs-python:

```
OSError: /usr/lib/liboqs.so.9: undefined symbol: ERR_clear_error
```


This is the regression reported in open-quantum-safe/liboqs-python#122 against 0.16 RC1.

## Fix

- Add `ERR_clear_error` to `src/common/ossl_functions.h`.
- Call it via `OSSL_FUNC(ERR_clear_error)()` in `probe_digest_squeeze()`.

Two lines; no behavior change for non-DLOPEN builds (there `OSSL_FUNC(x)` expands to `x`).

## Impact on consumers

No impact on non-DLOPEN consumers (the default build, used by oqs-provider and distro packages), and a strict improvement for DLOPEN builds:

- **Non-DLOPEN builds are unaffected.** All `#include "ossl_functions.h"` sites are inside `#ifdef OQS_DLOPEN_OPENSSL`, so the new table entry compiles to nothing without the flag. And `OSSL_FUNC(ERR_clear_error)()` expands to plain `ERR_clear_error()` — byte-identical to the previous source. Consumers such as oqs-provider link liboqs through the public `OQS_KEM_*`/`OQS_SIG_*` API and never reference the internal `_oqs_ossl_*` wrappers.
- **No ABI break.** The change is additive — one more wrapper of the same shape as the ~40 already generated. The backing pointer is `static`; no symbol is removed and no signature changes.
- **Slight correctness gain for DLOPEN builds.** The OpenSSL error queue is now cleared on the same libcrypto handle liboqs `dlopen`'d (where `EVP_DigestSqueeze` ran), rather than whatever a bare `ERR_clear_error` would have bound to — which is the multi-libcrypto scenario DLOPEN exists to support. The only runtime path the change can reach is the `EVP_DigestSqueeze`-probe fallback, and only in a DLOPEN build.

## Validation

Built with `-DOQS_DLOPEN_OPENSSL=ON -DOQS_USE_OPENSSL=ON` in the `openquantumsafe/ci-ubuntu-latest` image (SONAME `libcrypto.so.3`):

| | `nm -D liboqs.so` | `ctypes.CDLL` / `import oqs` |
|---|---|---|
| before | `U ERR_clear_error` | `OSError: undefined symbol: ERR_clear_error` |
| after  | symbol absent | loads cleanly, `import oqs` → `0.16.0-rc1` |

I also confirmed `ERR_clear_error` is the only OpenSSL function still called directly (rather than via `OSSL_FUNC()`) across the DLOPEN-affected sources.

Fixes open-quantum-safe/liboqs-python#122

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [NO] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [NO] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged. Also, make sure to update the list of algorithms in the continuous benchmarking files: .github/workflows/kem-bench.yml and sig-bench.yml)

<!-- If this contribution (code, documentation, descriptive text) was produced with the help of generative AI, please describe the nature of the use. Contributors are expected to have verified and affirm such contributions themselves before submission. -->

I used Claude Code to diagnose the problem and write the code. I've read the code, and run local tests.