### PR TITLE
Fixed msg len for ML-DSA extmu speed test

### DIFF
--- a/tests/speed_sig.c
+++ b/tests/speed_sig.c
@@ -43,6 +43,16 @@ static OQS_STATUS sig_speed_wrapper(const char *method_name, uint64_t duration, 
 	size_t signature_len = 0;
 	OQS_STATUS ret = OQS_ERROR;
 
+	if (strcmp(method_name, OQS_SIG_alg_ml_dsa_44_extmu) == 0) {
+		message_len = OQS_SIG_ml_dsa_44_extmu_length_mu;
+	}
+	if (strcmp(method_name, OQS_SIG_alg_ml_dsa_65_extmu) == 0) {
+		message_len = OQS_SIG_ml_dsa_65_extmu_length_mu;
+	}
+	if (strcmp(method_name, OQS_SIG_alg_ml_dsa_87_extmu) == 0) {
+		message_len = OQS_SIG_ml_dsa_87_extmu_length_mu;
+	}
+
 	sig = OQS_SIG_new(method_name);
 	if (sig == NULL) {
 		return OQS_SUCCESS;

--- a/tests/speed_sig.c
+++ b/tests/speed_sig.c
@@ -44,13 +44,25 @@ static OQS_STATUS sig_speed_wrapper(const char *method_name, uint64_t duration, 
 	OQS_STATUS ret = OQS_ERROR;
 
 	if (strcmp(method_name, OQS_SIG_alg_ml_dsa_44_extmu) == 0) {
+#if defined(OQS_ENABLE_SIG_ml_dsa_44_extmu)
 		message_len = OQS_SIG_ml_dsa_44_extmu_length_mu;
+#else
+        return ret;
+#endif /* OQS_ENABLE_SIG_ml_dsa_44_extmu */
 	}
 	if (strcmp(method_name, OQS_SIG_alg_ml_dsa_65_extmu) == 0) {
+#if defined(OQS_ENABLE_SIG_ml_dsa_65_extmu)
 		message_len = OQS_SIG_ml_dsa_65_extmu_length_mu;
+#else
+        return ret;
+#endif /* OQS_ENABLE_SIG_ml_dsa_65_extmu */
 	}
 	if (strcmp(method_name, OQS_SIG_alg_ml_dsa_87_extmu) == 0) {
+#if defined(OQS_ENABLE_SIG_ml_dsa_87_extmu)
 		message_len = OQS_SIG_ml_dsa_87_extmu_length_mu;
+#else
+        return ret;
+#endif /* OQS_ENABLE_SIG_ml_dsa_87_extmu */
 	}
 
 	sig = OQS_SIG_new(method_name);

--- a/tests/speed_sig.c
+++ b/tests/speed_sig.c
@@ -47,21 +47,24 @@ static OQS_STATUS sig_speed_wrapper(const char *method_name, uint64_t duration, 
 #if defined(OQS_ENABLE_SIG_ml_dsa_44_extmu)
 		message_len = OQS_SIG_ml_dsa_44_extmu_length_mu;
 #else
-        return ret;
+		fprintf(stderr, "ERROR: %s was not enabled\n", method_name);
+		return ret;
 #endif /* OQS_ENABLE_SIG_ml_dsa_44_extmu */
 	}
 	if (strcmp(method_name, OQS_SIG_alg_ml_dsa_65_extmu) == 0) {
 #if defined(OQS_ENABLE_SIG_ml_dsa_65_extmu)
 		message_len = OQS_SIG_ml_dsa_65_extmu_length_mu;
 #else
-        return ret;
+		fprintf(stderr, "ERROR: %s was not enabled\n", method_name);
+		return ret;
 #endif /* OQS_ENABLE_SIG_ml_dsa_65_extmu */
 	}
 	if (strcmp(method_name, OQS_SIG_alg_ml_dsa_87_extmu) == 0) {
 #if defined(OQS_ENABLE_SIG_ml_dsa_87_extmu)
 		message_len = OQS_SIG_ml_dsa_87_extmu_length_mu;
 #else
-        return ret;
+		fprintf(stderr, "ERROR: %s was not enabled\n", method_name);
+		return ret;
 #endif /* OQS_ENABLE_SIG_ml_dsa_87_extmu */
 	}
 

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -16,8 +16,10 @@ def test_kem(kem_name):
 @helpers.filtered_test
 @pytest.mark.parametrize('sig_name', helpers.available_sigs_by_name())
 def test_sig(sig_name):
-    kats = helpers.get_kats("sig")
-    if not(helpers.is_sig_enabled_by_name(sig_name)): pytest.skip('Not enabled')
+    if not(helpers.is_sig_enabled_by_name(sig_name)):
+        pytest.skip('Not enabled')
+    if "extmu" in sig_name:
+        pytest.skip("ML-DSA ExtMu will not be benchmarked")
     helpers.run_subprocess( [helpers.path_to_executable('speed_sig'), sig_name, "-f"])
 
 @helpers.filtered_test


### PR DESCRIPTION
This is a quick fix for [this CI failure](https://github.com/open-quantum-safe/liboqs/actions/runs/33408808656)

* [NO] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [NO] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged. Also, make sure to update the list of algorithms in the continuous benchmarking files: .github/workflows/kem-bench.yml and sig-bench.yml)