### PR TITLE
Point pre-commit hook at the requirements file that exists

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if ! command -v rumdl >/dev/null 2>&1; then
-  echo "Error: rumdl not found. Please install using requirements-dev.txt" >&2
+  echo "Error: rumdl not found. Please install using requirements-linter.txt" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Point the pre-commit hook at the requirements file that exists

Enable the hooks as `CONTRIBUTING.md` describes:

```bash
git config core.hooksPath .githooks
```

Without `rumdl` installed, the hook aborts and says:

```
Error: rumdl not found. Please install using requirements-dev.txt
```

That file isn't in the repository. And since the git-hooks section of
`CONTRIBUTING.md` doesn't name a requirements file, this message is the only
install instruction a contributor gets.

### Evidence

The string appears once in the whole tree — in the message itself:

```
$ git grep -n requirements-dev
.githooks/pre-commit:4:  echo "Error: rumdl not found. Please install using requirements-dev.txt" >&2
```

What actually exists:

```
$ git ls-files | grep -i requirement
.github/workflows/requirements.in
.github/workflows/requirements.txt
requirements-linter.txt
requirements.txt
scripts/copy_from_upstream/requirements.in
scripts/copy_from_upstream/requirements.txt
```

`requirements-linter.txt` pins `rumdl==0.2.18` and is what CI installs
(`.github/workflows/basic.yml:54`), so the correct name isn't a matter of
preference.

### How it went stale

In #2446 the hook was added while `requirements-dev.txt` was still the real
filename, so the message was right when written. A later commit in the same
series renamed the file and updated `basic.yml`, but the hook's string wasn't
part of that rename. The series was squash-merged as `14b9e6ad9`, so only the
end state shows up in `main`.

### One thing I noticed but didn't change

Line 5 exits `1` without checking what's staged, so a contributor who enables
the hooks without `rumdl` can't commit anything — a C file, a CMake change, a
commit with no Markdown in it at all.

This PR doesn't touch that. Happy to open a follow-up if you'd like it handled
(skip when no Markdown is staged, or warn instead of fail), and equally happy
to leave it if the current behaviour is intended.

### Testing

- With `rumdl` off `PATH`, the hook now points at `requirements-linter.txt`.
  Exit status is `1` either way — the control flow is untouched.
- `git grep -n requirements-dev` returns nothing.
- `pytest tests/test_code_conventions.py`: 264 passed, 3 skipped, plus the
  pre-existing `test_style` failure from a local `astyle` version difference.
  It can't be related — `run_astyle.sh` scans only `find src tests -name
  '*.[ch]'`, and the file it flags is byte-identical to `main` here.

One line changed.

