### PR TITLE
Fix out-of-bounds access in xmss_core_sign on secret key OID mismatch

### DIFF
--- a/src/sig_stfl/xmss/sig_stfl_xmss_xmssmt.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_xmssmt.c
@@ -69,6 +69,19 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss##xmss_v##_keypair(XMSS_UNUSED_ATT uint8
 }\
 \
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss##xmss_v##_sign(uint8_t *signature, size_t *signature_len, const uint8_t *message, size_t message_len, OQS_SIG_STFL_SECRET_KEY *secret_key) {\
+        if (secret_key == NULL || secret_key->secret_key_data == NULL) {\
+                return OQS_ERROR;\
+        }\
+        /* Reject secret keys whose OID disagrees with the variant the caller invoked. */\
+        /* The OID is part of the key material and selects every buffer offset used by */\
+        /* xmss_core_sign, so a deserialized key naming a larger parameter set reads and */\
+        /* writes past both secret_key_data and the caller's signature buffer. */\
+        const uint8_t *sk_oid_bytes = (const uint8_t *)secret_key->secret_key_data;\
+        uint32_t sk_oid = ((uint32_t)sk_oid_bytes[0] << 24) | ((uint32_t)sk_oid_bytes[1] << 16)\
+                        | ((uint32_t)sk_oid_bytes[2] <<  8) | ((uint32_t)sk_oid_bytes[3]);\
+        if (sk_oid != (uint32_t)OQS_SIG_STFL_alg_xmss##xmss_v##_oid) {\
+                return OQS_ERROR;\
+        }\
         return OQS_SIG_STFL_alg_xmss##mt##_sign(signature, signature_len, message, message_len, secret_key);\
 }\
 \

--- a/src/sig_stfl/xmss/sig_stfl_xmss_xmssmt.c
+++ b/src/sig_stfl/xmss/sig_stfl_xmss_xmssmt.c
@@ -105,9 +105,32 @@ OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss##xmss_v##_verify(const uint8_t *message
 }\
 \
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss##xmss_v##_sigs_remaining(unsigned long long *remain, const OQS_SIG_STFL_SECRET_KEY *secret_key) {\
+        if (remain == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {\
+                return OQS_ERROR;\
+        }\
+        /* Reject secret keys whose OID disagrees with the variant the caller invoked. */\
+        /* xmss_remaining_signatures re-parses the OID and reads the index using */\
+        /* parameter-set-specific index_bytes, so a foreign OID can read past */\
+        /* secret_key_data. */\
+        const uint8_t *sk_oid_bytes = (const uint8_t *)secret_key->secret_key_data;\
+        uint32_t sk_oid = ((uint32_t)sk_oid_bytes[0] << 24) | ((uint32_t)sk_oid_bytes[1] << 16)\
+                        | ((uint32_t)sk_oid_bytes[2] <<  8) | ((uint32_t)sk_oid_bytes[3]);\
+        if (sk_oid != (uint32_t)OQS_SIG_STFL_alg_xmss##xmss_v##_oid) {\
+                return OQS_ERROR;\
+        }\
         return OQS_SIG_STFL_alg_xmss##mt##_sigs_remaining(remain, secret_key);\
 }\
 \
 OQS_API OQS_STATUS OQS_SIG_STFL_alg_xmss##xmss_v##_sigs_total(unsigned long long *total, const OQS_SIG_STFL_SECRET_KEY *secret_key) {\
+        if (total == NULL || secret_key == NULL || secret_key->secret_key_data == NULL) {\
+                return OQS_ERROR;\
+        }\
+        /* Reject secret keys whose OID disagrees with the variant the caller invoked. */\
+        const uint8_t *sk_oid_bytes = (const uint8_t *)secret_key->secret_key_data;\
+        uint32_t sk_oid = ((uint32_t)sk_oid_bytes[0] << 24) | ((uint32_t)sk_oid_bytes[1] << 16)\
+                        | ((uint32_t)sk_oid_bytes[2] <<  8) | ((uint32_t)sk_oid_bytes[3]);\
+        if (sk_oid != (uint32_t)OQS_SIG_STFL_alg_xmss##xmss_v##_oid) {\
+                return OQS_ERROR;\
+        }\
         return OQS_SIG_STFL_alg_xmss##mt##_sigs_total(total, secret_key);\
 }

