### PR TITLE
release triggering for supported and ready downstreams and fix CI on forks

### DIFF
--- a/.github/workflows/downstream-basic.yml
+++ b/.github/workflows/downstream-basic.yml
@@ -8,6 +8,8 @@ on: [workflow_call, workflow_dispatch]
 jobs:
 
   trigger-downstream-ci:
+    # Dispatch secrets only exist upstream; skip in forks.
+    if: github.repository == 'open-quantum-safe/liboqs'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger OQS-BoringSSL CI

--- a/.github/workflows/downstream-release-tests.yml
+++ b/.github/workflows/downstream-release-tests.yml
@@ -1,0 +1,30 @@
+name: Downstream release tests
+
+permissions:
+  contents: read
+
+on: [workflow_call, workflow_dispatch]
+
+# Trigger oqs-provider release tests.
+# When triggered by a release (see release.yml), the liboqs release tag and the provider "<release tag>-tracker" branch are used.
+# When triggered by a commit message (see filter.yml), the triggering liboqs branch and the provider "<liboqs branch>-tracker" branch are used.
+# If the tracker branch does not exist, the downstream pipeline should detect it and run on the main branch instead.
+
+jobs:
+  oqs-provider-release-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release tests script
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v4
+        with:
+          sparse-checkout: |
+            scripts/provider-test-trigger.sh
+          sparse-checkout-cone-mode: false
+      - name: Trigger oqs-provider release tests
+        run: |
+          CURL_FLAGS="--silent --write-out \n%{response_code}\n" \
+          ACCESS_TOKEN="${{ secrets.OQSBOT_GITHUB_ACTIONS }}" \
+          LIBOQS_REF="${{ github.ref_name }}" \
+          PROVIDER_REF="${{ github.ref_name }}-tracker" \
+          ./scripts/provider-test-trigger.sh | tee curl_out \
+          && grep -q "204" curl_out

--- a/.github/workflows/downstream-release-tests.yml
+++ b/.github/workflows/downstream-release-tests.yml
@@ -7,7 +7,7 @@ on: [workflow_call, workflow_dispatch]
 
 # Trigger oqs-provider release tests.
 # When triggered by a release (see release.yml), the liboqs release tag and the provider "<release tag>-tracker" branch are used.
-# When triggered by a commit message (see filter.yml), the triggering liboqs branch and the provider "<liboqs branch>-tracker" branch are used.
+# When triggered by a commit message (see push.yml), the triggering liboqs branch and the provider "<liboqs branch>-tracker" branch are used.
 # If the tracker branch does not exist, the downstream pipeline should detect it and run on the main branch instead.
 
 jobs:

--- a/.github/workflows/downstream-release-tests.yml
+++ b/.github/workflows/downstream-release-tests.yml
@@ -12,19 +12,25 @@ on: [workflow_call, workflow_dispatch]
 
 jobs:
   oqs-provider-release-test:
+    # Release token only exists upstream; skip in forks.
+    if: github.repository == 'open-quantum-safe/liboqs'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout release tests script
+      - name: Checkout release trigger script
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v4
         with:
+          # Pin script to a trusted ref, not the caller branch.
+          ref: main
           sparse-checkout: |
             scripts/provider-test-trigger.sh
           sparse-checkout-cone-mode: false
       - name: Trigger oqs-provider release tests
+        # Ref via env, not interpolated into the shell line (injection).
+        env:
+          ACCESS_TOKEN: ${{ secrets.OQSBOT_GITHUB_ACTIONS }}
+          LIBOQS_REF: ${{ github.ref_name }}
+          PROVIDER_REF: ${{ github.ref_name }}-tracker
         run: |
           CURL_FLAGS="--silent --write-out \n%{response_code}\n" \
-          ACCESS_TOKEN="${{ secrets.OQSBOT_GITHUB_ACTIONS }}" \
-          LIBOQS_REF="${{ github.ref_name }}" \
-          PROVIDER_REF="${{ github.ref_name }}-tracker" \
           ./scripts/provider-test-trigger.sh | tee curl_out \
-          && grep -q "204" curl_out
+          && grep -qx "204" curl_out

--- a/.github/workflows/downstream-release.yml
+++ b/.github/workflows/downstream-release.yml
@@ -1,30 +1,29 @@
-name: Downstream release tests
+name: Downstream release triggers
 
 permissions:
   contents: read
 
 on: [workflow_call, workflow_dispatch]
 
