### PR TITLE
scripts: map upstream Arm AES CPU flags

### DIFF
--- a/scripts/copy_from_upstream/copy_from_upstream.py
+++ b/scripts/copy_from_upstream/copy_from_upstream.py
@@ -17,6 +17,7 @@ import json
 import platform
 import update_upstream_alg_docs
 import copy_from_slh_dsa_c
+from upstream_platforms import normalize_platform
 from copy import deepcopy
 
 # kats of all algs
@@ -243,7 +244,7 @@ def load_instructions(file='copy_from_upstream.yml'):
                 common_dep['sources'] = common_dep['sources'].split(" ")
                 if 'supported_platforms' in common_dep:
                     for i in range(len(common_dep['supported_platforms'])):
-                        req = common_dep['supported_platforms'][i]
+                        req = normalize_platform(common_dep['supported_platforms'][i])
                         common_dep['required_flags'] = req['required_flags']
             upstream['commons'] = dict(map(lambda x: (x['name'], x), common_deps['commons'] ))
 
@@ -715,18 +716,8 @@ def process_families(instructions, basedir, with_kat, with_generator, with_libja
                     # also add suitable defines:
                     try:
                         for i in range(len(impl['supported_platforms'])):
-                            req = impl['supported_platforms'][i]
-                            # if compiling for ARM64_V8, asimd/neon is implied and will cause errors
-                            # when provided to the compiler; OQS uses the term ARM_NEON
-                            if req['architecture'] == 'arm_8':
-                                req['architecture'] = 'ARM64_V8'
+                            req = normalize_platform(impl['supported_platforms'][i])
                             if 'required_flags' in req:
-                                if req['architecture'] == 'ARM64_V8' and 'asimd' in req['required_flags']:
-                                    req['required_flags'].remove('asimd')
-                                    req['required_flags'].append('arm_neon')
-                                if req['architecture'] == 'ARM64_V8' and 'sha3' in req['required_flags']:
-                                    req['required_flags'].remove('sha3')
-                                    req['required_flags'].append('arm_sha3')
                                 impl['required_flags'] = req['required_flags']
                                 family['all_required_flags'].update(req['required_flags'])
                     except KeyError as ke:

--- a/scripts/copy_from_upstream/src/kem/family/CMakeLists.txt
+++ b/scripts/copy_from_upstream/src/kem/family/CMakeLists.txt
@@ -13,7 +13,7 @@ if({% for used_by in common_deps_usedby[common_dep['name']] -%}OQS_ENABLE_KEM_{{
     add_library({{ family }}_{{ common_dep['name'] }} OBJECT {% for source_file in common_dep['sources_addl']|sort -%}{{ upstream_location }}_{{ common_dep['name'] }}/{{ source_file }}{%- if not loop.last %} {% endif -%}{%- endfor -%})
     target_include_directories({{ family }}_{{ common_dep['name'] }} PRIVATE ${CMAKE_CURRENT_LIST_DIR}/{{ upstream_location }}_{{ common_dep['name'] }})
         {%- if common_dep['required_flags'] %}
-    target_compile_options({{ family }}_{{ common_dep['name'] }} PRIVATE {%- for flag in common_dep['required_flags'] %}{%- if flag != 'arm_neon' %} -m{%- if flag == 'bmi1' -%} bmi {%- elif flag == 'sse4_1' -%} sse4.1 {%- elif flag == 'pclmulqdq' -%} pclmul {%- else -%}{{ flag }}{%- endif -%}{%- endif -%}{%- endfor -%})
+    target_compile_options({{ family }}_{{ common_dep['name'] }} PRIVATE {%- for flag in common_dep['required_flags'] %}{%- if flag == 'arm_sha3' %} -march=armv8-a+crypto+sha3 {%- elif flag == 'arm_aes' %}{%- if 'arm_sha3' not in common_dep['required_flags'] %} -march=armv8-a+crypto {%- endif -%}{%- else -%}{%- if flag != 'arm_neon' %} -m{%- if flag == 'bmi1' -%} bmi {%- elif flag == 'sse4_1' -%} sse4.1 {%- elif flag == 'pclmulqdq' -%} pclmul {%- else -%}{{ flag }}{%- endif -%}{%- endif -%}{%- endif -%}{%- endfor -%})
         {%- endif %}
         {%- if common_dep['compile_opts'] %}
     target_compile_options({{ family }}_{{ common_dep['name'] }} PUBLIC {{ common_dep['compile_opts'] }})
@@ -64,7 +64,7 @@ if(OQS_ENABLE_KEM_{{ family }}_{{ scheme['scheme_c'] }}_{{ impl['name'] }}{%- if
             {%- endfor %}
         {%- endif %}
         {%- if impl['name'] != scheme['default_implementation'] and impl['required_flags'] -%}
-           {%- set opts %}{% for flag in impl['required_flags'] %}{%- if flag != 'arm_neon' %} -m{%- if flag == 'bmi1' -%} bmi {% elif flag == 'sse4_1' -%} sse4.1 {% elif flag == 'pclmulqdq' -%} pclmul {% else -%}{{ flag }} {% endif %}{% endif -%}{% endfor %}{% endset %}
+           {%- set opts %}{% for flag in impl['required_flags'] %}{%- if flag == 'arm_sha3' %} -march=armv8-a+crypto+sha3 {% elif flag == 'arm_aes' %}{% if 'arm_sha3' not in impl['required_flags'] %} -march=armv8-a+crypto {% endif %}{% elif flag != 'arm_neon' %} -m{%- if flag == 'bmi1' -%} bmi {% elif flag == 'sse4_1' -%} sse4.1 {% elif flag == 'pclmulqdq' -%} pclmul {% else -%}{{ flag }} {% endif %}{% endif -%}{% endfor %}{% endset %}
            {%- if opts|length > 0 %}
     target_compile_options({{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }} PRIVATE {{ opts }})
            {%- endif -%}

--- a/scripts/copy_from_upstream/src/sig/family/CMakeLists.txt
+++ b/scripts/copy_from_upstream/src/sig/family/CMakeLists.txt
@@ -13,7 +13,7 @@ if({% for used_by in common_deps_usedby[common_dep['name']] -%}OQS_ENABLE_SIG_{{
     add_library({{ family }}_{{ common_dep['name'] }} OBJECT {% for source_file in common_dep['sources_addl']|sort -%}{{ upstream_location }}_{{ common_dep['name'] }}/{{ source_file }}{%- if not loop.last %} {% endif -%}{%- endfor -%})
     target_include_directories({{ family }}_{{ common_dep['name'] }} PRIVATE ${CMAKE_CURRENT_LIST_DIR}/{{ upstream_location }}_{{ common_dep['name'] }})
         {%- if common_dep['required_flags'] %}
-    target_compile_options({{ family }}_{{ common_dep['name'] }} PRIVATE {%- for flag in common_dep['required_flags'] %}{%- if flag == 'arm_sha3' %} -march=armv8-a+crypto+sha3 {%- else -%}{%- if flag != 'arm_neon' %} -m{%- if flag == 'bmi1' -%} bmi {%- elif flag == 'sse4_1' -%} sse4.1  {%- elif flag == 'pclmulqdq' -%} pclmul {%- else -%}{{ flag }}{%- endif -%}{%- endif -%}{%- endif -%}{%- endfor -%})
+    target_compile_options({{ family }}_{{ common_dep['name'] }} PRIVATE {%- for flag in common_dep['required_flags'] %}{%- if flag == 'arm_sha3' %} -march=armv8-a+crypto+sha3 {%- elif flag == 'arm_aes' %}{%- if 'arm_sha3' not in common_dep['required_flags'] %} -march=armv8-a+crypto {%- endif -%}{%- else -%}{%- if flag != 'arm_neon' %} -m{%- if flag == 'bmi1' -%} bmi {%- elif flag == 'sse4_1' -%} sse4.1  {%- elif flag == 'pclmulqdq' -%} pclmul {%- else -%}{{ flag }}{%- endif -%}{%- endif -%}{%- endif -%}{%- endfor -%})
         {%- endif %}
         {%- if common_dep['compile_opts'] %}
     target_compile_options({{ family }}_{{ common_dep['name'] }} PUBLIC {{ common_dep['compile_opts'] }})
@@ -52,7 +52,7 @@ if(OQS_ENABLE_SIG_{{ family }}_{{ scheme['scheme_c'] }}_{{ impl['name'] }}{%- if
             {%- endfor %}
         {%- endif %}
         {%- if impl['name'] != scheme['default_implementation'] and impl['required_flags'] %}
-    target_compile_options({{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }} PRIVATE {%- for flag in impl['required_flags'] %}{%- if flag == 'arm_sha3' %} -march=armv8-a+crypto+sha3 {%- else -%}{%- if flag != 'arm_neon' %} -m{%- if flag == 'bmi1' -%} bmi {%- elif flag == 'sse4_1' -%} sse4.1  {%- elif flag == 'pclmulqdq' -%} pclmul {%- else -%}{{ flag }}{%- endif -%}{%- endif -%}{%- endif -%}{%- endfor -%})
+    target_compile_options({{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }} PRIVATE {%- for flag in impl['required_flags'] %}{%- if flag == 'arm_sha3' %} -march=armv8-a+crypto+sha3 {%- elif flag == 'arm_aes' %}{%- if 'arm_sha3' not in impl['required_flags'] %} -march=armv8-a+crypto {%- endif -%}{%- else -%}{%- if flag != 'arm_neon' %} -m{%- if flag == 'bmi1' -%} bmi {%- elif flag == 'sse4_1' -%} sse4.1  {%- elif flag == 'pclmulqdq' -%} pclmul {%- else -%}{{ flag }}{%- endif -%}{%- endif -%}{%- endif -%}{%- endfor -%})
         {%- endif %}
         {%- if impl['compile_opts'] %}
     target_compile_options({{ family }}_{{ scheme['scheme'] }}_{{ impl['name'] }} PUBLIC {{ impl['compile_opts'] }})

--- a/scripts/copy_from_upstream/upstream_platforms.py
+++ b/scripts/copy_from_upstream/upstream_platforms.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+
+
+def normalize_platform(platform):
+    """Translate upstream Arm platform names to liboqs CPU extensions."""
+    if platform["architecture"] == "arm_8":
+        platform["architecture"] = "ARM64_V8"
+
+    if platform["architecture"] == "ARM64_V8" and "required_flags" in platform:
+        arm_flags = {
+            "asimd": "arm_neon",
+            "aes": "arm_aes",
+            "sha3": "arm_sha3",
+        }
+        platform["required_flags"] = [
+            arm_flags.get(flag, flag) for flag in platform["required_flags"]
+        ]
+
+    return platform

--- a/tests/test_copy_from_upstream.py
+++ b/tests/test_copy_from_upstream.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the upstream implementation importer."""
+
+import os
+import sys
+
+import pytest
+
+LIBOQS_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+COPY_SCRIPT_DIR = os.path.join(LIBOQS_ROOT, "scripts", "copy_from_upstream")
+sys.path.insert(0, COPY_SCRIPT_DIR)
+
+from upstream_platforms import normalize_platform  # noqa: E402
+
+
+def test_normalize_arm_platform_flags():
+    platform = {
+        "architecture": "arm_8",
+        "required_flags": ["asimd", "aes", "sha3"],
+    }
+
+    assert normalize_platform(platform) == {
+        "architecture": "ARM64_V8",
+        "required_flags": ["arm_neon", "arm_aes", "arm_sha3"],
+    }
+
+
+def _render_cmake_template(kind, required_flags, target):
+    jinja2 = pytest.importorskip("jinja2")
+    template_path = os.path.join(
+        COPY_SCRIPT_DIR, "src", kind, "family", "CMakeLists.txt"
+    )
+    with open(template_path, encoding="utf-8") as template_file:
+        template = jinja2.Template(template_file.read())
+
+    if target == "implementation":
+        implementation = {
+            "name": "neon",
+            "compile_opts": "",
+            "required_flags": required_flags,
+            "sources": [],
+            "upstream": {"name": "upstream"},
+        }
+        schemes = [
+            {
+                "default_implementation": "default",
+                "metadata": {"implementations": [implementation]},
+                "pqclean_scheme": "test",
+                "scheme": "test",
+                "scheme_c": "test",
+            }
+        ]
+        common_deps = []
+        common_deps_usedby = {}
+    else:
+        schemes = []
+        common_deps = [
+            {
+                "compile_opts": "",
+                "include_only": False,
+                "name": "common",
+                "required_flags": required_flags,
+                "sources_addl": [],
+            }
+        ]
+        common_deps_usedby = {
+            "common": [{"impl_name": "neon", "scheme_c": "test"}]
+        }
+
+    return template.render(
+        common_deps=common_deps,
+        common_deps_usedby=common_deps_usedby,
+        default_implementation="default",
+        family="test",
+        schemes=schemes,
+        upstream_location="upstream",
+    )
+
+
+@pytest.mark.parametrize("kind", ["kem", "sig"])
+@pytest.mark.parametrize("target", ["common", "implementation"])
+def test_arm_aes_and_sha3_compile_flags(kind, target):
+    output = _render_cmake_template(
+        kind, ["arm_neon", "arm_aes", "arm_sha3"], target
+    )
+
+    assert output.count("-march=armv8-a+crypto+sha3") == 1
+    assert "-marm_aes" not in output
+    assert "-marm_sha3" not in output
+
+
+@pytest.mark.parametrize("kind", ["kem", "sig"])
+@pytest.mark.parametrize("target", ["common", "implementation"])
+def test_arm_aes_only_compile_flags(kind, target):
+    output = _render_cmake_template(kind, ["arm_neon", "arm_aes"], target)
+
+    assert output.count("-march=armv8-a+crypto") == 1
+    assert "-marm_aes" not in output


### PR DESCRIPTION
## Summary

- normalize upstream AArch64 `aes` requirements to `arm_aes`
- generate valid Arm architecture options for AES-only and AES+SHA3 implementations
- cover both signature/KEM implementations and common dependencies with regression tests

This lets generated runtime dispatch include `OQS_CPU_EXT_ARM_AES` while avoiding invalid compiler options such as `-marm_aes`.

## Testing

- `python -m pytest -q tests/test_copy_from_upstream.py` (9 passed)
- `python -m pytest -q tests/test_alg_support_generators.py tests/test_copy_from_upstream.py` (13 passed)
- `python -m pytest -q tests/test_code_conventions.py` (1 passed, 267 skipped)
- AArch64 GCC 13 accepted the generated `-march=armv8-a+crypto+sha3` target while compiling the intended Arm AES source

## AI assistance disclosure

This patch and its tests were developed with assistance from OpenAI Codex. The submitted diff and test results were reviewed by the submitter.
