### PR TITLE
Vary the signature length in the stateful-signature fuzz harnesses

### DIFF
--- a/tests/fuzz_test_sig_stfl_lms.c
+++ b/tests/fuzz_test_sig_stfl_lms.c
@@ -204,6 +204,13 @@ static OQS_STATUS fuzz_sig_stfl_lms(const uint8_t *data, size_t data_len) {
 	size_t pk_len = sig->length_public_key;
 	size_t sig_len = kp->signature_len;
 	size_t msg_len = kp->message_len;
+	/* Vary the signature length from the fuzz input so truncated and oversized signatures are reached. */
+    size_t verify_sig_len = sig_len;
+    if (fuzz_len >= 2) {
+        verify_sig_len = (((size_t)fuzz_data[0] << 8) | fuzz_data[1]) % (sig_len + 65);
+    	fuzz_data += 2;
+    	fuzz_len -= 2;
+    }
 
 	uint8_t *mutated_pk = OQS_MEM_malloc(pk_len);
 	uint8_t *mutated_sig = OQS_MEM_malloc(sig_len);
@@ -268,8 +275,18 @@ static OQS_STATUS fuzz_sig_stfl_lms(const uint8_t *data, size_t data_len) {
 	 * Call OQS_SIG_STFL_verify with mutated inputs.
 	 * We expect OQS_ERROR for invalid inputs — a crash here is a bug.
 	 */
-	OQS_SIG_STFL_verify(sig, mutated_msg, msg_len, mutated_sig, sig_len,
-	                    mutated_pk);
+	/* Verify against a buffer sized to exactly verify_sig_len so the sanitizer catches length-driven out-of-bounds reads. */
+	uint8_t *verify_sig = OQS_MEM_malloc(verify_sig_len ? verify_sig_len : 1);
+	if (verify_sig != NULL) {
+		size_t copy = verify_sig_len < sig_len ? verify_sig_len : sig_len;
+		memcpy(verify_sig, mutated_sig, copy);
+		if (verify_sig_len > sig_len) {
+			memset(verify_sig + sig_len, 0xAB, verify_sig_len - sig_len);
+		}
+		OQS_SIG_STFL_verify(sig, mutated_msg, msg_len, verify_sig,
+		                    verify_sig_len, mutated_pk);
+		OQS_MEM_insecure_free(verify_sig);
+	}
 
 	OQS_MEM_insecure_free(mutated_pk);
 	OQS_MEM_insecure_free(mutated_sig);

--- a/tests/fuzz_test_sig_stfl_lms.c
+++ b/tests/fuzz_test_sig_stfl_lms.c
@@ -205,12 +205,12 @@ static OQS_STATUS fuzz_sig_stfl_lms(const uint8_t *data, size_t data_len) {
 	size_t sig_len = kp->signature_len;
 	size_t msg_len = kp->message_len;
 	/* Vary the signature length from the fuzz input so truncated and oversized signatures are reached. */
-    size_t verify_sig_len = sig_len;
-    if (fuzz_len >= 2) {
-        verify_sig_len = (((size_t)fuzz_data[0] << 8) | fuzz_data[1]) % (sig_len + 65);
-    	fuzz_data += 2;
-    	fuzz_len -= 2;
-    }
+	size_t verify_sig_len = sig_len;
+	if (fuzz_len >= 2) {
+		verify_sig_len = (((size_t)fuzz_data[0] << 8) | fuzz_data[1]) % (sig_len + 65);
+		fuzz_data += 2;
+		fuzz_len -= 2;
+	}
 
 	uint8_t *mutated_pk = OQS_MEM_malloc(pk_len);
 	uint8_t *mutated_sig = OQS_MEM_malloc(sig_len);

--- a/tests/fuzz_test_sig_stfl_xmss.c
+++ b/tests/fuzz_test_sig_stfl_xmss.c
@@ -201,6 +201,13 @@ static OQS_STATUS fuzz_sig_stfl_xmss(const uint8_t *data, size_t data_len) {
 	size_t pk_len = sig->length_public_key;
 	size_t sig_len = kp->signature_len;
 	size_t msg_len = kp->message_len;
+	/* Vary the signature length from the fuzz input so truncated and oversized signatures are reached. */
+	size_t verify_sig_len = sig_len;
+	if (fuzz_len >= 2) {
+		verify_sig_len = (((size_t)fuzz_data[0] << 8) | fuzz_data[1]) % (sig_len + 65);
+		fuzz_data += 2;
+		fuzz_len -= 2;
+	}
 
 	uint8_t *mutated_pk = OQS_MEM_malloc(pk_len);
 	uint8_t *mutated_sig = OQS_MEM_malloc(sig_len);
@@ -239,8 +246,18 @@ static OQS_STATUS fuzz_sig_stfl_xmss(const uint8_t *data, size_t data_len) {
 	 * Call OQS_SIG_STFL_verify with mutated inputs.
 	 * We expect OQS_ERROR for invalid inputs — a crash here is a bug.
 	 */
-	OQS_SIG_STFL_verify(sig, mutated_msg, msg_len, mutated_sig, sig_len,
-	                    mutated_pk);
+	/* Verify against a buffer sized to exactly verify_sig_len so the sanitizer catches length-driven out-of-bounds reads. */
+	uint8_t *verify_sig = OQS_MEM_malloc(verify_sig_len ? verify_sig_len : 1);
+	if (verify_sig != NULL) {
+		size_t copy = verify_sig_len < sig_len ? verify_sig_len : sig_len;
+		memcpy(verify_sig, mutated_sig, copy);
+		if (verify_sig_len > sig_len) {
+			memset(verify_sig + sig_len, 0xAB, verify_sig_len - sig_len);
+		}
+		OQS_SIG_STFL_verify(sig, mutated_msg, msg_len, verify_sig,
+		                    verify_sig_len, mutated_pk);
+		OQS_MEM_insecure_free(verify_sig);
+	}
 
 	OQS_MEM_insecure_free(mutated_pk);
 	OQS_MEM_insecure_free(mutated_sig);


### PR DESCRIPTION
> Replaces #2529, which GitHub auto-closed after a branch force-push (done to fix the DCO sign-off) and will not allow me to reopen. This is the same branch and the same change, with the sign-off now in place.

## Purpose

Fixes #2528.

The LMS and XMSS stateful-signature fuzz harnesses (`tests/fuzz_test_sig_stfl_lms.c`,
`tests/fuzz_test_sig_stfl_xmss.c`) always passed the fixed KAT signature length to
`OQS_SIG_STFL_verify`, using a full-size buffer seeded from the KAT and then overwritten
in place. Because the buffer handed to `verify` was always the full signature length, a
parser that reads past a short or malformed signature stayed inside the allocation, so the
sanitizer could not observe the access. Length-driven out-of-bounds reads in the verify
path were therefore invisible to these harnesses.

This change derives the signature length passed to `verify` from the fuzz input (range
`[0, sig_len + 64]`) and copies the mutated signature into a buffer allocated at exactly
that length, so the sanitizer red zones flank the input. The harnesses can now reach
truncated and oversized signatures and detect the class of out-of-bounds read that a
fixed-length harness cannot. The public-key and message handling is unchanged.

## Relationship to #2507

Against a build without the length check added in #2507, the upgraded LMS harness reports
the out-of-bounds read in `hss_validate_signature_init` at a four-byte signature, where the
previous fixed-length harness reported nothing. In other words this harness reaches the exact
bug #2507 fixes. It is best merged alongside or after #2507; until that lands, the fuzzers
will (correctly) flag that read.

## Testing

The fuzz targets build only under `OQS_BUILD_FUZZ_TESTS` and are not compiled or run by the
standard per-PR CI jobs (`fuzzbuildcheck` in `basic.yml` builds and runs `fuzz_test_sig`
only), so this does not change the default CI matrix.

Checked locally with an AddressSanitizer build and the stateful signatures enabled
(`OQS_ENABLE_SIG_STFL_LMS=ON`, `OQS_ENABLE_SIG_STFL_XMSS=ON`): both harnesses compile cleanly,
and driving the LMS harness with a short (four-byte) signature reproduces the
`hss_validate_signature_init` out-of-bounds read, where the previous fixed-length harness
reports nothing on the same input. With the header-length check from #2507 in place, a
signature that short is rejected before that read.

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm? No.
* [ ] Does this PR change the list of algorithms or an API? No. Test harness only.
