### PR TITLE
Additional CI profiling and sig_stfl CI bug fixes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,7 +20,7 @@ jobs:
           - name: arm64-slhdsa
             runner: ubuntu-24.04-arm
             container: openquantumsafe/ci-ubuntu-latest:latest
-            PYTEST_ARGS: --maxprocesses=10 --ignore=tests/test_kat_all.py
+            PYTEST_ARGS: --maxprocesses=10 --ignore=tests/test_kat_all.py --durations=0
             CMAKE_ARGS: -DOQS_MINIMAL_BUILD=SIG_slh_dsa
           - name: alpine
             runner: ubuntu-latest
@@ -31,7 +31,7 @@ jobs:
             runner: ubuntu-latest
             container: openquantumsafe/ci-alpine-amd64:latest
             CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_MINIMAL_BUILD=SIG_slh_dsa
-            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py --durations=0
           - name: alpine-libjade
             runner: ubuntu-latest
             container: openquantumsafe/ci-alpine-amd64:latest
@@ -56,12 +56,12 @@ jobs:
             runner: ubuntu-latest
             container: openquantumsafe/ci-alpine-amd64:latest
             CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON -DOQS_USE_AES_OPENSSL=ON -DOQS_USE_SHA2_OPENSSL=ON -DOQS_USE_SHA3_OPENSSL=ON -DOQS_MINIMAL_BUILD=SIG_slh_dsa
-            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py --durations=0
           - name: alpine-noopenssl-slhdsa
             runner: ubuntu-latest
             container: openquantumsafe/ci-alpine-amd64:latest
             CMAKE_ARGS: -DOQS_STRICT_WARNINGS=ON -DOQS_USE_OPENSSL=OFF -DOQS_MINIMAL_BUILD=SIG_slh_dsa
-            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py
+            PYTEST_ARGS: --ignore=tests/test_alg_info.py --ignore=tests/test_kat_all.py --durations=0
           - name: noble-nistr4-openssl
             runner: ubuntu-latest
             container: openquantumsafe/ci-ubuntu-latest:latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -80,4 +80,4 @@ jobs:
         run: pip.exe install --require-hashes -r .github\workflows\requirements.txt
       - name: Run tests
         run: |
-          python -m pytest --numprocesses=auto -vv --maxfail=10 --ignore=tests/test_code_conventions.py --ignore=tests/test_kat_all.py --junitxml=build\test-results\pytest\test-results.xml
+          python -m pytest --numprocesses=auto -vv --maxfail=10 --ignore=tests/test_code_conventions.py --ignore=tests/test_kat_all.py --durations=0 --junitxml=build\test-results\pytest\test-results.xml

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Generate Project
         run: cmake -B build --toolchain .CMake/toolchain_windows_arm64.cmake -DOQS_ENABLE_SIG_SLH_DSA=OFF -DOQS_ENABLE_SIG_STFL_LMS=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=${{ matrix.stfl_opt }} .
       - name: Build Project
-        run: cmake --build build
+        run: cmake --build build --config Release
 
   windows-arm64-slhdsa:
     strategy:
@@ -31,7 +31,7 @@ jobs:
       - name: Generate Project
         run: cmake -B build --toolchain .CMake/toolchain_windows_arm64.cmake -DOQS_MINIMAL_BUILD=SIG_slh_dsa .
       - name: Build Project  
-        run: cmake --build build
+        run: cmake --build build --config Release
 
   windows-x86:
     strategy:
@@ -51,7 +51,7 @@ jobs:
       - name: Generate Project
         run: cmake -B build --toolchain ${{ matrix.toolchain }} -DOQS_ENABLE_SIG_SLH_DSA=OFF -DOQS_ENABLE_SIG_STFL_LMS=ON -DOQS_ENABLE_SIG_STFL_XMSS=ON -DOQS_HAZARDOUS_EXPERIMENTAL_ENABLE_SIG_STFL_KEY_SIG_GEN=${{ matrix.stfl_opt }} .
       - name: Build Project
-        run: cmake --build build
+        run: cmake --build build --config Release
       - name: Test dependencies
         run: pip.exe install --require-hashes -r .github\workflows\requirements.txt
       - name: Run tests
@@ -75,7 +75,7 @@ jobs:
       - name: Generate Project
         run: cmake -B build --toolchain ${{ matrix.toolchain }} -DOQS_MINIMAL_BUILD=SIG_slh_dsa .
       - name: Build Project
-        run: cmake --build build
+        run: cmake --build build --config Release
       - name: Test dependencies
         run: pip.exe install --require-hashes -r .github\workflows\requirements.txt
       - name: Run tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -238,7 +238,7 @@ if (CMAKE_GENERATOR MATCHES "Visual Studio")
     # With Visual studio the output of tests go into a folder with the configuration option. Force it to the same folder as if
     # generating with Ninja
     set_target_properties(
-        dump_alg_info example_sig_stfl ${KEM_TESTS} ${SIG_TESTS} ${SIG_STFL_TESTS} 
+        dump_alg_info example_sig_stfl ${KEM_TESTS} ${SIG_TESTS} ${SIG_STFL_TESTS}
         PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY_DEBUG          "${CMAKE_BINARY_DIR}/tests"
         RUNTIME_OUTPUT_DIRECTORY_RELEASE        "${CMAKE_BINARY_DIR}/tests"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -238,7 +238,7 @@ if (CMAKE_GENERATOR MATCHES "Visual Studio")
     # With Visual studio the output of tests go into a folder with the configuration option. Force it to the same folder as if
     # generating with Ninja
     set_target_properties(
-        dump_alg_info ${KEM_TESTS} ${SIG_TESTS}
+        dump_alg_info ${KEM_TESTS} ${SIG_TESTS} ${SIG_STFL_TESTS}
         PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY_DEBUG          "${CMAKE_BINARY_DIR}/tests"
         RUNTIME_OUTPUT_DIRECTORY_RELEASE        "${CMAKE_BINARY_DIR}/tests"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -238,7 +238,7 @@ if (CMAKE_GENERATOR MATCHES "Visual Studio")
     # With Visual studio the output of tests go into a folder with the configuration option. Force it to the same folder as if
     # generating with Ninja
     set_target_properties(
-        dump_alg_info ${KEM_TESTS} ${SIG_TESTS} ${SIG_STFL_TESTS}
+        dump_alg_info example_sig_stfl ${KEM_TESTS} ${SIG_TESTS} ${SIG_STFL_TESTS} 
         PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY_DEBUG          "${CMAKE_BINARY_DIR}/tests"
         RUNTIME_OUTPUT_DIRECTORY_RELEASE        "${CMAKE_BINARY_DIR}/tests"


### PR DESCRIPTION
This PR generates additional output that can be used to analyze CI runtime problems.

It unearthed an incorrect Windows CI test setup (Debug instead of Release) that is also fixed in this PR, leading to massive CI runtime improvements (approx. 4x for the slowest jobs, SLH-DSA on Windows).

That fix in turn exposed a latent bug in the stateful hash based signature test setup on Windows (a missing CMake output-path override for SIG_STFL_TESTS, previously masked by the Debug build's incidental fallback path). This is also fixed here.