-# Trigger oqs-provider release tests.
-# When triggered by a release (see release.yml), the liboqs release tag and the provider "<release tag>-tracker" branch are used.
-# When triggered by a commit message (see filter.yml), the triggering liboqs branch and the provider "<liboqs branch>-tracker" branch are used.
-# If the tracker branch does not exist, the downstream pipeline should detect it and run on the main branch instead.
-
+# Triggers version-matched releases of downstream language wrappers when a liboqs
+# release is published. Each wrapper's own CI gates the actual release on tests.
 jobs:
-  oqs-provider-release-test:
+  trigger-downstream-releases:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout release tests script
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v4
-        with:
-          sparse-checkout: |
-            scripts/provider-test-trigger.sh
-          sparse-checkout-cone-mode: false
-      - name: Trigger oqs-provider release tests
+      - name: Trigger liboqs-go release
+        env:
+          VERSION: ${{ github.ref_name }}
         run: |
-          CURL_FLAGS="--silent --write-out \n%{response_code}\n" \
-          ACCESS_TOKEN="${{ secrets.OQSBOT_GITHUB_ACTIONS }}" \
-          LIBOQS_REF="${{ github.ref_name }}" \
-          PROVIDER_REF="${{ github.ref_name }}-tracker" \
-          ./scripts/provider-test-trigger.sh | tee curl_out \
+          curl --silent \
+               --write-out "\n%{response_code}\n" \
+               --request POST \
+               --header "Accept: application/vnd.github+json" \
+               --header "Authorization: Bearer ${{ secrets.OQSBOT_GITHUB_ACTIONS }}" \
+               --header "X-GitHub-Api-Version: 2022-11-28" \
+               --data "{\"event_type\":\"liboqs-go-release\",\"client_payload\":{\"version\":\"${VERSION}\"}}" \
+               https://api.github.com/repos/open-quantum-safe/liboqs-go/dispatches | tee curl_out \
           && grep -q "204" curl_out
+
+      # Add other language wrappers (liboqs-cpp, -java, -python, -rust) here as
+      # they gain release-dispatch receivers.

--- a/.github/workflows/downstream-release.yml
+++ b/.github/workflows/downstream-release.yml
@@ -3,27 +3,53 @@ name: Downstream release triggers
 permissions:
   contents: read
 
-on: [workflow_call, workflow_dispatch]
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release tag to publish downstream wrappers for (e.g. 0.16.0)'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release tag to publish downstream wrappers for (e.g. 0.16.0)'
+        required: true
+        type: string
 
 # Triggers version-matched releases of downstream language wrappers when a liboqs
 # release is published. Each wrapper's own CI gates the actual release on tests.
 jobs:
   trigger-downstream-releases:
+    # Release token only exists upstream; skip in forks.
+    if: github.repository == 'open-quantum-safe/liboqs'
     runs-on: ubuntu-latest
     steps:
+      # Reject non-release refs (e.g. a manual dispatch on a branch).
+      - name: Validate release version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$'; then
+            echo "::error::Refusing to trigger downstream releases for non-release version '$VERSION'"
+            exit 1
+          fi
+
       - name: Trigger liboqs-go release
         env:
-          VERSION: ${{ github.ref_name }}
+          DISPATCH_TOKEN: ${{ secrets.OQSBOT_GITHUB_ACTIONS }}
+          VERSION: ${{ inputs.version }}
         run: |
