### PR TITLE
Skip ML-DSA extmu variants in test_kat_all

### DIFF
--- a/tests/test_kat_all.py
+++ b/tests/test_kat_all.py
@@ -27,6 +27,8 @@ def test_sig(sig_name):
     kats = helpers.get_kats("sig")
     # slh dsa will run ACVP vectors instead
     if ("SLH_DSA" in sig_name): pytest.skip('slhdsa not enabled for KATs')
+    # the extmu variants have no KATs
+    if ("-extmu" in sig_name): pytest.skip('extmu variants not enabled for KATs')
     if not(helpers.is_sig_enabled_by_name(sig_name)): pytest.skip('Not enabled')
     output = helpers.run_subprocess(
         [helpers.path_to_executable('kat_sig'), sig_name, '--all'],


### PR DESCRIPTION
The extmu variants sign a fixed-length mu rather than an arbitrary message, so kat_sig cannot generate KATs for them and kats.json has no entries; test_kat.py already skips them for that reason. Apply the same skip in test_kat_all, whose ML-DSA-*-extmu cases have failed with "OQS_SIG_sign failed" since the variants were added.

- Resolves https://github.com/open-quantum-safe/liboqs/issues/2552
