### PR TITLE
Fix integer overflow in OQS_MEM_aligned_alloc size calculation

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -312,7 +312,15 @@ void *OQS_MEM_aligned_alloc(size_t alignment, size_t size) {
 	if (!size) {
 		return NULL;
 	}
+	// Check alignment (power of 2, and >= sizeof(void*)) and size (multiple of alignment)
+	if (alignment & (alignment - 1) || size & (alignment - 1) || alignment < sizeof(void *)) {
+		errno = EINVAL;
+		return NULL;
+	}
 	const size_t offset = alignment - 1 + sizeof(uint8_t);
+	if (offset > SIZE_MAX - size) {
+		return NULL;
+	}
 	uint8_t *buffer = OSSL_FUNC(CRYPTO_malloc)(size + offset, OPENSSL_FILE, OPENSSL_LINE);
 	if (!buffer) {
 		return NULL;
@@ -367,6 +375,9 @@ void *OQS_MEM_aligned_alloc(size_t alignment, size_t size) {
 	//            |
 	//       diff = ptr - buffer
 	const size_t offset = alignment - 1 + sizeof(uint8_t);
+	if (offset > SIZE_MAX - size) {
+		return NULL;
+	}
 	uint8_t *buffer = malloc(size + offset); // IGNORE memory-check
 	if (!buffer) {
 		return NULL;


### PR DESCRIPTION
Both the OpenSSL and fallback branches of OQS_MEM_aligned_alloc compute size + offset with no overflow check before passing the result to the underlying allocator. When size is near SIZE_MAX, this wraps to a small value, so the allocator returns a real but far too small buffer while the caller still treats the returned pointer as valid for the full requested size. Add a guard before each allocation call that rejects the request instead of letting the addition wrap.

Confirmed with ASan: before this change, an unaligned near-SIZE_MAX size drives CRYPTO_malloc/malloc down to an 8-byte (OpenSSL branch) or 1-byte (fallback branch) allocation, and the pointer-alignment bookkeeping inside OQS_MEM_aligned_alloc itself immediately writes past it (heap-buffer-overflow at common.c:329 and common.c:386 respectively). After the fix both cases return NULL cleanly.

Also adds the alignment/size validation that the fallback branch already performs (power-of-two alignment >= sizeof(void*), size a multiple of alignment) to the OpenSSL branch, which was missing it entirely.

See GHSA-54w9-9rvw-3fg4 for the original report.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->


