### PR TITLE
Fix SHA3 first-use dispatch race

### DIFF
--- a/src/common/sha3/sha3.c
+++ b/src/common/sha3/sha3.c
@@ -10,7 +10,7 @@
 
 extern struct OQS_SHA3_callbacks sha3_default_callbacks;
 
-static struct OQS_SHA3_callbacks *callbacks = &sha3_default_callbacks;
+static const struct OQS_SHA3_callbacks *callbacks = &sha3_default_callbacks;
 
 /* The top-level SHA3 backend is selected once, before any SHA3 entry point
  * is allowed to dispatch. We swap the `callbacks` pointer atomically (a
@@ -28,7 +28,7 @@ static void init_callbacks(void) {
 #if defined(OQS_USE_SHA3_AVX512VL) && defined(OQS_DIST_X86_64_BUILD)
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX512)) {
 		extern const struct OQS_SHA3_callbacks sha3_avx512vl_callbacks;
-		callbacks = (struct OQS_SHA3_callbacks *) &sha3_avx512vl_callbacks;
+		callbacks = &sha3_avx512vl_callbacks;
 	}
 #endif
 }
@@ -44,7 +44,7 @@ static inline void ensure_callbacks_initialized(void) {
 #endif
 }
 
-static inline struct OQS_SHA3_callbacks *get_cb(void) {
+static inline const struct OQS_SHA3_callbacks *get_cb(void) {
 	ensure_callbacks_initialized();
 	return callbacks;
 }

--- a/src/common/sha3/sha3.c
+++ b/src/common/sha3/sha3.c
@@ -4,158 +4,202 @@
 
 #include "sha3.h"
 
+#if OQS_USE_PTHREADS
+#include <pthread.h>
+#endif
+
 extern struct OQS_SHA3_callbacks sha3_default_callbacks;
 
 static struct OQS_SHA3_callbacks *callbacks = &sha3_default_callbacks;
 
+/* The top-level SHA3 backend is selected once, before any SHA3 entry point
+ * is allowed to dispatch. We swap the `callbacks` pointer atomically (a
+ * single aligned-pointer store) rather than overwriting the contents of the
+ * default callbacks struct, so concurrent readers never observe a torn
+ * vtable, and a single in-flight call cannot be split across two backends.
+ */
+#if OQS_USE_PTHREADS
+static pthread_once_t callbacks_init_once = PTHREAD_ONCE_INIT;
+#else
+static int callbacks_initialized = 0;
+#endif
+
+static void init_callbacks(void) {
+#if defined(OQS_USE_SHA3_AVX512VL) && defined(OQS_DIST_X86_64_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX512)) {
+		extern const struct OQS_SHA3_callbacks sha3_avx512vl_callbacks;
+		callbacks = (struct OQS_SHA3_callbacks *) &sha3_avx512vl_callbacks;
+	}
+#endif
+}
+
+static inline void ensure_callbacks_initialized(void) {
+#if OQS_USE_PTHREADS
+	pthread_once(&callbacks_init_once, init_callbacks);
+#else
+	if (!callbacks_initialized) {
+		init_callbacks();
+		callbacks_initialized = 1;
+	}
+#endif
+}
+
+static inline struct OQS_SHA3_callbacks *get_cb(void) {
+	ensure_callbacks_initialized();
+	return callbacks;
+}
+
 OQS_API void OQS_SHA3_set_callbacks(struct OQS_SHA3_callbacks *new_callbacks) {
+	/* Ensure the one-time auto-detection has run first, so a later SHA3
+	 * call cannot clobber the user's choice. */
+	ensure_callbacks_initialized();
 	callbacks = new_callbacks;
 }
 
 void OQS_SHA3_sha3_256(uint8_t *output, const uint8_t *input, size_t inplen) {
-	callbacks->SHA3_sha3_256(output, input, inplen);
+	get_cb()->SHA3_sha3_256(output, input, inplen);
 }
 
 void OQS_SHA3_sha3_256_inc_init(OQS_SHA3_sha3_256_inc_ctx *state) {
-	callbacks->SHA3_sha3_256_inc_init(state);
+	get_cb()->SHA3_sha3_256_inc_init(state);
 }
 
 void OQS_SHA3_sha3_256_inc_absorb(OQS_SHA3_sha3_256_inc_ctx *state, const uint8_t *input, size_t inlen) {
-	callbacks->SHA3_sha3_256_inc_absorb(state, input, inlen);
+	get_cb()->SHA3_sha3_256_inc_absorb(state, input, inlen);
 }
 
 void OQS_SHA3_sha3_256_inc_finalize(uint8_t *output, OQS_SHA3_sha3_256_inc_ctx *state) {
-	callbacks->SHA3_sha3_256_inc_finalize(output, state);
+	get_cb()->SHA3_sha3_256_inc_finalize(output, state);
 }
 
 void OQS_SHA3_sha3_256_inc_ctx_release(OQS_SHA3_sha3_256_inc_ctx *state) {
-	callbacks->SHA3_sha3_256_inc_ctx_release(state);
+	get_cb()->SHA3_sha3_256_inc_ctx_release(state);
 }
 
 void OQS_SHA3_sha3_256_inc_ctx_reset(OQS_SHA3_sha3_256_inc_ctx *state) {
-	callbacks->SHA3_sha3_256_inc_ctx_reset(state);
+	get_cb()->SHA3_sha3_256_inc_ctx_reset(state);
 }
 
 void OQS_SHA3_sha3_256_inc_ctx_clone(OQS_SHA3_sha3_256_inc_ctx *dest, const OQS_SHA3_sha3_256_inc_ctx *src) {
-	callbacks->SHA3_sha3_256_inc_ctx_clone(dest, src);
+	get_cb()->SHA3_sha3_256_inc_ctx_clone(dest, src);
 }
 
 void OQS_SHA3_sha3_384(uint8_t *output, const uint8_t *input, size_t inplen) {
-	callbacks->SHA3_sha3_384(output, input, inplen);
+	get_cb()->SHA3_sha3_384(output, input, inplen);
 }
 
 void OQS_SHA3_sha3_384_inc_init(OQS_SHA3_sha3_384_inc_ctx *state) {
-	callbacks->SHA3_sha3_384_inc_init(state);
+	get_cb()->SHA3_sha3_384_inc_init(state);
 }
 
 void OQS_SHA3_sha3_384_inc_absorb(OQS_SHA3_sha3_384_inc_ctx *state, const uint8_t *input, size_t inlen) {
-	callbacks->SHA3_sha3_384_inc_absorb(state, input, inlen);
+	get_cb()->SHA3_sha3_384_inc_absorb(state, input, inlen);
 }
 
 void OQS_SHA3_sha3_384_inc_finalize(uint8_t *output, OQS_SHA3_sha3_384_inc_ctx *state) {
-	callbacks->SHA3_sha3_384_inc_finalize(output, state);
+	get_cb()->SHA3_sha3_384_inc_finalize(output, state);
 }
 
 void OQS_SHA3_sha3_384_inc_ctx_release(OQS_SHA3_sha3_384_inc_ctx *state) {
-	callbacks->SHA3_sha3_384_inc_ctx_release(state);
+	get_cb()->SHA3_sha3_384_inc_ctx_release(state);
 }
 
 void OQS_SHA3_sha3_384_inc_ctx_reset(OQS_SHA3_sha3_384_inc_ctx *state) {
-	callbacks->SHA3_sha3_384_inc_ctx_reset(state);
+	get_cb()->SHA3_sha3_384_inc_ctx_reset(state);
 }
 
 void OQS_SHA3_sha3_384_inc_ctx_clone(OQS_SHA3_sha3_384_inc_ctx *dest, const OQS_SHA3_sha3_384_inc_ctx *src) {
-	callbacks->SHA3_sha3_384_inc_ctx_clone(dest, src);
+	get_cb()->SHA3_sha3_384_inc_ctx_clone(dest, src);
 }
 
 void OQS_SHA3_sha3_512(uint8_t *output, const uint8_t *input, size_t inplen) {
-	callbacks->SHA3_sha3_512(output, input, inplen);
+	get_cb()->SHA3_sha3_512(output, input, inplen);
 }
 
 void OQS_SHA3_sha3_512_inc_init(OQS_SHA3_sha3_512_inc_ctx *state) {
-	callbacks->SHA3_sha3_512_inc_init(state);
+	get_cb()->SHA3_sha3_512_inc_init(state);
 }
 
 void OQS_SHA3_sha3_512_inc_absorb(OQS_SHA3_sha3_512_inc_ctx *state, const uint8_t *input, size_t inlen) {
-	callbacks->SHA3_sha3_512_inc_absorb(state, input, inlen);
+	get_cb()->SHA3_sha3_512_inc_absorb(state, input, inlen);
 }
 
 void OQS_SHA3_sha3_512_inc_finalize(uint8_t *output, OQS_SHA3_sha3_512_inc_ctx *state) {
-	callbacks->SHA3_sha3_512_inc_finalize(output, state);
+	get_cb()->SHA3_sha3_512_inc_finalize(output, state);
 }
 
 void OQS_SHA3_sha3_512_inc_ctx_release(OQS_SHA3_sha3_512_inc_ctx *state) {
-	callbacks->SHA3_sha3_512_inc_ctx_release(state);
+	get_cb()->SHA3_sha3_512_inc_ctx_release(state);
 }
 
 void OQS_SHA3_sha3_512_inc_ctx_reset(OQS_SHA3_sha3_512_inc_ctx *state) {
-	callbacks->SHA3_sha3_512_inc_ctx_reset(state);
+	get_cb()->SHA3_sha3_512_inc_ctx_reset(state);
 }
 
 void OQS_SHA3_sha3_512_inc_ctx_clone(OQS_SHA3_sha3_512_inc_ctx *dest, const OQS_SHA3_sha3_512_inc_ctx *src) {
-	callbacks->SHA3_sha3_512_inc_ctx_clone(dest, src);
+	get_cb()->SHA3_sha3_512_inc_ctx_clone(dest, src);
 }
 
 void OQS_SHA3_shake128(uint8_t *output, size_t outlen, const uint8_t *input, size_t inplen) {
-	callbacks->SHA3_shake128(output, outlen, input, inplen);
+	get_cb()->SHA3_shake128(output, outlen, input, inplen);
 }
 
 void OQS_SHA3_shake128_inc_init(OQS_SHA3_shake128_inc_ctx *state) {
-	callbacks->SHA3_shake128_inc_init(state);
+	get_cb()->SHA3_shake128_inc_init(state);
 }
 
 void OQS_SHA3_shake128_inc_absorb(OQS_SHA3_shake128_inc_ctx *state, const uint8_t *input, size_t inlen) {
-	callbacks->SHA3_shake128_inc_absorb(state, input, inlen);
+	get_cb()->SHA3_shake128_inc_absorb(state, input, inlen);
 }
 
 void OQS_SHA3_shake128_inc_finalize(OQS_SHA3_shake128_inc_ctx *state) {
-	callbacks->SHA3_shake128_inc_finalize(state);
+	get_cb()->SHA3_shake128_inc_finalize(state);
 }
 
 void OQS_SHA3_shake128_inc_squeeze(uint8_t *output, size_t outlen, OQS_SHA3_shake128_inc_ctx *state) {
-	callbacks->SHA3_shake128_inc_squeeze(output, outlen, state);
+	get_cb()->SHA3_shake128_inc_squeeze(output, outlen, state);
 }
 
 void OQS_SHA3_shake128_inc_ctx_release(OQS_SHA3_shake128_inc_ctx *state) {
-	callbacks->SHA3_shake128_inc_ctx_release(state);
+	get_cb()->SHA3_shake128_inc_ctx_release(state);
 }
 
 void OQS_SHA3_shake128_inc_ctx_clone(OQS_SHA3_shake128_inc_ctx *dest, const OQS_SHA3_shake128_inc_ctx *src) {
-	callbacks->SHA3_shake128_inc_ctx_clone(dest, src);
+	get_cb()->SHA3_shake128_inc_ctx_clone(dest, src);
 }
 
 void OQS_SHA3_shake128_inc_ctx_reset(OQS_SHA3_shake128_inc_ctx *state) {
-	callbacks->SHA3_shake128_inc_ctx_reset(state);
+	get_cb()->SHA3_shake128_inc_ctx_reset(state);
 }
 
 void OQS_SHA3_shake256(uint8_t *output, size_t outlen, const uint8_t *input, size_t inplen) {
-	callbacks->SHA3_shake256(output, outlen, input, inplen);
+	get_cb()->SHA3_shake256(output, outlen, input, inplen);
 }
 
 void OQS_SHA3_shake256_inc_init(OQS_SHA3_shake256_inc_ctx *state) {
-	callbacks->SHA3_shake256_inc_init(state);
+	get_cb()->SHA3_shake256_inc_init(state);
 }
 
 void OQS_SHA3_shake256_inc_absorb(OQS_SHA3_shake256_inc_ctx *state, const uint8_t *input, size_t inlen) {
-	callbacks->SHA3_shake256_inc_absorb(state, input, inlen);
+	get_cb()->SHA3_shake256_inc_absorb(state, input, inlen);
 }
 
 void OQS_SHA3_shake256_inc_finalize(OQS_SHA3_shake256_inc_ctx *state) {
-	callbacks->SHA3_shake256_inc_finalize(state);
+	get_cb()->SHA3_shake256_inc_finalize(state);
 }
 
 void OQS_SHA3_shake256_inc_squeeze(uint8_t *output, size_t outlen, OQS_SHA3_shake256_inc_ctx *state) {
-	callbacks->SHA3_shake256_inc_squeeze(output, outlen, state);
+	get_cb()->SHA3_shake256_inc_squeeze(output, outlen, state);
 }
 
 void OQS_SHA3_shake256_inc_ctx_release(OQS_SHA3_shake256_inc_ctx *state) {
-	callbacks->SHA3_shake256_inc_ctx_release(state);
+	get_cb()->SHA3_shake256_inc_ctx_release(state);
 }
 
 void OQS_SHA3_shake256_inc_ctx_clone(OQS_SHA3_shake256_inc_ctx *dest, const OQS_SHA3_shake256_inc_ctx *src) {
-	callbacks->SHA3_shake256_inc_ctx_clone(dest, src);
+	get_cb()->SHA3_shake256_inc_ctx_clone(dest, src);
 }
 
 void OQS_SHA3_shake256_inc_ctx_reset(OQS_SHA3_shake256_inc_ctx *state) {
-	callbacks->SHA3_shake256_inc_ctx_reset(state);
+	get_cb()->SHA3_shake256_inc_ctx_reset(state);
 }

