### PR TITLE
Fix usage of XGETBV inline assembly in CPU extension detection

### DIFF
--- a/src/common/x86_64_helpers.h
+++ b/src/common/x86_64_helpers.h
@@ -27,7 +27,7 @@ typedef struct {
 static inline uint32_t xgetbv_eax(uint32_t xcr) {
 #if defined(__GNUC__) || defined(__clang__)
 	uint32_t eax;
-	__asm__ ( ".byte 0x0f, 0x01, 0xd0" : "=a"(eax) : "c"(xcr));
+	__asm__ ( ".byte 0x0f, 0x01, 0xd0" : "=a"(eax) : "c"(xcr) : "edx");
 	return eax;
 #elif defined(_MSC_VER)
 	return _xgetbv(xcr) & 0xFFFF;


### PR DESCRIPTION
CPU runtime detection uses inline XGETBV assembly that declares only EAX as an output, however XGETBV overwrites EDX:EAX. With -march=nocona -mtune=nocona, GCC may retain the AES CPUID bit in EDX across XGETBV. The overwritten high XCR0 word (normally zero) is then recorded as the AES capability, disabling the AES CPU extension.

I've reproduced on gcc v14.3.0 and v16.1.1. This potential bug has existed since the initial commit of `src/common/x86_64_helpers.h`.

The following 3 tests were all run on the same system.

Here is an example of a general build that works without modification.

```
git checkout main && \
CFLAGS="-march=x86-64 -mtune=generic" \
cmake -B build-generic -S . -G Ninja \
    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
    -DOQS_DIST_BUILD=ON \
    -DOQS_USE_OPENSSL=OFF && \
ninja -C build-generic && \
./build-generic/tests/test_kem nop | grep CPU
CPU exts active:  ADX AES AVX AVX2 BMI1 BMI2 PCLMULQDQ POPCNT SSE SSE2 SSE3
```

Here is an example of a build that reproduces the issue of AES not being detected.

```
git checkout main && \
CFLAGS="-march=nocona -mtune=nocona" \
cmake -B build-nocona -S . -G Ninja \
    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
    -DOQS_DIST_BUILD=ON \
    -DOQS_USE_OPENSSL=OFF && \
ninja -C build-nocona && \
./build-nocona/tests/test_kem nop | grep CPU
CPU exts active:  ADX AVX AVX2 BMI1 BMI2 PCLMULQDQ POPCNT SSE SSE2 SSE3
```

Here is an example of a build on this branch, which clobbers `EDX` when issuing `XGETBV`.

```
git checkout xgetbv && \
CFLAGS="-march=nocona -mtune=nocona" \
cmake -B build-xgetbv -S . -G Ninja \
    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
    -DOQS_DIST_BUILD=ON \
    -DOQS_USE_OPENSSL=OFF && \
ninja -C build-xgetbv && \
./build-xgetbv/tests/test_kem nop | grep CPU
CPU exts active:  ADX AES AVX AVX2 BMI1 BMI2 PCLMULQDQ POPCNT SSE SSE2 SSE3
```