### PR TITLE
Fixes to make weekly tests working again

### DIFF
--- a/.github/workflows/extended.yml
+++ b/.github/workflows/extended.yml
@@ -142,8 +142,8 @@ jobs:
         run: ninja
         working-directory: build
       - name: Run tests
-        timeout-minutes: 90
-        run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --numprocesses=auto --ignore=tests/test_distbuild.py --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py --maxprocesses=10
+        timeout-minutes: 60
+        run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --ignore=tests/test_acvp_vectors.py --numprocesses=auto --ignore=tests/test_distbuild.py --ignore=tests/test_leaks.py --ignore=tests/test_kat_all.py --maxprocesses=10
 
   address-sanitizer-stfl:
     name: ASAN with STFL key generation
@@ -279,7 +279,7 @@ jobs:
         working-directory: build
       - name: Run tests
         timeout-minutes: 90
-        run: mkdir -p tmp && python3 -m pytest --verbose --numprocesses=auto ${{ matrix.PYTEST_ARGS }}
+        run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --numprocesses=auto ${{ matrix.PYTEST_ARGS }}
 
   slhdsa-windows-arm64-tests:
     name: SLH-DSA Windows arm64 tests
@@ -400,7 +400,7 @@ jobs:
         working-directory: build
       - name: Run tests
         timeout-minutes: 60
-        run: mkdir -p tmp && python3 -m pytest --verbose --numprocesses=auto ${{ matrix.PYTEST_ARGS }}
+        run: mkdir -p tmp && python3 -m pytest --verbose --ignore=tests/test_code_conventions.py --numprocesses=auto ${{ matrix.PYTEST_ARGS }}
 
   full-code-coverage:
     name: Run full code coverage with ACVP tests


### PR DESCRIPTION
The weekly [tests](https://github.com/open-quantum-safe/liboqs/actions/workflows/weekly.yml) have been failing for a while. PR #2553 fixed most issues, but three failing jobs remained. Solved by:

- Skip libjade formatting checks in the weekly workflow because the required formatting tools are not available in the container, and formatting is already validated by regular CI.
- Skip ACVP tests in slh-asan jobs because they cause timeouts. In line with CI policy, these tests could still be run manually before a release. Regular SLHDSA-ACVP tests still run in the extended tests.

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)
* [ ] Does this PR change the list of algorithms available -- either adding, removing, or renaming? Does this PR otherwise change an API? (If so, PRs in fully supported downstream projects dependent on these, i.e., [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) will also need to be ready for review and merge by the time this is merged. Also, make sure to update the list of algorithms in the continuous benchmarking files: .github/workflows/kem-bench.yml and sig-bench.yml)

<!-- If this contribution (code, documentation, descriptive text) was produced with the help of generative AI, please describe the nature of the use. Contributors are expected to have verified and affirm such contributions themselves before submission. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->