--- a/tests/test_sig_stfl.c
+++ b/tests/test_sig_stfl.c
@@ -408,6 +408,22 @@ static char *convert_method_name_to_file_name(const char *method_name) {
 #define TEST_INVALID_SIG_MALICIOUS_SIG_LEN 10
 /* XMSS-SHA2_10_256 OID; stored so low byte is at pk[TEST_XMSS_OID_LEN - 1] (see xmss.c). */
 #define TEST_XMSS_OID_SHA2_10_256 0x01U
+#ifdef OQS_ALLOW_XMSS_KEY_AND_SIG_GEN
+/* Largest sk_bytes in each OID namespace, two per namespace so the variant under test can
+ * always name a parameter set other than its own. */
+#define TEST_XMSS_OID_LARGEST_SK 0x06U       /* XMSS-SHA2_20_512 */
+#define TEST_XMSS_OID_LARGEST_SK_ALT 0x0cU   /* XMSS-SHAKE_20_512 */
+#define TEST_XMSSMT_OID_LARGEST_SK 0x08U     /* XMSSMT-SHA2_60/12_256 */
+#define TEST_XMSSMT_OID_LARGEST_SK_ALT 0x18U /* XMSSMT-SHAKE_60/12_256 */
+
+/* Store callback for keys that must never reach signing; discards instead of writing a file. */
+static OQS_STATUS discard_secret_key(uint8_t *key_buf, size_t buf_len, void *context) {
+	(void)key_buf;
+	(void)buf_len;
+	(void)context;
+	return OQS_SUCCESS;
+}
+#endif
 #endif
 
 /*
@@ -456,11 +472,56 @@ static OQS_STATUS test_invalid_sig(const char *method_name) {
 	memset(full_sig, 0, sig->length_signature);
 	pk[TEST_XMSS_OID_LEN - 1] = 0x02; // mirrors the GHSA-2wxh-55qf-c7wg PoC for XMSS-SHA2_10_256
 	status = OQS_SIG_STFL_verify(sig, message, sizeof(message) - 1, full_sig, sig->length_signature, pk);
-	OQS_MEM_insecure_free(full_sig);
-	OQS_SIG_STFL_free(sig);
 	if (status == OQS_SUCCESS) {
+		OQS_MEM_insecure_free(full_sig);
+		OQS_SIG_STFL_free(sig);
 		return OQS_ERROR;
 	}
+
+#ifdef OQS_ALLOW_XMSS_KEY_AND_SIG_GEN
+	// Sub-case 3: secret key blob of exactly the declared algorithm's length, but with OID
+	// bytes naming a different parameter set. The OID is part of the key material and
+	// xmss_sign re-parses it, so sk_bytes, sig_bytes and wots_sig_bytes all come from the
+	// mutated value. Pre-fix, xmss_core_sign walked the deserialized key with the geometry of
+	// the foreign parameter set and read past the end of secret_key_data (see
+	// xmss_deserialize_state). Post-fix, the wrapper rejects the mismatch before any offset
+	// is derived from it.
+	uint32_t foreign_oid;
+	if (strstr(method_name, "XMSSMT") != NULL) {
+		foreign_oid = (sig->oid == TEST_XMSSMT_OID_LARGEST_SK) ? TEST_XMSSMT_OID_LARGEST_SK_ALT : TEST_XMSSMT_OID_LARGEST_SK;
+	} else {
+		foreign_oid = (sig->oid == TEST_XMSS_OID_LARGEST_SK) ? TEST_XMSS_OID_LARGEST_SK_ALT : TEST_XMSS_OID_LARGEST_SK;
+	}
+
+	OQS_SIG_STFL_SECRET_KEY *foreign_sk = OQS_SIG_STFL_SECRET_KEY_new(method_name);
+	uint8_t *sk_buf = OQS_MEM_malloc(sig->length_secret_key);
+	if (foreign_sk == NULL || sk_buf == NULL) {
+		OQS_MEM_insecure_free(sk_buf);
+		OQS_SIG_STFL_SECRET_KEY_free(foreign_sk);
+		OQS_MEM_insecure_free(full_sig);
+		OQS_SIG_STFL_free(sig);
+		return OQS_ERROR;
+	}
+	memset(sk_buf, 0, sig->length_secret_key);
+	sk_buf[TEST_XMSS_OID_LEN - 1] = (uint8_t)foreign_oid;
+
+	status = OQS_SIG_STFL_SECRET_KEY_deserialize(foreign_sk, sk_buf, sig->length_secret_key, NULL);
+	if (status == OQS_SUCCESS) {
+		size_t foreign_sig_len = 0;
+		OQS_SIG_STFL_SECRET_KEY_SET_store_cb(foreign_sk, discard_secret_key, NULL);
+		status = OQS_SIG_STFL_sign(sig, full_sig, &foreign_sig_len, message, sizeof(message) - 1, foreign_sk);
+	}
+	OQS_MEM_insecure_free(sk_buf);
+	OQS_SIG_STFL_SECRET_KEY_free(foreign_sk);
+	if (status == OQS_SUCCESS) {
+		OQS_MEM_insecure_free(full_sig);
+		OQS_SIG_STFL_free(sig);
+		return OQS_ERROR;
+	}
+#endif
+
+	OQS_MEM_insecure_free(full_sig);
+	OQS_SIG_STFL_free(sig);
 	return OQS_SUCCESS;
 #endif
 }

--- a/tests/test_sig_stfl.c
+++ b/tests/test_sig_stfl.c
@@ -408,6 +408,22 @@ static char *convert_method_name_to_file_name(const char *method_name) {
 #define TEST_INVALID_SIG_MALICIOUS_SIG_LEN 10
 /* XMSS-SHA2_10_256 OID; stored so low byte is at pk[TEST_XMSS_OID_LEN - 1] (see xmss.c). */
 #define TEST_XMSS_OID_SHA2_10_256 0x01U
+#ifdef OQS_ALLOW_XMSS_KEY_AND_SIG_GEN
+/* Largest sk_bytes in each OID namespace, two per namespace so the variant under test can
+ * always name a parameter set other than its own. */
+#define TEST_XMSS_OID_LARGEST_SK 0x06U       /* XMSS-SHA2_20_512 */
+#define TEST_XMSS_OID_LARGEST_SK_ALT 0x0cU   /* XMSS-SHAKE_20_512 */
+#define TEST_XMSSMT_OID_LARGEST_SK 0x08U     /* XMSSMT-SHA2_60/12_256 */
+#define TEST_XMSSMT_OID_LARGEST_SK_ALT 0x18U /* XMSSMT-SHAKE_60/12_256 */
+
+/* Store callback for keys that must never reach signing; discards instead of writing a file. */
+static OQS_STATUS discard_secret_key(uint8_t *key_buf, size_t buf_len, void *context) {
+	(void)key_buf;
+	(void)buf_len;
+	(void)context;
+	return OQS_SUCCESS;
+}
+#endif
 #endif
 
 #ifdef OQS_ENABLE_SIG_STFL_LMS
@@ -473,11 +489,56 @@ static OQS_STATUS test_invalid_sig(const char *method_name) {
 	memset(full_sig, 0, sig->length_signature);
 	pk[TEST_XMSS_OID_LEN - 1] = 0x02; // mirrors the GHSA-2wxh-55qf-c7wg PoC for XMSS-SHA2_10_256
 	status = OQS_SIG_STFL_verify(sig, message, sizeof(message) - 1, full_sig, sig->length_signature, pk);
-	OQS_MEM_insecure_free(full_sig);
-	OQS_SIG_STFL_free(sig);
 	if (status == OQS_SUCCESS) {
+		OQS_MEM_insecure_free(full_sig);
+		OQS_SIG_STFL_free(sig);
 		return OQS_ERROR;
 	}
+
+#ifdef OQS_ALLOW_XMSS_KEY_AND_SIG_GEN
+	// Sub-case 3: secret key blob of exactly the declared algorithm's length, but with OID
+	// bytes naming a different parameter set. The OID is part of the key material and
+	// xmss_sign re-parses it, so sk_bytes, sig_bytes and wots_sig_bytes all come from the
+	// mutated value. Pre-fix, xmss_core_sign walked the deserialized key with the geometry of
+	// the foreign parameter set and read past the end of secret_key_data (see
+	// xmss_deserialize_state). Post-fix, the wrapper rejects the mismatch before any offset
+	// is derived from it.
+	uint32_t foreign_oid;
+	if (strstr(method_name, "XMSSMT") != NULL) {
+		foreign_oid = (sig->oid == TEST_XMSSMT_OID_LARGEST_SK) ? TEST_XMSSMT_OID_LARGEST_SK_ALT : TEST_XMSSMT_OID_LARGEST_SK;
+	} else {
+		foreign_oid = (sig->oid == TEST_XMSS_OID_LARGEST_SK) ? TEST_XMSS_OID_LARGEST_SK_ALT : TEST_XMSS_OID_LARGEST_SK;
+	}
+
+	OQS_SIG_STFL_SECRET_KEY *foreign_sk = OQS_SIG_STFL_SECRET_KEY_new(method_name);
+	uint8_t *sk_buf = OQS_MEM_malloc(sig->length_secret_key);
+	if (foreign_sk == NULL || sk_buf == NULL) {
+		OQS_MEM_insecure_free(sk_buf);
+		OQS_SIG_STFL_SECRET_KEY_free(foreign_sk);
+		OQS_MEM_insecure_free(full_sig);
+		OQS_SIG_STFL_free(sig);
+		return OQS_ERROR;
+	}
+	memset(sk_buf, 0, sig->length_secret_key);
+	sk_buf[TEST_XMSS_OID_LEN - 1] = (uint8_t)foreign_oid;
+
+	status = OQS_SIG_STFL_SECRET_KEY_deserialize(foreign_sk, sk_buf, sig->length_secret_key, NULL);
+	if (status == OQS_SUCCESS) {
+		size_t foreign_sig_len = 0;
+		OQS_SIG_STFL_SECRET_KEY_SET_store_cb(foreign_sk, discard_secret_key, NULL);
+		status = OQS_SIG_STFL_sign(sig, full_sig, &foreign_sig_len, message, sizeof(message) - 1, foreign_sk);
+	}
+	OQS_MEM_insecure_free(sk_buf);
+	OQS_SIG_STFL_SECRET_KEY_free(foreign_sk);
+	if (status == OQS_SUCCESS) {
+		OQS_MEM_insecure_free(full_sig);
+		OQS_SIG_STFL_free(sig);
+		return OQS_ERROR;
+	}
+#endif
+
+	OQS_MEM_insecure_free(full_sig);
+	OQS_SIG_STFL_free(sig);
 	return OQS_SUCCESS;
 #endif
 }

--- a/tests/test_sig_stfl.c
+++ b/tests/test_sig_stfl.c
@@ -496,13 +496,11 @@ static OQS_STATUS test_invalid_sig(const char *method_name) {
 	}
 
 #ifdef OQS_ALLOW_XMSS_KEY_AND_SIG_GEN
-	// Sub-case 3: secret key blob of exactly the declared algorithm's length, but with OID
-	// bytes naming a different parameter set. The OID is part of the key material and
-	// xmss_sign re-parses it, so sk_bytes, sig_bytes and wots_sig_bytes all come from the
-	// mutated value. Pre-fix, xmss_core_sign walked the deserialized key with the geometry of
-	// the foreign parameter set and read past the end of secret_key_data (see
-	// xmss_deserialize_state). Post-fix, the wrapper rejects the mismatch before any offset
-	// is derived from it.
+	// Sub-case 3: a secret key buffer sized for this algorithm, but with OID bytes that
+	// identify a different XMSS/XMSSMT variant. Sign, sigs_remaining, and sigs_total all
+	// read the OID from the key to decide field sizes and offsets. If that OID names a
+	// larger variant, those functions can read beyond secret_key_data (see
+	// xmss_deserialize_state). The per-algorithm wrappers must reject the mismatch first.
 	uint32_t foreign_oid;
 	if (strstr(method_name, "XMSSMT") != NULL) {
 		foreign_oid = (sig->oid == TEST_XMSSMT_OID_LARGEST_SK) ? TEST_XMSSMT_OID_LARGEST_SK_ALT : TEST_XMSSMT_OID_LARGEST_SK;
@@ -524,9 +522,18 @@ static OQS_STATUS test_invalid_sig(const char *method_name) {
 
 	status = OQS_SIG_STFL_SECRET_KEY_deserialize(foreign_sk, sk_buf, sig->length_secret_key, NULL);
 	if (status == OQS_SUCCESS) {
-		size_t foreign_sig_len = 0;
-		OQS_SIG_STFL_SECRET_KEY_SET_store_cb(foreign_sk, discard_secret_key, NULL);
-		status = OQS_SIG_STFL_sign(sig, full_sig, &foreign_sig_len, message, sizeof(message) - 1, foreign_sk);
+		unsigned long long dummy = 0;
+
+		/* Acceptance by any of the three consumers is the failure being tested for, so it
+		 * must leave status == OQS_SUCCESS for the check below to flag. */
+		if (OQS_SIG_STFL_sigs_remaining(sig, &dummy, foreign_sk) == OQS_SUCCESS ||
+		        OQS_SIG_STFL_sigs_total(sig, &dummy, foreign_sk) == OQS_SUCCESS) {
+			status = OQS_SUCCESS;
+		} else {
+			size_t foreign_sig_len = 0;
+			OQS_SIG_STFL_SECRET_KEY_SET_store_cb(foreign_sk, discard_secret_key, NULL);
+			status = OQS_SIG_STFL_sign(sig, full_sig, &foreign_sig_len, message, sizeof(message) - 1, foreign_sk);
+		}
 	}
 	OQS_MEM_insecure_free(sk_buf);
 	OQS_SIG_STFL_SECRET_KEY_free(foreign_sk);


### PR DESCRIPTION
Repro: deserialise an XMSS secret key blob of exactly `sig->length_secret_key` bytes whose first four bytes name a different parameter set, then call `OQS_SIG_STFL_sign`. For `XMSS-SHA2_10_192` (1057-byte key) carrying the OID of `XMSS-SHA2_20_512` (`sk_bytes` 4973), ASAN reports `heap-buffer-overflow READ of size 1 ... 1216 bytes after 1057-byte region` in `bytes_to_ull` (`utils.c:28`), reached via `xmssmt_deserialize_state` (`xmss_core_fast.c:111`) <- `xmss_deserialize_state` <- `xmss_core_sign` (`xmss_core_fast.c:663`) <- `xmss_sign` (`xmss.c:95`) <- `OQS_SIG_STFL_sign` (`sig_stfl.c:1035`). Three calls from the documented public API, with the blob fully attacker-controlled.

Cause: the OID is part of the secret key material and selects `n`, `tree_height`, `d`, `index_bytes`, `sk_bytes`, `sig_bytes` and `wots_sig_bytes`. `OQS_SECRET_KEY_XMSS_deserialize_key` checks only that the blob length equals `sk->length_secret_key`, and `xmss_sign` re-parses the OID out of the loaded bytes, so the BDS state is walked with the geometry of the named parameter set rather than the allocated one. The signature is written past the end of the caller's buffer for the same reason.

Fix: decode `secret_key_data[0..3]` as a big-endian OID in the per-variant sign wrapper and reject anything other than the variant's compile-time OID constant, before any offset is derived from it. The check sits in the `XMSS_ALG` macro, so it reaches all 37 XMSS and XMSS^MT variants from one place. `xmss_keypair` writes the variant's own OID into the secret key, so a legitimately serialised key always carries the matching value and valid signing is untouched; the XMSS and XMSS^MT KATs are unchanged.

The public-key side of this check already lives in the same macro's verify wrapper (GHSA-2wxh-55qf-c7wg); the secret key side was left open. `OQS_SECRET_KEY_XMSS_deserialize_key` cannot make the equivalent check itself, since it is shared by every variant and the key object carries only a length, leaving it unable to tell an XMSS OID from an XMSS^MT OID with the same numeric value. `sigs_remaining` and `sigs_total` read only the OID and index prefix, so `sign` is the sole consumer that derives buffer offsets from it. The regression test adds a third sub-case to `test_invalid_sig`: unpatched, 33 of the 37 variants abort under ASAN and the other 4 accept the mismatched key and sign with it, so every variant is covered.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged. Also, make sure to update the list of algorithms in the continuous benchmarking files: .github/workflows/kem-bench.yml and sig-bench.yml)