--- a/src/common/sha3/sha3.c
+++ b/src/common/sha3/sha3.c
@@ -12,11 +12,9 @@ extern struct OQS_SHA3_callbacks sha3_default_callbacks;
 
 static const struct OQS_SHA3_callbacks *callbacks = &sha3_default_callbacks;
 
-/* The top-level SHA3 backend is selected once, before any SHA3 entry point
- * is allowed to dispatch. We swap the `callbacks` pointer atomically (a
- * single aligned-pointer store) rather than overwriting the contents of the
- * default callbacks struct, so concurrent readers never observe a torn
- * vtable, and a single in-flight call cannot be split across two backends.
+/* Select the top-level SHA3 backend once before dispatching any entry point.
+ * pthread_once synchronizes concurrent first-use callers; the callback table
+ * is not modified while an operation is in progress.
  */
 #if OQS_USE_PTHREADS
 static pthread_once_t callbacks_init_once = PTHREAD_ONCE_INIT;
@@ -50,8 +48,7 @@ static inline const struct OQS_SHA3_callbacks *get_cb(void) {
 }
 
 OQS_API void OQS_SHA3_set_callbacks(struct OQS_SHA3_callbacks *new_callbacks) {
-	/* Ensure the one-time auto-detection has run first, so a later SHA3
-	 * call cannot clobber the user's choice. */
+	/* Complete automatic initialization before accepting a custom table. */
 	ensure_callbacks_initialized();
 	callbacks = new_callbacks;
 }

