### PR TITLE
Rename shadowed test_sig to test_sig_stfl in tests/test_speed.py

### DIFF
--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -22,7 +22,7 @@ def test_sig(sig_name):
 
 @helpers.filtered_test
 @pytest.mark.parametrize('sig_stfl_name', helpers.available_sig_stfls_by_name())
-def test_sig(sig_stfl_name):
+def test_sig_stfl(sig_stfl_name):
     # Define the list of LMS varients to allow
     names_to_allow = ["LMS_SHA256_H5_W1", "LMS_SHA256_H5_W2", 
                         "LMS_SHA256_H5_W4",


### PR DESCRIPTION
<!-- SPDX-License-Identifier: MIT -->
<!-- Draft PR body for the F14 fix. NOT POSTED. Baseline 8979276. -->

## Rename the shadowed `test_sig` in `tests/test_speed.py` to `test_sig_stfl`

`tests/test_speed.py` defines `test_sig` twice. The second definition, for
stateful signatures, rebinds the module-level name, so the stateless
signature benchmark defined immediately above it is never collected.

### This aligns the file with its three sibling modules

Across the test suite, functions covering stateful signatures are named after
the stateful parameter they take — they carry a `sig_stfl` prefix rather than
being called `test_sig`. `test_speed.py` is the only place where a stateful
test is named `test_sig`:

```
tests/test_cmdline.py:32:def test_sig_stfl(sig_stfl_name):
tests/test_kat.py:45:   def test_sig_stfl(sig_stfl_name):
tests/test_leaks.py:41: def test_sig_stfl_leak(sig_stfl_name):
tests/test_speed.py:25: def test_sig(sig_stfl_name):     <-- the outlier
```

The parameter is already named `sig_stfl_name`, and the body invokes the
`speed_sig_stfl` binary, so the rename simply makes the function name agree
with everything around it.

### Evidence

Collected with a stub `helpers` module declaring two algorithms in each of the
three categories, so a correct module must collect six tests.

**Before:**

```
test_speed.py::test_kem[KEM_A]
test_speed.py::test_kem[KEM_B]
test_speed.py::test_sig[STFL_A]
test_speed.py::test_sig[STFL_B]

4 tests collected
```

Four, not six. The stateless names are absent entirely, and the two items
reported under `test_sig` are the **stateful** ones.

**After:**

```
test_speed.py::test_kem[KEM_A]
test_speed.py::test_kem[KEM_B]
test_speed.py::test_sig[SIG_A]
test_speed.py::test_sig[SIG_B]
test_speed.py::test_sig_stfl[STFL_A]
test_speed.py::test_sig_stfl[STFL_B]

6 tests collected
```

### Why it matters

The function at line 18 is fully written — it has its own `parametrize`
decorator and invokes a different binary (`speed_sig` rather than
`speed_sig_stfl`) — but it is constructed and then discarded at import time.
Anyone running the speed module gets a green result that benchmarks zero
stateless signature schemes, and sees stateful algorithm names reported under
the name `test_sig`.

To be clear about scope: no CI workflow runs this module
(`grep -rn 'test_speed' .github/workflows/` is empty), and the `kem-bench` /
`sig-bench` workflows invoke the `speed_*` binaries directly rather than
through pytest. So this does not change any CI result. It affects anyone who
runs the pytest suite locally.

### One behaviour change worth flagging

`tests/helpers.py:156` derives a filter key from the function name:

```python
def filtered_test(func):
    funcname = func.__name__[len("test_"):]
    ...
        if ('SKIP_TESTS' in os.environ) and (funcname in os.environ['SKIP_TESTS'].lower().split(',')):
```

So `SKIP_TESTS=sig` currently skips the stateful speed test; after this change
it would need `SKIP_TESTS=sig_stfl`. That is consistent with how
`test_kat.py` and `test_cmdline.py` already behave. No workflow in the
repository sets `SKIP_TESTS` (`grep -rn 'SKIP_TESTS' .` matches only
`tests/helpers.py:168`), so nothing in CI is affected.

### Scope

One line. I have deliberately left the unused `kats` locals and the unused
`os.path` / `platform` imports in this file alone, to keep the diff reviewable.

### Testing

- `python3 -m pytest tests/test_code_conventions.py` — unchanged before and
  after this edit: 264 passed, 3 skipped, and one pre-existing `test_style`
  failure caused by a local `astyle` version difference, unrelated to this
  change (this file is `.py`; `tests/run_astyle.sh` only scans `*.[ch]`).
- The collection listings above.


