### PR TITLE
TEST ONLY: CodeQL enforce OpenSSL return code check

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,3 +1,0 @@
-name: "OQS CodeQL config"
-queries:
-  - uses: ./.github/codeql/openssl-return-check.ql

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,3 @@
+name: "OQS CodeQL config"
+queries:
+  - uses: ./.github/codeql/openssl-return-check.ql

--- a/.github/codeql/openssl-return-check.ql
+++ b/.github/codeql/openssl-return-check.ql
@@ -1,0 +1,26 @@
+/**
+ * @name Unchecked OpenSSL EVP return value
+ * @description Calls to OpenSSL EVP functions whose return value is not
+ *              checked by the OQS_OPENSSL_GUARD macro may silently ignore
+ *              errors, leading to undefined behaviour.
+ * @kind problem
+ * @problem.severity warning
+ * @precision medium
+ * @id cpp/openssl-unchecked-return
+ * @tags security
+ *       correctness
+ */
+
+import cpp
+
+from FunctionCall call, Function f
+where
+  f = call.getTarget() and
+  f.getName().matches("EVP%") and
+  not f.getType() instanceof PointerType and
+  not f.getType() instanceof VoidType and
+  not exists(MacroAccess m |
+    m.getLocation().subsumes(call.getLocation()) and
+    m.getMacroName() = "OQS_OPENSSL_GUARD"
+  )
+select call, "Return value of " + f.getName() + "() is not checked by OQS_OPENSSL_GUARD."

--- a/.github/codeql/test/openssl-return-check-bad.c
+++ b/.github/codeql/test/openssl-return-check-bad.c
@@ -1,0 +1,5 @@
+/* expect-fail: EVP return value not checked via OQS_OPENSSL_GUARD */
+#include <openssl/evp.h>
+void bad_example(EVP_MD_CTX *ctx, const EVP_MD *md) {
+    EVP_DigestInit_ex(ctx, md, NULL);
+}

--- a/.github/codeql/test/openssl-return-check-bad.c
+++ b/.github/codeql/test/openssl-return-check-bad.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 /* expect-fail: EVP return value not checked via OQS_OPENSSL_GUARD */
 #include <openssl/evp.h>
 void bad_example(EVP_MD_CTX *ctx, const EVP_MD *md) {

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
         uses: github/codeql-action/init@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3
         with:
           languages: cpp
-          queries: .github/codeql/openssl-return-check.ql
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Build liboqs
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,3 +33,4 @@ jobs:
         uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3
         with:
           category: "/language:cpp"
+          upload: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,8 @@ jobs:
     permissions:
       contents: read
       security-events: write
+    env:
+      CODEQL_EXTRACTOR_CPP_TRAP_CACHING: false
     name: CodeQL
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,6 @@
 name: CodeQL analysis
-
 permissions:
   contents: read
-
 on:
   workflow_call:
   workflow_dispatch:
@@ -10,32 +8,25 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-
 jobs:
   codeql:
     permissions:
       contents: read
       security-events: write
-
     name: CodeQL
     runs-on: ubuntu-latest
-    env:
-      CODEQL_EXTRACTOR_CPP_TRAP_CACHING: false
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3
         with:
           languages: cpp
-          config-file: ./.github/codeql/codeql-config.yml
-
+          queries: security-and-quality,./.github/codeql/openssl-return-check.ql
       - name: Build liboqs
         run: |
           cmake -S . -B build -DOQS_MINIMAL_BUILD="KEM_ml_kem_768;SIG_ml_dsa_65"
           cmake --build build --parallel $(nproc)
-
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,6 @@ name: CodeQL analysis
 
 permissions:
   contents: read
-  security-events: write
 
 on:
   workflow_call:
@@ -14,6 +13,10 @@ on:
 
 jobs:
   codeql:
+    permissions:
+      contents: read
+      security-events: write
+
     name: CodeQL
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL analysis
+
+permissions:
+  contents: read
+  security-events: write
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3
+        with:
+          languages: cpp
+          queries: .github/codeql/openssl-return-check.ql
+
+      - name: Build liboqs
+        run: |
+          cmake -S . -B build -DOQS_MINIMAL_BUILD="KEM_ml_kem_768;SIG_ml_dsa_65"
+          cmake --build build --parallel $(nproc)
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3
+        with:
+          category: "/language:cpp"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,8 @@ jobs:
 
     name: CodeQL
     runs-on: ubuntu-latest
+    env:
+      CODEQL_EXTRACTOR_CPP_TRAP_CACHING: false
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,4 +33,4 @@ jobs:
         uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3
         with:
           category: "/language:cpp"
-          upload: false
+          upload: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,3 +31,11 @@ jobs:
       contents: read
       id-token: write
       security-events: write
+
+  codeql:
+    needs: basic-checks
+    uses: ./.github/workflows/codeql.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      security-events: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,3 +106,11 @@ If you feel like contributing but don't know what specific topic to work on,
 please check the [open issues tagged "good first issue" or "help wanted"](https://github.com/open-quantum-safe/liboqs/issues).
 
 You can also take a look at the [contribution wishlist](https://github.com/open-quantum-safe/liboqs/wiki/Contribution-wishlist) for more substantial contributions we are interested in.
+
+## Verifying the CodeQL OpenSSL return-check query
+The query detects EVP_* calls not wrapped in OQS_OPENSSL_GUARD.
+A deliberately bad example lives in
+.github/codeql/test/openssl-return-check-bad.c.
+When CodeQL runs, any match against this file confirms the query
+is scanning correctly. CI will flag new violations automatically
+on every PR.


### PR DESCRIPTION
This is a duplicate of #2415. This is for testing purpose only and will not be merged.

#2415 was raised on a fork, which is probably why the CodeQL analysis result was not uploaded to Code Scanning.