--- a/src/common/sha3/sha3x4.c
+++ b/src/common/sha3/sha3x4.c
@@ -4,74 +4,112 @@
 
 #include "sha3x4.h"
 
+#if OQS_USE_PTHREADS
+#include <pthread.h>
+#endif
+
 extern struct OQS_SHA3_x4_callbacks sha3_x4_default_callbacks;
 
 static struct OQS_SHA3_x4_callbacks *callbacks = &sha3_x4_default_callbacks;
 
+/* See sha3.c for the rationale: select the backend once, with a single
+ * atomic pointer swap, before any SHA3-x4 entry point can dispatch. */
+#if OQS_USE_PTHREADS
+static pthread_once_t callbacks_init_once = PTHREAD_ONCE_INIT;
+#else
+static int callbacks_initialized = 0;
+#endif
+
+static void init_callbacks(void) {
+#if defined(OQS_USE_SHA3_AVX512VL) && defined(OQS_DIST_X86_64_BUILD)
+	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX512)) {
+		extern const struct OQS_SHA3_x4_callbacks sha3_x4_avx512vl_callbacks;
+		callbacks = (struct OQS_SHA3_x4_callbacks *) &sha3_x4_avx512vl_callbacks;
+	}
+#endif
+}
+
+static inline void ensure_callbacks_initialized(void) {
+#if OQS_USE_PTHREADS
+	pthread_once(&callbacks_init_once, init_callbacks);
+#else
+	if (!callbacks_initialized) {
+		init_callbacks();
+		callbacks_initialized = 1;
+	}
+#endif
+}
+
+static inline struct OQS_SHA3_x4_callbacks *get_cb(void) {
+	ensure_callbacks_initialized();
+	return callbacks;
+}
+
 OQS_API void OQS_SHA3_x4_set_callbacks(struct OQS_SHA3_x4_callbacks *new_callbacks) {
+	ensure_callbacks_initialized();
 	callbacks = new_callbacks;
 }
 
 void OQS_SHA3_shake128_x4(uint8_t *out0, uint8_t *out1, uint8_t *out2, uint8_t *out3, size_t outlen, const uint8_t *in0, const uint8_t *in1, const uint8_t *in2, const uint8_t *in3, size_t inlen) {
-	callbacks->SHA3_shake128_x4(out0, out1, out2, out3, outlen, in0, in1, in2, in3, inlen);
+	get_cb()->SHA3_shake128_x4(out0, out1, out2, out3, outlen, in0, in1, in2, in3, inlen);
 }
 
 void OQS_SHA3_shake128_x4_inc_init(OQS_SHA3_shake128_x4_inc_ctx *state) {
-	callbacks->SHA3_shake128_x4_inc_init(state);
+	get_cb()->SHA3_shake128_x4_inc_init(state);
 }
 
 void OQS_SHA3_shake128_x4_inc_absorb(OQS_SHA3_shake128_x4_inc_ctx *state, const uint8_t *in0, const uint8_t *in1, const uint8_t *in2, const uint8_t *in3, size_t inlen) {
-	callbacks->SHA3_shake128_x4_inc_absorb(state, in0, in1, in2, in3, inlen);
+	get_cb()->SHA3_shake128_x4_inc_absorb(state, in0, in1, in2, in3, inlen);
 }
 
 void OQS_SHA3_shake128_x4_inc_finalize(OQS_SHA3_shake128_x4_inc_ctx *state) {
-	callbacks->SHA3_shake128_x4_inc_finalize(state);
+	get_cb()->SHA3_shake128_x4_inc_finalize(state);
 }
 
 void OQS_SHA3_shake128_x4_inc_squeeze(uint8_t *out0, uint8_t *out1, uint8_t *out2, uint8_t *out3, size_t outlen, OQS_SHA3_shake128_x4_inc_ctx *state) {
-	callbacks->SHA3_shake128_x4_inc_squeeze(out0, out1, out2, out3, outlen, state);
+	get_cb()->SHA3_shake128_x4_inc_squeeze(out0, out1, out2, out3, outlen, state);
 }
 
 void OQS_SHA3_shake128_x4_inc_ctx_release(OQS_SHA3_shake128_x4_inc_ctx *state) {
-	callbacks->SHA3_shake128_x4_inc_ctx_release(state);
+	get_cb()->SHA3_shake128_x4_inc_ctx_release(state);
 }
 
 void OQS_SHA3_shake128_x4_inc_ctx_clone(OQS_SHA3_shake128_x4_inc_ctx *dest, const OQS_SHA3_shake128_x4_inc_ctx *src) {
-	callbacks->SHA3_shake128_x4_inc_ctx_clone(dest, src);
+	get_cb()->SHA3_shake128_x4_inc_ctx_clone(dest, src);
 }
 
 void OQS_SHA3_shake128_x4_inc_ctx_reset(OQS_SHA3_shake128_x4_inc_ctx *state) {
-	callbacks->SHA3_shake128_x4_inc_ctx_reset(state);
+	get_cb()->SHA3_shake128_x4_inc_ctx_reset(state);
 }
 
 void OQS_SHA3_shake256_x4(uint8_t *out0, uint8_t *out1, uint8_t *out2, uint8_t *out3, size_t outlen, const uint8_t *in0, const uint8_t *in1, const uint8_t *in2, const uint8_t *in3, size_t inlen) {
-	callbacks->SHA3_shake256_x4(out0, out1, out2, out3, outlen, in0, in1, in2, in3, inlen);
+	get_cb()->SHA3_shake256_x4(out0, out1, out2, out3, outlen, in0, in1, in2, in3, inlen);
 }
 
 void OQS_SHA3_shake256_x4_inc_init(OQS_SHA3_shake256_x4_inc_ctx *state) {
-	callbacks->SHA3_shake256_x4_inc_init(state);
+	get_cb()->SHA3_shake256_x4_inc_init(state);
 }
 
 void OQS_SHA3_shake256_x4_inc_absorb(OQS_SHA3_shake256_x4_inc_ctx *state, const uint8_t *in0, const uint8_t *in1, const uint8_t *in2, const uint8_t *in3, size_t inlen) {
-	callbacks->SHA3_shake256_x4_inc_absorb(state, in0, in1, in2, in3, inlen);
+	get_cb()->SHA3_shake256_x4_inc_absorb(state, in0, in1, in2, in3, inlen);
 }
 
 void OQS_SHA3_shake256_x4_inc_finalize(OQS_SHA3_shake256_x4_inc_ctx *state) {
-	callbacks->SHA3_shake256_x4_inc_finalize(state);
+	get_cb()->SHA3_shake256_x4_inc_finalize(state);
 }
 
 void OQS_SHA3_shake256_x4_inc_squeeze(uint8_t *out0, uint8_t *out1, uint8_t *out2, uint8_t *out3, size_t outlen, OQS_SHA3_shake256_x4_inc_ctx *state) {
-	callbacks->SHA3_shake256_x4_inc_squeeze(out0, out1, out2, out3, outlen, state);
+	get_cb()->SHA3_shake256_x4_inc_squeeze(out0, out1, out2, out3, outlen, state);
 }
 
 void OQS_SHA3_shake256_x4_inc_ctx_release(OQS_SHA3_shake256_x4_inc_ctx *state) {
-	callbacks->SHA3_shake256_x4_inc_ctx_release(state);
+	get_cb()->SHA3_shake256_x4_inc_ctx_release(state);
 }
 
 void OQS_SHA3_shake256_x4_inc_ctx_clone(OQS_SHA3_shake256_x4_inc_ctx *dest, const OQS_SHA3_shake256_x4_inc_ctx *src) {
-	callbacks->SHA3_shake256_x4_inc_ctx_clone(dest, src);
+	get_cb()->SHA3_shake256_x4_inc_ctx_clone(dest, src);
 }
 
 void OQS_SHA3_shake256_x4_inc_ctx_reset(OQS_SHA3_shake256_x4_inc_ctx *state) {
-	callbacks->SHA3_shake256_x4_inc_ctx_reset(state);
+	get_cb()->SHA3_shake256_x4_inc_ctx_reset(state);
 }