-          curl --silent \
-               --write-out "\n%{response_code}\n" \
+          response_code=$(curl --silent --output /dev/null \
+               --write-out '%{response_code}' \
                --request POST \
                --header "Accept: application/vnd.github+json" \
-               --header "Authorization: Bearer ${{ secrets.OQSBOT_GITHUB_ACTIONS }}" \
+               --header "Authorization: Bearer $DISPATCH_TOKEN" \
                --header "X-GitHub-Api-Version: 2022-11-28" \
                --data "{\"event_type\":\"liboqs-go-release\",\"client_payload\":{\"version\":\"${VERSION}\"}}" \
-               https://api.github.com/repos/open-quantum-safe/liboqs-go/dispatches | tee curl_out \
-          && grep -q "204" curl_out
+               https://api.github.com/repos/open-quantum-safe/liboqs-go/dispatches)
+          echo "Dispatch response code: $response_code"
+          test "$response_code" = "204"
 
       # Add other language wrappers (liboqs-cpp, -java, -python, -rust) here as
       # they gain release-dispatch receivers.

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,5 +29,5 @@ jobs:
   downstream-release-tests:
     needs: basic-checks
     if: contains( github.event.head_commit.message, '[trigger downstream]' )
-    uses: ./.github/workflows/downstream-release.yml
+    uses: ./.github/workflows/downstream-release-tests.yml
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,4 +20,6 @@ jobs:
   downstream-releases:
     needs: [extended-tests, downstream-release-tests]
     uses: ./.github/workflows/downstream-release.yml
+    with:
+      version: ${{ github.ref_name }}  # tag name (release: published)
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,5 +13,11 @@ jobs:
     uses: ./.github/workflows/extended.yml
 
   downstream-release-tests:
+    uses: ./.github/workflows/downstream-release-tests.yml
+    secrets: inherit
+
+  # Trigger downstream releases only once release readiness has been verified.
+  downstream-releases:
+    needs: [extended-tests, downstream-release-tests]
     uses: ./.github/workflows/downstream-release.yml
     secrets: inherit

--- a/CI.md
+++ b/CI.md
@@ -18,7 +18,7 @@ This workflow is triggered by pushes to non-`main` branches.
 It calls only [basic checks](#basic.yml) unless one of the following strings is included in the commit message:
 - "[full tests]": calls [all platform tests](#platforms.yml).
 - "[extended tests]": calls the [extended tests](#extended.yml).
-- "[trigger downstream]": calls the [downstream release tests](#downstream-release.yml).
+- "[trigger downstream]": calls the [downstream release tests](#downstream-release-tests.yml).
 
 To trigger multiple test suites, include multiple trigger strings in the commit message.
 For example, "[full tests] [trigger downstream]" will trigger both the platform tests and the downstream release tests.
@@ -41,7 +41,7 @@ It calls [extended tests](#extended.yml), [scorecard analysis](#scorecard.yml), 
 #### <a name="release.yml"></a> Release workflow (`release.yml`)
 
 This workflow is triggered when a release (including a pre-release) is published on GitHub.
-It calls [extended tests](#extended) and [downstream release tests](#downstream-release.yml).
+It calls [extended tests](#extended) and [downstream release tests](#downstream-release-tests.yml), and triggers [downstream releases](#downstream-release.yml) once release readiness has been verified.
 
 ### Callable workflows
 
@@ -93,10 +93,16 @@ Currently, these include
 
 Callers must include `secrets: inherit` in order for the appropriate access tokens to be passed to this workflow.
 
+#### <a name="downstream-release-tests.yml"></a> Downstream release tests (`downstream-release-tests.yml`)
+
+This workflow triggers release-readiness tests for a selection of projects that depend on `liboqs`.
+Currently, this is only the [`OQS OpenSSL3 provider`](https://github.com/open-quantum-safe/oqs-provider).
+Callers must include `secrets: inherit` in order for the appropriate access tokens to be passed to this workflow.
+
 #### <a name="downstream-release.yml"></a> Downstream release trigger (`downstream-release.yml`)
 
-This workflow triggers release tests for a selection of projects that depend on `liboqs`.
-Currently, this is only the [`OQS OpenSSL3 provider`](https://github.com/open-quantum-safe/oqs-provider).
+This workflow triggers version-matched releases of downstream language wrappers that depend on `liboqs`.
+Currently, this is only [`liboqs-go`](https://github.com/open-quantum-safe/liboqs-go); each wrapper's own CI gates the release on its tests.
 Callers must include `secrets: inherit` in order for the appropriate access tokens to be passed to this workflow.
 
 #### <a name="scorecard.yml"></a> OpenSSF scorecard analysis (`scorecard.yml`)


### PR DESCRIPTION
Proof-in-doing of the concept discussed in the liboqs status meeting Tue 14 Jul 2026: the uses liboqs-go as an example.

A release of `liboqs` triggers release(s) of [tested and ready] downstream language wrappers.

This PR is in parallel with the PR on `liboqs-go`, which contains the release job triggered: https://github.com/open-quantum-safe/liboqs-go/pull/55

A release job is only _dispatched_ on `liboqs` release, so there are no release-blocking failures if the downstream repo is not ready or is breaking. However, if any necessary changes are in situ, it will allow the language wrapper release to be made at the same time as the main liboqs release.

The `downstream-release` workflow is renamed `downstream-release-tests` to better reflect the “readiness” functionality, while `downstream-release` now handles the actual downstream release, as its name implies.

Also fixes a longstanding issue preventing all CI passing on forks: there is now a repository check to skip downstream dispatches where repository secrets are absent.

Claude assistance with greps and hash pins; code review by corerabbit.ai 

Motivation:

liboqs-go wrapper releases stalled between 0.10 and 0.15, though only the latter release contained any breaking changes.  Similar CI changes could rapidly speed up the deployment of other language wrappers.
