### PR TITLE
Correct OQS_init doc comment about OpenSSL prefetching

### DIFF
--- a/src/common/common.h
+++ b/src/common/common.h
@@ -212,8 +212,10 @@ typedef enum {
 OQS_API int OQS_CPU_has_extension(OQS_CPU_EXT ext);
 
 /**
- * This currently sets the values in the OQS_CPU_EXTENSIONS
- * and prefetches the OpenSSL objects if necessary.
+ * This currently only sets the values in the OQS_CPU_EXTENSIONS,
+ * and so has effect only when OQS_DIST_BUILD is set. The OpenSSL
+ * objects used by liboqs are not fetched here; they are fetched
+ * lazily on first use.
  */
 OQS_API void OQS_init(void);
 


### PR DESCRIPTION
### What this changes

`src/common/common.h:216` says `OQS_init()` "prefetches the OpenSSL objects if necessary".
It does not, in any build configuration — `src/common/common.c:237-241` is:

```c
OQS_API void OQS_init(void) {
#if defined(OQS_DIST_BUILD)
	OQS_CPU_has_extension(OQS_CPU_EXT_INIT);
#endif
}
```

The sentence was accurate when it was added in `871f9e26d` (#1431), which also added an
`oqs_fetch_ossl_objects()` call to `OQS_init()`. `5f5eee842` (#1469) removed that call and moved
to fetching lazily in the `ossl_helpers.c` accessors; the comment was not updated at the time.

The replacement also restores the `OQS_DIST_BUILD` qualifier that `871f9e26d` dropped and that
`common.c:238-240` still implements, and says where the objects are actually fetched — so that
the existing wording on `OQS_destroy()` at `common.h:229` ("frees prefetched OpenSSL objects")
still has an antecedent.

```diff
 /**
- * This currently sets the values in the OQS_CPU_EXTENSIONS
- * and prefetches the OpenSSL objects if necessary.
+ * This currently only sets the values in the OQS_CPU_EXTENSIONS,
+ * and so has effect only when OQS_DIST_BUILD is set. The OpenSSL
+ * objects used by liboqs are not fetched here; they are fetched
+ * lazily on first use.
  */
 OQS_API void OQS_init(void);
```

Documentation only; no functional change.

### Checklist

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it
  change known answer test values)? **No.**
* [ ] Does this PR change the list of algorithms available — either adding, removing, or
  renaming? Does this PR otherwise change an API? **No.** Comment text only; no declaration,
  symbol or behaviour changes.

### Use of generative AI

This change and its description were produced with the help of generative AI (Claude). The AI
assistance covered locating the divergence, the commit archaeology behind it, and drafting this
description and the replacement comment. I have verified it myself: the line numbers were
re-derived against `8c7f6592e`, the two commits named above were read in full, and the tree was
configured and built with the change applied (exit 0). Disclosed per `CONTRIBUTING.md:28-29`.
