### PR TITLE
Enable reduced-RAM ML-DSA under OQS_MEMOPT_BUILD

### DIFF
--- a/scripts/copy_from_upstream/src/sig/family/CMakeLists.txt
+++ b/scripts/copy_from_upstream/src/sig/family/CMakeLists.txt
@@ -5,6 +5,13 @@
 
 set(_{{ family|upper }}_OBJS "")
 
+{%- if family == "ml_dsa" %}
+
+if(OQS_MEMOPT_BUILD)
+    add_compile_definitions(MLD_CONFIG_REDUCE_RAM)
+endif()
+{%- endif %}
+
 {%- if common_deps is defined %}
     {%- for common_dep in common_deps %}
         {%- if not common_dep['include_only'] %}

--- a/src/sig/ml_dsa/CMakeLists.txt
+++ b/src/sig/ml_dsa/CMakeLists.txt
@@ -5,6 +5,10 @@
 
 set(_ML_DSA_OBJS "")
 
+if(OQS_MEMOPT_BUILD)
+    add_compile_definitions(MLD_CONFIG_REDUCE_RAM)
+endif()
+
 if(OQS_ENABLE_SIG_ml_dsa_44 OR OQS_ENABLE_SIG_ml_dsa_44_extmu)
     add_library(ml_dsa_44_ref OBJECT sig_ml_dsa_44.c mldsa-native_ml-dsa-44_ref/mldsa/src/ct.c mldsa-native_ml-dsa-44_ref/mldsa/src/debug.c mldsa-native_ml-dsa-44_ref/mldsa/src/packing.c mldsa-native_ml-dsa-44_ref/mldsa/src/poly.c mldsa-native_ml-dsa-44_ref/mldsa/src/poly_kl.c mldsa-native_ml-dsa-44_ref/mldsa/src/polyvec.c mldsa-native_ml-dsa-44_ref/mldsa/src/polyvec_lazy.c mldsa-native_ml-dsa-44_ref/mldsa/src/sign.c)
     target_compile_options(ml_dsa_44_ref PUBLIC -DMLD_CONFIG_PARAMETER_SET=44 -DMLD_CONFIG_FILE="../../integration/liboqs/config_c.h")


### PR DESCRIPTION
Fixes #2483.

## Summary

Enable mldsa-native's `MLD_CONFIG_REDUCE_RAM` configuration when liboqs is built with `OQS_MEMOPT_BUILD=ON`.

mldsa-native already provides this reduced-memory mode. This change connects the existing liboqs memory-optimized build option to the ML-DSA integration.

The change is made in the `copy_from_upstream` CMake template so regenerated ML-DSA build files retain the configuration.

## Testing

Tested on WSL2/Linux with GCC and Ninja.

Normal build:
- Built ML-DSA-44, ML-DSA-65, and ML-DSA-87
- Confirmed `MLD_CONFIG_REDUCE_RAM` is absent from compile commands
- `test_sig` passes for ML-DSA-44/65/87

Memory-optimized build:
- Built with `OQS_MEMOPT_BUILD=ON`
- Confirmed `-DMLD_CONFIG_REDUCE_RAM` is present in ML-DSA compile commands
- `test_sig` passes for ML-DSA-44/65/87

Additional checks:
- Built with `OQS_STRICT_WARNINGS=ON`
- `python3 -m pytest -q tests/test_code_conventions.py`
  - 265 passed, 3 skipped
- `git diff --check`

## API / algorithm behavior

- Does this change known-answer-test values? No.
- Does this add/remove algorithms or change the public API? No.

## Generative AI

I used ChatGPT to help inspect the liboqs build/generation structure and suggest testing steps. I reviewed the resulting change and ran the listed tests locally.
