### PR TITLE
slh_dsa: guard memcpy against NULL message in sha2_{256,512}_update

### DIFF
--- a/src/sig/slh_dsa/slh_dsa_c/sha2_256.c
+++ b/src/sig/slh_dsa/slh_dsa_c/sha2_256.c
@@ -190,7 +190,10 @@ void sha2_256_update(sha2_256_t *sha, const uint8_t *m, size_t m_sz)
 
   if (m_sz < l)
   {
-    memcpy(mp + sha->i, m, m_sz);
+    if (m_sz > 0)
+    {
+      memcpy(mp + sha->i, m, m_sz);
+    }
     sha->i += m_sz;
     return;
   }
@@ -209,7 +212,10 @@ void sha2_256_update(sha2_256_t *sha, const uint8_t *m, size_t m_sz)
     m_sz -= 64;
     m += 64;
   }
-  memcpy(mp, m, m_sz);
+  if (m_sz > 0)
+  {
+    memcpy(mp, m, m_sz);
+  }
   sha->i = m_sz;
 }
 

--- a/src/sig/slh_dsa/slh_dsa_c/sha2_512.c
+++ b/src/sig/slh_dsa/slh_dsa_c/sha2_512.c
@@ -257,7 +257,10 @@ void sha2_512_update(sha2_512_t *sha, const uint8_t *m, size_t m_sz)
 
   if (m_sz < l)
   {
-    memcpy(mp + sha->i, m, m_sz);
+    if (m_sz > 0)
+    {
+      memcpy(mp + sha->i, m, m_sz);
+    }
     sha->i += m_sz;
     return;
   }
@@ -276,7 +279,10 @@ void sha2_512_update(sha2_512_t *sha, const uint8_t *m, size_t m_sz)
     m_sz -= 128;
     m += 128;
   }
-  memcpy(mp, m, m_sz);
+  if (m_sz > 0)
+  {
+    memcpy(mp, m, m_sz);
+  }
   sha->i = m_sz;
 }
 


### PR DESCRIPTION
## Summary

`sha2_256_update()` and `sha2_512_update()` in `src/sig/slh_dsa/slh_dsa_c/{sha2_256.c,sha2_512.c}` call `memcpy(dst, m, m_sz)` at two points without checking `m_sz == 0` first. Both functions are reached from `slh_sha2.c`'s `sha2_256_h_msg()` / `sha2_512_h_msg()`, which pass the caller-supplied message pointer and length straight through to the running hash.

FIPS 205 (SLH-DSA) explicitly permits signing and verifying an empty message, and passing `NULL` for a zero-length buffer is idiomatic C, so calling `OQS_SIG_sign()`/`OQS_SIG_verify()` with `message == NULL, message_len == 0` is a legitimate, expected call pattern -- not just a fuzzer artifact. Doing so on any of the six SHA2-based "pure" SLH-DSA parameter sets (`SLH_DSA_PURE_SHA2_{128,192,256}{S,F}`) reaches `memcpy()` with a NULL source pointer and a length of 0, which UndefinedBehaviorSanitizer flags because glibc's `memcpy` declares its source parameter `nonnull`:

```
sha2_256.c:193:25: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
```

This is undefined behavior per the C standard even at length 0, and while glibc's `memcpy` tolerates it in practice, it is exactly the kind of UB an optimizing compiler is permitted to miscompile around, and that hardened/fortified libc implementations (musl in strict mode, some embedded libcs) can turn into an actual fault.

I found this via the project's own `tests/fuzz_test_sig.c` libFuzzer harness (built per `docs/FUZZING.md` with `-fsanitize=fuzzer-no-link,address,undefined`), and reproduced it standalone with a minimal 25-line program calling `OQS_SIG_sign(sig, signature, &siglen, NULL, 0, sk)` directly.

The SHAKE-based "pure" SLH-DSA variants are **not** affected: their `sha3_update()` (`src/sig/slh_dsa/slh_dsa_c/sha3_api.c`) absorbs the message with a `for (i = 0; i < len; i++)` byte loop that never dereferences the data pointer when `len == 0`, so passing NULL there is safe.

## Fix

Guard the two `memcpy()` call sites in each of `sha2_256_update()` and `sha2_512_update()` with `if (m_sz > 0)`, matching the safe pattern `sha3_update()` already has. No behavior change for any non-empty message; only the previously-UB NULL/zero-length case is affected, which now returns without touching `memcpy` at all.

## Verification

- The standalone reproducer no longer triggers any ASan/UBSan diagnostic after the fix, and still returns `OQS_SUCCESS` with a correctly-sized signature.
- `tests/test_sig` for all six affected algorithms (`slh_dsa_pure_sha2_{128,192,256}{s,f}`) passes, including their EUF-CMA bit-flip verification check.
- Confirmed via `git stash` that an unrelated `tests/kat_sig` failure ("combine_message_signature failed") for these algorithms is pre-existing on unmodified `main` and unaffected by this change.

## Test plan

- [x] Built with `clang -fsanitize=fuzzer-no-link,address,undefined` per `docs/FUZZING.md`
- [x] Ran `tests/fuzz_test_sig` and confirmed the UB is triggered on unmodified `main`
- [x] Ran `tests/fuzz_test_sig` after the fix with no diagnostics
- [x] `tests/test_sig` passes for all six affected algorithms before and after