--- a/src/common/sha3/sha3x4.c
+++ b/src/common/sha3/sha3x4.c
@@ -10,7 +10,7 @@
 
 extern struct OQS_SHA3_x4_callbacks sha3_x4_default_callbacks;
 
-static struct OQS_SHA3_x4_callbacks *callbacks = &sha3_x4_default_callbacks;
+static const struct OQS_SHA3_x4_callbacks *callbacks = &sha3_x4_default_callbacks;
 
 /* See sha3.c for the rationale: select the backend once, with a single
  * atomic pointer swap, before any SHA3-x4 entry point can dispatch. */
@@ -24,7 +24,7 @@ static void init_callbacks(void) {
 #if defined(OQS_USE_SHA3_AVX512VL) && defined(OQS_DIST_X86_64_BUILD)
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX512)) {
 		extern const struct OQS_SHA3_x4_callbacks sha3_x4_avx512vl_callbacks;
-		callbacks = (struct OQS_SHA3_x4_callbacks *) &sha3_x4_avx512vl_callbacks;
+		callbacks = &sha3_x4_avx512vl_callbacks;
 	}
 #endif
 }
@@ -40,7 +40,7 @@ static inline void ensure_callbacks_initialized(void) {
 #endif
 }
 
-static inline struct OQS_SHA3_x4_callbacks *get_cb(void) {
+static inline const struct OQS_SHA3_x4_callbacks *get_cb(void) {
 	ensure_callbacks_initialized();
 	return callbacks;
 }

--- a/src/common/sha3/sha3x4.c
+++ b/src/common/sha3/sha3x4.c
@@ -12,8 +12,8 @@ extern struct OQS_SHA3_x4_callbacks sha3_x4_default_callbacks;
 
 static const struct OQS_SHA3_x4_callbacks *callbacks = &sha3_x4_default_callbacks;
 
-/* See sha3.c for the rationale: select the backend once, with a single
- * atomic pointer swap, before any SHA3-x4 entry point can dispatch. */
+/* Select the top-level SHA3-x4 backend once before dispatching any entry
+ * point; see sha3.c for the initialization rationale. */
 #if OQS_USE_PTHREADS
 static pthread_once_t callbacks_init_once = PTHREAD_ONCE_INIT;
 #else

--- a/src/common/sha3/xkcp_sha3.c
+++ b/src/common/sha3/xkcp_sha3.c
@@ -41,15 +41,17 @@ extern struct OQS_SHA3_callbacks sha3_default_callbacks;
 
 static void Keccak_Dispatch(void) {
 // TODO: Simplify this when we have a Windows-compatible AVX2 implementation of SHA3
+//
+// Selection of an alternate top-level SHA3 callbacks table (e.g. AVX512VL) is
+// intentionally NOT performed here. Doing so would race against concurrent
+// SHA3 callers (the assignment is a non-atomic struct copy) and would split a
+// single in-flight call across two backends — `_inc_init` would run via the
+// XKCP path that triggered this dispatch, but the subsequent `_inc_absorb` /
+// `_inc_finalize` calls on the same context would route through the
+// newly-installed table. The top-level dispatch is now handled once, before
+// any SHA3 entry point can run, in sha3.c.
 #if defined(OQS_DIST_X86_64_BUILD)
 #if defined(OQS_ENABLE_SHA3_xkcp_low_avx2)
-#if defined(OQS_USE_SHA3_AVX512VL)
-	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX512)) {
-		extern const struct OQS_SHA3_callbacks sha3_avx512vl_callbacks;
-
-		sha3_default_callbacks = sha3_avx512vl_callbacks;
-	}
-#endif
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
 		Keccak_Initialize_ptr = &KeccakP1600_Initialize_avx2;
 		Keccak_AddByte_ptr = &KeccakP1600_AddByte_avx2;

