### PR TITLE
Fix undersized allocation in oqs_aes128_load_schedule_no_bitslice

### DIFF
--- a/src/common/aes/aes_c.c
+++ b/src/common/aes/aes_c.c
@@ -54,6 +54,11 @@ typedef struct {
 } aes256ctx;
 
 typedef struct {
+	uint32_t sk_exp[44];
+	uint8_t iv[16];
+} aes128ctx_nobitslice;
+
+typedef struct {
 	uint32_t sk_exp[60];
 	uint8_t iv[16];
 } aes256ctx_nobitslice;
@@ -752,9 +757,9 @@ void oqs_aes256_load_iv_u64_c(uint64_t iv, void *schedule) {
 }
 
 void oqs_aes128_load_schedule_no_bitslice(const uint8_t *key, void **_schedule) {
-	*_schedule = OQS_MEM_malloc(44 * sizeof(int));
+	*_schedule = OQS_MEM_malloc(sizeof(aes128ctx_nobitslice));
 	assert(*_schedule != NULL);
-	uint32_t *schedule = (uint32_t *) *_schedule;
+	uint32_t *schedule = ((aes128ctx_nobitslice *) *_schedule)->sk_exp;
 	aes_keysched_no_bitslice(schedule, (const unsigned char *) key, 16);
 }
 
@@ -838,6 +843,6 @@ void oqs_aes256_free_schedule_no_bitslice(void *schedule) {
 
 void oqs_aes128_free_schedule_no_bitslice(void *schedule) {
 	if (schedule != NULL) {
-		OQS_MEM_secure_free(schedule, 44 * sizeof(int));
+		OQS_MEM_secure_free(schedule, sizeof(aes128ctx_nobitslice));
 	}
 }

--- a/tests/test_aes.c
+++ b/tests/test_aes.c
@@ -76,6 +76,17 @@ static int test_aes128ctr_correctness(void) {
 	return EXIT_SUCCESS;
 }
 
+// OQS_AES128_CTR_inc_iv() stores the IV inside the key schedule; this entry
+// point had no coverage, so an undersized schedule went unnoticed under ASan.
+static int test_aes128ctr_inc_iv(void) {
+	void *schedule = NULL;
+	OQS_AES128_CTR_inc_init(test_aes128ctr_key, &schedule);
+	OQS_AES128_CTR_inc_iv(test_aes128ctr_iv, 12, schedule);
+	OQS_AES128_CTR_inc_iv(test_aes128ctr_iv, sizeof(test_aes128ctr_iv), schedule);
+	OQS_AES128_free_schedule(schedule);
+	return EXIT_SUCCESS;
+}
+
 static int test_aes256_correctness(void) {
 	uint8_t derived_ciphertext[16];
 	void *schedule = NULL;
@@ -184,6 +195,10 @@ int main(int argc, char **argv) {
 		return EXIT_FAILURE;
 	}
 	if (test_aes128ctr_correctness() != EXIT_SUCCESS) {
+		OQS_destroy();
+		return EXIT_FAILURE;
+	}
+	if (test_aes128ctr_inc_iv() != EXIT_SUCCESS) {
 		OQS_destroy();
 		return EXIT_FAILURE;
 	}


### PR DESCRIPTION
Repro: build with `-DOQS_USE_OPENSSL=OFF` (or `-DOQS_USE_AES_OPENSSL=OFF`) on an ARMv8-crypto host, then call `OQS_AES128_CTR_inc_init` followed by `OQS_AES128_CTR_inc_iv`. ASan on the unpatched tree reports `heap-buffer-overflow WRITE of size 16 ... 0 bytes after 176-byte region` in `oqs_aes128_load_iv_armv8` (`aes128_armv8.c:22`), for a region allocated by `oqs_aes128_load_schedule_no_bitslice` (`aes_c.c:755`). The test added here reproduces it directly.

Cause: that allocator hands out `44 * sizeof(int)` = 176 bytes, but the ARM implementations cast the buffer to `aes128ctx { uint64_t sk_exp[22]; uint8_t iv[16]; }` = 192 bytes, so `ctx->iv` begins exactly at the end of the allocation. `oqs_aes128_ctr_enc_sch_upd_blks_armv8` reads and writes the counter at offset 188 for the same reason, and the matching free cleanses only the first 176 bytes.

Fix: size the allocation and the secure free with a named `aes128ctx_nobitslice`, the way `oqs_aes256_load_schedule_no_bitslice` already does for the 256-bit twin (that one was written with the IV included and is unaffected). Round keys stay at offset 0, so valid-input behaviour is unchanged and the AES-128 ECB/CTR KATs are untouched.

Only the ARM slot of `C_OR_NI_OR_ARM` pairs this allocator with a context that holds an IV. I checked every schedule allocation and free under `src/common/aes`: this is the only one sized from a raw byte literal, while the C, AES-NI and OpenSSL paths all use `sizeof` of their own context struct, so there is no second site to fix.

`OQS_AES128_CTR_inc_iv` had no test coverage, which is why the address-sanitizer job never saw this. The new case exercises both the 12- and 16-byte IV forms.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged. Also, make sure to update the list of algorithms in the continuous benchmarking files: .github/workflows/kem-bench.yml and sig-bench.yml)
