### PR TITLE
Documentation: link independent ML-KEM ACVP reproducibility study using liboqs 0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ You can cross compile liboqs for various platforms. Detailed information is avai
 
 More detailed information on building, optional build parameters, example applications, coding conventions and more can be found in the [wiki](https://github.com/open-quantum-safe/liboqs/wiki).
 
+Independent reproducibility study using liboqs 0.16.0 against pinned public NIST ML-KEM ACVP vectors: [arXiv:2608.13784](https://arxiv.org/abs/2608.13784), [artifact](https://doi.org/10.5281/zenodo.21910571).
+
 ## Contributing
 
 Contributions that meet the acceptance criteria are gratefully welcomed. See our [Contributing Guide](https://github.com/open-quantum-safe/liboqs/wiki/Contributing-Guide) for more details.


### PR DESCRIPTION
One-line addition under Documentation: an independent reproducibility study (arXiv:2608.13784) used liboqs 0.16.0 (pinned, minimal static build) against pinned public NIST ML-KEM ACVP vectors; all liboqs executable identities matched the NIST oracle per repetition. Public MIT artifact at doi:10.5281/zenodo.21910571. Disclosure: I am the founder of HEOSSI (QNSI), the organization behind the study and artifact - submitted transparently; both are independently verifiable (the artifact reruns in ~2 minutes; any outcome is a result).