--- a/src/common/sha3/xkcp_sha3.c
+++ b/src/common/sha3/xkcp_sha3.c
@@ -37,19 +37,11 @@ static KeccakPermuteFn *Keccak_Permute_ptr = NULL;
 static KeccakExtractBytesFn *Keccak_ExtractBytes_ptr = NULL;
 static KeccakFastLoopAbsorbFn *Keccak_FastLoopAbsorb_ptr = NULL;
 
-extern struct OQS_SHA3_callbacks sha3_default_callbacks;
-
 static void Keccak_Dispatch(void) {
 // TODO: Simplify this when we have a Windows-compatible AVX2 implementation of SHA3
 //
-// Selection of an alternate top-level SHA3 callbacks table (e.g. AVX512VL) is
-// intentionally NOT performed here. Doing so would race against concurrent
-// SHA3 callers (the assignment is a non-atomic struct copy) and would split a
-// single in-flight call across two backends — `_inc_init` would run via the
-// XKCP path that triggered this dispatch, but the subsequent `_inc_absorb` /
-// `_inc_finalize` calls on the same context would route through the
-// newly-installed table. The top-level dispatch is now handled once, before
-// any SHA3 entry point can run, in sha3.c.
+// Top-level callback-table selection is handled once in sha3.c before any
+// SHA3 entry point can run. This function only selects XKCP's implementation.
 #if defined(OQS_DIST_X86_64_BUILD)
 #if defined(OQS_ENABLE_SHA3_xkcp_low_avx2)
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {

--- a/src/common/sha3/xkcp_sha3x4.c
+++ b/src/common/sha3/xkcp_sha3x4.c
@@ -35,15 +35,12 @@ extern struct OQS_SHA3_x4_callbacks sha3_x4_default_callbacks;
 
 static void Keccak_X4_Dispatch(void) {
 // TODO: Simplify this when we have a Windows-compatible AVX2 implementation of SHA3
+//
+// See the equivalent comment in xkcp_sha3.c::Keccak_Dispatch: the top-level
+// callbacks-table swap is intentionally not performed here. It is handled
+// once, before any SHA3-x4 entry point can run, in sha3x4.c.
 #if defined(OQS_DIST_X86_64_BUILD)
 #if defined(OQS_ENABLE_SHA3_xkcp_low_avx2)
-#if defined(OQS_USE_SHA3_AVX512VL)
-	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX512)) {
-		extern const struct OQS_SHA3_x4_callbacks sha3_x4_avx512vl_callbacks;
-
-		sha3_x4_default_callbacks = sha3_x4_avx512vl_callbacks;
-	}
-#endif
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {
 		Keccak_X4_Initialize_ptr = &KeccakP1600times4_InitializeAll_avx2;
 		Keccak_X4_AddByte_ptr = &KeccakP1600times4_AddByte_avx2;

--- a/src/common/sha3/xkcp_sha3x4.c
+++ b/src/common/sha3/xkcp_sha3x4.c
@@ -31,14 +31,11 @@ static KeccakX4AddBytesFn *Keccak_X4_AddBytes_ptr = NULL;
 static KeccakX4PermuteFn *Keccak_X4_Permute_ptr = NULL;
 static KeccakX4ExtractBytesFn *Keccak_X4_ExtractBytes_ptr = NULL;
 
-extern struct OQS_SHA3_x4_callbacks sha3_x4_default_callbacks;
-
 static void Keccak_X4_Dispatch(void) {
 // TODO: Simplify this when we have a Windows-compatible AVX2 implementation of SHA3
 //
-// See the equivalent comment in xkcp_sha3.c::Keccak_Dispatch: the top-level
-// callbacks-table swap is intentionally not performed here. It is handled
-// once, before any SHA3-x4 entry point can run, in sha3x4.c.
+// Top-level callback-table selection is handled once in sha3x4.c before any
+// SHA3-x4 entry point can run. This function only selects XKCP's implementation.
 #if defined(OQS_DIST_X86_64_BUILD)
 #if defined(OQS_ENABLE_SHA3_xkcp_low_avx2)
 	if (OQS_CPU_has_extension(OQS_CPU_EXT_AVX2)) {

--- a/tests/test_sha3.c
+++ b/tests/test_sha3.c
@@ -1552,14 +1552,31 @@ static void override_SHA3_shake128_x4_inc_init(OQS_SHA3_shake128_x4_inc_ctx *sta
 /**
  * \brief Trigger SHA3 internal callback dispatcher.
  *
- * This is required to trigger runtime AVX512/AVX2 detection and set
- * SHA3 default callbacks before test application callbacks are configured.
+ * First-use dispatch must not modify the default callback entries.
  */
-static void sha3_trigger_dispatcher(void) {
+static int sha3_trigger_dispatcher(void) {
+	int status = EXIT_SUCCESS;
+	struct OQS_SHA3_callbacks sha3_callbacks_before = sha3_default_callbacks;
 	OQS_SHA3_sha3_256_inc_ctx state;
 
 	OQS_SHA3_sha3_256_inc_init(&state);
 	OQS_SHA3_sha3_256_inc_ctx_release(&state);
+	if (sha3_callbacks_before.SHA3_sha3_256_inc_init != sha3_default_callbacks.SHA3_sha3_256_inc_init) {
+		printf("Failure! SHA3 first-use dispatch modified the default callbacks\n");
+		status = EXIT_FAILURE;
+	}
+
+	struct OQS_SHA3_x4_callbacks sha3_x4_callbacks_before = sha3_x4_default_callbacks;
+	OQS_SHA3_shake128_x4_inc_ctx x4_state;
+
+	OQS_SHA3_shake128_x4_inc_init(&x4_state);
+	OQS_SHA3_shake128_x4_inc_ctx_release(&x4_state);
+	if (sha3_x4_callbacks_before.SHA3_shake128_x4_inc_init != sha3_x4_default_callbacks.SHA3_shake128_x4_inc_init) {
+		printf("Failure! SHA3-x4 first-use dispatch modified the default callbacks\n");
+		status = EXIT_FAILURE;
+	}
+
+	return status;
 }
 #endif
 
@@ -1571,7 +1588,9 @@ int main(UNUSED int argc, UNUSED char **argv) {
 
 #ifdef OQS_USE_SHA3_AVX512VL
 	/* set SHA3 default callbacks */
-	sha3_trigger_dispatcher();
+	if (sha3_trigger_dispatcher() == EXIT_FAILURE) {
+		ret = EXIT_FAILURE;
+	}
 #endif
 	struct OQS_SHA3_callbacks sha3_callbacks = sha3_default_callbacks;
 


### PR DESCRIPTION
Fixes #2482

## Summary

On current `main`, the first SHA3/SHAKE call can enter the XKCP callback table
while `Keccak_Dispatch()` installs the AVX512VL table by copying over the live
default callback struct. This creates a production data race for concurrent
first use. It also allows one incremental context to be initialized through
XKCP and then absorbed, finalized, or squeezed through AVX512VL.

PR #2426 (Douglas Stebila) previously identified both mechanisms and proposed
moving top-level backend selection into `sha3.c`/`sha3x4.c`. This change applies
that SHA3 dispatch design to current `main`; the reproduction and validation
below are the additional evidence for issue #2482.

The top-level callback table is now selected once, before public dispatch, with
`pthread_once` when pthread support is enabled and the existing first-use path
for non-pthread builds. The selected table is held through a callback-table
pointer. `Keccak_Dispatch()` and `Keccak_X4_Dispatch()` only select XKCP's
internal implementation pointers. `OQS_SHA3_set_callbacks()` and
`OQS_SHA3_x4_set_callbacks()` still accept a custom table after automatic
initialization; concurrent calls to those setter APIs are not made safe by this
change.

## Deterministic actual-entry reproduction

Temporary diagnostic instrumentation of the actual XKCP function bodies and
linker wrappers around the AVX512VL assembly entry points was run in a fresh,
single-threaded process. On current `main`:

    XKCP shake256_inc_init
    AVX512VL shake256_inc_absorb
    AVX512VL shake256_inc_finalize
    AVX512VL shake256_inc_squeeze

    XKCP shake128_x4_inc_init
    AVX512VL shake128_x4_inc_absorb
    AVX512VL shake128_x4_inc_finalize
    AVX512VL shake128_x4_inc_squeeze

With this change:

    AVX512VL shake256_inc_init
    AVX512VL shake256_inc_absorb
    AVX512VL shake256_inc_finalize
    AVX512VL shake256_inc_squeeze

    AVX512VL shake128_x4_inc_init
    AVX512VL shake128_x4_inc_absorb
    AVX512VL shake128_x4_inc_finalize
    AVX512VL shake128_x4_inc_squeeze

The trace observes function entry rather than inferring backend identity from a
callback-table read. The temporary instrumentation and wrappers are not part
of this change.

## ThreadSanitizer evidence

A temporary reproducer using only the public scalar SHAKE incremental API
(`OQS_SHA3_shake256_inc_*`) reports a race between `Keccak_Dispatch()` writing
`sha3_default_callbacks` and another thread reading it from
`OQS_SHA3_shake256_inc_init` on current `main`. An equivalent public API
SHAKE128 x4 workload reports the same race in `Keccak_X4_Dispatch()` against
`sha3_x4_default_callbacks`.

The same two workloads report no TSan warnings with this change. The
reproducers do not inspect callback tables or include private SHA3 headers.

## Tests

The existing `tests/test_sha3.c` callback override checks were run for scalar
and x4 callbacks, along with the SHA3/SHAKE known-answer tests for:

* SHA3-256, SHA3-384, SHA3-512
* SHAKE-128 and SHAKE-256
* four-way SHAKE-128 and four-way SHAKE-256

The same test now snapshots representative scalar and x4 first-use callback
entries before first-use incremental dispatch and verifies that those entries
remain unchanged. With the current-main source and this test, the test
fails deterministically with:

    Failure! SHA3 first-use dispatch modified the default callbacks
    Failure! SHA3-x4 first-use dispatch modified the default callbacks

With this change it passes.

Commands used for the ordinary test builds included:

    cmake -S . -B /tmp/liboqs-2482-min -GNinja \
      -DCMAKE_BUILD_TYPE=Release -DOQS_DIST_BUILD=ON \
      -DOQS_USE_SHA3_OPENSSL=OFF -DOQS_BUILD_ONLY_LIB=OFF \
      -DOQS_MINIMAL_BUILD=KEM_ml_kem_512
    cmake --build /tmp/liboqs-2482-min --target test_sha3
    /tmp/liboqs-2482-min/tests/test_sha3

    cmake -S . -B /tmp/liboqs-2482-fix-nopthread -GNinja \
      -DCMAKE_BUILD_TYPE=Release -DOQS_DIST_BUILD=ON \
      -DOQS_USE_SHA3_OPENSSL=OFF -DOQS_BUILD_ONLY_LIB=OFF \
      -DOQS_MINIMAL_BUILD=KEM_ml_kem_512 -DOQS_EMBEDDED_BUILD=ON
    cmake --build /tmp/liboqs-2482-fix-nopthread --target test_sha3
    /tmp/liboqs-2482-fix-nopthread/tests/test_sha3

The tests passed in AVX512VL distribution, debug, and non-pthread embedded-style
configurations. No SHA3 output, KAT value, public API, or algorithm availability
changed.

The permanent regression test checks representative callback entries rather
than backend identity or every field of each table. The public API intentionally
does not expose the selected backend, so linker wrapping, private symbols, or
production-only tracing would be unnecessarily brittle in the normal suite.
The actual-entry and TSan harnesses are retained as investigation evidence
rather than committed test machinery.

## Scope

This work reproduces and fixes a real C data race/undefined concurrent behavior
and a deterministic cross-backend incremental-context ownership violation. No
incorrect digest, production crash, memory corruption, secret leakage, or
security compromise was reproduced, and none is claimed here.

## Generative-AI disclosure

I used Codex/ChatGPT to assist with repository investigation, reproducer
development, testing strategy, and drafting. I manually reviewed the resulting
changes and validation results before submission.
